### PR TITLE
Add checkboxes element support in Block Kit

### DIFF
--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -300,7 +300,8 @@
       "browsers_dismissed_people_low_results_education": false,
       "browsers_seen_initial_people_education": false,
       "activity_view": "",
-      "up_to_browse_kb_shortcut": false
+      "up_to_browse_kb_shortcut": false,
+      "suppress_link_warning": false
     },
     "created": 12345,
     "manual_presence": ""

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -10,7 +10,6 @@
       "elements": [
         {
           "type": "button",
-          "fallback": "",
           "text": {
             "type": "plain_text",
             "text": "",
@@ -45,7 +44,6 @@
         },
         {
           "type": "channels_select",
-          "fallback": "",
           "placeholder": {
             "type": "plain_text",
             "text": "",
@@ -78,7 +76,6 @@
         },
         {
           "type": "conversations_select",
-          "fallback": "",
           "placeholder": {
             "type": "plain_text",
             "text": "",
@@ -111,7 +108,6 @@
         },
         {
           "type": "datepicker",
-          "fallback": "",
           "action_id": "",
           "placeholder": {
             "type": "plain_text",
@@ -144,7 +140,6 @@
         },
         {
           "type": "external_select",
-          "fallback": "",
           "placeholder": {
             "type": "plain_text",
             "text": "",
@@ -191,16 +186,15 @@
         },
         {
           "type": "image",
-          "fallback": "",
           "image_url": "",
+          "alt_text": "",
+          "fallback": "",
           "image_width": 123,
           "image_height": 123,
-          "image_bytes": 123,
-          "alt_text": ""
+          "image_bytes": 123
         },
         {
           "type": "overflow",
-          "fallback": "",
           "action_id": "",
           "confirm": {
             "title": {
@@ -227,7 +221,6 @@
         },
         {
           "type": "static_select",
-          "fallback": "",
           "placeholder": {
             "type": "plain_text",
             "text": "",
@@ -273,7 +266,6 @@
         },
         {
           "type": "users_select",
-          "fallback": "",
           "placeholder": {
             "type": "plain_text",
             "text": "",
@@ -312,12 +304,12 @@
       "elements": [
         {
           "type": "image",
-          "fallback": "",
           "image_url": "",
+          "alt_text": "",
+          "fallback": "",
           "image_width": 123,
           "image_height": 123,
-          "image_bytes": 123,
-          "alt_text": ""
+          "image_bytes": 123
         }
       ],
       "block_id": ""
@@ -363,12 +355,12 @@
       ],
       "accessory": {
         "type": "image",
-        "fallback": "",
         "image_url": "",
+        "alt_text": "",
+        "fallback": "",
         "image_width": 123,
         "image_height": 123,
-        "image_bytes": 123,
-        "alt_text": ""
+        "image_bytes": 123
       }
     }
   ],

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -157,7 +157,13 @@
               "text": "",
               "emoji": false
             },
-            "value": ""
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
           },
           "min_query_length": 123,
           "confirm": {
@@ -234,7 +240,13 @@
               "text": "",
               "emoji": false
             },
-            "value": ""
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
           },
           "confirm": {
             "title": {

--- a/json-logs/samples/rtm/PinAddedEvent.json
+++ b/json-logs/samples/rtm/PinAddedEvent.json
@@ -165,7 +165,13 @@
                   "text": "",
                   "emoji": false
                 },
-                "value": ""
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
               },
               "min_query_length": 123,
               "confirm": {
@@ -242,7 +248,13 @@
                   "text": "",
                   "emoji": false
                 },
-                "value": ""
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
               },
               "confirm": {
                 "title": {

--- a/json-logs/samples/rtm/PinAddedEvent.json
+++ b/json-logs/samples/rtm/PinAddedEvent.json
@@ -18,7 +18,6 @@
           "elements": [
             {
               "type": "button",
-              "fallback": "",
               "text": {
                 "type": "plain_text",
                 "text": "",
@@ -53,7 +52,6 @@
             },
             {
               "type": "channels_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -86,7 +84,6 @@
             },
             {
               "type": "conversations_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -119,7 +116,6 @@
             },
             {
               "type": "datepicker",
-              "fallback": "",
               "action_id": "",
               "placeholder": {
                 "type": "plain_text",
@@ -152,7 +148,6 @@
             },
             {
               "type": "external_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -199,16 +194,15 @@
             },
             {
               "type": "image",
-              "fallback": "",
               "image_url": "",
+              "alt_text": "",
+              "fallback": "",
               "image_width": 123,
               "image_height": 123,
-              "image_bytes": 123,
-              "alt_text": ""
+              "image_bytes": 123
             },
             {
               "type": "overflow",
-              "fallback": "",
               "action_id": "",
               "confirm": {
                 "title": {
@@ -235,7 +229,6 @@
             },
             {
               "type": "static_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -281,7 +274,6 @@
             },
             {
               "type": "users_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -320,12 +312,12 @@
           "elements": [
             {
               "type": "image",
-              "fallback": "",
               "image_url": "",
+              "alt_text": "",
+              "fallback": "",
               "image_width": 123,
               "image_height": 123,
-              "image_bytes": 123,
-              "alt_text": ""
+              "image_bytes": 123
             }
           ],
           "block_id": ""
@@ -371,12 +363,12 @@
           ],
           "accessory": {
             "type": "image",
-            "fallback": "",
             "image_url": "",
+            "alt_text": "",
+            "fallback": "",
             "image_width": 123,
             "image_height": 123,
-            "image_bytes": 123,
-            "alt_text": ""
+            "image_bytes": 123
           }
         }
       ],

--- a/json-logs/samples/rtm/PinRemovedEvent.json
+++ b/json-logs/samples/rtm/PinRemovedEvent.json
@@ -165,7 +165,13 @@
                   "text": "",
                   "emoji": false
                 },
-                "value": ""
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
               },
               "min_query_length": 123,
               "confirm": {
@@ -242,7 +248,13 @@
                   "text": "",
                   "emoji": false
                 },
-                "value": ""
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
               },
               "confirm": {
                 "title": {

--- a/json-logs/samples/rtm/PinRemovedEvent.json
+++ b/json-logs/samples/rtm/PinRemovedEvent.json
@@ -18,7 +18,6 @@
           "elements": [
             {
               "type": "button",
-              "fallback": "",
               "text": {
                 "type": "plain_text",
                 "text": "",
@@ -53,7 +52,6 @@
             },
             {
               "type": "channels_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -86,7 +84,6 @@
             },
             {
               "type": "conversations_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -119,7 +116,6 @@
             },
             {
               "type": "datepicker",
-              "fallback": "",
               "action_id": "",
               "placeholder": {
                 "type": "plain_text",
@@ -152,7 +148,6 @@
             },
             {
               "type": "external_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -199,16 +194,15 @@
             },
             {
               "type": "image",
-              "fallback": "",
               "image_url": "",
+              "alt_text": "",
+              "fallback": "",
               "image_width": 123,
               "image_height": 123,
-              "image_bytes": 123,
-              "alt_text": ""
+              "image_bytes": 123
             },
             {
               "type": "overflow",
-              "fallback": "",
               "action_id": "",
               "confirm": {
                 "title": {
@@ -235,7 +229,6 @@
             },
             {
               "type": "static_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -281,7 +274,6 @@
             },
             {
               "type": "users_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -320,12 +312,12 @@
           "elements": [
             {
               "type": "image",
-              "fallback": "",
               "image_url": "",
+              "alt_text": "",
+              "fallback": "",
               "image_width": 123,
               "image_height": 123,
-              "image_bytes": 123,
-              "alt_text": ""
+              "image_bytes": 123
             }
           ],
           "block_id": ""
@@ -371,12 +363,12 @@
           ],
           "accessory": {
             "type": "image",
-            "fallback": "",
             "image_url": "",
+            "alt_text": "",
+            "fallback": "",
             "image_width": 123,
             "image_height": 123,
-            "image_bytes": 123,
-            "alt_text": ""
+            "image_bytes": 123
           }
         }
       ],

--- a/json-logs/samples/rtm/StarAddedEvent.json
+++ b/json-logs/samples/rtm/StarAddedEvent.json
@@ -164,7 +164,13 @@
                   "text": "",
                   "emoji": false
                 },
-                "value": ""
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
               },
               "min_query_length": 123,
               "confirm": {
@@ -241,7 +247,13 @@
                   "text": "",
                   "emoji": false
                 },
-                "value": ""
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
               },
               "confirm": {
                 "title": {

--- a/json-logs/samples/rtm/StarAddedEvent.json
+++ b/json-logs/samples/rtm/StarAddedEvent.json
@@ -17,7 +17,6 @@
           "elements": [
             {
               "type": "button",
-              "fallback": "",
               "text": {
                 "type": "plain_text",
                 "text": "",
@@ -52,7 +51,6 @@
             },
             {
               "type": "channels_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -85,7 +83,6 @@
             },
             {
               "type": "conversations_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -118,7 +115,6 @@
             },
             {
               "type": "datepicker",
-              "fallback": "",
               "action_id": "",
               "placeholder": {
                 "type": "plain_text",
@@ -151,7 +147,6 @@
             },
             {
               "type": "external_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -198,16 +193,15 @@
             },
             {
               "type": "image",
-              "fallback": "",
               "image_url": "",
+              "alt_text": "",
+              "fallback": "",
               "image_width": 123,
               "image_height": 123,
-              "image_bytes": 123,
-              "alt_text": ""
+              "image_bytes": 123
             },
             {
               "type": "overflow",
-              "fallback": "",
               "action_id": "",
               "confirm": {
                 "title": {
@@ -234,7 +228,6 @@
             },
             {
               "type": "static_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -280,7 +273,6 @@
             },
             {
               "type": "users_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -319,12 +311,12 @@
           "elements": [
             {
               "type": "image",
-              "fallback": "",
               "image_url": "",
+              "alt_text": "",
+              "fallback": "",
               "image_width": 123,
               "image_height": 123,
-              "image_bytes": 123,
-              "alt_text": ""
+              "image_bytes": 123
             }
           ],
           "block_id": ""
@@ -370,12 +362,12 @@
           ],
           "accessory": {
             "type": "image",
-            "fallback": "",
             "image_url": "",
+            "alt_text": "",
+            "fallback": "",
             "image_width": 123,
             "image_height": 123,
-            "image_bytes": 123,
-            "alt_text": ""
+            "image_bytes": 123
           }
         }
       ],

--- a/json-logs/samples/rtm/StarRemovedEvent.json
+++ b/json-logs/samples/rtm/StarRemovedEvent.json
@@ -164,7 +164,13 @@
                   "text": "",
                   "emoji": false
                 },
-                "value": ""
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
               },
               "min_query_length": 123,
               "confirm": {
@@ -241,7 +247,13 @@
                   "text": "",
                   "emoji": false
                 },
-                "value": ""
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
               },
               "confirm": {
                 "title": {

--- a/json-logs/samples/rtm/StarRemovedEvent.json
+++ b/json-logs/samples/rtm/StarRemovedEvent.json
@@ -17,7 +17,6 @@
           "elements": [
             {
               "type": "button",
-              "fallback": "",
               "text": {
                 "type": "plain_text",
                 "text": "",
@@ -52,7 +51,6 @@
             },
             {
               "type": "channels_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -85,7 +83,6 @@
             },
             {
               "type": "conversations_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -118,7 +115,6 @@
             },
             {
               "type": "datepicker",
-              "fallback": "",
               "action_id": "",
               "placeholder": {
                 "type": "plain_text",
@@ -151,7 +147,6 @@
             },
             {
               "type": "external_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -198,16 +193,15 @@
             },
             {
               "type": "image",
-              "fallback": "",
               "image_url": "",
+              "alt_text": "",
+              "fallback": "",
               "image_width": 123,
               "image_height": 123,
-              "image_bytes": 123,
-              "alt_text": ""
+              "image_bytes": 123
             },
             {
               "type": "overflow",
-              "fallback": "",
               "action_id": "",
               "confirm": {
                 "title": {
@@ -234,7 +228,6 @@
             },
             {
               "type": "static_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -280,7 +273,6 @@
             },
             {
               "type": "users_select",
-              "fallback": "",
               "placeholder": {
                 "type": "plain_text",
                 "text": "",
@@ -319,12 +311,12 @@
           "elements": [
             {
               "type": "image",
-              "fallback": "",
               "image_url": "",
+              "alt_text": "",
+              "fallback": "",
               "image_width": 123,
               "image_height": 123,
-              "image_bytes": 123,
-              "alt_text": ""
+              "image_bytes": 123
             }
           ],
           "block_id": ""
@@ -370,12 +362,12 @@
           ],
           "accessory": {
             "type": "image",
-            "fallback": "",
             "image_url": "",
+            "alt_text": "",
+            "fallback": "",
             "image_width": 123,
             "image_height": 123,
-            "image_bytes": 123,
-            "alt_text": ""
+            "image_bytes": 123
           }
         }
       ],

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/OptionObject.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/OptionObject.java
@@ -13,6 +13,31 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OptionObject {
+
+    /**
+     * The formatting to use for this text object. Can be one of plain_text or mrkdwn.
+     */
     private PlainTextObject text;
+
+    /**
+     *	The text for the block. This field accepts any of the standard text formatting markup when type is mrkdwn.
+     */
     private String value;
+
+    /**
+     * A plain_text https://api.slack.com/reference/block-kit/composition-objects#text
+     * only text object that defines a line of descriptive text shown below the text field beside the radio button.
+     * Maximum length for the text object within this field is 75 characters.
+     */
+    private PlainTextObject description;
+
+    /**
+     * A URL to load in the user's browser when the option is clicked.
+     * The url attribute is only available in overflow menus.
+     * https://api.slack.com/reference/block-kit/block-elements#overflow
+     * <p>
+     * Maximum length for this field is 3000 characters.
+     * If you're using url, you'll still receive an interaction payload and will need to send an acknowledgement response.
+     */
+    private String url;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/BlockElements.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/BlockElements.java
@@ -29,6 +29,12 @@ public class BlockElements {
         return configurator.configure(ButtonElement.builder()).build();
     }
 
+    // CheckboxesElement
+
+    public static CheckboxesElement checkboxes(ModelConfigurator<CheckboxesElement.CheckboxesElementBuilder> configurator) {
+        return configurator.configure(CheckboxesElement.builder()).build();
+    }
+
     // OverflowMenuElement
 
     public static OverflowMenuElement overflowMenu(ModelConfigurator<OverflowMenuElement.OverflowMenuElementBuilder> configurator) {

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ButtonElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ButtonElement.java
@@ -5,7 +5,7 @@ import com.slack.api.model.block.composition.PlainTextObject;
 import lombok.*;
 
 /**
- * https://api.slack.com/reference/messaging/block-elements#button
+ * https://api.slack.com/reference/block-kit/block-elements#button
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -15,11 +15,50 @@ import lombok.*;
 public class ButtonElement extends BlockElement {
     public static final String TYPE = "button";
     private final String type = TYPE;
-    private String fallback;
+
+    /**
+     * A text object that defines the button's text. Can only be of type: plain_text.
+     * Maximum length for the text in this field is 75 characters.
+     */
     private PlainTextObject text;
+
+    /**
+     * An identifier for this action. You can use this when you receive an interaction payload
+     * to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
+
+    /**
+     * A URL to load in the user's browser when the button is clicked.
+     * Maximum length for this field is 3000 characters.
+     * If you're using url, you'll still receive an interaction payload and will need to send an acknowledgement response.
+     */
     private String url;
+
+    /**
+     * The value to send along with the interaction payload.
+     * Maximum length for this field is 2000 characters.
+     */
     private String value;
+
+    /**
+     * Decorates buttons with alternative visual color schemes.
+     * Use this option with restraint.
+     * <p>
+     * `primary` gives buttons a green outline and text, ideal for affirmation or confirmation actions.
+     * `primary` should only be used for one button within a set.
+     * <p>
+     * `danger` gives buttons a red outline and text, and should be used when the action is destructive.
+     * Use danger even more sparingly than `primary`.
+     * <p>
+     * If you don't include this field, the `default` button style will be used.
+     */
     private String style; // possible values: primary, danger
+
+    /**
+     * A confirm object that defines an optional confirmation dialog after the button is clicked.
+     */
     private ConfirmationDialogObject confirm;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ChannelsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ChannelsSelectElement.java
@@ -5,7 +5,7 @@ import com.slack.api.model.block.composition.PlainTextObject;
 import lombok.*;
 
 /**
- * https://api.slack.com/reference/messaging/block-elements#channels-select
+ * https://api.slack.com/reference/block-kit/block-elements#channel_select
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -15,9 +15,28 @@ import lombok.*;
 public class ChannelsSelectElement extends BlockElement {
     public static final String TYPE = "channels_select";
     private final String type = TYPE;
-    private String fallback;
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the menu.
+     * Maximum length for the text in this field is 150 characters.
+     */
     private PlainTextObject placeholder;
+
+    /**
+     * An identifier for the action triggered when a menu option is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
+
+    /**
+     * The ID of any valid public channel to be pre-selected when the menu loads.
+     */
     private String initialChannel;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears after a menu item is selected.
+     */
     private ConfirmationDialogObject confirm;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/CheckboxesElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/CheckboxesElement.java
@@ -1,0 +1,52 @@
+package com.slack.api.model.block.element;
+
+import com.slack.api.model.block.composition.ConfirmationDialogObject;
+import com.slack.api.model.block.composition.OptionObject;
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/reference/block-kit/block-elements#checkboxes
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CheckboxesElement extends BlockElement {
+    public static final String TYPE = "checkboxes";
+    private final String type = TYPE;
+
+    /**
+     * An identifier for the action triggered when the checkbox group is changed.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
+    private String actionId;
+
+    /**
+     * An array of option objects.
+     * <p>
+     * NOTE: The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
+     * when it encounters an empty list in the generated JSON.
+     * The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
+     *
+     * @see "https://github.com/slackapi/java-slack-sdk/pull/103"
+     * @see "https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists"
+     */
+    private List<OptionObject> options;
+
+    /**
+     * An array of option objects that exactly matches one or more of the options within options.
+     * These options will be selected when the checkbox group initially loads.
+     */
+    private List<OptionObject> initialOptions;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog
+     * that appears after clicking one of the checkboxes in this element.
+     */
+    private ConfirmationDialogObject confirm;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsSelectElement.java
@@ -5,7 +5,7 @@ import com.slack.api.model.block.composition.PlainTextObject;
 import lombok.*;
 
 /**
- * https://api.slack.com/reference/messaging/block-elements#conversations-select
+ * https://api.slack.com/reference/block-kit/block-elements#conversation_select
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -15,9 +15,29 @@ import lombok.*;
 public class ConversationsSelectElement extends BlockElement {
     public static final String TYPE = "conversations_select";
     private final String type = TYPE;
-    private String fallback;
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the menu.
+     * Maximum length for the text in this field is 150 characters.
+     */
     private PlainTextObject placeholder;
+
+    /**
+     * An identifier for the action triggered when a menu option is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
+
+    /**
+     * The ID of any valid conversation to be pre-selected when the menu loads.
+     */
     private String initialConversation;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears after a menu item is selected.
+     */
     private ConfirmationDialogObject confirm;
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/DatePickerElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/DatePickerElement.java
@@ -5,7 +5,7 @@ import com.slack.api.model.block.composition.PlainTextObject;
 import lombok.*;
 
 /**
- * https://api.slack.com/reference/messaging/block-elements#datepicker
+ * https://api.slack.com/reference/block-kit/block-elements#datepicker
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -15,9 +15,29 @@ import lombok.*;
 public class DatePickerElement extends BlockElement {
     public static final String TYPE = "datepicker";
     private final String type = TYPE;
-    private String fallback;
+
+    /**
+     * An identifier for the action triggered when a menu option is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the datepicker.
+     * Maximum length for the text in this field is 150 characters.
+     */
     private PlainTextObject placeholder;
+
+    /**
+     * The initial date that is selected when the element is loaded. This should be in the format YYYY-MM-DD.
+     */
     private String initialDate;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears after a date is selected.
+     */
     private ConfirmationDialogObject confirm;
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ExternalSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ExternalSelectElement.java
@@ -6,7 +6,7 @@ import com.slack.api.model.block.composition.PlainTextObject;
 import lombok.*;
 
 /**
- * https://api.slack.com/reference/messaging/block-elements#external-select
+ * https://api.slack.com/reference/block-kit/block-elements#external_select
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -16,10 +16,38 @@ import lombok.*;
 public class ExternalSelectElement extends BlockElement {
     public static final String TYPE = "external_select";
     private final String type = TYPE;
-    private String fallback;
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the menu.
+     * Maximum length for the text in this field is 150 characters.
+     */
     private PlainTextObject placeholder;
+
+    /**
+     * An identifier for the action triggered when a menu option is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
+
+    /**
+     * A single option that exactly matches one of the options within the options or
+     * option_groups loaded from the external data source.
+     * This option will be selected when the menu initially loads.
+     */
     private OptionObject initialOption;
+
+    /**
+     * When the typeahead field is used, a request will be sent on every character change.
+     * If you prefer fewer requests or more fully ideated queries,
+     * use the min_query_length attribute to tell Slack the fewest number of typed characters required before dispatch.
+     */
     private Integer minQueryLength;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears after a menu item is selected.
+     */
     private ConfirmationDialogObject confirm;
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ImageElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ImageElement.java
@@ -4,7 +4,7 @@ import com.slack.api.model.block.ContextBlockElement;
 import lombok.*;
 
 /**
- * https://api.slack.com/reference/messaging/block-elements#image
+ * https://api.slack.com/reference/block-kit/block-elements#image
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -14,10 +14,19 @@ import lombok.*;
 public class ImageElement extends BlockElement implements ContextBlockElement {
     public static final String TYPE = "image";
     private final String type = TYPE;
-    private String fallback;
+
+    /**
+     * The URL of the image to be displayed.
+     */
     private String imageUrl;
+
+    /**
+     * A plain-text summary of the image. This should not contain any markup.
+     */
+    private String altText;
+
+    private String fallback;
     private Integer imageWidth;
     private Integer imageHeight;
     private Integer imageBytes;
-    private String altText;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiChannelsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiChannelsSelectElement.java
@@ -7,7 +7,7 @@ import lombok.*;
 import java.util.List;
 
 /**
- * https://api.slack.com/reference/block-kit/block-elements#multi_select
+ * https://api.slack.com/reference/block-kit/block-elements#channel_multi_select
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -17,10 +17,36 @@ import java.util.List;
 public class MultiChannelsSelectElement extends BlockElement {
     public static final String TYPE = "multi_channels_select";
     private final String type = TYPE;
-    private String fallback;
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the menu.
+     * Maximum length for the text in this field is 150 characters.
+     */
     private PlainTextObject placeholder;
+
+    /**
+     * An identifier for the action triggered when a menu option is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
+
+    /**
+     * An array of one or more IDs of any valid public channel to be pre-selected when the menu loads.
+     */
     private List<String> initialChannels;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears
+     * before the multi-select choices are submitted.
+     */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * Specifies the maximum number of items that can be selected in the menu.
+     * Minimum number is 1.
+     */
     private Integer maxSelectedItems;
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiConversationsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiConversationsSelectElement.java
@@ -7,7 +7,7 @@ import lombok.*;
 import java.util.List;
 
 /**
- * https://api.slack.com/reference/block-kit/block-elements#multi_select
+ * https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -17,10 +17,36 @@ import java.util.List;
 public class MultiConversationsSelectElement extends BlockElement {
     public static final String TYPE = "multi_conversations_select";
     private final String type = TYPE;
-    private String fallback;
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the menu.
+     * Maximum length for the text in this field is 150 characters.
+     */
     private PlainTextObject placeholder;
+
+    /**
+     * An identifier for the action triggered when a menu option is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
+
+    /**
+     * An array of one or more IDs of any valid conversations to be pre-selected when the menu loads.
+     */
     private List<String> initialConversations;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears
+     * before the multi-select choices are submitted.
+     */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * Specifies the maximum number of items that can be selected in the menu.
+     * Minimum number is 1.
+     */
     private Integer maxSelectedItems;
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiExternalSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiExternalSelectElement.java
@@ -8,7 +8,7 @@ import lombok.*;
 import java.util.List;
 
 /**
- * https://api.slack.com/reference/block-kit/block-elements#multi_select
+ * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -18,11 +18,44 @@ import java.util.List;
 public class MultiExternalSelectElement extends BlockElement {
     public static final String TYPE = "multi_external_select";
     private final String type = TYPE;
-    private String fallback;
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the menu.
+     * Maximum length for the text in this field is 150 characters.
+     */
     private PlainTextObject placeholder;
+
+    /**
+     * An identifier for the action triggered when a menu option is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
+
+    /**
+     * An array of option objects that exactly match one or more of the options within options or option_groups.
+     * These options will be selected when the menu initially loads.
+     */
     private List<OptionObject> initialOptions;
+
+    /**
+     * When the typeahead field is used, a request will be sent on every character change.
+     * If you prefer fewer requests or more fully ideated queries, use the min_query_length attribute
+     * to tell Slack the fewest number of typed characters required before dispatch.
+     */
     private Integer minQueryLength;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog
+     * that appears before the multi-select choices are submitted.
+     */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * Specifies the maximum number of items that can be selected in the menu.
+     * Minimum number is 1.
+     */
     private Integer maxSelectedItems;
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiStaticSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiStaticSelectElement.java
@@ -24,14 +24,14 @@ public class MultiStaticSelectElement extends BlockElement {
     private PlainTextObject placeholder;
     private String actionId;
 
-    // https://github.com/seratch/jslack/pull/103
+    // https://github.com/slackapi/java-slack-sdk/pull/103
     // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
     // when it encounters an empty list in the generated JSON.
     // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
     // (e.g. something like https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists)
     private List<OptionObject> options;
 
-    // https://github.com/seratch/jslack/pull/103
+    // https://github.com/slackapi/java-slack-sdk/pull/103
     // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
     // when it encounters an empty list in the generated JSON.
     // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiStaticSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiStaticSelectElement.java
@@ -19,26 +19,60 @@ import java.util.List;
 public class MultiStaticSelectElement extends BlockElement {
     public static final String TYPE = "multi_static_select";
     private final String type = TYPE;
-    private String fallback;
 
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the menu.
+     * Maximum length for the text in this field is 150 characters.
+     */
     private PlainTextObject placeholder;
+
+    /**
+     * An identifier for the action triggered when a menu option is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
 
-    // https://github.com/slackapi/java-slack-sdk/pull/103
-    // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
-    // when it encounters an empty list in the generated JSON.
-    // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
-    // (e.g. something like https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists)
+    /**
+     * An array of option objects. Maximum number of options is 100.
+     * If option_groups is specified, this field should not be.
+     * <p>
+     * NOTE: The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
+     * when it encounters an empty list in the generated JSON.
+     * The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
+     *
+     * @see "https://github.com/slackapi/java-slack-sdk/pull/103"
+     * @see "https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists"
+     */
     private List<OptionObject> options;
 
-    // https://github.com/slackapi/java-slack-sdk/pull/103
-    // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
-    // when it encounters an empty list in the generated JSON.
-    // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
-    // (e.g. something like https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists)
+    /**
+     * An array of option group objects. Maximum number of option groups is 100.
+     * If options is specified, this field should not be.
+     * <p>
+     * NOTE: The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
+     * when it encounters an empty list in the generated JSON.
+     * The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
+     *
+     * @see "https://github.com/slackapi/java-slack-sdk/pull/103"
+     * @see "https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists"
+     */
     private List<OptionGroupObject> optionGroups;
 
+    /**
+     * An array of option objects that exactly match one or more of the options within options or option_groups.
+     * These options will be selected when the menu initially loads.
+     */
     private List<OptionObject> initialOptions;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears before the multi-select choices are submitted.
+     */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * Specifies the maximum number of items that can be selected in the menu. Minimum number is 1.
+     */
     private Integer maxSelectedItems;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiUsersSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiUsersSelectElement.java
@@ -7,7 +7,7 @@ import lombok.*;
 import java.util.List;
 
 /**
- * https://api.slack.com/reference/block-kit/block-elements#multi_select
+ * https://api.slack.com/reference/block-kit/block-elements#users_multi_select
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -17,11 +17,34 @@ import java.util.List;
 public class MultiUsersSelectElement extends BlockElement {
     public static final String TYPE = "multi_users_select";
     private final String type = TYPE;
-    private String fallback;
 
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the menu.
+     * Maximum length for the text in this field is 150 characters.
+     */
     private PlainTextObject placeholder;
+
+    /**
+     * An identifier for the action triggered when a menu option is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
+
+    /**
+     * An array of user IDs of any valid users to be pre-selected when the menu loads.
+     */
     private List<String> initialUsers;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears before the multi-select choices are submitted.
+     */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * Specifies the maximum number of items that can be selected in the menu.
+     * Minimum number is 1.
+     */
     private Integer maxSelectedItems;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/OverflowMenuElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/OverflowMenuElement.java
@@ -21,7 +21,7 @@ public class OverflowMenuElement extends BlockElement {
 
     private String actionId;
 
-    // https://github.com/seratch/jslack/pull/103
+    // https://github.com/slackapi/java-slack-sdk/pull/103
     // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
     // when it encounters an empty list in the generated JSON.
     // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/OverflowMenuElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/OverflowMenuElement.java
@@ -7,7 +7,7 @@ import lombok.*;
 import java.util.List;
 
 /**
- * https://api.slack.com/reference/messaging/block-elements#overflow
+ * https://api.slack.com/reference/block-kit/block-elements#overflow
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -17,16 +17,29 @@ import java.util.List;
 public class OverflowMenuElement extends BlockElement {
     public static final String TYPE = "overflow";
     private final String type = TYPE;
-    private String fallback;
 
+    /**
+     * An identifier for the action triggered when a menu option is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * hould be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
 
-    // https://github.com/slackapi/java-slack-sdk/pull/103
-    // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
-    // when it encounters an empty list in the generated JSON.
-    // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
-    // (e.g. something like https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists)
+    /**
+     * An array of option objects to display in the menu. Maximum number of options is 5, minimum is 2.
+     * <p>
+     * NOTE: The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
+     * when it encounters an empty list in the generated JSON.
+     * The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
+     *
+     * @see "https://github.com/slackapi/java-slack-sdk/pull/103"
+     * @see "https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists"
+     */
     private List<OptionObject> options;
 
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears after a menu item is selected.
+     */
     private ConfirmationDialogObject confirm;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/PlainTextInputElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/PlainTextInputElement.java
@@ -14,10 +14,40 @@ import lombok.*;
 public class PlainTextInputElement extends BlockElement {
     public static final String TYPE = "plain_text_input";
     private final String type = TYPE;
+
+    /**
+     * An identifier for the input value when the parent modal is submitted.
+     * You can use this when you receive a view_submission payload to identify the value of the input element.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown in the plain-text input.
+     * Maximum length for the text in this field is 150 characters.
+     */
     private PlainTextObject placeholder;
+
+    /**
+     * The initial value in the plain-text input when it is loaded.
+     */
     private String initialValue;
+
+    /**
+     * Indicates whether the input will be a single line (false) or a larger textarea (true).
+     * Defaults to false.
+     */
     private boolean multiline;
+
+    /**
+     * The minimum length of input that the user must provide. If the user provides less, they will receive an error.
+     * Maximum value is 3000.
+     */
     private Integer minLength;
+
+    /**
+     * The maximum length of input that the user can provide. If the user provides more, they will receive an error.
+     */
     private Integer maxLength;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RadioButtonsElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RadioButtonsElement.java
@@ -23,7 +23,7 @@ public class RadioButtonsElement extends BlockElement {
     private PlainTextObject placeholder;
     private String actionId;
 
-    // https://github.com/seratch/jslack/pull/103
+    // https://github.com/slackapi/java-slack-sdk/pull/103
     // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
     // when it encounters an empty list in the generated JSON.
     // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RadioButtonsElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RadioButtonsElement.java
@@ -18,18 +18,36 @@ import java.util.List;
 public class RadioButtonsElement extends BlockElement {
     public static final String TYPE = "radio_buttons";
     private final String type = TYPE;
-    private String fallback;
 
-    private PlainTextObject placeholder;
+    /**
+     * An identifier for the action triggered when the radio button group is changed.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
     private String actionId;
 
-    // https://github.com/slackapi/java-slack-sdk/pull/103
-    // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
-    // when it encounters an empty list in the generated JSON.
-    // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
-    // (e.g. something like https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists)
+    /**
+     * An array of option objects.
+     * <p>
+     * NOTE: The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
+     * when it encounters an empty list in the generated JSON.
+     * The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
+     *
+     * @see "https://github.com/slackapi/java-slack-sdk/pull/103"
+     * @see "https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists"
+     */
     private List<OptionObject> options;
 
+    /**
+     * An option object that exactly matches one of the options within options.
+     * This option will be selected when the radio button group initially loads.
+     */
     private OptionObject initialOption;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog
+     * that appears after clicking one of the radio buttons in this element.
+     */
     private ConfirmationDialogObject confirm;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextSectionElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextSectionElement.java
@@ -139,6 +139,7 @@ public class RichTextSectionElement extends BlockElement implements RichTextElem
         private boolean bold;
         private boolean italic;
         private boolean strike;
+        private boolean code;
     }
 
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/StaticSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/StaticSelectElement.java
@@ -19,23 +19,32 @@ import java.util.List;
 public class StaticSelectElement extends BlockElement {
     public static final String TYPE = "static_select";
     private final String type = TYPE;
-    private String fallback;
 
     private PlainTextObject placeholder;
     private String actionId;
 
-    // https://github.com/slackapi/java-slack-sdk/pull/103
-    // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
-    // when it encounters an empty list in the generated JSON.
-    // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
-    // (e.g. something like https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists)
+    /**
+     * An array of option objects.
+     * <p>
+     * NOTE: The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
+     * when it encounters an empty list in the generated JSON.
+     * The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
+     *
+     * @see "https://github.com/slackapi/java-slack-sdk/pull/103"
+     * @see "https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists"
+     */
     private List<OptionObject> options;
 
-    // https://github.com/slackapi/java-slack-sdk/pull/103
-    // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
-    // when it encounters an empty list in the generated JSON.
-    // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
-    // (e.g. something like https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists)
+    /**
+     * An array of option group objects.
+     * <p>
+     * NOTE: The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
+     * when it encounters an empty list in the generated JSON.
+     * The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
+     *
+     * @see "https://github.com/slackapi/java-slack-sdk/pull/103"
+     * @see "https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists"
+     */
     private List<OptionGroupObject> optionGroups;
 
     private OptionObject initialOption;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/StaticSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/StaticSelectElement.java
@@ -24,14 +24,14 @@ public class StaticSelectElement extends BlockElement {
     private PlainTextObject placeholder;
     private String actionId;
 
-    // https://github.com/seratch/jslack/pull/103
+    // https://github.com/slackapi/java-slack-sdk/pull/103
     // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
     // when it encounters an empty list in the generated JSON.
     // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists
     // (e.g. something like https://stackoverflow.com/questions/11942118/how-do-you-get-gson-to-omit-null-or-empty-objects-and-empty-arrays-and-lists)
     private List<OptionObject> options;
 
-    // https://github.com/seratch/jslack/pull/103
+    // https://github.com/slackapi/java-slack-sdk/pull/103
     // The reason I didn't initialize the List<> fields is because Slack (sometimes) gives errors
     // when it encounters an empty list in the generated JSON.
     // The proper solution if/when you don't want un-initialized fields is to have a Gson type adapter that skips empty lists

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/UsersSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/UsersSelectElement.java
@@ -15,7 +15,6 @@ import lombok.*;
 public class UsersSelectElement extends BlockElement {
     public static final String TYPE = "users_select";
     private final String type = TYPE;
-    private String fallback;
 
     private PlainTextObject placeholder;
     private String actionId;

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonBlockElementFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonBlockElementFactory.java
@@ -84,6 +84,8 @@ public class GsonBlockElementFactory implements JsonDeserializer<BlockElement>, 
                 return RichTextPreformattedElement.class;
             case RadioButtonsElement.TYPE:
                 return RadioButtonsElement.class;
+            case CheckboxesElement.TYPE:
+                return CheckboxesElement.class;
             default:
                 if (failOnUnknownProperties) {
                     throw new JsonParseException("Unknown block element type: " + typeName);

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -5,6 +5,7 @@ import com.slack.api.model.Message;
 import com.slack.api.model.block.InputBlock;
 import com.slack.api.model.block.RichTextBlock;
 import com.slack.api.model.block.SectionBlock;
+import com.slack.api.model.block.element.CheckboxesElement;
 import com.slack.api.model.block.element.RadioButtonsElement;
 import com.slack.api.model.block.element.RichTextSectionElement;
 import com.slack.api.model.block.element.RichTextUnknownElement;
@@ -785,6 +786,108 @@ public class BlockKitTest {
         // never fails - invalid types are just skipped
         GsonFactory.createSnakeCaseWithoutUnknownPropertyDetection(true)
                 .fromJson(unknownTextObjectsInInputBlocksJson, Message.class);
+    }
+
+    @Test
+    public void parseCheckboxes() {
+        String json = "{\n" +
+                "  \"blocks\": [\n" +
+                "    {\n" +
+                "      \"type\": \"input\",\n" +
+                "      \"element\": {\n" +
+                "        \"type\": \"checkboxes\",\n" +
+                "        \"action_id\": \"input-action-id\",\n" +
+                "        \"options\": [\n" +
+                "          {\n" +
+                "            \"text\": {\n" +
+                "              \"type\": \"plain_text\",\n" +
+                "              \"text\": \"*this is plain_text text*\",\n" +
+                "              \"emoji\": true\n" +
+                "            },\n" +
+                "            \"value\": \"value-0\"\n" +
+                "          },\n" +
+                "          {\n" +
+                "            \"text\": {\n" +
+                "              \"type\": \"plain_text\",\n" +
+                "              \"text\": \"*this is plain_text text*\",\n" +
+                "              \"emoji\": true\n" +
+                "            },\n" +
+                "            \"value\": \"value-1\"\n" +
+                "          },\n" +
+                "          {\n" +
+                "            \"text\": {\n" +
+                "              \"type\": \"plain_text\",\n" +
+                "              \"text\": \"*this is plain_text text*\",\n" +
+                "              \"emoji\": true\n" +
+                "            },\n" +
+                "            \"value\": \"value-2\"\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      \"label\": {\n" +
+                "        \"type\": \"plain_text\",\n" +
+                "        \"text\": \"Label\",\n" +
+                "        \"emoji\": true\n" +
+                "      }\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"type\": \"section\",\n" +
+                "      \"text\": {\n" +
+                "        \"type\": \"mrkdwn\",\n" +
+                "        \"text\": \"This is a section block with checkboxes.\"\n" +
+                "      },\n" +
+                "      \"accessory\": {\n" +
+                "        \"type\": \"checkboxes\",\n" +
+                "        \"action_id\": \"section-action-id\",\n" +
+                "        \"options\": [\n" +
+                "          {\n" +
+                "            \"text\": {\n" +
+                "              \"type\": \"mrkdwn\",\n" +
+                "              \"text\": \"*this is mrkdwn text*\"\n" +
+                "            },\n" +
+                "            \"description\": {\n" +
+                "              \"type\": \"mrkdwn\",\n" +
+                "              \"text\": \"*this is mrkdwn text*\"\n" +
+                "            },\n" +
+                "            \"value\": \"value-0\"\n" +
+                "          },\n" +
+                "          {\n" +
+                "            \"text\": {\n" +
+                "              \"type\": \"mrkdwn\",\n" +
+                "              \"text\": \"*this is mrkdwn text*\"\n" +
+                "            },\n" +
+                "            \"description\": {\n" +
+                "              \"type\": \"mrkdwn\",\n" +
+                "              \"text\": \"*this is mrkdwn text*\"\n" +
+                "            },\n" +
+                "            \"value\": \"value-1\"\n" +
+                "          },\n" +
+                "          {\n" +
+                "            \"text\": {\n" +
+                "              \"type\": \"mrkdwn\",\n" +
+                "              \"text\": \"*this is mrkdwn text*\"\n" +
+                "            },\n" +
+                "            \"description\": {\n" +
+                "              \"type\": \"mrkdwn\",\n" +
+                "              \"text\": \"*this is mrkdwn text*\"\n" +
+                "            },\n" +
+                "            \"value\": \"value-2\"\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+        Message message = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+        assertThat(message, is(notNullValue()));
+
+        InputBlock input = (InputBlock) message.getBlocks().get(0);
+        CheckboxesElement checkboxes1 = (CheckboxesElement) input.getElement();
+        assertThat(checkboxes1.getActionId(), is("input-action-id"));
+
+        SectionBlock block = (SectionBlock) message.getBlocks().get(1);
+        CheckboxesElement checkboxes2 = (CheckboxesElement) block.getAccessory();
+        assertThat(checkboxes2.getActionId(), is("section-action-id"));
     }
 
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -80,4 +80,10 @@ public class BlocksTest {
         assertThat(section(s -> s.blockId("block-id").fields(asSectionFields(plainText("foo")))), is(notNullValue()));
     }
 
+    @Test
+    public void testCheckboxes() {
+        assertThat(section(s -> s.blockId("block-id").accessory(checkboxes(c -> c.actionId("foo")))), is(notNullValue()));
+        assertThat(input(i -> i.element(checkboxes(c -> c.actionId("foo")))), is(notNullValue()));
+    }
+
 }


### PR DESCRIPTION
###  Summary

`checkboxes` element in Block Kit has been released recently. 
https://api.slack.com/reference/block-kit/block-elements#checkboxes

The main purpose of this pull request is to add support for it in this SDK. Also, as plus points, improvements like adding the missing fields in `OptionObject` are included.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
