### PR TITLE
Improve intializers for Amazon S3 backed services

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
@@ -1,5 +1,7 @@
 package com.slack.api.bolt.service.builtin;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
@@ -32,10 +34,17 @@ public class AmazonS3InstallationService implements InstallationService {
     @Override
     public Initializer initializer() {
         return (app) -> {
-            try {
-                // The first access to S3 tends to be slow on AWS Lambda.
-                this.createS3Client().getObjectMetadata(bucketName, "dummy-for-initializer");
-            } catch (AmazonS3Exception ignored) {
+            // The first access to S3 tends to be slow on AWS Lambda.
+            AWSCredentials credentials = DefaultAWSCredentialsProviderChain.getInstance().getCredentials();
+            if (credentials == null || credentials.getAWSAccessKeyId() == null) {
+                throw new IllegalStateException("AWS credentials not found");
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("AWS credentials loaded (access key id: {})", credentials.getAWSAccessKeyId());
+            }
+            boolean bucketExists = createS3Client().doesBucketExistV2(bucketName);
+            if (!bucketExists) {
+                throw new IllegalStateException("Failed to access the Amazon S3 bucket (name: " + bucketName + ")");
             }
         };
     }

--- a/bolt/src/test/java/test_with_remote_apis/service/aws/AmazonS3InstallationServiceTest.java
+++ b/bolt/src/test/java/test_with_remote_apis/service/aws/AmazonS3InstallationServiceTest.java
@@ -1,0 +1,16 @@
+package test_with_remote_apis.service.aws;
+
+import com.slack.api.bolt.service.builtin.AmazonS3InstallationService;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class AmazonS3InstallationServiceTest {
+
+    @Test
+    public void init() {
+        String bucketName = "java-slack-sdk-test-dummy-bucket" + UUID.randomUUID();
+        AmazonS3InstallationService service = new AmazonS3InstallationService(bucketName);
+        service.initializer().accept(null);
+    }
+}

--- a/bolt/src/test/java/test_with_remote_apis/service/aws/AmazonS3OAuthStateServiceTest.java
+++ b/bolt/src/test/java/test_with_remote_apis/service/aws/AmazonS3OAuthStateServiceTest.java
@@ -1,0 +1,16 @@
+package test_with_remote_apis.service.aws;
+
+import com.slack.api.bolt.service.builtin.AmazonS3OAuthStateService;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class AmazonS3OAuthStateServiceTest {
+
+    @Test
+    public void init() {
+        String bucketName = "java-slack-sdk-test-dummy-bucket" + UUID.randomUUID();
+        AmazonS3OAuthStateService service = new AmazonS3OAuthStateService(bucketName);
+        service.initializer().accept(null);
+    }
+}


### PR DESCRIPTION
###  Summary

This pull request improves the initializers for Amazon S3 backed services. Issuing HTTP requests to S3 services beforehand seems to be effective for eliminating cold-starts with the service on Lambda. 

```
02:19:50
START RequestId: d1f746ba-3c60-4c9e-9a0c-62157c93683f Version: $LATEST
02:19:51
2020-02-25 02:19:51,294 DEBUG [main] com.slack.api.bolt.service.builtin.AmazonS3InstallationService AWS credentials loaded (access key id: ***)
02:19:53
2020-02-25 02:19:53,800 INFO [main] com.slack.api.bolt.aws_lambda.SlackApiLambdaHandler Successfully responded to a warmup request (ApiGatewayRequest(...))
02:19:53
END RequestId: d1f746ba-3c60-4c9e-9a0c-62157c93683f
```

To run the services, the following actions are necessary.

- s3:GetObject
- s3:PutObject
- s3:DeleteObject
- s3:GetBucketAcl

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
