### PR TITLE
Apply a bunch of improvements for eliminating code-start issues in general

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
   - echo 'skipped'
 script:
   - travis_retry ./mvnw test-compile
-  - travis_retry ./mvnw '-Dtest=test_locally.**.*Test' test -DfailIfNoTests=false
+  - travis_retry ./scripts/run_no_prep_tests.sh
   - travis_retry ./mvnw install -Dmaven.test.skip=true
   - travis_retry ./mvnw duplicate-finder:check

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -45,7 +45,6 @@ public class AppConfig {
 
     private static SlackHttpClient buildSlackHttpClient() {
         Map<String, String> userAgentCustomInfo = new HashMap<>();
-        String version = AppConfig.class.getPackage().getImplementationVersion();
         userAgentCustomInfo.put("bolt", BoltLibraryVersion.get());
         SlackHttpClient client = new SlackHttpClient(userAgentCustomInfo);
         return client;
@@ -123,6 +122,10 @@ public class AppConfig {
     @Builder.Default
     private String oauthCompletionUrl = System.getenv(EnvVariableName.SLACK_APP_OAUTH_COMPLETION_URL);
 
-    private boolean alwaysRequestUserTokenNeeded;
+    @Builder.Default
+    private boolean alwaysRequestUserTokenNeeded = false;
+
+    @Builder.Default
+    private boolean appInitializersEnabled = true;
 
 }

--- a/bolt/src/main/java/com/slack/api/bolt/Initializer.java
+++ b/bolt/src/main/java/com/slack/api/bolt/Initializer.java
@@ -1,0 +1,6 @@
+package com.slack.api.bolt;
+
+import java.util.function.Consumer;
+
+public interface Initializer extends Consumer<App> {
+}

--- a/bolt/src/main/java/com/slack/api/bolt/service/InstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/InstallationService.java
@@ -1,5 +1,6 @@
 package com.slack.api.bolt.service;
 
+import com.slack.api.bolt.Initializer;
 import com.slack.api.bolt.model.Bot;
 import com.slack.api.bolt.model.Installer;
 import com.slack.api.model.block.LayoutBlock;
@@ -9,7 +10,7 @@ import java.util.List;
 /**
  * A service that manages Slack app installations.
  */
-public interface InstallationService {
+public interface InstallationService extends Service {
 
     /**
      * Returns true if the historical data management is enabled.
@@ -46,10 +47,16 @@ public interface InstallationService {
      */
     Installer findInstaller(String enterpriseId, String teamId, String userId);
 
+    /**
+     * Returns a message text to inform unknown users.
+     */
     default String getInstallationGuideText(String enterpriseId, String teamId, String userId) {
         return "This app was not able to respond to your action. Please install this Slack app :bow:";
     }
 
+    /**
+     * Returns a message (Block Kit) to inform unknown users.
+     */
     default List<LayoutBlock> getInstallationGuideBlocks(String enterpriseId, String teamId, String userId) {
         return null;
     }

--- a/bolt/src/main/java/com/slack/api/bolt/service/OAuthCallbackService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/OAuthCallbackService.java
@@ -6,7 +6,7 @@ import com.slack.api.bolt.response.Response;
 /**
  * Handle callback requests from the Slack OAuth confirmation page.
  */
-public interface OAuthCallbackService {
+public interface OAuthCallbackService extends Service {
 
     Response handle(OAuthCallbackRequest request);
 

--- a/bolt/src/main/java/com/slack/api/bolt/service/OAuthStateService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/OAuthStateService.java
@@ -10,7 +10,7 @@ import java.util.*;
  *
  * @see <a href="https://api.slack.com/docs/oauth">Slack OAuth</a>
  */
-public interface OAuthStateService {
+public interface OAuthStateService extends Service {
 
     long DEFAULT_EXPIRATION_IN_SECONDS = 10 * 60; // default 10 min
 

--- a/bolt/src/main/java/com/slack/api/bolt/service/Service.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/Service.java
@@ -1,0 +1,20 @@
+package com.slack.api.bolt.service;
+
+import com.slack.api.bolt.Initializer;
+
+/**
+ * Service interface
+ */
+public interface Service {
+
+    /**
+     * Returns the initializer for this service. If the service has time-consuming initialization steps,
+     * putting those into this function would be a good way to avoid timeout errors
+     * for the first incoming request (in other words, to avoid cold-start problems).
+     */
+    default Initializer initializer() {
+        return (app) -> {
+        };
+    }
+
+}

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.util.IOUtils;
+import com.slack.api.bolt.Initializer;
 import com.slack.api.bolt.model.Bot;
 import com.slack.api.bolt.model.Installer;
 import com.slack.api.bolt.model.builtin.DefaultBot;
@@ -26,6 +27,17 @@ public class AmazonS3InstallationService implements InstallationService {
 
     public AmazonS3InstallationService(String bucketName) {
         this.bucketName = bucketName;
+    }
+
+    @Override
+    public Initializer initializer() {
+        return (app) -> {
+            try {
+                // The first access to S3 tends to be slow on AWS Lambda.
+                this.createS3Client().getObjectMetadata(bucketName, "dummy-for-initializer");
+            } catch (AmazonS3Exception ignored) {
+            }
+        };
     }
 
     @Override

--- a/bolt/src/test/java/test_locally/AppTest.java
+++ b/bolt/src/test/java/test_locally/AppTest.java
@@ -1,12 +1,16 @@
 package test_locally;
 
 import com.slack.api.bolt.App;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 
+@Slf4j
 public class AppTest {
 
     @Test
@@ -55,6 +59,47 @@ public class AppTest {
 
         app = app.toOAuthStartApp();
         assertNotNull(app.config());
+    }
+
+    @Test
+    public void initializer_called() {
+        App app = new App();
+        final AtomicBoolean called = new AtomicBoolean(false);
+        assertThat(called.get(), is(false));
+
+        app.initializer("foo", (theApp) -> {
+            called.set(true);
+        });
+        app.initialize();
+        assertThat(called.get(), is(true));
+    }
+
+    @Test
+    public void initializer_start() {
+        App app = new App();
+        final AtomicBoolean called = new AtomicBoolean(false);
+        assertThat(called.get(), is(false));
+
+        app.initializer("foo", (theApp) -> {
+            called.set(true);
+        });
+        app.start();
+        assertThat(called.get(), is(true));
+    }
+
+    @Test
+    public void initializer_same_key() {
+        App app = new App();
+        final AtomicBoolean called = new AtomicBoolean(false);
+        assertThat(called.get(), is(false));
+
+        app.initializer("foo", (theApp) -> {
+            called.set(true);
+        });
+        app.initializer("foo", (theApp) -> {
+        });
+        app.initialize();
+        assertThat(called.get(), is(false));
     }
 
 }

--- a/scripts/run_no_prep_tests.sh
+++ b/scripts/run_no_prep_tests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./mvnw clean test-compile '-Dtest=test_locally.**.*Test' test -DfailIfNoTests=false


### PR DESCRIPTION
###  Summary

This pull request introduces `Initializer` for handling time-consuming initialization. Now all the `Service`s have their `Initializer`s and they are called when an `App` starts.

This mechanism is useful for eliminating cold-start problems in general but in particular, the `bolt-aws-lambda` module will get benefits from it. The following AWS Lambda handler is a simple example demonstrating how to warmup lambda functions.

```java
import com.amazonaws.services.lambda.AWSLambda;
import com.amazonaws.services.lambda.AWSLambdaClient;
import com.amazonaws.services.lambda.model.InvokeRequest;
import com.amazonaws.services.lambda.model.InvokeResult;
import com.amazonaws.services.lambda.runtime.Context;
import com.amazonaws.services.lambda.runtime.RequestHandler;
import com.slack.api.bolt.aws_lambda.request.ApiGatewayRequest;
import com.slack.api.bolt.aws_lambda.response.ApiGatewayResponse;

import java.util.Arrays;
import java.util.List;

public class WarmupHandler implements RequestHandler<ApiGatewayRequest, ApiGatewayResponse> {
  private List<String> functionNames = Arrays.asList("function-1", "function-2");
  @Override
  public ApiGatewayResponse handleRequest(ApiGatewayRequest req, Context context) {
    AWSLambda lambda = AWSLambdaClient.builder().build();
    for (String functionName : functionNames) {
      InvokeRequest invokeReq = new InvokeRequest().withFunctionName(functionName).withPayload("{\"body\":\"this is a wamrup request\"}");
      InvokeResult result = lambda.invoke(invokeReq);
      if (result.getStatusCode() != 200 || result.getFunctionError() != null) {
        throw new RuntimeException("status: " + result.getStatusCode() + " function error: " + result.getFunctionError());
      }
    }
    return ApiGatewayResponse.builder().statusCode(200).rawBody("done").build();
  }
}
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
