### PR TITLE
Fix #317 Change User-Agent

### DIFF
--- a/lightning/src/main/java/com/slack/api/lightning/AppConfig.java
+++ b/lightning/src/main/java/com/slack/api/lightning/AppConfig.java
@@ -1,11 +1,15 @@
 package com.slack.api.lightning;
 
 import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.util.http.SlackHttpClient;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 @Data
@@ -33,7 +37,16 @@ public class AppConfig {
     }
 
     @Builder.Default
-    private Slack slack = Slack.getInstance();
+    private Slack slack = Slack.getInstance(SlackConfig.DEFAULT, buildSlackHttpClient());
+
+    private static SlackHttpClient buildSlackHttpClient() {
+        Map<String, String> userAgentCustomInfo = new HashMap<>();
+        String version = AppConfig.class.getPackage().getImplementationVersion();
+        userAgentCustomInfo.put("lightning", version == null ? "unknown" : version);
+        SlackHttpClient client = new SlackHttpClient(userAgentCustomInfo);
+        return client;
+    }
+
     @Builder.Default
     private String singleTeamBotToken = System.getenv(EnvVariableName.SLACK_BOT_TOKEN);
     @Builder.Default

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-versions-plugin.version>2.7</maven-versions-plugin.version>
     </properties>
 
@@ -148,6 +149,18 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 @Slf4j
@@ -17,8 +18,14 @@ public class SlackHttpClient implements AutoCloseable {
 
     private SlackConfig config = SlackConfig.DEFAULT;
 
+    public SlackHttpClient(Map<String, String> userAgentCustomInfo) {
+        this.okHttpClient = new OkHttpClient.Builder()
+                .addInterceptor(new UserAgentInterceptor(userAgentCustomInfo))
+                .build();
+    }
+
     public SlackHttpClient() {
-        this.okHttpClient = new OkHttpClient.Builder().build();
+        this(Collections.emptyMap());
     }
 
     public SlackHttpClient(OkHttpClient okHttpClient) {

--- a/slack-api-client/src/main/java/com/slack/api/util/http/UserAgentInterceptor.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/UserAgentInterceptor.java
@@ -1,0 +1,53 @@
+package com.slack.api.util.http;
+
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+public class UserAgentInterceptor implements Interceptor {
+
+    private final String userAgent;
+
+    public UserAgentInterceptor(Map<String, String> additionalInfo) {
+        this.userAgent = buildDefaultUserAgent(additionalInfo);
+    }
+
+    public static String buildDefaultUserAgent(Map<String, String> additionalInfo) {
+        String libraryVersion = loadLibraryVersion();
+        String library = "slack-api-client/" + libraryVersion + "";
+        String jvm = "" + System.getProperty("java.vm.name") + "/" + System.getProperty("java.version") + "";
+        String os = "" + System.getProperty("os.name") + "/" + System.getProperty("os.version") + "";
+        String lastPart = "";
+        for (Map.Entry<String, String> each : additionalInfo.entrySet()) {
+            lastPart += " " + each.getKey() + "/" + each.getValue() + ";";
+        }
+        return library + "; " + jvm + "; " + os + ";" + lastPart;
+    }
+
+    private static String loadLibraryVersion() {
+        String artifactId = "slack-api-client";
+        String libraryVersion = "unknown";
+        try {
+            String parsedVersion = UserAgentInterceptor.class.getPackage().getImplementationVersion();
+            if (parsedVersion != null) {
+                libraryVersion = parsedVersion;
+            }
+        } catch (Exception e ) {
+            log.info("Failed to parse {}.jar to fetch the library version", artifactId);
+        }
+        return libraryVersion;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        // Modify "User-Agent" header
+        Request request = chain.request().newBuilder().header("User-Agent", userAgent).build();
+        return chain.proceed(request);
+    }
+
+}

--- a/slack-api-client/src/test/java/test_locally/api/util/UserAgentInterceptorTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/util/UserAgentInterceptorTest.java
@@ -1,0 +1,23 @@
+package test_locally.api.util;
+
+import com.slack.api.util.http.UserAgentInterceptor;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UserAgentInterceptorTest {
+
+    @Test
+    public void defaultUserAgent() {
+        String userAgent = UserAgentInterceptor.buildDefaultUserAgent(Collections.emptyMap());
+        String[] elements = userAgent.split(";");
+        assertEquals(userAgent, 3, elements.length);
+        assertTrue(elements[0], elements[0].trim().matches("slack-api-client/unknown"));
+        assertTrue(elements[1], elements[1].trim().matches("[^/]+/.+"));
+        assertTrue(elements[2], elements[2].trim().matches("[^/]+/.+"));
+    }
+
+}


### PR DESCRIPTION
###  Summary

This pull request fixes #317 by adding an okhttp interceptor which adds the `User-Agent` header with sufficient information.

```
User-Agent: slack-api-client/0.99.0-SNAPSHOT; OpenJDK 64-Bit Server VM/11.0.5; Mac OS X/10.15.3; lightning/0.99.0-SNAPSHOT;
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
