### PR TITLE
Fix #342 Add say() utility to Bolt (for Java)

### DIFF
--- a/bolt-kotlin-examples/src/main/kotlin/examples/say_something/app.kt
+++ b/bolt-kotlin-examples/src/main/kotlin/examples/say_something/app.kt
@@ -1,0 +1,73 @@
+package examples.say_something
+
+import com.slack.api.bolt.App
+import com.slack.api.bolt.context.Context
+import com.slack.api.bolt.context.builtin.SlashCommandContext
+import com.slack.api.bolt.jetty.SlackAppServer
+import com.slack.api.methods.request.conversations.ConversationsListRequest
+import com.slack.api.model.ConversationType
+
+fun main() {
+
+    // export SLACK_BOT_TOKEN=xoxb-***
+    // export SLACK_SIGNING_SECRET=123abc***
+    val app = App()
+
+    // requires channels:read scope
+    fun toConversationId(ctx: Context, where: String): String? {
+        val name = where.replaceFirst("#", "").trim()
+        var cursor: String? = null
+        var conversationId: String? = null
+        while (conversationId == null && cursor != "") {
+            val rb =
+                    ConversationsListRequest.builder().limit(1000).types(listOf(ConversationType.PUBLIC_CHANNEL))
+            val req = if (cursor != null) rb.cursor(cursor).build() else rb.build()
+            val list = ctx.client().conversationsList(req)
+            for (c in list.channels) {
+                if (c.name == name) {
+                    conversationId = c.id
+                    break
+                }
+            }
+        }
+        return conversationId
+    }
+
+    // requires channels:join scope
+    fun joinConversation(ctx: Context, conversationId: String) {
+        val res = ctx.client().conversationsJoin { it.channel(conversationId) }
+        ctx.logger.info("conversions.join result - {}", res)
+        res
+    }
+
+    fun saySomething(ctx: SlashCommandContext, where: String, text: String) {
+        val conversationId = toConversationId(ctx, where)
+        if (conversationId == null) {
+            ctx.ack { it.text("[Error] $where was not found") }
+        } else {
+            joinConversation(ctx, conversationId)
+            val res = ctx.say { it.channel(where).text(text) }
+            ctx.logger.info("say result - {}", res)
+        }
+    }
+
+    app.command("/say-something") { req, ctx ->
+        val elements = req.payload.text?.split(" at ")
+        if (elements == null || elements.size < 2) {
+            ctx.ack { it.text("[Usage] /say-something Hey folks, how have you been doing? at #general") }
+        } else {
+            if (elements.size == 2) {
+                val where = elements[1].trim()
+                val text = elements[0].trim()
+                saySomething(ctx, where, "$text by <@${req.payload.userId}>")
+            } else {
+                val where = elements[elements.size - 1].trim()
+                val text = elements.dropLast(1).joinToString { " at " }.trim()
+                saySomething(ctx, where, "$text by <@${req.payload.userId}>")
+            }
+            ctx.ack()
+        }
+    }
+    val server = SlackAppServer(app)
+    server.start()
+}

--- a/bolt/src/main/java/com/slack/api/bolt/context/Context.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/Context.java
@@ -4,16 +4,23 @@ import com.google.gson.JsonElement;
 import com.slack.api.Slack;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.util.BuilderConfigurator;
 import com.slack.api.bolt.util.JsonOps;
+import com.slack.api.methods.AsyncMethodsClient;
 import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Represents a context behind a request from Slack API.
@@ -63,6 +70,20 @@ public abstract class Context {
 
     public MethodsClient client() {
         return slack.methods(botToken);
+    }
+
+    public AsyncMethodsClient asyncClient() {
+        return slack.methodsAsync(botToken);
+    }
+
+    public ChatPostMessageResponse say(BuilderConfigurator<ChatPostMessageRequest.ChatPostMessageRequestBuilder> request) throws IOException, SlackApiException {
+        ChatPostMessageResponse response = client().chatPostMessage(request.configure(ChatPostMessageRequest.builder()).build());
+        return response;
+    }
+
+    public CompletableFuture<ChatPostMessageResponse> sayAsync(BuilderConfigurator<ChatPostMessageRequest.ChatPostMessageRequestBuilder> request) {
+        CompletableFuture<ChatPostMessageResponse> response = asyncClient().chatPostMessage(request.configure(ChatPostMessageRequest.builder()).build());
+        return response;
     }
 
     public Response ack() {

--- a/bolt/src/test/java/samples/EventsSample.java
+++ b/bolt/src/test/java/samples/EventsSample.java
@@ -20,7 +20,7 @@ public class EventsSample {
 
         app.event(MessageEvent.class, (event, ctx) -> {
             ctx.logger.info("new message by a user - {}", event);
-            ctx.client().chatPostMessage(r -> r
+            ctx.say(r -> r
                     .text("Hi there!")
                     .channel(event.getEvent().getChannel()));
             return ctx.ack();


### PR DESCRIPTION
###  Summary

This pull request adds `say()` utility to Bolt for Java.

```java
app.event(MessageEvent.class, (event, ctx) -> {
  ctx.say(r -> r.channel(event.getEvent().getChannel()).text("Hi there!"));
  return ctx.ack();
});
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
