### PR TITLE
Bump dependencies

### DIFF
--- a/lightning-micronaut/pom.xml
+++ b/lightning-micronaut/pom.xml
@@ -10,8 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.base.version>1.2.6</micronaut.base.version>
-        <micronaut.version>1.3.1</micronaut.version>
+        <micronaut.version>1.3.0</micronaut.version>
         <micronaut-test-junit5.version>1.1.2</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>
@@ -26,7 +25,7 @@
             <dependency>
                 <groupId>io.micronaut</groupId>
                 <artifactId>micronaut-bom</artifactId>
-                <version>${micronaut.base.version}</version>
+                <version>${micronaut.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -57,13 +56,13 @@
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-http-server-netty</artifactId>
-            <version>${micronaut.base.version}</version>
+            <version>${micronaut.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-http-client</artifactId>
-            <version>${micronaut.base.version}</version>
+            <version>${micronaut.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -95,7 +94,7 @@
                             <path>
                                 <groupId>io.micronaut</groupId>
                                 <artifactId>micronaut-inject-java</artifactId>
-                                <version>${micronaut.base.version}</version>
+                                <version>${micronaut.version}</version>
                             </path>
                         </annotationProcessorPaths>
                     </configuration>
@@ -113,7 +112,7 @@
                                     <path>
                                         <groupId>io.micronaut</groupId>
                                         <artifactId>micronaut-inject-java</artifactId>
-                                        <version>${micronaut.base.version}</version>
+                                        <version>${micronaut.version}</version>
                                     </path>
                                 </annotationProcessorPaths>
                             </configuration>

--- a/lightning-quarkus-examples/pom.xml
+++ b/lightning-quarkus-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <quarkus.version>1.0.1.Final</quarkus.version>
+        <quarkus.version>1.2.0.Final</quarkus.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/lightning-spring-boot-examples/pom.xml
+++ b/lightning-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.2.1.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/maven-versions-rules.xml
+++ b/maven-versions-rules.xml
@@ -1,0 +1,5 @@
+<ruleset>
+    <ignoreVersions>
+        <ignoreVersion type="regex">.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|RC|M|EA)[-_\.]?[0-9]*</ignoreVersion>
+    </ignoreVersions>
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -34,15 +34,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <okhttp.version>4.2.2</okhttp.version>
+        <okhttp.version>4.3.1</okhttp.version>
         <gson.version>2.8.6</gson.version>
-        <lombok.version>1.18.10</lombok.version>
+        <lombok.version>1.18.12</lombok.version>
         <slf4j.version>1.7.29</slf4j.version>
-        <aws.s3.version>1.11.683</aws.s3.version>
-        <junit.version>4.13-rc-1</junit.version>
+        <aws.s3.version>1.11.718</aws.s3.version>
+        <junit.version>4.13</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.2.0</mockito-core.version>
+        <mockito-core.version>3.2.4</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -51,6 +51,7 @@
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
+        <maven-versions-plugin.version>2.7</maven-versions-plugin.version>
     </properties>
 
     <licenses>
@@ -147,6 +148,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>${maven-versions-plugin.version}</version>
+                <configuration>
+                    <rulesUri>file://${maven.multiModuleProjectDirectory}/maven-versions-rules.xml</rulesUri>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
###  Summary

This pull request bumps all the dependencies to the latest stable versions. The ones I didn't upgrade are intentional.

```
$ mvn versions:display-dependency-updates
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Java Slack SDK Project                                             [pom]
[INFO] slack-api-model                                                    [jar]
[INFO] slack-api-client                                                   [jar]
[INFO] slack-app-backend                                                  [jar]
[INFO] lightning                                                          [jar]
[INFO] lightning-jetty                                                    [jar]
[INFO] lightning-aws-lambda                                               [jar]
[INFO] lightning-micronaut                                                [jar]
[INFO] lightning-spring-boot-examples                                     [jar]
[INFO] lightning-kotlin-examples                                          [jar]
[INFO] lightning-quarkus-examples                                         [jar]
[INFO] 
[INFO] -------------------< com.slack.api:slack-sdk-parent >-------------------
[INFO] Building Java Slack SDK Project 0.99.0-SNAPSHOT                   [1/11]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ slack-sdk-parent ---
[INFO] No dependencies in Dependencies have newer versions.
[INFO] 
[INFO] 
[INFO] -------------------< com.slack.api:slack-api-model >--------------------
[INFO] Building slack-api-model 0.99.0-SNAPSHOT                          [2/11]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ slack-api-model ---
[INFO] No dependencies in Dependencies have newer versions.
[INFO] 
[INFO] 
[INFO] -------------------< com.slack.api:slack-api-client >-------------------
[INFO] Building slack-api-client 0.99.0-SNAPSHOT                         [3/11]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ slack-api-client ---
[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   org.eclipse.jetty:jetty-server ...
[INFO]                                     9.2.27.v20190403 -> 9.4.26.v20200117
[INFO]   org.eclipse.jetty:jetty-servlet ...
[INFO]                                     9.2.27.v20190403 -> 9.4.26.v20200117
[INFO]   org.eclipse.jetty:jetty-webapp ...
[INFO]                                     9.2.27.v20190403 -> 9.4.26.v20200117
[INFO]   org.slf4j:slf4j-api ................................. 1.7.29 -> 1.7.30
[INFO] 
[INFO] 
[INFO] ------------------< com.slack.api:slack-app-backend >-------------------
[INFO] Building slack-app-backend 0.99.0-SNAPSHOT                        [4/11]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ slack-app-backend ---
[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   javax.servlet:javax.servlet-api ....................... 3.1.0 -> 4.0.1
[INFO]   org.eclipse.jetty:jetty-server ...
[INFO]                                     9.2.27.v20190403 -> 9.4.26.v20200117
[INFO]   org.eclipse.jetty:jetty-servlet ...
[INFO]                                     9.2.27.v20190403 -> 9.4.26.v20200117
[INFO]   org.eclipse.jetty:jetty-webapp ...
[INFO]                                     9.2.27.v20190403 -> 9.4.26.v20200117
[INFO]   org.slf4j:slf4j-api ................................. 1.7.29 -> 1.7.30
[INFO] 
[INFO] 
[INFO] ----------------------< com.slack.api:lightning >-----------------------
[INFO] Building lightning 0.99.0-SNAPSHOT                                [5/11]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ lightning ---
[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   javax.servlet:javax.servlet-api ....................... 3.1.0 -> 4.0.1
[INFO]   org.eclipse.jetty:jetty-server ...
[INFO]                                     9.2.27.v20190403 -> 9.4.26.v20200117
[INFO]   org.eclipse.jetty:jetty-servlet ...
[INFO]                                     9.2.27.v20190403 -> 9.4.26.v20200117
[INFO]   org.eclipse.jetty:jetty-webapp ...
[INFO]                                     9.2.27.v20190403 -> 9.4.26.v20200117
[INFO] 
[INFO] 
[INFO] -------------------< com.slack.api:lightning-jetty >--------------------
[INFO] Building lightning-jetty 0.99.0-SNAPSHOT                          [6/11]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ lightning-jetty ---
[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   javax.servlet:javax.servlet-api ....................... 3.1.0 -> 4.0.1
[INFO]   org.eclipse.jetty:jetty-server ...
[INFO]                                     9.4.24.v20191120 -> 9.4.26.v20200117
[INFO]   org.eclipse.jetty:jetty-servlet ...
[INFO]                                     9.4.24.v20191120 -> 9.4.26.v20200117
[INFO]   org.eclipse.jetty:jetty-webapp ...
[INFO]                                     9.4.24.v20191120 -> 9.4.26.v20200117
[INFO] 
[INFO] 
[INFO] -----------------< com.slack.api:lightning-aws-lambda >-----------------
[INFO] Building lightning-aws-lambda 0.99.0-SNAPSHOT                     [7/11]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ lightning-aws-lambda ---
[INFO] No dependencies in Dependencies have newer versions.
[INFO] 
[INFO] 
[INFO] -----------------< com.slack.api:lightning-micronaut >------------------
[INFO] Building lightning-micronaut 0.99.0-SNAPSHOT                      [8/11]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ lightning-micronaut ---
[INFO] The following dependencies in Dependency Management have newer versions:
[INFO]   com.fasterxml.jackson.core:jackson-annotations ...... 2.10.1 -> 2.10.2
[INFO]   com.fasterxml.jackson.core:jackson-core ............. 2.10.1 -> 2.10.2
[INFO]   com.fasterxml.jackson.core:jackson-databind ......... 2.10.1 -> 2.10.2
[INFO]   com.fasterxml.jackson.dataformat:jackson-dataformat-xml ...
[INFO]                                                         2.10.1 -> 2.10.2
[INFO]   com.fasterxml.jackson.datatype:jackson-datatype-jdk8 ...
[INFO]                                                         2.10.1 -> 2.10.2
[INFO]   com.fasterxml.jackson.datatype:jackson-datatype-jsr310 ...
[INFO]                                                         2.10.1 -> 2.10.2
[INFO]   com.fasterxml.jackson.module:jackson-module-afterburner ...
[INFO]                                                         2.10.1 -> 2.10.2
[INFO]   com.fasterxml.jackson.module:jackson-module-jaxb-annotations ...
[INFO]                                                         2.10.1 -> 2.10.2
[INFO]   com.fasterxml.jackson.module:jackson-module-kotlin ...
[INFO]                                                         2.10.1 -> 2.10.2
[INFO]   com.fasterxml.jackson.module:jackson-module-parameter-names ...
[INFO]                                                         2.10.1 -> 2.10.2
[INFO]   com.github.akarnokd:rxjava2-interop ................. 0.13.5 -> 0.13.7
[INFO]   com.h2database:h2 ................................. 1.4.199 -> 1.4.200
[INFO]   info.picocli:picocli .................................. 4.0.1 -> 4.1.4
[INFO]   io.jaegertracing:jaeger-thrift ........................ 1.0.0 -> 1.1.0
[INFO]   io.methvin:directory-watcher .......................... 0.9.6 -> 0.9.9
[INFO]   io.micrometer:micrometer-core ......................... 1.3.1 -> 1.3.3
[INFO]   io.micrometer:micrometer-registry-atlas ............... 1.3.1 -> 1.3.3
[INFO]   io.micrometer:micrometer-registry-graphite ............ 1.3.1 -> 1.3.3
[INFO]   io.micrometer:micrometer-registry-prometheus .......... 1.3.1 -> 1.3.3
[INFO]   io.micrometer:micrometer-registry-statsd .............. 1.3.1 -> 1.3.3
[INFO]   io.micronaut:micronaut-function-aws ................... 1.3.8 -> 1.3.9
[INFO]   io.micronaut.aws:micronaut-function-aws-alexa ......... 1.3.8 -> 1.3.9
[INFO]   io.micronaut.aws:micronaut-function-aws-api-proxy ..... 1.3.8 -> 1.3.9
[INFO]   io.micronaut.configuration:micronaut-aws-common ....... 1.3.8 -> 1.3.9
[INFO]   io.micronaut.configuration:micronaut-neo4j-bolt ....... 1.3.0 -> 2.0.0
[INFO]   io.opentracing.brave:brave-opentracing .............. 0.35.0 -> 0.35.1
[INFO]   io.projectreactor:reactor-core ....... 3.2.10.RELEASE -> 3.3.2.RELEASE
[INFO]   io.reactivex.rxjava2:rxjava ......................... 2.2.10 -> 2.2.17
[INFO]   io.swagger.core.v3:swagger-annotations ................ 2.0.4 -> 2.1.1
[INFO]   io.swagger.core.v3:swagger-core ....................... 2.0.4 -> 2.1.1
[INFO]   io.swagger.core.v3:swagger-models ..................... 2.0.4 -> 2.1.1
[INFO]   io.zipkin.brave:brave-instrumentation-http ............ 5.9.0 -> 5.9.4
[INFO]   io.zipkin.reporter2:zipkin-reporter ................. 2.10.0 -> 2.12.1
[INFO]   javax.cache:cache-api ................................. 1.1.0 -> 1.1.1
[INFO]   net.java.dev.jna:jna .................................. 5.3.1 -> 5.5.0
[INFO]   org.apache.tomcat:tomcat-jdbc ....................... 9.0.21 -> 9.0.30
[INFO]   org.codehaus.groovy:groovy ............................ 2.5.8 -> 2.5.9
[INFO]   org.codehaus.groovy:groovy-ant ........................ 2.5.8 -> 2.5.9
[INFO]   org.codehaus.groovy:groovy-jmx ........................ 2.5.8 -> 2.5.9
[INFO]   org.codehaus.groovy:groovy-json ....................... 2.5.8 -> 2.5.9
[INFO]   org.codehaus.groovy:groovy-templates .................. 2.5.8 -> 2.5.9
[INFO]   org.codehaus.groovy:groovy-test ....................... 2.5.8 -> 2.5.9
[INFO]   org.elasticsearch.client:elasticsearch-rest-high-level-client ...
[INFO]                                                           6.4.0 -> 7.5.2
[INFO]   org.flywaydb:flyway-core .............................. 5.2.4 -> 6.2.2
[INFO]   org.hibernate:hibernate-core ............ 5.4.10.Final -> 5.4.11.Final
[INFO]   org.junit.jupiter:junit-jupiter-api ................... 5.5.2 -> 5.6.0
[INFO]   org.junit.jupiter:junit-jupiter-engine ................ 5.5.2 -> 5.6.0
[INFO]   org.junit.jupiter:junit-jupiter-params ................ 5.5.2 -> 5.6.0
[INFO]   org.liquibase:liquibase-core .......................... 3.6.3 -> 3.8.6
[INFO]   org.mongodb:mongo-java-driver ....................... 3.12.0 -> 3.12.1
[INFO]   org.mongodb:mongodb-driver-async .................... 3.12.0 -> 3.12.1
[INFO]   org.neo4j.driver:neo4j-java-driver .................... 1.7.5 -> 4.0.0
[INFO]   org.neo4j.test:neo4j-harness .......................... 3.5.2 -> 4.0.0
[INFO]   org.slf4j:slf4j-api ................................. 1.7.26 -> 1.7.30
[INFO]   org.slf4j:slf4j-simple .............................. 1.7.26 -> 1.7.30
[INFO]   org.spockframework:spock-core .... 1.3-groovy-2.5 -> 2.0-M1-groovy-2.5
[INFO]   org.yaml:snakeyaml ...................................... 1.24 -> 1.25
[INFO] 
[INFO] No dependencies in Dependencies have newer versions.
[INFO] 
[INFO] 
[INFO] ------------< com.slack.api:lightning-spring-boot-examples >------------
[INFO] Building lightning-spring-boot-examples 0.99.0-SNAPSHOT           [9/11]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ lightning-spring-boot-examples ---
[INFO] No dependencies in Dependencies have newer versions.
[INFO] 
[INFO] 
[INFO] --------------< com.slack.api:lightning-kotlin-examples >---------------
[INFO] Building lightning-kotlin-examples 0.99.0-SNAPSHOT               [10/11]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ lightning-kotlin-examples ---
[INFO] No dependencies in Dependencies have newer versions.
[INFO] 
[INFO] 
[INFO] --------------< com.slack.api:lightning-quarkus-examples >--------------
[INFO] Building lightning-quarkus-examples 0.99.0-SNAPSHOT              [11/11]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.7:display-dependency-updates (default-cli) @ lightning-quarkus-examples ---
[INFO] No dependencies in Dependencies have newer versions.
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Java Slack SDK Project 0.99.0-SNAPSHOT:
[INFO] 
[INFO] Java Slack SDK Project ............................. SUCCESS [  0.581 s]
[INFO] slack-api-model .................................... SUCCESS [  0.011 s]
[INFO] slack-api-client ................................... SUCCESS [  0.027 s]
[INFO] slack-app-backend .................................. SUCCESS [  0.022 s]
[INFO] lightning .......................................... SUCCESS [  0.019 s]
[INFO] lightning-jetty .................................... SUCCESS [  0.015 s]
[INFO] lightning-aws-lambda ............................... SUCCESS [  0.009 s]
[INFO] lightning-micronaut ................................ SUCCESS [  0.121 s]
[INFO] lightning-spring-boot-examples ..................... SUCCESS [  0.008 s]
[INFO] lightning-kotlin-examples .......................... SUCCESS [  0.010 s]
[INFO] lightning-quarkus-examples ......................... SUCCESS [  0.082 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.158 s
[INFO] Finished at: 2020-02-09T21:19:09+09:00
[INFO] ------------------------------------------------------------------------
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
