### PR TITLE
Change the boot message a bit to align with Bolt for JS

### DIFF
--- a/bolt-jetty/src/main/java/com/slack/api/bolt/jetty/SlackAppServer.java
+++ b/bolt-jetty/src/main/java/com/slack/api/bolt/jetty/SlackAppServer.java
@@ -122,7 +122,7 @@ public class SlackAppServer {
             app.start();
         }
         server.start();
-        log.info("⚡️ Your Bolt app is running!");
+        log.info("⚡️ Bolt app is running!");
         server.join();
     }
 

--- a/bolt/src/test/java/samples/util/TestSlackAppServer.java
+++ b/bolt/src/test/java/samples/util/TestSlackAppServer.java
@@ -91,7 +91,7 @@ public class TestSlackAppServer {
             app.start();
         }
         server.start();
-        log.info("⚡️ Your Bolt app is running!");
+        log.info("⚡️ Bolt app is running!");
         server.join();
     }
 


### PR DESCRIPTION
###  Summary

As we decided to rename the server-side framework to Bolt, the message shown when bootstrapping the app should be the same.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
