### PR TITLE
Add BlockElements.imageElement(r -> r) to avoid the conflict with Blocks.image

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/BlockElements.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/BlockElements.java
@@ -59,6 +59,11 @@ public class BlockElements {
         return configurator.configure(ImageElement.builder()).build();
     }
 
+    // NOTE: just as an alias to avoid conflict with Blocks.image()
+    public static ImageElement imageElement(ModelConfigurator<ImageElement.ImageElementBuilder> configurator) {
+        return image(configurator);
+    }
+
     // RadioButtonsElement
 
     public static RadioButtonsElement radioButtons(ModelConfigurator<RadioButtonsElement.RadioButtonsElementBuilder> configurator) {

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -5,7 +5,6 @@ import com.slack.api.model.block.Blocks;
 import com.slack.api.model.block.ContextBlock;
 import com.slack.api.model.block.ContextBlockElement;
 import com.slack.api.model.block.element.BlockElement;
-import com.slack.api.model.block.element.BlockElements;
 import org.junit.Test;
 
 import java.util.List;
@@ -35,7 +34,7 @@ public class BlocksTest {
 
     @Test
     public void testContext() {
-        List<ContextBlockElement> elements = asContextElements(BlockElements.image(r -> r.imageUrl("https://www.example.com/logo.png")));
+        List<ContextBlockElement> elements = asContextElements(imageElement(r -> r.imageUrl("https://www.example.com/logo.png")));
         {
             ContextBlock block = context(elements);
             assertThat(block, is(notNullValue()));


### PR DESCRIPTION
###  Summary

This pull request improves developers' usability for building Block Kit messages with the builder interface. `Blocks.image` and `BlockElements.image` tend to conflict when using wildcard imports. The only way to deal with it used to be explicitly using `BlockElements.image`. This pull request introduces the `imageElement` method,  a bit simpler way to deal with it.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
