### PR TITLE
Change the initial state of EventsDispatcher

### DIFF
--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/EventsDispatcherImpl.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/EventsDispatcherImpl.java
@@ -17,7 +17,7 @@ public class EventsDispatcherImpl implements EventsDispatcher {
 
     private final ConcurrentMap<String, List<EventHandler<?>>> eventTypeAndHandlers = new ConcurrentHashMap<>();
 
-    private AtomicBoolean closed = new AtomicBoolean(false);
+    private AtomicBoolean closed = new AtomicBoolean(true);
 
     private long maxTerminationDelayMillis = 10000L;
 
@@ -138,8 +138,8 @@ public class EventsDispatcherImpl implements EventsDispatcher {
 
     @Override
     public void start() {
-        closed.set(false);
         eventLoopThread.start();
+        closed.set(false);
     }
 
     @Override


### PR DESCRIPTION
###  Summary

While writing more tests, I've noticed that the initial state of `EventsDispatcher` has been **running** even before calling `EventsDispatcher#start()`. This pull request corrects the bug.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
