### PR TITLE
Allow the absence of scope/user_scope settings

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -319,17 +319,19 @@ public class App {
         if (config.getClientId() == null || config.getScope() == null || state == null) {
             return null;
         } else {
+            String scope = config.getScope() == null ? "" : config.getScope();
             if (config.isClassicAppPermissionsEnabled()) {
                 // https://api.slack.com/authentication/migration
                 return "https://slack.com/oauth/authorize" +
                         "?client_id=" + config.getClientId() +
-                        "&scope=" + config.getScope() +
+                        "&scope=" + scope +
                         "&state=" + state;
             } else {
+                String userScope = config.getUserScope() == null ? "" : config.getUserScope();
                 return "https://slack.com/oauth/v2/authorize" +
                         "?client_id=" + config.getClientId() +
-                        "&scope=" + config.getScope() +
-                        "&user_scope=" + config.getUserScope() +
+                        "&scope=" + scope +
+                        "&user_scope=" + userScope +
                         "&state=" + state;
             }
         }


### PR DESCRIPTION
###  Summary

This pull request brings a minor improvement for the Bolt app configuration. Previously, the absence of env variables resulted in OAuth flow errors.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
