### PR TITLE
Complete HTTP proxy supports for all the API clients (including #4)

### DIFF
--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -301,7 +301,10 @@
       "browsers_seen_initial_people_education": false,
       "activity_view": "",
       "up_to_browse_kb_shortcut": false,
-      "suppress_link_warning": false
+      "suppress_link_warning": false,
+      "seen_ia_education": false,
+      "browsers_dismissed_user_groups_low_results_education": false,
+      "browsers_seen_initial_user_groups_education": false
     },
     "created": 12345,
     "manual_presence": ""

--- a/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
@@ -77,12 +77,22 @@ public class SlackConfig {
         public void setMethodsConfig(MethodsConfig methodsConfig) {
             throwException();
         }
+
+        @Override
+        public void setProxyUrl(String proxyUrl) {
+            throwException();
+        }
     };
 
     public SlackConfig() {
         getHttpClientResponseHandlers().add(new DetailedLoggingListener());
         getHttpClientResponseHandlers().add(new ResponsePrettyPrintingListener());
     }
+
+    /**
+     * The proxy server URL supposed to be used for all api calls.
+     */
+    private String proxyUrl = null;
 
     private boolean prettyResponseLoggingEnabled = false;
 

--- a/slack-api-client/src/main/java/com/slack/api/rtm/RTMClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/rtm/RTMClient.java
@@ -6,10 +6,13 @@ import com.slack.api.methods.request.rtm.RTMConnectRequest;
 import com.slack.api.methods.response.rtm.RTMConnectResponse;
 import com.slack.api.model.User;
 import lombok.extern.slf4j.Slf4j;
+import org.glassfish.tyrus.client.ClientManager;
+import org.glassfish.tyrus.client.ClientProperties;
 
 import javax.websocket.*;
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -77,8 +80,16 @@ public class RTMClient implements Closeable {
      * Calling this method won't work as you expect.
      */
     public void connect() throws IOException, DeploymentException {
-        WebSocketContainer container = ContainerProvider.getWebSocketContainer();
-        container.connectToServer(this, wssUri);
+        ClientManager client = ClientManager.createClient();
+        String proxy = null;
+        proxy = slack.getHttpClient().getConfig().getProxyUrl();
+        if (proxy != null) {
+            if (log.isDebugEnabled()) {
+                log.debug("The RTM client's going to use an HTTP proxy: {}", proxy);
+            }
+            client.getProperties().put(ClientProperties.PROXY_URI, proxy);
+        }
+        client.connectToServer(this, wssUri);
         log.debug("client connected to the server: {}", wssUri);
     }
 

--- a/slack-api-client/src/test/java/config/Constants.java
+++ b/slack-api-client/src/test/java/config/Constants.java
@@ -19,6 +19,8 @@ public class Constants {
     // normal user token / bot token
     public static final String SLACK_SDK_TEST_USER_TOKEN = "SLACK_SDK_TEST_USER_TOKEN";
     public static final String SLACK_SDK_TEST_BOT_TOKEN = "SLACK_SDK_TEST_BOT_TOKEN";
+    // https://api.slack.com/apps?new_classic_app=1
+    public static final String SLACK_SDK_TEST_CLASSIC_APP_BOT_TOKEN = "SLACK_SDK_TEST_CLASSIC_APP_BOT_TOKEN";
 
     // shared channel tests
     public static final String SLACK_SDK_TEST_SHARED_CHANNEL_ID = "SLACK_SDK_TEST_SHARED_CHANNEL_ID";

--- a/slack-api-client/src/test/java/test_with_remote_apis/ProxyTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/ProxyTest.java
@@ -1,0 +1,93 @@
+package test_with_remote_apis;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.audit.response.SchemasResponse;
+import com.slack.api.methods.response.auth.AuthTestResponse;
+import com.slack.api.rtm.RTMClient;
+import com.slack.api.scim.SCIMApiException;
+import com.slack.api.scim.response.ServiceProviderConfigsGetResponse;
+import com.slack.api.status.v2.model.CurrentStatus;
+import com.slack.api.util.http.SlackHttpClient;
+import config.Constants;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Slf4j
+public class ProxyTest {
+
+    static String proxyUrl = "http://localhost:8888";
+
+    static SlackConfig config = new SlackConfig();
+
+    static {
+        config.setProxyUrl(proxyUrl);
+    }
+
+    static Slack slack = Slack.getInstance(config);
+
+    static String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    static String rtmBotToken = System.getenv(Constants.SLACK_SDK_TEST_CLASSIC_APP_BOT_TOKEN);
+    static String scimToken = System.getenv(Constants.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN);
+    static String auditLogsToken = System.getenv(Constants.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN);
+
+    @Ignore
+    @Test
+    public void methods() throws Exception {
+        AuthTestResponse apiResponse = slack.methods().authTest(r -> r.token(botToken));
+        assertThat(apiResponse.getError(), is(nullValue()));
+    }
+
+    @Ignore
+    @Test
+    public void rtm() throws Exception {
+        SlackHttpClient httpClient = new SlackHttpClient();
+        Slack slack = Slack.getInstance(config, httpClient);
+        final AtomicBoolean received = new AtomicBoolean(false);
+        try (RTMClient rtm = slack.rtmConnect(rtmBotToken)) { // slack-msgs.com
+            rtm.addMessageHandler((msg) -> {
+                log.info("Got a message - {}", msg);
+                received.set(true);
+            });
+            rtm.addErrorHandler((e) -> {
+                log.error("Got an error - {}", e.getMessage(), e);
+            });
+            rtm.connect();
+            Thread.sleep(1000L);
+            rtm.sendMessage("foo");
+        }
+        assertThat(received.get(), is(true));
+    }
+
+    @Ignore
+    @Test
+    public void audit() throws Exception {
+        if (auditLogsToken != null) {
+            SchemasResponse response = slack.audit(auditLogsToken).getSchemas();
+            assertThat(response, is(notNullValue()));
+        }
+    }
+
+    @Ignore
+    @Test
+    public void scim() throws IOException, SCIMApiException {
+        if (scimToken != null) {
+            ServiceProviderConfigsGetResponse response = slack.scim(scimToken).getServiceProviderConfigs(req -> req);
+            assertThat(response.getAuthenticationSchemes(), is(notNullValue()));
+        }
+    }
+
+    @Ignore
+    @Test
+    public void status() throws Exception {
+        CurrentStatus current = slack.status().current();
+        assertThat(current, is(notNullValue()));
+    }
+}


### PR DESCRIPTION
###  Summary

This pull request adds a complete HTTP proxy supports for all the API clients in this SDK. 

It also fixes #4 . Using `org.glassfish.tyrus.client.ClientManager` allows us to create a client instance that has proxy support. It adds a new dependency in the code but the RTM client has been supposed to be used with Tyrus from the beginning. So, I think it's fine to depend on the implementation.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
