### PR TITLE
Make Granular permissions default

### DIFF
--- a/lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/app.kt
+++ b/lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/app.kt
@@ -32,6 +32,8 @@ fun main() {
     }
 
     val oauthConfig = ResourceLoader.loadAppConfig()
+    // https://api.slack.com/authentication/migration
+    oauthConfig.isClassicAppPermissionsEnabled = true
     val oauthApp = App(oauthConfig).asOAuthApp(true)
 
     oauthApp.endpoint("GET", "/slack/oauth/completion") { _, _ ->

--- a/lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/aws.kt
+++ b/lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow/aws.kt
@@ -41,6 +41,8 @@ fun main() {
     }
 
     val oauthConfig = ResourceLoader.loadAppConfig()
+    // https://api.slack.com/authentication/migration
+    oauthConfig.isClassicAppPermissionsEnabled = true
     val oauthApp = App(oauthConfig).asOAuthApp(true)
 
     oauthApp.service(installationService)

--- a/lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow_v2/v2_app.kt
+++ b/lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow_v2/v2_app.kt
@@ -33,7 +33,6 @@ fun main() {
     }
 
     val oauthConfig = ResourceLoader.loadAppConfig("appConfig_GBP.json")
-    oauthConfig.isGranularBotPermissionsEnabled = true
     val oauthApp = App(oauthConfig).asOAuthApp(true)
 
     oauthApp.endpoint("GET", "/slack/oauth/completion") { _, _ ->

--- a/lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow_v2/v2_aws.kt
+++ b/lightning-kotlin-examples/src/main/kotlin/examples/oauth_flow_v2/v2_aws.kt
@@ -42,7 +42,6 @@ fun main() {
     }
 
     val oauthConfig = ResourceLoader.loadAppConfig("appConfig_GBP.json")
-    oauthConfig.isGranularBotPermissionsEnabled = true
     val oauthApp = App(oauthConfig).asOAuthApp(true)
 
     oauthApp.service(installationService)

--- a/lightning/src/main/java/com/slack/api/lightning/App.java
+++ b/lightning/src/main/java/com/slack/api/lightning/App.java
@@ -356,10 +356,10 @@ public class App {
 
     public App service(InstallationService installationService) {
         this.installationService = installationService;
-        if (config().isGranularBotPermissionsEnabled()) {
-            return oauthCallback(new OAuthV2DefaultSuccessHandler(installationService));
-        } else {
+        if (config().isClassicAppPermissionsEnabled()) {
             return oauthCallback(new OAuthDefaultSuccessHandler(installationService));
+        } else {
+            return oauthCallback(new OAuthV2DefaultSuccessHandler(installationService));
         }
     }
 

--- a/lightning/src/main/java/com/slack/api/lightning/AppConfig.java
+++ b/lightning/src/main/java/com/slack/api/lightning/AppConfig.java
@@ -50,7 +50,9 @@ public class AppConfig {
 
     private boolean oAuthStartEnabled = false;
     private boolean oAuthCallbackEnabled = false;
-    private boolean granularBotPermissionsEnabled = false;
+
+    // https://api.slack.com/authentication/migration
+    private boolean classicAppPermissionsEnabled = false;
 
     public void setOauthStartPath(String oauthStartPath) {
         this.oauthStartPath = oauthStartPath;
@@ -77,16 +79,17 @@ public class AppConfig {
         if (clientId == null || scope == null || state == null) {
             return null;
         } else {
-            if (isGranularBotPermissionsEnabled()) {
+            if (isClassicAppPermissionsEnabled()) {
+                // https://api.slack.com/authentication/migration
+                return "https://slack.com/oauth/authorize" +
+                        "?client_id=" + clientId +
+                        "&scope=" + scope +
+                        "&state=" + state;
+            } else {
                 return "https://slack.com/oauth/v2/authorize" +
                         "?client_id=" + clientId +
                         "&scope=" + scope +
                         "&user_scope=" + userScope +
-                        "&state=" + state;
-            } else {
-                return "https://slack.com/oauth/authorize" +
-                        "?client_id=" + clientId +
-                        "&scope=" + scope +
                         "&state=" + state;
             }
         }

--- a/lightning/src/main/java/com/slack/api/lightning/service/builtin/DefaultOAuthCallbackService.java
+++ b/lightning/src/main/java/com/slack/api/lightning/service/builtin/DefaultOAuthCallbackService.java
@@ -63,21 +63,21 @@ public class DefaultOAuthCallbackService implements OAuthCallbackService {
                 return errorHandler.handle(request, response);
             }
             if (stateService.isValid(request)) {
-                if (config.isGranularBotPermissionsEnabled()) {
-                    OAuthV2AccessResponse oauthAccess = operator.callOAuthV2AccessMethod(payload);
-                    if (oauthAccess.isOk()) {
-                        stateService.consume(request, response);
-                        return successV2Handler.handle(request, response, oauthAccess);
-                    } else {
-                        return accessV2ErrorHandler.handle(request, response, oauthAccess);
-                    }
-                } else {
+                if (config.isClassicAppPermissionsEnabled()) {
                     OAuthAccessResponse oauthAccess = operator.callOAuthAccessMethod(payload);
                     if (oauthAccess.isOk()) {
                         stateService.consume(request, response);
                         return successHandler.handle(request, response, oauthAccess);
                     } else {
                         return accessErrorHandler.handle(request, response, oauthAccess);
+                    }
+                } else {
+                    OAuthV2AccessResponse oauthAccess = operator.callOAuthV2AccessMethod(payload);
+                    if (oauthAccess.isOk()) {
+                        stateService.consume(request, response);
+                        return successV2Handler.handle(request, response, oauthAccess);
+                    } else {
+                        return accessV2ErrorHandler.handle(request, response, oauthAccess);
                     }
                 }
             } else {


### PR DESCRIPTION
###  Summary

When a Slack app developer creates a new Slack app, the app will be granular permissions enabled one by default. Although it's also possible to create a classic one from [here](https://api.slack.com/apps?new_classic_app=1), granular permission apps already should be expected one for most users. So, this pull request brings the following changes.

* Remove the term`isGranularBotPermissionsEnabled` from this library 
* Introduce a new flag named `isClassicAppPermissionsEnabled` for classic apps - https://api.slack.com/authentication/migration
* Make non-classic apps (=granular permissions enabled apps) default

**NOTE**: This pull request brings a change incompatible with jSlack library (the predecessor of this project).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
