### PR TITLE
Add lightning-aws-lambda module

### DIFF
--- a/lightning-aws-lambda/pom.xml
+++ b/lightning-aws-lambda/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.slack.api</groupId>
+        <artifactId>slack-sdk-parent</artifactId>
+        <version>0.99.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <aws-lambda-core.version>1.2.0</aws-lambda-core.version>
+    </properties>
+
+    <groupId>com.slack.api</groupId>
+    <artifactId>lightning-aws-lambda</artifactId>
+    <version>0.99.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.slack.api</groupId>
+            <artifactId>slack-api-model</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.slack.api</groupId>
+            <artifactId>slack-api-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.slack.api</groupId>
+            <artifactId>slack-app-backend</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.slack.api</groupId>
+            <artifactId>lightning</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>${aws-lambda-core.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/SlackApiLambdaHandler.java
+++ b/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/SlackApiLambdaHandler.java
@@ -1,0 +1,62 @@
+package com.slack.api.lightning.aws_lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.slack.api.lightning.App;
+import com.slack.api.lightning.aws_lambda.request.ApiGatewayRequest;
+import com.slack.api.lightning.aws_lambda.response.ApiGatewayResponse;
+import com.slack.api.lightning.request.Request;
+import com.slack.api.lightning.request.RequestHeaders;
+import com.slack.api.lightning.response.Response;
+import com.slack.api.lightning.util.SlackRequestParser;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class SlackApiLambdaHandler implements RequestHandler<ApiGatewayRequest, ApiGatewayResponse> {
+
+    private final SlackRequestParser requestParser;
+    private final App app;
+
+    public SlackApiLambdaHandler(App app) {
+        this.app = app;
+        this.requestParser = new SlackRequestParser(app.config());
+    }
+
+    protected Request<?> toSlackRequest(ApiGatewayRequest awsReq) {
+        if (log.isDebugEnabled()) {
+            log.debug("AWS API Gateway Request: {}", awsReq);
+        }
+        SlackRequestParser.HttpRequest rawRequest = SlackRequestParser.HttpRequest.builder()
+                .requestUri(awsReq.getPath())
+                .queryString(awsReq.getQueryStringParameters())
+                .headers(new RequestHeaders(awsReq.getHeaders()))
+                .requestBody(awsReq.getBody())
+                .remoteAddress(awsReq.getRequestContext().getIdentity() != null ? awsReq.getRequestContext().getIdentity().getSourceIp() : null)
+                .build();
+        return requestParser.parse(rawRequest);
+    }
+
+    protected ApiGatewayResponse toApiGatewayResponse(Response slackResp) {
+        return ApiGatewayResponse.builder()
+                .statusCode(slackResp.getStatusCode())
+                .headers(slackResp.getHeaders())
+                .rawBody(slackResp.getBody())
+                .build();
+    }
+
+    protected abstract boolean isWarmupRequest(ApiGatewayRequest awsReq);
+
+    @Override
+    public ApiGatewayResponse handleRequest(ApiGatewayRequest input, Context context) {
+        if (isWarmupRequest(input)) {
+            return ApiGatewayResponse.builder().statusCode(200).build();
+        }
+        Request<?> req = toSlackRequest(input);
+        try {
+            return toApiGatewayResponse(app.run(req));
+        } catch (Exception e) {
+            return ApiGatewayResponse.builder().statusCode(500).rawBody(e.getMessage()).build();
+        }
+    }
+
+}

--- a/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/request/ApiGatewayRequest.java
+++ b/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/request/ApiGatewayRequest.java
@@ -1,0 +1,21 @@
+package com.slack.api.lightning.aws_lambda.request;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class ApiGatewayRequest {
+
+    private String resource;
+    private String path;
+    private String httpMethod;
+    private Map<String, String> headers;
+    private Map<String, String> queryStringParameters;
+    private Map<String, String> pathParameters;
+    private Map<String, String> stageVariables;
+    private RequestContext requestContext;
+    private String body;
+    private boolean isBase64Encoded;
+
+}

--- a/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/request/Identity.java
+++ b/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/request/Identity.java
@@ -1,0 +1,19 @@
+package com.slack.api.lightning.aws_lambda.request;
+
+import lombok.Data;
+
+@Data
+public class Identity {
+
+    private String cognitoIdentityPoolId;
+    private String accountId;
+    private String cognitoIdentityId;
+    private String caller;
+    private String apiKey;
+    private String sourceIp;
+    private String cognitoAuthenticationType;
+    private String cognitoAuthenticationProvider;
+    private String userArn;
+    private String userAgent;
+    private String user;
+}

--- a/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/request/PayloadExtractor.java
+++ b/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/request/PayloadExtractor.java
@@ -1,0 +1,40 @@
+package com.slack.api.lightning.aws_lambda.request;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+public class PayloadExtractor {
+
+    /**
+     * Extract URL decoded JSON string from body parameter given by AWS Lambda/API Gateway.
+     *
+     * @param body a string value like "payload=%7B%22type%22%3A%22block_actions%22%2C%22team%22%3A%7B%22id%22%3A% ..."
+     * @return
+     */
+    public String extractPayloadJsonAsString(String body) {
+        if (body == null) {
+            return null;
+        }
+        String[] pairs = body.split("\\&");
+        for (String pair : pairs) {
+            String[] elements = pair.split("=");
+            if (elements.length == 2 && elements[0].equals("payload")) {
+                try {
+                    return URLDecoder.decode(elements[1], "UTF-8");
+                } catch (UnsupportedEncodingException e) {
+                    return elements[1];
+                }
+            }
+        }
+        return null;
+    }
+
+    public String extractPayloadJsonAsString(ApiGatewayRequest request) {
+        if (request == null) {
+            return null;
+        } else {
+            return extractPayloadJsonAsString(request.getBody());
+        }
+    }
+
+}

--- a/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/request/RequestContext.java
+++ b/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/request/RequestContext.java
@@ -1,0 +1,15 @@
+package com.slack.api.lightning.aws_lambda.request;
+
+import lombok.Data;
+
+@Data
+public class RequestContext {
+    private String accountId;
+    private String resourceId;
+    private String stage;
+    private String requestId;
+    private Identity identity;
+    private String resourcePath;
+    private String httpMethod;
+    private String apiId;
+}

--- a/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/response/ApiGatewayResponse.java
+++ b/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/response/ApiGatewayResponse.java
@@ -1,4 +1,4 @@
-package com.slack.api.app_backend.vendor.aws.lambda.response;
+package com.slack.api.lightning.aws_lambda.response;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>slack-app-backend</module>
         <module>lightning</module>
         <module>lightning-jetty</module>
+        <module>lightning-aws-lambda</module>
         <module>lightning-micronaut</module>
         <module>lightning-spring-boot-examples</module>
         <module>lightning-kotlin-examples</module>


### PR DESCRIPTION
###  Summary

This pull request adds a new Lightning extension module for AWS Lambda.

#### src/main/java/example/handler/ApiHandler.java

```java
package example.handler;

import com.slack.api.lightning.App;
import com.slack.api.lightning.aws_lambda.SlackApiLambdaHandler;
import com.slack.api.lightning.aws_lambda.request.ApiGatewayRequest;
    
public class ApiHandler extends SlackApiLambdaHandler {

  private static App initApp() {
    App app = new App();
    app.command("/echo", (req, ctx) -> {
      return ctx.ack(r -> r.text(req.getPayload().getText()));
    });
    return app;
  }

  public ApiHandler() {
    this(initApp());
  }

  public ApiHandler(App app) {
    super(app);
  }

  @Override
  protected boolean isWarmupRequest(ApiGatewayRequest awsReq) {
      return false;
  }
}
```

#### serverless.yml

```yaml
provider:
  name: aws
  runtime: java8
  stage: ${opt:stage, 'dev'}
  environment:
    SERVERLESS_STAGE: ${opt:stage, 'dev'}
    SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN}
    SLACK_SIGNING_SECRET: ${env:SLACK_SIGNING_SECRET}

functions:
  api:
    handler: example.handler.ApiHandler
    events:
      - http:
          path: slack/events
          method: post
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
