### PR TITLE
Add cookie-based OAuth state parameter verification

### DIFF
--- a/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/response/ApiGatewayResponse.java
+++ b/lightning-aws-lambda/src/main/java/com/slack/api/lightning/aws_lambda/response/ApiGatewayResponse.java
@@ -17,7 +17,13 @@ public class ApiGatewayResponse {
 
     private final int statusCode;
     private final String body;
+
+    /**
+     * Note: We cannot have multiple values with the same header name here.
+     * See also "https://forums.aws.amazon.com/thread.jspa?threadID=205782"
+     */
     private final Map<String, String> headers;
+
     private final boolean isBase64Encoded;
 
     public ApiGatewayResponse(int statusCode, String body, Map<String, String> headers, boolean isBase64Encoded) {

--- a/lightning-micronaut/src/main/java/com/slack/api/lightning/micronaut/SlackAppMicronautAdapter.java
+++ b/lightning-micronaut/src/main/java/com/slack/api/lightning/micronaut/SlackAppMicronautAdapter.java
@@ -40,7 +40,7 @@ public class SlackAppMicronautAdapter {
                 return e.getKey() + "=" + e.getValue();
             }
         }).collect(Collectors.joining("&"));
-        RequestHeaders headers = new RequestHeaders(flatten(req.getHeaders().asMap()));
+        RequestHeaders headers = new RequestHeaders(req.getHeaders().asMap());
 
         SlackRequestParser.HttpRequest rawRequest = SlackRequestParser.HttpRequest.builder()
                 .requestUri(req.getPath())
@@ -57,8 +57,11 @@ public class SlackAppMicronautAdapter {
     public HttpResponse<String> toMicronautResponse(Response resp) {
         HttpStatus status = HttpStatus.valueOf(resp.getStatusCode());
         MutableHttpResponse<String> response = micronautResponseFactory.status(status);
-        for (Map.Entry<String, String> header : resp.getHeaders().entrySet()) {
-            response.header(header.getKey(), header.getValue());
+        for (Map.Entry<String, List<String>> header : resp.getHeaders().entrySet()) {
+            String name = header.getKey();
+            for (String value : header.getValue()) {
+                response.header(name, value);
+            }
         }
         response.body(resp.getBody());
         return response;

--- a/lightning/src/main/java/com/slack/api/lightning/handler/OAuthAccessErrorHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/OAuthAccessErrorHandler.java
@@ -7,6 +7,6 @@ import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 @FunctionalInterface
 public interface OAuthAccessErrorHandler {
 
-    Response handle(OAuthCallbackRequest req, OAuthAccessResponse apiResponse);
+    Response handle(OAuthCallbackRequest request, Response response, OAuthAccessResponse apiResponse);
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/OAuthErrorHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/OAuthErrorHandler.java
@@ -6,6 +6,6 @@ import com.slack.api.lightning.response.Response;
 @FunctionalInterface
 public interface OAuthErrorHandler {
 
-    Response handle(OAuthCallbackRequest req);
+    Response handle(OAuthCallbackRequest request, Response response);
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/OAuthExceptionHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/OAuthExceptionHandler.java
@@ -6,6 +6,6 @@ import com.slack.api.lightning.response.Response;
 @FunctionalInterface
 public interface OAuthExceptionHandler {
 
-    Response handle(OAuthCallbackRequest req, Exception e);
+    Response handle(OAuthCallbackRequest request, Response response, Exception e);
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/OAuthStateErrorHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/OAuthStateErrorHandler.java
@@ -6,6 +6,6 @@ import com.slack.api.lightning.response.Response;
 @FunctionalInterface
 public interface OAuthStateErrorHandler {
 
-    Response handle(OAuthCallbackRequest req);
+    Response handle(OAuthCallbackRequest request, Response response);
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/OAuthSuccessHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/OAuthSuccessHandler.java
@@ -7,6 +7,6 @@ import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 @FunctionalInterface
 public interface OAuthSuccessHandler {
 
-    Response handle(OAuthCallbackRequest req, OAuthAccessResponse oauthAccess);
+    Response handle(OAuthCallbackRequest request, Response response, OAuthAccessResponse oauthAccess);
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/OAuthV2AccessErrorHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/OAuthV2AccessErrorHandler.java
@@ -7,6 +7,6 @@ import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
 @FunctionalInterface
 public interface OAuthV2AccessErrorHandler {
 
-    Response handle(OAuthCallbackRequest req, OAuthV2AccessResponse apiResponse);
+    Response handle(OAuthCallbackRequest request, Response response, OAuthV2AccessResponse apiResponse);
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/OAuthV2SuccessHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/OAuthV2SuccessHandler.java
@@ -7,6 +7,6 @@ import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
 @FunctionalInterface
 public interface OAuthV2SuccessHandler {
 
-    Response handle(OAuthCallbackRequest req, OAuthV2AccessResponse oauthAccess);
+    Response handle(OAuthCallbackRequest request, Response response, OAuthV2AccessResponse oauthAccess);
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/WebEndpointHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/WebEndpointHandler.java
@@ -7,6 +7,6 @@ import com.slack.api.lightning.response.Response;
 @FunctionalInterface
 public interface WebEndpointHandler {
 
-    Response apply(WebEndpointRequest req, WebEndpointContext context);
+    Response apply(WebEndpointRequest request, WebEndpointContext context);
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthDefaultAccessErrorHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthDefaultAccessErrorHandler.java
@@ -6,18 +6,18 @@ import com.slack.api.lightning.response.Response;
 import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
 
 @Slf4j
 public class OAuthDefaultAccessErrorHandler implements OAuthAccessErrorHandler {
 
     @Override
-    public Response handle(OAuthCallbackRequest req, OAuthAccessResponse apiResponse) {
+    public Response handle(OAuthCallbackRequest request, Response response, OAuthAccessResponse apiResponse) {
         log.error("Failed to run an oauth.access API call: {} - {}", apiResponse.getError(), apiResponse);
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Location", req.getContext().getOauthCancellationUrl());
-        return Response.builder().statusCode(302).headers(headers).build();
+
+        response.setStatusCode(302);
+        response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        return response;
     }
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthDefaultErrorHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthDefaultErrorHandler.java
@@ -5,18 +5,18 @@ import com.slack.api.lightning.request.builtin.OAuthCallbackRequest;
 import com.slack.api.lightning.response.Response;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
 
 @Slf4j
 public class OAuthDefaultErrorHandler implements OAuthErrorHandler {
 
     @Override
-    public Response handle(OAuthCallbackRequest req) {
-        log.error("Received error code in OAuth callback: {}", req.getPayload());
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Location", req.getContext().getOauthCancellationUrl());
-        return Response.builder().statusCode(302).headers(headers).build();
+    public Response handle(OAuthCallbackRequest request, Response response) {
+        log.error("Received error code in OAuth callback: {}", request.getPayload());
+
+        response.setStatusCode(302);
+        response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        return response;
     }
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthDefaultExceptionHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthDefaultExceptionHandler.java
@@ -5,18 +5,18 @@ import com.slack.api.lightning.request.builtin.OAuthCallbackRequest;
 import com.slack.api.lightning.response.Response;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
 
 @Slf4j
 public class OAuthDefaultExceptionHandler implements OAuthExceptionHandler {
 
     @Override
-    public Response handle(OAuthCallbackRequest req, Exception e) {
+    public Response handle(OAuthCallbackRequest request, Response response, Exception e) {
         log.error("Failed to run an OAuth callback operation - {}", e.getMessage(), e);
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Location", req.getContext().getOauthCancellationUrl());
-        return Response.builder().statusCode(302).headers(headers).build();
+
+        response.setStatusCode(302);
+        response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        return response;
     }
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthDefaultStateErrorHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthDefaultStateErrorHandler.java
@@ -5,18 +5,18 @@ import com.slack.api.lightning.request.builtin.OAuthCallbackRequest;
 import com.slack.api.lightning.response.Response;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
 
 @Slf4j
 public class OAuthDefaultStateErrorHandler implements OAuthStateErrorHandler {
 
     @Override
-    public Response handle(OAuthCallbackRequest req) {
-        log.warn("Invalid state parameter detected - payload: {}", req.getPayload());
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Location", req.getContext().getOauthCancellationUrl());
-        return Response.builder().statusCode(302).headers(headers).build();
+    public Response handle(OAuthCallbackRequest request, Response response) {
+        log.warn("Invalid state parameter detected - payload: {}", request.getPayload());
+
+        response.setStatusCode(302);
+        response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        return response;
     }
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthDefaultSuccessHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthDefaultSuccessHandler.java
@@ -13,8 +13,7 @@ import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
 
 @Slf4j
 public class OAuthDefaultSuccessHandler implements OAuthSuccessHandler {
@@ -26,8 +25,8 @@ public class OAuthDefaultSuccessHandler implements OAuthSuccessHandler {
     }
 
     @Override
-    public Response handle(OAuthCallbackRequest req, OAuthAccessResponse o) {
-        OAuthCallbackContext context = req.getContext();
+    public Response handle(OAuthCallbackRequest request, Response response, OAuthAccessResponse o) {
+        OAuthCallbackContext context = request.getContext();
         context.setEnterpriseId(o.getEnterpriseId());
         context.setTeamId(o.getTeamId());
         context.setBotUserId(o.getBot().getBotUserId());
@@ -66,15 +65,15 @@ public class OAuthDefaultSuccessHandler implements OAuthSuccessHandler {
         }
         Installer installer = i.build();
 
-        Map<String, String> headers = new HashMap<>();
+        response.setStatusCode(302);
         try {
             installationService.saveInstallerAndBot(installer);
-            headers.put("Location", context.getOauthCompletionUrl());
+            response.getHeaders().put("Location", Arrays.asList(context.getOauthCompletionUrl()));
         } catch (Exception e) {
             log.warn("Failed to store the installation - {}", e.getMessage(), e);
-            headers.put("Location", context.getOauthCancellationUrl());
+            response.getHeaders().put("Location", Arrays.asList(context.getOauthCancellationUrl()));
         }
-        return Response.builder().statusCode(302).headers(headers).build();
+        return response;
     }
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthV2DefaultAccessErrorHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthV2DefaultAccessErrorHandler.java
@@ -6,18 +6,18 @@ import com.slack.api.lightning.response.Response;
 import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
 
 @Slf4j
 public class OAuthV2DefaultAccessErrorHandler implements OAuthV2AccessErrorHandler {
 
     @Override
-    public Response handle(OAuthCallbackRequest req, OAuthV2AccessResponse apiResponse) {
+    public Response handle(OAuthCallbackRequest req, Response response, OAuthV2AccessResponse apiResponse) {
         log.error("Failed to run an oauth.v2.access API call: {} - {}", apiResponse.getError(), apiResponse);
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Location", req.getContext().getOauthCancellationUrl());
-        return Response.builder().statusCode(302).headers(headers).build();
+
+        response.setStatusCode(302);
+        response.getHeaders().put("Location", Arrays.asList(req.getContext().getOauthCancellationUrl()));
+        return response;
     }
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthV2DefaultSuccessHandler.java
+++ b/lightning/src/main/java/com/slack/api/lightning/handler/builtin/OAuthV2DefaultSuccessHandler.java
@@ -13,8 +13,7 @@ import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
 
 @Slf4j
 public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
@@ -26,8 +25,8 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
     }
 
     @Override
-    public Response handle(OAuthCallbackRequest req, OAuthV2AccessResponse o) {
-        OAuthCallbackContext context = req.getContext();
+    public Response handle(OAuthCallbackRequest request, Response response, OAuthV2AccessResponse o) {
+        OAuthCallbackContext context = request.getContext();
         if (o.getEnterprise() != null) {
             context.setEnterpriseId(o.getEnterprise().getId());
         }
@@ -75,14 +74,14 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
 
         Installer installer = i.build();
 
-        Map<String, String> headers = new HashMap<>();
+        response.setStatusCode(302);
         try {
             installationService.saveInstallerAndBot(installer);
-            headers.put("Location", context.getOauthCompletionUrl());
+            response.getHeaders().put("Location", Arrays.asList(context.getOauthCompletionUrl()));
         } catch (Exception e) {
             log.warn("Failed to store the installation - {}", e.getMessage(), e);
-            headers.put("Location", context.getOauthCancellationUrl());
+            response.getHeaders().put("Location", Arrays.asList(context.getOauthCancellationUrl()));
         }
-        return Response.builder().statusCode(302).headers(headers).build();
+        return response;
     }
 }

--- a/lightning/src/main/java/com/slack/api/lightning/middleware/builtin/RequestVerification.java
+++ b/lightning/src/main/java/com/slack/api/lightning/middleware/builtin/RequestVerification.java
@@ -26,7 +26,7 @@ public class RequestVerification implements Middleware {
         if (req.isValid(verifier)) {
             return chain.next(req);
         } else {
-            String signature = req.getHeaders().get(SlackSignature.HeaderNames.X_SLACK_SIGNATURE);
+            String signature = req.getHeaders().getFirstValue(SlackSignature.HeaderNames.X_SLACK_SIGNATURE);
             log.info("Invalid signature detected - {}", signature);
             return Response.json(401, "{\"error\":\"invalid request\"}");
         }

--- a/lightning/src/main/java/com/slack/api/lightning/request/Request.java
+++ b/lightning/src/main/java/com/slack/api/lightning/request/Request.java
@@ -50,8 +50,8 @@ public abstract class Request<CTX extends Context> {
     }
 
     public boolean isValid(SlackSignature.Verifier verifier, long nowInMillis) {
-        String requestTimestamp = getHeaders().get(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP);
-        String requestSignature = getHeaders().get(SlackSignature.HeaderNames.X_SLACK_SIGNATURE);
+        String requestTimestamp = getHeaders().getFirstValue(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP);
+        String requestSignature = getHeaders().getFirstValue(SlackSignature.HeaderNames.X_SLACK_SIGNATURE);
         return verifier.isValid(requestTimestamp, getRequestBodyAsString(), requestSignature, nowInMillis);
     }
 

--- a/lightning/src/main/java/com/slack/api/lightning/request/RequestHeaders.java
+++ b/lightning/src/main/java/com/slack/api/lightning/request/RequestHeaders.java
@@ -2,28 +2,38 @@ package com.slack.api.lightning.request;
 
 import lombok.ToString;
 
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 @ToString
-public class RequestHeaders extends HashMap<String, String> {
+public class RequestHeaders {
 
-    private final Map<String, String> underlying = new HashMap<>();
+    private final Map<String, List<String>> underlying = new HashMap<>();
 
-    public Set<String> getHeaderNames() {
+    public Set<String> getNames() {
         return underlying.keySet();
     }
 
-    public RequestHeaders(Map<String, String> headers) {
-        for (Entry<String, String> entry : headers.entrySet()) {
-            this.underlying.put(entry.getKey().toLowerCase(Locale.ENGLISH), entry.getValue());
+    public RequestHeaders(Map<String, List<String>> headers) {
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            this.underlying.put(normalizeKey(entry.getKey()), entry.getValue());
         }
     }
 
-    public String get(String name) {
+    public String getFirstValue(String name) {
+        List<String> values = this.underlying.get(normalizeKey(name));
+        if (values != null && values.size() > 0) {
+            return values.get(0);
+        } else {
+            return null;
+        }
+    }
+
+    public List<String> getMultipleValues(String name) {
         return this.underlying.get(name.toLowerCase(Locale.ENGLISH));
+    }
+
+    private static String normalizeKey(String name) {
+        return name != null ? name.toLowerCase(Locale.ENGLISH) : null;
     }
 
 }

--- a/lightning/src/main/java/com/slack/api/lightning/response/Response.java
+++ b/lightning/src/main/java/com/slack/api/lightning/response/Response.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.slack.api.lightning.util.JsonOps.toJsonString;
@@ -21,7 +22,7 @@ public class Response {
     @Builder.Default
     private String contentType = "plain/text";
     @Builder.Default
-    private Map<String, String> headers = new HashMap<>();
+    private Map<String, List<String>> headers = new HashMap<>();
     private String body;
 
     public static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";

--- a/lightning/src/main/java/com/slack/api/lightning/service/builtin/CookieOAuthStateService.java
+++ b/lightning/src/main/java/com/slack/api/lightning/service/builtin/CookieOAuthStateService.java
@@ -1,0 +1,68 @@
+package com.slack.api.lightning.service.builtin;
+
+import com.slack.api.lightning.request.Request;
+import com.slack.api.lightning.response.Response;
+import com.slack.api.lightning.service.OAuthStateService;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+public class CookieOAuthStateService implements OAuthStateService {
+
+    public static final long EXPIRATION_IN_SECONDS = 10 * 60; // default 10 min
+    public static final String DEFAULT_COOKIE_NAME = "slack-app-oauth-state";
+
+    private final Request request;
+    private final Response response;
+    private final String cookieName;
+
+    public CookieOAuthStateService(Request request, Response response) {
+        this(request, response, DEFAULT_COOKIE_NAME);
+    }
+
+    public CookieOAuthStateService(Request request, Response response, String cookieName) {
+        this.request = request;
+        this.response = response;
+        this.cookieName = cookieName;
+    }
+
+    @Override
+    public String issueNewState() throws Exception {
+        String newState = UUID.randomUUID().toString();
+        String value = cookieName + "=" + newState + "; Secure; HttpOnly; Path=/; Max-Age=" + EXPIRATION_IN_SECONDS;
+        response.getHeaders().put("Set-Cookie", Arrays.asList(value));
+        return newState;
+    }
+
+    @Override
+    public boolean isValid(String state) {
+        String cookieHeader = request.getHeaders().getFirstValue("Cookie");
+        if (cookieHeader != null) {
+            String[] elements = cookieHeader.split(cookieName + "=");
+            if (elements != null && elements.length == 2) {
+                String cookieValue = elements[1].split(";")[0];
+                if (cookieValue != null) {
+                    return cookieValue.equals(state);
+                }
+            }
+        } else {
+            log.debug("Failed to fetch {} cookie value for state: {}", cookieName, state);
+        }
+        return false;
+    }
+
+    @Override
+    public void consume(String state) throws Exception {
+        List<String> setCookieHeaderValues = response.getHeaders().get("Set-Cookie");
+        if (setCookieHeaderValues == null) {
+            setCookieHeaderValues = new ArrayList<>();
+        }
+        setCookieHeaderValues.add(cookieName + "=deleted; Secure; HttpOnly; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT");
+        response.getHeaders().put("Set-Cookie", setCookieHeaderValues);
+    }
+
+}

--- a/lightning/src/main/java/com/slack/api/lightning/servlet/SlackAppServletAdapter.java
+++ b/lightning/src/main/java/com/slack/api/lightning/servlet/SlackAppServletAdapter.java
@@ -11,7 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Map;
+
+import static com.slack.api.lightning.servlet.ServletAdapterOps.toHeaderMap;
 
 @Slf4j
 public class SlackAppServletAdapter {
@@ -37,10 +38,6 @@ public class SlackAppServletAdapter {
 
     protected String doReadRequestBodyAsString(HttpServletRequest req) throws IOException {
         return ServletAdapterOps.doReadRequestBodyAsString(req);
-    }
-
-    protected Map<String, String> toHeaderMap(HttpServletRequest req) {
-        return ServletAdapterOps.toHeaderMap(req);
     }
 
     public void writeResponse(HttpServletResponse resp, Response slackResp) throws IOException {

--- a/lightning/src/main/java/com/slack/api/lightning/servlet/WebEndpointServletAdapter.java
+++ b/lightning/src/main/java/com/slack/api/lightning/servlet/WebEndpointServletAdapter.java
@@ -9,7 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Map;
+
+import static com.slack.api.lightning.servlet.ServletAdapterOps.toHeaderMap;
 
 @Slf4j
 public class WebEndpointServletAdapter {
@@ -41,10 +42,6 @@ public class WebEndpointServletAdapter {
 
     protected String doReadRequestBodyAsString(HttpServletRequest req) throws IOException {
         return ServletAdapterOps.doReadRequestBodyAsString(req);
-    }
-
-    protected Map<String, String> toHeaderMap(HttpServletRequest req) {
-        return ServletAdapterOps.toHeaderMap(req);
     }
 
     public void writeResponse(HttpServletResponse resp, Response slackResp) throws IOException {

--- a/lightning/src/main/java/com/slack/api/lightning/util/SlackRequestParser.java
+++ b/lightning/src/main/java/com/slack/api/lightning/util/SlackRequestParser.java
@@ -127,7 +127,7 @@ public class SlackRequestParser {
             if (slackRequest != null) {
                 slackRequest.updateContext(appConfig);
 
-                String ipAddress = headers.get("X-FORWARDED-FOR");
+                String ipAddress = headers.getFirstValue("X-FORWARDED-FOR");
                 if (ipAddress == null) {
                     ipAddress = httpRequest.getRemoteAddress();
                 }


### PR DESCRIPTION
###  Summary

This pull request adds a cookie-based OAuth state verification module. Also, Lightning uses this one as the default. With this implementation, Slack apps don't need to prepare server-side storage for persisting state values with expiration.

To fully support the variations of real-world cookies, I had to introduce a breaking change to Request, Response, and OAuth related handlers. They are no longer compatible with the jSlack version.

cc @stevengill @aoberoi 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
