### PR TITLE
Support text, blocks as parameters to ack / respond methods

### DIFF
--- a/bolt-kotlin-examples/src/main/kotlin/examples/meeting_arrangement_modals/app.kt
+++ b/bolt-kotlin-examples/src/main/kotlin/examples/meeting_arrangement_modals/app.kt
@@ -47,7 +47,7 @@ fun main() {
             errors["agenda"] = "Agenda needs to be longer than 10 characters."
         }
         if (errors.isNotEmpty()) {
-            ctx.ack { it.responseAction("errors").errors(errors) }
+            ctx.ackWithErrors(errors)
         } else {
             // Operate something with the data
             ctx.logger.info("state: $stateValues private_metadata: ${req.payload.view.privateMetadata}")

--- a/bolt-kotlin-examples/src/main/kotlin/examples/say_something/app.kt
+++ b/bolt-kotlin-examples/src/main/kotlin/examples/say_something/app.kt
@@ -43,7 +43,7 @@ fun main() {
     fun saySomething(ctx: SlashCommandContext, where: String, text: String) {
         val conversationId = toConversationId(ctx, where)
         if (conversationId == null) {
-            ctx.ack { it.text("[Error] $where was not found") }
+            ctx.ack("[Error] $where was not found")
         } else {
             joinConversation(ctx, conversationId)
             val res = ctx.say { it.channel(where).text(text) }
@@ -54,7 +54,7 @@ fun main() {
     app.command("/say-something") { req, ctx ->
         val elements = req.payload.text?.split(" at ")
         if (elements == null || elements.size < 2) {
-            ctx.ack { it.text("[Usage] /say-something Hey folks, how have you been doing? at #general") }
+            ctx.ack("[Usage] /say-something Hey folks, how have you been doing? at #general")
         } else {
             if (elements.size == 2) {
                 val where = elements[1].trim()

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/ActionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/ActionContext.java
@@ -4,10 +4,12 @@ import com.slack.api.app_backend.interactive_components.response.ActionResponse;
 import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.response.ResponseUrlSender;
 import com.slack.api.bolt.util.BuilderConfigurator;
+import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.webhook.WebhookResponse;
 import lombok.*;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Action type request's context.
@@ -24,6 +26,14 @@ public class ActionContext extends Context {
     private String triggerId;
     private String responseUrl;
     private ResponseUrlSender responseUrlSender;
+
+    public WebhookResponse respond(String text) throws IOException {
+        return respond(ActionResponse.builder().text(text).build());
+    }
+
+    public WebhookResponse respond(List<LayoutBlock> blocks) throws IOException {
+        return respond(ActionResponse.builder().blocks(blocks).build());
+    }
 
     public WebhookResponse respond(ActionResponse response) throws IOException {
         if (responseUrlSender == null) {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/AttachmentActionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/AttachmentActionContext.java
@@ -5,10 +5,12 @@ import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.context.SayUtility;
 import com.slack.api.bolt.response.ResponseUrlSender;
 import com.slack.api.bolt.util.BuilderConfigurator;
+import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.webhook.WebhookResponse;
 import lombok.*;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Action type request's context from attachments in messages.
@@ -26,6 +28,14 @@ public class AttachmentActionContext extends Context implements SayUtility {
     private String channelId;
     private String responseUrl;
     private ResponseUrlSender responseUrlSender;
+
+    public WebhookResponse respond(String text) throws IOException {
+        return respond(ActionResponse.builder().text(text).build());
+    }
+
+    public WebhookResponse respond(List<LayoutBlock> blocks) throws IOException {
+        return respond(ActionResponse.builder().blocks(blocks).build());
+    }
 
     public WebhookResponse respond(ActionResponse response) throws IOException {
         if (responseUrlSender == null) {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogCancellationContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogCancellationContext.java
@@ -5,10 +5,12 @@ import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.context.SayUtility;
 import com.slack.api.bolt.response.ResponseUrlSender;
 import com.slack.api.bolt.util.BuilderConfigurator;
+import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.webhook.WebhookResponse;
 import lombok.*;
 
 import java.io.IOException;
+import java.util.List;
 
 @Getter
 @Setter
@@ -22,6 +24,14 @@ public class DialogCancellationContext extends Context implements SayUtility {
     private String responseUrl;
     private String channelId;
     private ResponseUrlSender responseUrlSender;
+
+    public WebhookResponse respond(String text) throws IOException {
+        return respond(ActionResponse.builder().text(text).build());
+    }
+
+    public WebhookResponse respond(List<LayoutBlock> blocks) throws IOException {
+        return respond(ActionResponse.builder().blocks(blocks).build());
+    }
 
     public WebhookResponse respond(ActionResponse response) throws IOException {
         if (responseUrlSender == null) {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSubmissionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSubmissionContext.java
@@ -1,16 +1,19 @@
 package com.slack.api.bolt.context.builtin;
 
 import com.slack.api.app_backend.dialogs.response.DialogSubmissionErrorResponse;
+import com.slack.api.app_backend.dialogs.response.Error;
 import com.slack.api.app_backend.interactive_components.response.ActionResponse;
 import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.context.SayUtility;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.response.ResponseUrlSender;
 import com.slack.api.bolt.util.BuilderConfigurator;
+import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.webhook.WebhookResponse;
 import lombok.*;
 
 import java.io.IOException;
+import java.util.List;
 
 @Getter
 @Setter
@@ -25,6 +28,14 @@ public class DialogSubmissionContext extends Context implements SayUtility {
     private String channelId;
     private ResponseUrlSender responseUrlSender;
 
+    public WebhookResponse respond(String text) throws IOException {
+        return respond(ActionResponse.builder().text(text).build());
+    }
+
+    public WebhookResponse respond(List<LayoutBlock> blocks) throws IOException {
+        return respond(ActionResponse.builder().blocks(blocks).build());
+    }
+
     public WebhookResponse respond(ActionResponse response) throws IOException {
         if (responseUrlSender == null) {
             responseUrlSender = new ResponseUrlSender(slack, responseUrl);
@@ -35,6 +46,10 @@ public class DialogSubmissionContext extends Context implements SayUtility {
     public WebhookResponse respond(
             BuilderConfigurator<ActionResponse.ActionResponseBuilder> builder) throws IOException {
         return respond(builder.configure(ActionResponse.builder()).build());
+    }
+
+    public Response ack(List<Error> errors) {
+        return ack(DialogSubmissionErrorResponse.builder().errors(errors).build());
     }
 
     public Response ack(DialogSubmissionErrorResponse error) {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/MessageActionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/MessageActionContext.java
@@ -5,10 +5,12 @@ import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.context.SayUtility;
 import com.slack.api.bolt.response.ResponseUrlSender;
 import com.slack.api.bolt.util.BuilderConfigurator;
+import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.webhook.WebhookResponse;
 import lombok.*;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Action type request's context from attachments in messages.
@@ -26,6 +28,14 @@ public class MessageActionContext extends Context implements SayUtility {
     private String channelId;
     private String responseUrl;
     private ResponseUrlSender responseUrlSender;
+
+    public WebhookResponse respond(String text) throws IOException {
+        return respond(ActionResponse.builder().text(text).build());
+    }
+
+    public WebhookResponse respond(List<LayoutBlock> blocks) throws IOException {
+        return respond(ActionResponse.builder().blocks(blocks).build());
+    }
 
     public WebhookResponse respond(ActionResponse response) throws IOException {
         if (responseUrlSender == null) {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/OutgoingWebhooksContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/OutgoingWebhooksContext.java
@@ -18,7 +18,10 @@ public class OutgoingWebhooksContext extends Context implements SayUtility {
 
     private String triggerId;
     private String channelId;
-    private String responseUrl;
+
+    public Response ack(String text) {
+        return Response.json(200, WebhookResponse.builder().text(text).build());
+    }
 
     public Response ack(WebhookResponse response) {
         return Response.json(200, response);

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/SlashCommandContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/SlashCommandContext.java
@@ -6,10 +6,12 @@ import com.slack.api.bolt.context.SayUtility;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.response.ResponseUrlSender;
 import com.slack.api.bolt.util.BuilderConfigurator;
+import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.webhook.WebhookResponse;
 import lombok.*;
 
 import java.io.IOException;
+import java.util.List;
 
 @Getter
 @Setter
@@ -25,6 +27,14 @@ public class SlashCommandContext extends Context implements SayUtility {
     private String responseUrl;
     private ResponseUrlSender responseUrlSender;
 
+    public WebhookResponse respond(String text) throws IOException {
+        return respond(SlashCommandResponse.builder().text(text).build());
+    }
+
+    public WebhookResponse respond(List<LayoutBlock> blocks) throws IOException {
+        return respond(SlashCommandResponse.builder().blocks(blocks).build());
+    }
+
     public WebhookResponse respond(SlashCommandResponse response) throws IOException {
         if (responseUrlSender == null) {
             responseUrlSender = new ResponseUrlSender(slack, responseUrl);
@@ -35,6 +45,14 @@ public class SlashCommandContext extends Context implements SayUtility {
     public WebhookResponse respond(
             BuilderConfigurator<SlashCommandResponse.SlashCommandResponseBuilder> builder) throws IOException {
         return respond(builder.configure(SlashCommandResponse.builder()).build());
+    }
+
+    public Response ack(String text) {
+        return Response.json(200, SlashCommandResponse.builder().text(text).build());
+    }
+
+    public Response ack(List<LayoutBlock> blocks) {
+        return Response.json(200, SlashCommandResponse.builder().blocks(blocks).build());
     }
 
     public Response ack(SlashCommandResponse response) {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/ViewSubmissionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/ViewSubmissionContext.java
@@ -4,7 +4,10 @@ import com.slack.api.app_backend.views.response.ViewSubmissionResponse;
 import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.util.BuilderConfigurator;
+import com.slack.api.model.view.View;
 import lombok.*;
+
+import java.util.Map;
 
 @Getter
 @Setter
@@ -23,6 +26,46 @@ public class ViewSubmissionContext extends Context {
     public Response ack(
             BuilderConfigurator<ViewSubmissionResponse.ViewSubmissionResponseBuilder> builder) {
         return ack(builder.configure(ViewSubmissionResponse.builder()).build());
+    }
+
+    public Response ackWithErrors(Map<String, String> errors) {
+        ViewSubmissionResponse response = ViewSubmissionResponse.builder()
+                .responseAction("errors")
+                .errors(errors)
+                .build();
+        return ack(response);
+    }
+
+    public Response ackWithUpdate(View view) {
+        return ack("update", view);
+    }
+
+    public Response ackWithUpdate(String view) {
+        return ack("update", view);
+    }
+
+    public Response ackWithPush(View view) {
+        return ack("push", view);
+    }
+
+    public Response ackWithPush(String view) {
+        return ack("push", view);
+    }
+
+    public Response ack(String responseAction, View view) {
+        ViewSubmissionResponse response = ViewSubmissionResponse.builder()
+                .responseAction(responseAction)
+                .view(view)
+                .build();
+        return ack(response);
+    }
+
+    public Response ack(String responseAction, String view) {
+        ViewSubmissionResponse response = ViewSubmissionResponse.builder()
+                .responseAction(responseAction)
+                .viewAsString(view)
+                .build();
+        return ack(response);
     }
 
 }

--- a/bolt/src/test/java/samples/DialogSample.java
+++ b/bolt/src/test/java/samples/DialogSample.java
@@ -46,7 +46,7 @@ public class DialogSample {
             if (req.getPayload().getSubmission().get("comment").length() < 10) {
                 List<Error> errors = Arrays.asList(
                         new Error("comment", "must be longer than 10 characters"));
-                return ctx.ack(r -> r.errors(errors));
+                return ctx.ack(errors);
             } else {
                 ctx.respond(r -> r.text("Thanks!!"));
                 return ctx.ack();

--- a/bolt/src/test/java/samples/OutgoingWebhooksSample.java
+++ b/bolt/src/test/java/samples/OutgoingWebhooksSample.java
@@ -23,7 +23,7 @@ public class OutgoingWebhooksSample {
 
         app.webhook("something", (req, ctx) -> {
             ctx.logger.info("outgoing webhook - {}", req);
-            return ctx.ack(r -> r.text("Hello " + req.getPayload().getUserName()));
+            return ctx.ack("Hello " + req.getPayload().getUserName());
         });
         TestSlackAppServer server = new TestSlackAppServer(app);
         server.start();

--- a/bolt/src/test/java/samples/PingPongSample.java
+++ b/bolt/src/test/java/samples/PingPongSample.java
@@ -1,0 +1,40 @@
+package samples;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.model.block.LayoutBlock;
+import samples.util.ResourceLoader;
+import samples.util.TestSlackAppServer;
+
+import java.util.List;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static com.slack.api.model.block.element.BlockElements.asElements;
+import static com.slack.api.model.block.element.BlockElements.button;
+
+public class PingPongSample {
+
+    public static void main(String[] args) throws Exception {
+        List<LayoutBlock> blocks = asBlocks(
+                section(section -> section.text(markdownText(":wave: pong"))),
+                actions(actions -> actions
+                        .elements(asElements(
+                                button(b -> b.actionId("ping-again").text(plainText(pt -> pt.text("Ping"))).value("ping"))
+                        ))
+                )
+        );
+
+        AppConfig config = ResourceLoader.loadAppConfig();
+        App app = new App(config);
+        app.command("/ping", (req, ctx) -> ctx.ack(blocks));
+        app.blockAction("ping-again", (req, ctx) -> {
+            ctx.respond(blocks);
+            return ctx.ack();
+        });
+
+        TestSlackAppServer server = new TestSlackAppServer(app);
+        server.start();
+    }
+}

--- a/bolt/src/test/java/samples/ViewSample.java
+++ b/bolt/src/test/java/samples/ViewSample.java
@@ -79,11 +79,11 @@ public class ViewSample {
                 errors.put("agenda", "The agenda needs to be longer than 10 characters.");
             }
             if (errors.size() > 0) {
-                return ctx.ack(r -> r.responseAction("errors").errors(errors));
+                return ctx.ackWithErrors(errors);
             } else {
                 View view = GsonFactory.createSnakeCase().fromJson(view2, View.class);
                 view.setPrivateMetadata(JsonOps.toJsonString(req.getPayload().getView().getState()));
-                return ctx.ack(r -> r.responseAction("update").view(view));
+                return ctx.ackWithUpdate(view);
             }
         });
 

--- a/bolt/src/test/java/test_locally/AckTest.java
+++ b/bolt/src/test/java/test_locally/AckTest.java
@@ -1,0 +1,152 @@
+package test_locally;
+
+import com.slack.api.app_backend.dialogs.response.DialogSubmissionErrorResponse;
+import com.slack.api.app_backend.dialogs.response.DialogSuggestionResponse;
+import com.slack.api.app_backend.dialogs.response.Error;
+import com.slack.api.bolt.App;
+import com.slack.api.model.event.MessageEvent;
+import com.slack.api.model.view.View;
+import org.junit.Test;
+
+import java.util.*;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.view.Views.*;
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+
+public class AckTest {
+
+    App app = new App();
+
+    @Test
+    public void event() {
+        // only ack with an empty body supported
+        app.event(MessageEvent.class, (req, ctx) -> ctx.ack());
+    }
+
+    @Test
+    public void command() {
+        app.command("/foo", (req, ctx) -> ctx.ack());
+        app.command("/foo", (req, ctx) -> ctx.ack("bar"));
+        app.command("/foo", (req, ctx) -> ctx.ack(asBlocks(section(s -> s.text(markdownText("*bold* _italic_"))), divider())));
+        app.command("/foo", (req, ctx) -> ctx.ack(r -> r.text("bar")));
+    }
+
+    @Test
+    public void messageAction() {
+        // TODO
+        app.messageAction("callback-id", (req, ctx) -> ctx.ack());
+    }
+
+    @Test
+    public void blockAction() {
+        // only ack with an empty body supported
+        app.blockAction("action-id", (req, ctx) -> ctx.ack());
+    }
+
+    @Test
+    public void blockSuggestion() {
+        // only ack with an empty body supported
+        app.blockSuggestion("action-id", (req, ctx) -> ctx.ack());
+    }
+
+    @Test
+    public void viewSubmission() {
+        Map<String, String> errors = new HashMap<>();
+        errors.put("block_id", "error message");
+
+        View view = view(v -> v
+                .callbackId("callback-id")
+                .title(viewTitle(vt -> vt.text("title")))
+                .submit(viewSubmit(vs -> vs.text("submit")))
+                .close(viewClose(vc -> vc.text("cancel")))
+                .notifyOnClose(true)
+                .blocks(asBlocks(divider())));
+
+        String viewAsString = "{\n" +
+                "  \"callback_id\": \"meeting-arrangement\",\n" +
+                "  \"type\": \"modal\",\n" +
+                "  \"notify_on_close\": true,\n" +
+                "  \"title\": { \"type\": \"plain_text\", \"text\": \"Meeting Arrangement\", \"emoji\": true },\n" +
+                "  \"submit\": { \"type\": \"plain_text\", \"text\": \"Submit\", \"emoji\": true },\n" +
+                "  \"close\": { \"type\": \"plain_text\", \"text\": \"Cancel\", \"emoji\": true },\n" +
+                "  \"blocks\": [\n" +
+                "    {\n" +
+                "      \"block_id\": \"title-block\",\n" +
+                "      \"type\": \"input\",\n" +
+                "      \"element\": { \"action_id\": \"title-action\", \"type\": \"plain_text_input\", \"initial_value\": \"${commandArg}\" },\n" +
+                "      \"label\": { \"type\": \"plain_text\", \"text\": \"Meeting Title\", \"emoji\": true }\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+
+        // close
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ack());
+
+        // update
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ack(r -> r.responseAction("update").view(view)));
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ack(r -> r.responseAction("update").viewAsString(viewAsString)));
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ackWithUpdate(view));
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ackWithUpdate(viewAsString));
+
+        // push
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ack(r -> r.responseAction("push").view(view)));
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ack(r -> r.responseAction("push").viewAsString(viewAsString)));
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ackWithPush(view));
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ackWithPush(viewAsString));
+
+        // errors
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ack(r -> r.responseAction("errors").errors(errors)));
+        app.viewSubmission("callback-id", (req, ctx) -> ctx.ackWithErrors(errors));
+    }
+
+    @Test
+    public void viewClosed() {
+        // only ack with an empty body supported
+        app.viewClosed("callback-id", (req, ctx) -> ctx.ack());
+    }
+
+    @Test
+    public void dialogSubmission() {
+        // ok
+        app.dialogSubmission("callback-id", (req, ctx) -> ctx.ack());
+
+        List<Error> errors = new ArrayList<>();
+        errors.add(Error.builder().name("name").error("something wrong").build());
+        app.dialogSubmission("callback-id", (req, ctx) -> ctx.ack(errors));
+
+        DialogSubmissionErrorResponse error = DialogSubmissionErrorResponse.builder().errors(errors).build();
+        app.dialogSubmission("callback-id", (req, ctx) -> ctx.ack(error));
+    }
+
+    @Test
+    public void dialogSuggestion() {
+        app.dialogSuggestion("callback-id", (req, ctx) -> ctx.ack());
+
+        app.dialogSuggestion("callback-id", (req, ctx) -> ctx.ack(res ->
+                res.options(Collections.emptyList()).optionGroups(Collections.emptyList())));
+
+        DialogSuggestionResponse response = DialogSuggestionResponse.builder()
+                .options(Collections.emptyList())
+                .optionGroups(Collections.emptyList())
+                .build();
+        app.dialogSuggestion("callback-id", (req, ctx) -> ctx.ack(response));
+    }
+
+    @Test
+    public void dialogCancellation() {
+        // only ack with an empty body supported
+        app.dialogCancellation("callback-id", (req, ctx) -> ctx.ack());
+    }
+
+    @Test
+    public void attachmentAction() {
+        app.attachmentAction("callback-id", (req, ctx) -> ctx.ack());
+    }
+
+    @Test
+    public void webhook() {
+        app.webhook("trigger word", (req, ctx) -> ctx.ack());
+        app.webhook("trigger word", (req, ctx) -> ctx.ack("Thanks!"));
+    }
+}

--- a/bolt/src/test/java/test_locally/RespondTest.java
+++ b/bolt/src/test/java/test_locally/RespondTest.java
@@ -1,0 +1,102 @@
+package test_locally;
+
+import com.slack.api.bolt.App;
+import org.junit.Test;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+
+public class RespondTest {
+
+    App app = new App();
+
+    @Test
+    public void event() {
+        // doesn't support respond method
+    }
+
+    @Test
+    public void command() {
+        app.command("/foo", (req, ctx) -> {
+            ctx.respond("bar");
+            ctx.respond(asBlocks(section(s -> s.text(markdownText("*bold* _italic_"))), divider()));
+            ctx.respond(r -> r.text("bar"));
+            return ctx.ack();
+        });
+    }
+
+    @Test
+    public void messageAction() {
+        app.messageAction("callback-id", (req, ctx) -> {
+            ctx.respond("bar");
+            ctx.respond(asBlocks(section(s -> s.text(markdownText("*bold* _italic_"))), divider()));
+            ctx.respond(r -> r.text("bar"));
+            return ctx.ack();
+        });
+    }
+
+    @Test
+    public void blockAction() {
+        app.blockAction("action-id", (req, ctx) -> {
+            ctx.respond("bar");
+            ctx.respond(asBlocks(section(s -> s.text(markdownText("*bold* _italic_"))), divider()));
+            ctx.respond(r -> r.text("bar"));
+            return ctx.ack();
+        });
+    }
+
+    @Test
+    public void blockSuggestion() {
+        // doesn't support respond method
+    }
+
+    @Test
+    public void viewSubmission() {
+        // doesn't support respond method
+    }
+
+    @Test
+    public void viewClosed() {
+        // doesn't support respond method
+    }
+
+    @Test
+    public void dialogSubmission() {
+        app.dialogSubmission("callback-id", (req, ctx) -> {
+            ctx.respond("bar");
+            ctx.respond(asBlocks(section(s -> s.text(markdownText("*bold* _italic_"))), divider()));
+            ctx.respond(r -> r.text("bar"));
+            return ctx.ack();
+        });
+    }
+
+    @Test
+    public void dialogSuggestion() {
+        // doesn't support respond method
+    }
+
+    @Test
+    public void dialogCancellation() {
+        app.dialogCancellation("callback-id", (req, ctx) -> {
+            ctx.respond("bar");
+            ctx.respond(asBlocks(section(s -> s.text(markdownText("*bold* _italic_"))), divider()));
+            ctx.respond(r -> r.text("bar"));
+            return ctx.ack();
+        });
+    }
+
+    @Test
+    public void attachmentAction() {
+        app.attachmentAction("callback-id", (req, ctx) -> {
+            ctx.respond("bar");
+            ctx.respond(asBlocks(section(s -> s.text(markdownText("*bold* _italic_"))), divider()));
+            ctx.respond(r -> r.text("bar"));
+            return ctx.ack();
+        });
+    }
+
+    @Test
+    public void webhook() {
+        // doesn't support respond method
+    }
+}


### PR DESCRIPTION
###  Summary

To be more compatible with Bolt for JavaScript, this pull request adds more parameter supports for `ack` and `respond` method.

Currently, the only way to pass text, blocks to those methods is to use a lambda function to configure the parameters.

```java
app.command("/hi", (req, ctx) -> {
  return ctx.ack(res -> res.text("How are you?"));
});
app.command("/hi", (req, ctx) -> {
  return ctx.ack(res -> res.blocks(asBlocks(divider())));
});
app.command("/hi", (req, ctx) -> {
  ctx.respond(res -> res.text("How are you?"));
  return ctx.ack();
});
app.command("/hi", (req, ctx) -> {
  ctx.respond(res -> res.blocks(asBlocks(divider())));
  return ctx.ack();
});
```

With the changes in this PR, the following code will work as well.

```java
app.command("/hi", (req, ctx) -> {
  return ctx.ack("How are you?");
});
app.command("/hi", (req, ctx) -> {
  return ctx.ack(asBlocks(divider()));
});
app.command("/hi", (req, ctx) -> {
  ctx.respond("How are you?");
  return ctx.ack();
});
app.command("/hi", (req, ctx) -> {
  ctx.respond(asBlocks(divider()));
  return ctx.ack();
});
```


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
