### PR TITLE
Fix #372 chat.update and others' issues with bot tokens in Granular Permissions

### DIFF
--- a/json-logs/samples/api/channels.history.json
+++ b/json-logs/samples/api/channels.history.json
@@ -32,7 +32,22 @@
           }
         ],
         "subscribed": false,
-        "last_read": "0000000000.000000"
+        "last_read": "0000000000.000000",
+        "user": "U00000000",
+        "team": "T00000000",
+        "bot_profile": {
+          "id": "B00000000",
+          "deleted": false,
+          "name": "",
+          "updated": 12345,
+          "app_id": "A00000000",
+          "icons": {
+            "image_36": "https://www.example.com/",
+            "image_48": "https://www.example.com/",
+            "image_72": "https://www.example.com/"
+          },
+          "team_id": "T00000000"
+        }
       },
       "username": "",
       "icons": {
@@ -759,7 +774,8 @@
           ],
           "count": 12345
         }
-      ]
+      ],
+      "parent_user_id": "U00000000"
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/channels.replies.json
+++ b/json-logs/samples/api/channels.replies.json
@@ -14,15 +14,35 @@
       "reply_users_count": 12345,
       "latest_reply": "0000000000.000000",
       "reply_users": [
-        "B00000000"
+        "B00000000",
+        "U00000000"
       ],
       "replies": [
         {
           "user": "B00000000",
           "ts": "0000000000.000000"
+        },
+        {
+          "user": "U00000000",
+          "ts": "0000000000.000000"
         }
       ],
-      "subscribed": false
+      "subscribed": false,
+      "team": "T00000000",
+      "bot_profile": {
+        "id": "B00000000",
+        "deleted": false,
+        "name": "",
+        "updated": 12345,
+        "app_id": "A00000000",
+        "icons": {
+          "image_36": "https://www.example.com/",
+          "image_48": "https://www.example.com/",
+          "image_72": "https://www.example.com/"
+        },
+        "team_id": "T00000000"
+      },
+      "parent_user_id": "U00000000"
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -34,7 +34,22 @@
           }
         ],
         "subscribed": false,
-        "last_read": "0000000000.000000"
+        "last_read": "0000000000.000000",
+        "user": "U00000000",
+        "team": "T00000000",
+        "bot_profile": {
+          "id": "B00000000",
+          "deleted": false,
+          "name": "",
+          "updated": 12345,
+          "app_id": "A00000000",
+          "icons": {
+            "image_36": "https://www.example.com/",
+            "image_48": "https://www.example.com/",
+            "image_72": "https://www.example.com/"
+          },
+          "team_id": "T00000000"
+        }
       },
       "username": "",
       "icons": {
@@ -759,7 +774,8 @@
           ],
           "count": 12345
         }
-      ]
+      ],
+      "parent_user_id": "U00000000"
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/conversations.join.json
+++ b/json-logs/samples/api/conversations.join.json
@@ -44,6 +44,12 @@
     ],
     "priority": 12345
   },
+  "warning": "",
+  "response_metadata": {
+    "warnings": [
+      ""
+    ]
+  },
   "error": "",
   "needed": "",
   "provided": ""

--- a/json-logs/samples/api/conversations.open.json
+++ b/json-logs/samples/api/conversations.open.json
@@ -15,13 +15,129 @@
       "ts": "0000000000.000000",
       "username": "",
       "bot_id": "B00000000",
-      "thread_ts": "0000000000.000000"
+      "thread_ts": "0000000000.000000",
+      "blocks": [
+        {
+          "type": "",
+          "elements": [
+            {
+              "type": "",
+              "text": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                }
+              },
+              "placeholder": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "initial_channel": "",
+              "initial_conversation": "",
+              "initial_date": "",
+              "initial_option": {
+                "text": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "min_query_length": 12345,
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 12345,
+              "image_height": 12345,
+              "image_bytes": 12345,
+              "initial_user": ""
+            },
+            {
+              "type": "",
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 12345,
+              "image_height": 12345,
+              "image_bytes": 12345
+            }
+          ],
+          "block_id": "",
+          "fallback": "",
+          "image_url": "",
+          "image_width": 12345,
+          "image_height": 12345,
+          "image_bytes": 12345,
+          "alt_text": "",
+          "title": {
+            "type": "",
+            "text": "",
+            "emoji": false
+          },
+          "text": {
+            "type": "",
+            "text": "",
+            "emoji": false
+          },
+          "fields": [
+            {
+              "type": "",
+              "text": "",
+              "emoji": false,
+              "verbatim": false
+            }
+          ],
+          "accessory": {
+            "type": "",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 12345,
+            "image_height": 12345,
+            "image_bytes": 12345
+          }
+        }
+      ]
     },
     "unread_count": 12345,
     "unread_count_display": 12345,
     "is_open": false,
     "priority": 12345
   },
+  "no_op": false,
+  "already_open": false,
   "error": "",
   "needed": "",
   "provided": ""

--- a/json-logs/samples/api/conversations.replies.json
+++ b/json-logs/samples/api/conversations.replies.json
@@ -12,15 +12,36 @@
       "reply_users_count": 12345,
       "latest_reply": "0000000000.000000",
       "reply_users": [
-        "B00000000"
+        "B00000000",
+        "U00000000"
       ],
       "replies": [
         {
           "user": "B00000000",
           "ts": "0000000000.000000"
+        },
+        {
+          "user": "U00000000",
+          "ts": "0000000000.000000"
         }
       ],
-      "subscribed": false
+      "subscribed": false,
+      "user": "U00000000",
+      "team": "T00000000",
+      "bot_profile": {
+        "id": "B00000000",
+        "deleted": false,
+        "name": "",
+        "updated": 12345,
+        "app_id": "A00000000",
+        "icons": {
+          "image_36": "https://www.example.com/",
+          "image_48": "https://www.example.com/",
+          "image_72": "https://www.example.com/"
+        },
+        "team_id": "T00000000"
+      },
+      "parent_user_id": "U00000000"
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/reactions.get.json
+++ b/json-logs/samples/api/reactions.get.json
@@ -18,7 +18,22 @@
         "count": 12345
       }
     ],
-    "permalink": "https://www.example.com/"
+    "permalink": "https://www.example.com/",
+    "user": "U00000000",
+    "team": "T00000000",
+    "bot_profile": {
+      "id": "B00000000",
+      "deleted": false,
+      "name": "",
+      "updated": 12345,
+      "app_id": "A00000000",
+      "icons": {
+        "image_36": "https://www.example.com/",
+        "image_48": "https://www.example.com/",
+        "image_72": "https://www.example.com/"
+      },
+      "team_id": "T00000000"
+    }
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -499,6 +499,9 @@
         ],
         "subteam": [
           ""
+        ],
+        "type": [
+          ""
         ]
       },
       "channel_email_addresses_enabled": false,
@@ -511,7 +514,19 @@
         "type": [
           ""
         ]
-      }
+      },
+      "who_can_manage_private_channels": {
+        "user": [
+          ""
+        ],
+        "subteam": [
+          ""
+        ],
+        "type": [
+          ""
+        ]
+      },
+      "single_user_exports": false
     },
     "icon": {
       "image_34": "https://www.example.com/",
@@ -762,6 +777,7 @@
   ],
   "url": "",
   "is_europe": false,
+  "accept_tos_url": "https://www.example.com/",
   "error": "",
   "needed": "",
   "provided": ""

--- a/json-logs/samples/api/search.all.json
+++ b/json-logs/samples/api/search.all.json
@@ -1160,7 +1160,8 @@
               "image_bytes": 12345
             }
           }
-        ]
+        ],
+        "no_reactions": false
       }
     ]
   },

--- a/json-logs/samples/api/search.messages.json
+++ b/json-logs/samples/api/search.messages.json
@@ -1055,7 +1055,8 @@
               }
             }
           ]
-        }
+        },
+        "no_reactions": false
       }
     ]
   },

--- a/json-logs/samples/api/users.profile.get.json
+++ b/json-logs/samples/api/users.profile.get.json
@@ -30,7 +30,10 @@
     "image_192": "https://www.example.com/",
     "image_512": "https://www.example.com/",
     "image_1024": "https://www.example.com/",
-    "status_text_canonical": ""
+    "status_text_canonical": "",
+    "api_app_id": "A00000000",
+    "always_active": false,
+    "bot_id": "B00000000"
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/views.publish.json
+++ b/json-logs/samples/api/views.publish.json
@@ -1,6 +1,11 @@
 {
   "ok": false,
   "error": "",
+  "response_metadata": {
+    "messages": [
+      ""
+    ]
+  },
   "needed": "",
   "provided": ""
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
@@ -60,7 +60,7 @@ public class AsyncRateLimitExecutor {
         final String teamId = token != null ? teamIdCache.lookupOrResolve(token) : null;
         final ExecutorService executorService = teamId != null ? ThreadPools.getOrCreate(config, teamId) : ThreadPools.getDefault(config);
         return CompletableFuture.supplyAsync(() -> {
-            if (NO_TOKEN_METHOD_NAMES.contains(methodName)) {
+            if (NO_TOKEN_METHOD_NAMES.contains(methodName) || teamId == null) {
                 return runWithoutQueue(teamId, methodName, methodsSupplier);
             } else {
                 String messageId = generateMessageId();

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatDeleteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatDeleteRequest.java
@@ -1,8 +1,7 @@
 package com.slack.api.methods.request.chat;
 
 import com.slack.api.methods.SlackApiRequest;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 @Data
 @Builder
@@ -28,5 +27,23 @@ public class ChatDeleteRequest implements SlackApiRequest {
      * [Bot users](/bot-users) in this context are considered authed users.
      * If unused or false, the message will be deleted with `chat:write:bot` scope.
      */
-    private boolean asUser;
+    /**
+     * Pass true to post the message as the authed user, instead of as a bot.
+     * Defaults to false. See [authorship](#authorship) below.
+     * <p>
+     * NOTE: The default value is intentionally null to support workplace apps.
+     */
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private Boolean asUser;
+
+    // NOTE: The default value is intentionally null to support workplace apps.
+    public Boolean isAsUser() {
+        return this.asUser;
+    }
+
+    // NOTE: The default value is intentionally null to support workplace apps.
+    public void setAsUser(Boolean asUser) {
+        this.asUser = asUser;
+    }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatPostEphemeralRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatPostEphemeralRequest.java
@@ -3,8 +3,7 @@ package com.slack.api.methods.request.chat;
 import com.slack.api.methods.SlackApiRequest;
 import com.slack.api.model.Attachment;
 import com.slack.api.model.block.LayoutBlock;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.util.List;
 
@@ -35,9 +34,24 @@ public class ChatPostEphemeralRequest implements SlackApiRequest {
     private String user;
 
     /**
-     * Pass true to post the message as the authed bot. Defaults to false.
+     * Pass true to post the message as the authed user, instead of as a bot.
+     * Defaults to false. See [authorship](#authorship) below.
+     * <p>
+     * NOTE: The default value is intentionally null to support workplace apps.
      */
-    private boolean asUser;
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private Boolean asUser;
+
+    // NOTE: The default value is intentionally null to support workplace apps.
+    public Boolean isAsUser() {
+        return this.asUser;
+    }
+
+    // NOTE: The default value is intentionally null to support workplace apps.
+    public void setAsUser(Boolean asUser) {
+        this.asUser = asUser;
+    }
 
     /**
      * A JSON-based array of structured blocks, presented as a URL-encoded string.

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUpdateRequest.java
@@ -3,8 +3,7 @@ package com.slack.api.methods.request.chat;
 import com.slack.api.methods.SlackApiRequest;
 import com.slack.api.model.Attachment;
 import com.slack.api.model.block.LayoutBlock;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.util.List;
 
@@ -40,9 +39,24 @@ public class ChatUpdateRequest implements SlackApiRequest {
     private String user;
 
     /**
-     * Pass true to post the message as the authed bot. Defaults to false.
+     * Pass true to post the message as the authed user, instead of as a bot.
+     * Defaults to false. See [authorship](#authorship) below.
+     * <p>
+     * NOTE: The default value is intentionally null to support workplace apps.
      */
-    private boolean asUser;
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private Boolean asUser;
+
+    // NOTE: The default value is intentionally null to support workplace apps.
+    public Boolean isAsUser() {
+        return this.asUser;
+    }
+
+    // NOTE: The default value is intentionally null to support workplace apps.
+    public void setAsUser(Boolean asUser) {
+        this.asUser = asUser;
+    }
 
     /**
      * A JSON-based array of structured blocks, presented as a URL-encoded string.

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatDeleteResponse.java
@@ -11,6 +11,7 @@ public class ChatDeleteResponse implements SlackApiResponse {
     private String error;
     private String needed;
     private String provided;
+    private String deprecatedArgument;
 
     private String channel;
     private String ts;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatPostEphemeralResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatPostEphemeralResponse.java
@@ -11,6 +11,7 @@ public class ChatPostEphemeralResponse implements SlackApiResponse {
     private String error;
     private String needed;
     private String provided;
+    private String deprecatedArgument;
 
     private String messageTs;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatPostMessageResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatPostMessageResponse.java
@@ -13,6 +13,7 @@ public class ChatPostMessageResponse implements SlackApiResponse {
     private String error;
     private String needed;
     private String provided;
+    private String deprecatedArgument;
 
     private ErrorResponseMetadata responseMetadata;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatUpdateResponse.java
@@ -12,6 +12,7 @@ public class ChatUpdateResponse implements SlackApiResponse {
     private String error;
     private String needed;
     private String provided;
+    private String deprecatedArgument;
 
     private String channel;
     private String ts;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsCloseResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsCloseResponse.java
@@ -11,4 +11,6 @@ public class ConversationsCloseResponse implements SlackApiResponse {
     private String error;
     private String needed;
     private String provided;
+    private Boolean noOp;
+    private Boolean alreadyClosed;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsJoinResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsJoinResponse.java
@@ -2,6 +2,7 @@ package com.slack.api.methods.response.conversations;
 
 import com.slack.api.methods.SlackApiResponse;
 import com.slack.api.model.Conversation;
+import com.slack.api.model.WarningResponseMetadata;
 import lombok.Data;
 
 @Data
@@ -14,4 +15,5 @@ public class ConversationsJoinResponse implements SlackApiResponse {
     private String provided;
 
     private Conversation channel;
+    private WarningResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsGetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsGetResponse.java
@@ -1,6 +1,7 @@
 package com.slack.api.methods.response.reactions;
 
 import com.slack.api.methods.SlackApiResponse;
+import com.slack.api.model.BotProfile;
 import com.slack.api.model.Reaction;
 import lombok.Data;
 
@@ -25,8 +26,11 @@ public class ReactionsGetResponse implements SlackApiResponse {
         private String subtype;
         private String text;
         private String ts;
+        private String user;
         private String username;
+        private String team;
         private String botId;
+        private BotProfile botProfile;
         private String permalink;
         private List<Reaction> reactions;
     }

--- a/slack-api-client/src/test/java/test_locally/api/methods/FieldValidation_a_to_c_Test.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/FieldValidation_a_to_c_Test.java
@@ -230,11 +230,11 @@ public class FieldValidation_a_to_c_Test {
         String prefix = "chat.";
         {
             ChatPostEphemeralResponse obj = parse(prefix + "postEphemeral", ChatPostEphemeralResponse.class);
-            verifyIfAllGettersReturnNonNull(obj, "getWarning", "getChannel");
+            verifyIfAllGettersReturnNonNull(obj, "getWarning", "getChannel", "getDeprecatedArgument");
         }
         {
             ChatPostMessageResponse obj = parse(prefix + "postMessage", ChatPostMessageResponse.class);
-            verifyIfAllGettersReturnNonNull(obj);
+            verifyIfAllGettersReturnNonNull(obj, "getDeprecatedArgument", "getWarning");
             validateMessage(obj.getMessage());
             verifyIfAllGettersReturnNonNull(obj.getResponseMetadata());
         }
@@ -244,7 +244,7 @@ public class FieldValidation_a_to_c_Test {
     public void chat_update() throws Exception {
         String prefix = "chat.";
         ChatUpdateResponse obj = parse(prefix + "update", ChatUpdateResponse.class);
-        verifyIfAllGettersReturnNonNull(obj);
+        verifyIfAllGettersReturnNonNull(obj, "getDeprecatedArgument", "getWarning");
         verifyIfAllGettersReturnNonNullRecursively(obj.getMessage(),
                 "getTs",
                 "getAttachments",
@@ -283,7 +283,7 @@ public class FieldValidation_a_to_c_Test {
     public void chat_delete() throws Exception {
         String prefix = "chat.";
         ChatDeleteResponse obj = parse(prefix + "delete", ChatDeleteResponse.class);
-        verifyIfAllGettersReturnNonNull(obj);
+        verifyIfAllGettersReturnNonNull(obj, "getDeprecatedArgument", "getWarning");
     }
 
     @Test
@@ -378,7 +378,7 @@ public class FieldValidation_a_to_c_Test {
         }
         {
             ConversationsCloseResponse obj = parse(prefix + "close", ConversationsCloseResponse.class);
-            verifyIfAllGettersReturnNonNull(obj);
+            verifyIfAllGettersReturnNonNull(obj, "getNoOp", "getWarning", "getAlreadyClosed");
         }
         {
             ConversationsCreateResponse obj = parse(prefix + "create", ConversationsCreateResponse.class);

--- a/slack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
@@ -31,7 +31,8 @@ public class IncomingWebhooksTest {
     // String url = "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX";
     String url = System.getenv(Constants.SLACK_SDK_TEST_INCOMING_WEBHOOK_URL);
     String channel = System.getenv(Constants.SLACK_SDK_TEST_INCOMING_WEBHOOK_CHANNEL_NAME);
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
@@ -246,11 +247,27 @@ public class IncomingWebhooksTest {
         assertThat(response.getCode(), is(200));
     }
 
+    @Test
+    public void testWithThreads_bot() throws Exception {
+        ChatPostMessageResponse chatPostMessageResponse = slack.methods().chatPostMessage(r ->
+                r.token(botToken).channel(channel).text("[thread] Hello"));
+        assertThat(chatPostMessageResponse.getError(), is(nullValue()));
+
+        Payload payload = Payload.builder()
+                .threadTs(chatPostMessageResponse.getMessage().getTs())
+                .text("Reply via Incoming Webhook!").build();
+
+        WebhookResponse response = slack.send(url, payload);
+        log.info(response.toString());
+
+        assertThat(response.getBody(), is("ok"));
+        assertThat(response.getCode(), is(200));
+    }
 
     @Test
-    public void testWithThreads() throws Exception {
+    public void testWithThreads_user() throws Exception {
         ChatPostMessageResponse chatPostMessageResponse = slack.methods().chatPostMessage(r ->
-                r.token(token).channel(channel).text("[thread] Hello"));
+                r.token(userToken).channel(channel).text("[thread] Hello"));
         assertThat(chatPostMessageResponse.getError(), is(nullValue()));
 
         Payload payload = Payload.builder()

--- a/slack-api-client/src/test/java/test_with_remote_apis/SimpleExampleTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/SimpleExampleTest.java
@@ -32,16 +32,16 @@ public class SimpleExampleTest {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
 
     @Test
     public void postAMessageToRandomChannel() throws IOException, SlackApiException, InterruptedException {
 
         // find all channels in the team
-        ConversationsListResponse channelsResponse = slack.methods().conversationsList(r -> r.token(token));
+        ConversationsListResponse channelsResponse = slack.methods().conversationsList(r -> r.token(botToken));
         assertThat(channelsResponse.isOk(), is(true));
         // find #random
-        List<Conversation> channels_ = slack.methods().conversationsList(r -> r.token(token)).getChannels();
+        List<Conversation> channels_ = slack.methods().conversationsList(r -> r.token(botToken)).getChannels();
         Conversation random = null;
         for (Conversation c : channels_) {
             if (c.getName().equals("random")) {
@@ -52,7 +52,7 @@ public class SimpleExampleTest {
 
         // https://slack.com/api/chat.postMessage
         ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
-                .token(token)
+                .token(botToken)
                 .channel(random.getId())
                 .text("Hello World!")
                 .build());
@@ -65,7 +65,7 @@ public class SimpleExampleTest {
         Thread.sleep(1000L);
 
         ChatDeleteResponse deleteResponse = slack.methods().chatDelete(ChatDeleteRequest.builder()
-                .token(token)
+                .token(botToken)
                 .channel(random.getId())
                 .ts(messageTimestamp)
                 .build());

--- a/slack-api-client/src/test/java/test_with_remote_apis/UnnecessaryChannelsCleanerTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/UnnecessaryChannelsCleanerTest.java
@@ -25,6 +25,8 @@ public class UnnecessaryChannelsCleanerTest {
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
 
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+
     @AfterClass
     public static void tearDown() throws InterruptedException {
         SlackTestConfig.awaitCompletion(testConfig);
@@ -33,17 +35,17 @@ public class UnnecessaryChannelsCleanerTest {
     @Ignore
     @Test
     public void deleteUnnecessaryPublicChannels() throws Exception {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
-        for (Channel channel : slack.methods().channelsList(r -> r
-                .token(token)
+        for (Conversation channel : slack.methods().conversationsList(r -> r
+                .token(botToken)
+                .types(Arrays.asList(ConversationType.PUBLIC_CHANNEL))
                 .excludeArchived(true)
-                .limit(1000)).getChannels()) {
+                .limit(5000)).getChannels()) {
 
             log.info(channel.toString());
 
             if (channel.getName().startsWith("test") && !channel.isGeneral()) {
-                ChannelsArchiveResponse resp = slack.methods().channelsArchive(r -> r
-                        .token(token).channel(channel.getId()));
+                ConversationsArchiveResponse resp = slack.methods().conversationsArchive(r -> r
+                        .token(botToken).channel(channel.getId()));
                 assertThat(resp.getError(), is(nullValue()));
             }
         }
@@ -52,9 +54,8 @@ public class UnnecessaryChannelsCleanerTest {
     @Ignore
     @Test
     public void deleteUnnecessaryPrivateChannels() throws Exception {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
         for (Conversation channel : slack.methods().conversationsList(r -> r
-                .token(token)
+                .token(botToken)
                 .excludeArchived(true)
                 .limit(1000)
                 .types(Arrays.asList(ConversationType.PRIVATE_CHANNEL))).getChannels()) {
@@ -64,7 +65,7 @@ public class UnnecessaryChannelsCleanerTest {
             if ((channel.getName().startsWith("test") || channel.getName().startsWith("secret-"))
                     && !channel.isGeneral()) {
                 ConversationsArchiveResponse resp = slack.methods().conversationsArchive(r -> r
-                        .token(token)
+                        .token(botToken)
                         .channel(channel.getId()));
                 assertThat(resp.getError(), is(nullValue()));
             }

--- a/slack-api-client/src/test/java/test_with_remote_apis/UserDefinedMethodsTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/UserDefinedMethodsTest.java
@@ -30,6 +30,7 @@ public class UserDefinedMethodsTest {
         private String user;
         private String teamId;
         private String userId;
+        private String botId;
     }
 
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
@@ -40,14 +41,14 @@ public class UserDefinedMethodsTest {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
 
     @Test
     public void runMethods() throws IOException, SlackApiException {
         MyResponse response = slack.methods().postFormWithTokenAndParseResponse(
                 f -> f.add("something", "important"), // request body
                 "auth.test", // endpoint
-                token, // xoxb-***
+                botToken, // xoxb-***
                 MyResponse.class // response class
         );
         assertThat(response.getError(), is(nullValue()));

--- a/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
@@ -34,17 +34,17 @@ public class ApiTest {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN);
+    String orgAdminUserToken = System.getenv(Constants.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN);
 
     @Test
     public void getSchemas() throws IOException, AuditApiException {
-        if (token != null) {
+        if (orgAdminUserToken != null) {
             {
-                SchemasResponse response = slack.audit(token).getSchemas();
+                SchemasResponse response = slack.audit(orgAdminUserToken).getSchemas();
                 assertThat(response, is(notNullValue()));
             }
             {
-                SchemasResponse response = slack.audit(token).getSchemas(req -> req);
+                SchemasResponse response = slack.audit(orgAdminUserToken).getSchemas(req -> req);
                 assertThat(response, is(notNullValue()));
             }
         }
@@ -64,13 +64,13 @@ public class ApiTest {
 
     @Test
     public void getActions() throws IOException, AuditApiException {
-        if (token != null) {
+        if (orgAdminUserToken != null) {
             {
-                ActionsResponse response = slack.audit(token).getActions();
+                ActionsResponse response = slack.audit(orgAdminUserToken).getActions();
                 assertThat(response, is(notNullValue()));
             }
             {
-                ActionsResponse response = slack.audit(token).getActions(req -> req);
+                ActionsResponse response = slack.audit(orgAdminUserToken).getActions(req -> req);
                 assertThat(response, is(notNullValue()));
             }
         }
@@ -135,8 +135,8 @@ public class ApiTest {
 
     @Test
     public void getLogs() throws IOException, AuditApiException {
-        if (token != null) {
-            LogsResponse response = slack.audit(token).getLogs(req ->
+        if (orgAdminUserToken != null) {
+            LogsResponse response = slack.audit(orgAdminUserToken).getLogs(req ->
                     req.oldest(1521214343).action(Actions.User.user_login).limit(10));
             assertThat(response, is(notNullValue()));
         }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/BlockKit_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/BlockKit_Test.java
@@ -38,7 +38,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BlockKit_Test {
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
 
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
@@ -55,7 +55,7 @@ public class BlockKit_Test {
         if (randomChannelId == null) {
             String channelId = null;
             ConversationsListResponse conversations = slack.methods().conversationsList(req -> req
-                    .token(token)
+                    .token(botToken)
                     .types(Arrays.asList(ConversationType.PUBLIC_CHANNEL))
                     .excludeArchived(true)
                     .limit(100));
@@ -79,14 +79,14 @@ public class BlockKit_Test {
         // ephemeral message creation
         {
             String userId = slack.methods().conversationsMembers(ConversationsMembersRequest.builder()
-                    .token(token)
+                    .token(botToken)
                     .channel(randomChannelId)
                     .build()
             ).getMembers().get(0);
 
             ChatPostEphemeralRequest request = ChatPostEphemeralRequest.builder()
                     .channel(randomChannelId)
-                    .token(token)
+                    .token(botToken)
                     .user(userId)
                     .text("Example message")
                     .blocks(blocks)
@@ -103,7 +103,7 @@ public class BlockKit_Test {
         {
             ChatPostMessageRequest request = ChatPostMessageRequest.builder()
                     .channel("random")
-                    .token(token)
+                    .token(botToken)
                     .text("Example message")
                     .blocks(blocks)
                     .build();
@@ -122,7 +122,7 @@ public class BlockKit_Test {
         newBlocks.add(SectionBlock.builder().text(MarkdownTextObject.builder().text("Added section!").build()).build());
         {
             ChatUpdateRequest request = ChatUpdateRequest.builder()
-                    .token(token)
+                    .token(botToken)
                     .text("Modified text")
                     .channel(postResponse.getChannel())
                     .ts(postResponse.getTs())
@@ -141,14 +141,14 @@ public class BlockKit_Test {
         // ephemeral message creation
         {
             String userId = slack.methods().conversationsMembers(ConversationsMembersRequest.builder()
-                    .token(token)
+                    .token(botToken)
                     .channel(randomChannelId)
                     .build()
             ).getMembers().get(0);
 
             ChatPostEphemeralRequest request = ChatPostEphemeralRequest.builder()
                     .channel(randomChannelId)
-                    .token(token)
+                    .token(botToken)
                     .user(userId)
                     .text("Example message")
                     .blocksAsString(blocksAsString)
@@ -165,7 +165,7 @@ public class BlockKit_Test {
         {
             ChatPostMessageRequest request = ChatPostMessageRequest.builder()
                     .channel("random")
-                    .token(token)
+                    .token(botToken)
                     .text("Example message")
                     .blocksAsString(blocksAsString)
                     .build();
@@ -180,7 +180,7 @@ public class BlockKit_Test {
         // message modification
         {
             ChatUpdateRequest request = ChatUpdateRequest.builder()
-                    .token(token)
+                    .token(botToken)
                     .text("Modified text")
                     .channel(postResponse.getChannel())
                     .ts(postResponse.getTs())
@@ -314,7 +314,7 @@ public class BlockKit_Test {
     @Test
     public void useBlockOps() throws IOException, SlackApiException {
         List<LayoutBlock> blocks = asBlocks(actions(asElements(button(b -> b.text(plainText(pt -> pt.text("foo"))).value("v")))));
-        ChatPostMessageResponse response = slack.methods(token).chatPostMessage(req -> req
+        ChatPostMessageResponse response = slack.methods(botToken).chatPostMessage(req -> req
                 .channel(randomChannelId)
                 .blocks(blocks));
         assertThat(response.getError(), is(nullValue()));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/apps_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/apps_Test.java
@@ -13,14 +13,17 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-// TODO: valid test
 @Slf4j
 public class apps_Test {
 
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
+
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @AfterClass
     public static void tearDown() throws InterruptedException {
@@ -28,18 +31,23 @@ public class apps_Test {
     }
 
     @Test
-    public void appsUninstall() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
-        AppsUninstallResponse response = slack.methods().appsUninstall(req -> req.token(token));
+    public void appsUninstall_bot() throws IOException, SlackApiException {
+        AppsUninstallResponse response = slack.methods().appsUninstall(req -> req.token(botToken));
+        assertThat(response.getError(), is(notNullValue()));
+    }
+
+    @Ignore
+    @Test
+    public void appsUninstall_user() throws IOException, SlackApiException {
+        AppsUninstallResponse response = slack.methods().appsUninstall(req -> req.token(userToken));
         assertThat(response.getError(), is("not_allowed_token_type"));
         assertThat(response.isOk(), is(false));
     }
 
     @Ignore
     @Test
-    public void appsUninstall_async() throws Exception {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
-        AppsUninstallResponse response = slack.methodsAsync().appsUninstall(req -> req.token(token)).get();
+    public void appsUninstall_async_user() throws Exception {
+        AppsUninstallResponse response = slack.methodsAsync().appsUninstall(req -> req.token(userToken)).get();
         assertThat(response.getError(), is("not_allowed_token_type"));
         assertThat(response.isOk(), is(false));
     }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/auth_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/auth_Test.java
@@ -13,6 +13,7 @@ import config.Constants;
 import config.SlackTestConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -30,7 +31,8 @@ public class auth_Test {
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @AfterClass
     public static void tearDown() throws InterruptedException {
@@ -47,8 +49,7 @@ public class auth_Test {
 
     @Test
     public void authTest_user() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
-        AuthTestResponse response = slack.methods().authTest(req -> req.token(token));
+        AuthTestResponse response = slack.methods().authTest(req -> req.token(userToken));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getUrl(), is(notNullValue()));
@@ -56,7 +57,7 @@ public class auth_Test {
 
     @Test
     public void authTest_user_async() throws Exception {
-        AuthTestResponse response = slack.methodsAsync().authTest(req -> req.token(token)).get();
+        AuthTestResponse response = slack.methodsAsync().authTest(req -> req.token(userToken)).get();
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getUrl(), is(notNullValue()));
@@ -64,7 +65,7 @@ public class auth_Test {
 
     @Test
     public void authTest_user_2() throws IOException, SlackApiException {
-        AuthTestResponse response = slack.methods(token).authTest(req -> req);
+        AuthTestResponse response = slack.methods(userToken).authTest(req -> req);
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getUrl(), is(notNullValue()));
@@ -72,7 +73,7 @@ public class auth_Test {
 
     @Test
     public void authTest_user_2_async() throws Exception {
-        AuthTestResponse response = slack.methodsAsync(token).authTest(req -> req).get();
+        AuthTestResponse response = slack.methodsAsync(userToken).authTest(req -> req).get();
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getUrl(), is(notNullValue()));
@@ -80,8 +81,7 @@ public class auth_Test {
 
     @Test
     public void authTest_bot() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
-        AuthTestResponse response = slack.methods(token).authTest(req -> req);
+        AuthTestResponse response = slack.methods(botToken).authTest(req -> req);
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getUrl(), is(notNullValue()));
@@ -89,8 +89,7 @@ public class auth_Test {
 
     @Test
     public void authTest_bot_async() throws Exception {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
-        AuthTestResponse response = slack.methodsAsync(token).authTest(req -> req).get();
+        AuthTestResponse response = slack.methodsAsync(botToken).authTest(req -> req).get();
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getUrl(), is(notNullValue()));
@@ -98,8 +97,8 @@ public class auth_Test {
 
     @Test
     public void authTest_grid() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN);
-        AuthTestResponse response = slack.methods().authTest(req -> req.token(token));
+        String gridAdminToken = System.getenv(Constants.SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN);
+        AuthTestResponse response = slack.methods().authTest(req -> req.token(gridAdminToken));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getUrl(), is(notNullValue()));
@@ -108,8 +107,8 @@ public class auth_Test {
 
     @Test
     public void authTest_grid_async() throws Exception {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN);
-        AuthTestResponse response = slack.methodsAsync().authTest(req -> req.token(token)).get();
+        String gridAdminToken = System.getenv(Constants.SLACK_SDK_TEST_GRID_WORKSPACE_ADMIN_USER_TOKEN);
+        AuthTestResponse response = slack.methodsAsync().authTest(req -> req.token(gridAdminToken)).get();
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getUrl(), is(notNullValue()));
@@ -124,12 +123,13 @@ public class auth_Test {
         slack.methods().authTest(req -> req);
     }
 
+    @Ignore
     @Test
     public void authTest_burst() throws Exception {
-        AuthTestResponse authTest = slack.methodsAsync(token).authTest(r -> r).get();
+        AuthTestResponse authTest = slack.methodsAsync(botToken).authTest(r -> r).get();
         List<CompletableFuture<AuthTestResponse>> futures = new ArrayList<>();
         for (int i = 0; i < 300; i++) {
-            futures.add(slack.methodsAsync(token).authTest(r -> r));
+            futures.add(slack.methodsAsync(botToken).authTest(r -> r));
         }
 
         boolean currentQueueSizeWorking = false;
@@ -152,14 +152,15 @@ public class auth_Test {
         assertThat(stats.getRateLimitedMethods().containsKey("auth.test"), is(false));
     }
 
+    @Ignore
     @Test
     public void lastMinuteRequests() throws Exception {
-        String teamId = slack.methods().authTest(r -> r.token(token)).getTeamId();
+        String teamId = slack.methods().authTest(r -> r.token(botToken)).getTeamId();
         MethodsStats before = testConfig.getMetricsDatastore().getStats(teamId);
 
-        AuthTestResponse sync = slack.methods().authTest(r -> r.token(token));
+        AuthTestResponse sync = slack.methods().authTest(r -> r.token(botToken));
         assertThat(sync.getError(), is(nullValue()));
-        AuthTestResponse async = slack.methodsAsync().authTest(r -> r.token(token)).get();
+        AuthTestResponse async = slack.methodsAsync().authTest(r -> r.token(botToken)).get();
         assertThat(async.getError(), is(nullValue()));
 
         MethodsStats after = testConfig.getMetricsDatastore().getStats(teamId);

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/bots_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/bots_Test.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Slf4j
 public class bots_Test {
 
-    static String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    static String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
 
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
@@ -45,7 +45,7 @@ public class bots_Test {
     @BeforeClass
     public static void loadBotId() throws IOException, SlackApiException {
         if (cachedBotId == null) {
-            List<User> users = slack.methods(token).usersList(req -> req).getMembers();
+            List<User> users = slack.methods(botToken).usersList(req -> req).getMembers();
             User user = null;
             for (User u : users) {
                 if (u.isBot() && !"USLACKBOT".equals(u.getId())) {
@@ -74,7 +74,7 @@ public class bots_Test {
     @Test
     public void botsInfo() throws IOException, SlackApiException {
         String botId = findBotId();
-        BotsInfoResponse response = slack.methods(token).botsInfo(req -> req.bot(botId));
+        BotsInfoResponse response = slack.methods(botToken).botsInfo(req -> req.bot(botId));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getBot(), is(notNullValue()));
@@ -83,7 +83,7 @@ public class bots_Test {
     @Test
     public void botsInfo_async() throws Exception {
         String botId = findBotId();
-        BotsInfoResponse response = slack.methodsAsync(token).botsInfo(req -> req.bot(botId)).get();
+        BotsInfoResponse response = slack.methodsAsync(botToken).botsInfo(req -> req.bot(botId)).get();
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getBot(), is(notNullValue()));
@@ -92,7 +92,7 @@ public class bots_Test {
     @Test(expected = ExecutionException.class)
     public void botsInfo_async_error() throws Exception {
         String botId = findBotId();
-        brokenSlack.methodsAsync(token).botsInfo(req -> req.bot(botId)).get();
+        brokenSlack.methodsAsync(botToken).botsInfo(req -> req.bot(botId)).get();
     }
 
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
@@ -5,12 +5,10 @@ import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import com.slack.api.methods.request.chat.ChatUnfurlRequest;
 import com.slack.api.methods.request.chat.ChatUpdateRequest;
-import com.slack.api.methods.response.channels.ChannelsListResponse;
 import com.slack.api.methods.response.chat.*;
 import com.slack.api.methods.response.conversations.ConversationsListResponse;
 import com.slack.api.methods.response.conversations.ConversationsMembersResponse;
 import com.slack.api.model.Attachment;
-import com.slack.api.model.Channel;
 import com.slack.api.model.Conversation;
 import com.slack.api.model.User;
 import com.slack.api.model.block.DividerBlock;
@@ -34,7 +32,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Slf4j
 public class chat_Test {
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
@@ -48,7 +47,8 @@ public class chat_Test {
 
     void loadRandomChannelId() throws IOException, SlackApiException {
         if (randomChannelId == null) {
-            ConversationsListResponse channelsListResponse = slack.methods().conversationsList(r -> r.token(token).excludeArchived(true).limit(100));
+            ConversationsListResponse channelsListResponse =
+                    slack.methods().conversationsList(r -> r.token(botToken).excludeArchived(true).limit(100));
             assertThat(channelsListResponse.getError(), is(nullValue()));
             for (Conversation channel : channelsListResponse.getChannels()) {
                 if (channel.getName().equals("random")) {
@@ -144,9 +144,18 @@ public class chat_Test {
             "]";
 
     @Test
-    public void postMessage() throws Exception {
+    public void postMessage_bot() throws Exception {
         loadRandomChannelId();
-        ChatPostMessageResponse response = slack.methods(token).chatPostMessage(req -> req
+        ChatPostMessageResponse response = slack.methods(botToken).chatPostMessage(req -> req
+                .channel(randomChannelId)
+                .text("You can also do slack.methods(token)"));
+        assertThat(response.getError(), is(nullValue()));
+    }
+
+    @Test
+    public void postMessage_user() throws Exception {
+        loadRandomChannelId();
+        ChatPostMessageResponse response = slack.methods(userToken).chatPostMessage(req -> req
                 .channel(randomChannelId)
                 .text("You can also do slack.methods(token)"));
         assertThat(response.getError(), is(nullValue()));
@@ -154,11 +163,11 @@ public class chat_Test {
 
     // https://github.com/slackapi/java-slack-sdk/issues/157
     @Test
-    public void postMessage_blocksInAttachment_do_not_work() throws Exception {
+    public void postMessage_blocksInAttachment_do_not_work_bot() throws Exception {
         loadRandomChannelId();
         ChatPostMessageResponse firstMessageCreation = slack.methods().chatPostMessage(req -> req
                 .channel(randomChannelId)
-                .token(token)
+                .token(botToken)
                 .attachments(Arrays.asList(
                         Attachment
                                 .builder()
@@ -171,10 +180,26 @@ public class chat_Test {
     }
 
     @Test
-    public void chat_getPermalink() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    public void postMessage_blocksInAttachment_do_not_work_user() throws Exception {
+        loadRandomChannelId();
+        ChatPostMessageResponse firstMessageCreation = slack.methods().chatPostMessage(req -> req
+                .channel(randomChannelId)
+                .token(userToken)
+                .attachments(Arrays.asList(
+                        Attachment
+                                .builder()
+                                .id(123)
+                                .callbackId("callback")
+                                .title("hi")
+                                .blocks(Arrays.asList(DividerBlock.builder().blockId("123").build()))
+                                .build())));
+        assertThat(firstMessageCreation.getError(), is("invalid_attachments"));
+    }
+
+    @Test
+    public void chat_getPermalink_bot() throws IOException, SlackApiException {
         ConversationsListResponse channels = slack.methods().conversationsList(req -> req
-                .token(token)
+                .token(botToken)
                 .excludeArchived(true));
         assertThat(channels.getError(), is(nullValue()));
         assertThat(channels.isOk(), is(true));
@@ -183,14 +208,14 @@ public class chat_Test {
 
         ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(req -> req
                 .channel(channelId)
-                .token(token)
+                .token(botToken)
                 .text("Hi, this is a test message from Java Slack SDK's unit tests")
                 .linkNames(true));
         assertThat(postResponse.getError(), is(nullValue()));
         assertThat(postResponse.isOk(), is(true));
 
         ChatGetPermalinkResponse permalink = slack.methods().chatGetPermalink(req -> req
-                .token(token)
+                .token(botToken)
                 .channel(channelId)
                 .messageTs(postResponse.getTs()));
         assertThat(permalink.getError(), is(nullValue()));
@@ -199,10 +224,36 @@ public class chat_Test {
     }
 
     @Test
-    public void chat_getPermalink_async() throws ExecutionException, InterruptedException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    public void chat_getPermalink_user() throws IOException, SlackApiException {
+        ConversationsListResponse channels = slack.methods().conversationsList(req -> req
+                .token(userToken)
+                .excludeArchived(true));
+        assertThat(channels.getError(), is(nullValue()));
+        assertThat(channels.isOk(), is(true));
+
+        String channelId = channels.getChannels().get(0).getId();
+
+        ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(req -> req
+                .channel(channelId)
+                .token(userToken)
+                .text("Hi, this is a test message from Java Slack SDK's unit tests")
+                .linkNames(true));
+        assertThat(postResponse.getError(), is(nullValue()));
+        assertThat(postResponse.isOk(), is(true));
+
+        ChatGetPermalinkResponse permalink = slack.methods().chatGetPermalink(req -> req
+                .token(userToken)
+                .channel(channelId)
+                .messageTs(postResponse.getTs()));
+        assertThat(permalink.getError(), is(nullValue()));
+        assertThat(permalink.isOk(), is(true));
+        assertThat(permalink.getPermalink(), is(notNullValue()));
+    }
+
+    @Test
+    public void chat_getPermalink_bot_async() throws ExecutionException, InterruptedException {
         ConversationsListResponse channels = slack.methodsAsync().conversationsList(req -> req
-                .token(token)
+                .token(botToken)
                 .excludeArchived(true))
                 .get();
         assertThat(channels.getError(), is(nullValue()));
@@ -212,7 +263,7 @@ public class chat_Test {
 
         ChatPostMessageResponse postResponse = slack.methodsAsync().chatPostMessage(req -> req
                 .channel(channelId)
-                .token(token)
+                .token(botToken)
                 .text("Hi, this is a test message from Java Slack SDK's unit tests")
                 .linkNames(true))
                 .get();
@@ -220,7 +271,7 @@ public class chat_Test {
         assertThat(postResponse.isOk(), is(true));
 
         ChatGetPermalinkResponse permalink = slack.methodsAsync().chatGetPermalink(req -> req
-                .token(token)
+                .token(botToken)
                 .channel(channelId)
                 .messageTs(postResponse.getTs()))
                 .get();
@@ -246,7 +297,7 @@ public class chat_Test {
 
     private void makeSureIfGivingChannelNameWorks(String channelName) throws IOException, SlackApiException {
         ChatPostMessageResponse response = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
-                .token(token)
+                .token(botToken)
                 .channel(channelName)
                 .text("Hello!")
                 .build());
@@ -259,12 +310,12 @@ public class chat_Test {
     // NOTE: You need to add "youtube.com" at
     // Features > Event Subscriptions > App Unfurl Domains
     @Test
-    public void unfurl_raw_json() throws Exception {
+    public void unfurl_raw_json_bot() throws Exception {
         loadRandomChannelId();
 
         String url = "https://www.youtube.com/watch?v=wq1R93UMqlk";
         ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
-                .token(token)
+                .token(userToken)
                 .channel(randomChannelId)
                 .text(url)
                 .unfurlLinks(true)
@@ -279,7 +330,36 @@ public class chat_Test {
         unfurls.put(url, detail);
 
         ChatUnfurlResponse unfurlResponse = slack.methods().chatUnfurl(ChatUnfurlRequest.builder()
-                .token(token)
+                .token(botToken)
+                .channel(randomChannelId)
+                .ts(ts)
+                .rawUnfurls(GsonFactory.createSnakeCase().toJson(unfurls))
+                .build());
+        assertThat(unfurlResponse.getError(), is(nullValue()));
+    }
+
+    @Test
+    public void unfurl_raw_json_user() throws Exception {
+        loadRandomChannelId();
+
+        String url = "https://www.youtube.com/watch?v=wq1R93UMqlk";
+        ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+                .token(userToken)
+                .channel(randomChannelId)
+                .text(url)
+                .unfurlLinks(true)
+                .unfurlMedia(true)
+                .build());
+        assertThat(postResponse.getError(), is(nullValue()));
+
+        String ts = postResponse.getTs();
+        Map<String, ChatUnfurlRequest.UnfurlDetail> unfurls = new HashMap<>();
+        ChatUnfurlRequest.UnfurlDetail detail = new ChatUnfurlRequest.UnfurlDetail();
+        detail.setText("Every day is the test.");
+        unfurls.put(url, detail);
+
+        ChatUnfurlResponse unfurlResponse = slack.methods().chatUnfurl(ChatUnfurlRequest.builder()
+                .token(userToken)
                 .channel(randomChannelId)
                 .ts(ts)
                 .rawUnfurls(GsonFactory.createSnakeCase().toJson(unfurls))
@@ -295,7 +375,7 @@ public class chat_Test {
 
         String url = "https://www.youtube.com/watch?v=wq1R93UMqlk";
         ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
-                .token(token)
+                .token(botToken)
                 .channel(randomChannelId)
                 .text(url)
                 .unfurlLinks(true)
@@ -310,7 +390,7 @@ public class chat_Test {
         unfurls.put(url, detail);
 
         ChatUnfurlResponse unfurlResponse = slack.methods().chatUnfurl(ChatUnfurlRequest.builder()
-                .token(token)
+                .token(botToken)
                 .channel(randomChannelId)
                 .ts(ts)
                 .unfurls(unfurls)
@@ -324,7 +404,7 @@ public class chat_Test {
 
         String url = "https://www.youtube.com/watch?v=wq1R93UMqlk";
         ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
-                .token(token)
+                .token(botToken)
                 .channel(randomChannelId)
                 .text(url)
                 .unfurlLinks(true)
@@ -339,7 +419,7 @@ public class chat_Test {
         unfurls.put(url, detail);
 
         ChatUnfurlResponse unfurlResponse = slack.methods().chatUnfurl(ChatUnfurlRequest.builder()
-                .token(token)
+                .token(botToken)
                 .channel(randomChannelId)
                 .ts(ts)
                 .unfurls(unfurls)
@@ -348,11 +428,20 @@ public class chat_Test {
     }
 
     @Test
-    public void postMessage_blocksAsString() throws Exception {
+    public void chatUpdateWithBotToken_issue_372() throws IOException, SlackApiException {
+        loadRandomChannelId();
+        ChatPostMessageResponse creation = slack.methods(botToken).chatPostMessage(r -> r.channel(randomChannelId).text("This is original"));
+        assertThat(creation.getError(), is(nullValue()));
+        ChatUpdateResponse modified = slack.methods(botToken).chatUpdate(r -> r.channel(randomChannelId).text("modified").ts(creation.getTs()));
+        assertThat(modified.getError(), is(nullValue()));
+    }
+
+    @Test
+    public void postMessage_blocksAsString_bot() throws Exception {
         loadRandomChannelId();
 
         ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
-                .token(token)
+                .token(botToken)
                 .channel(randomChannelId)
                 .text("test")
                 .blocksAsString(blocksAsString)
@@ -361,7 +450,7 @@ public class chat_Test {
 
         ChatUpdateResponse updateMessage = slack.methods().chatUpdate(ChatUpdateRequest.builder()
                 .channel(randomChannelId)
-                .token(token)
+                .token(botToken)
                 .ts(postResponse.getTs())
                 .text("modified")
                 .blocksAsString(blocksAsString)
@@ -371,7 +460,39 @@ public class chat_Test {
         // To show the text instead of blocks
         ChatUpdateResponse updateMessage2 = slack.methods().chatUpdate(ChatUpdateRequest.builder()
                 .channel(randomChannelId)
-                .token(token)
+                .token(botToken)
+                .ts(postResponse.getTs())
+                .blocksAsString("[]")
+                .text("modified2")
+                .build());
+        assertThat(updateMessage2.getError(), is(nullValue()));
+    }
+
+    @Test
+    public void postMessage_blocksAsString_user() throws Exception {
+        loadRandomChannelId();
+
+        ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+                .token(userToken)
+                .channel(randomChannelId)
+                .text("test")
+                .blocksAsString(blocksAsString)
+                .build());
+        assertThat(postResponse.getError(), is(nullValue()));
+
+        ChatUpdateResponse updateMessage = slack.methods().chatUpdate(ChatUpdateRequest.builder()
+                .channel(randomChannelId)
+                .token(userToken)
+                .ts(postResponse.getTs())
+                .text("modified")
+                .blocksAsString(blocksAsString)
+                .build());
+        assertThat(updateMessage.getError(), is(nullValue()));
+
+        // To show the text instead of blocks
+        ChatUpdateResponse updateMessage2 = slack.methods().chatUpdate(ChatUpdateRequest.builder()
+                .channel(randomChannelId)
+                .token(userToken)
                 .ts(postResponse.getTs())
                 .blocksAsString("[]")
                 .text("modified2")
@@ -383,18 +504,18 @@ public class chat_Test {
     public void postEphemeral_thread() throws Exception {
         loadRandomChannelId();
         String userId = findUser();
-        ChatPostMessageResponse first = slack.methods(token).chatPostMessage(r -> r
+        ChatPostMessageResponse first = slack.methods(botToken).chatPostMessage(r -> r
                 .channel(randomChannelId)
                 .text("first message"));
         assertThat(first.getError(), is(nullValue()));
 
-        ChatPostMessageResponse second = slack.methods(token).chatPostMessage(r -> r
+        ChatPostMessageResponse second = slack.methods(botToken).chatPostMessage(r -> r
                 .channel(randomChannelId)
                 .threadTs(first.getTs())
                 .text("reply to create an active thread"));
         assertThat(second.getError(), is(nullValue()));
 
-        ChatPostEphemeralResponse third = slack.methods(token).chatPostEphemeral(r -> r
+        ChatPostEphemeralResponse third = slack.methods(botToken).chatPostEphemeral(r -> r
                 .user(userId)
                 .channel(randomChannelId)
                 .text("ephemeral reply in thread")
@@ -407,7 +528,7 @@ public class chat_Test {
         loadRandomChannelId();
 
         String userId = findUser();
-        ChatPostEphemeralResponse response = slack.methods(token).chatPostEphemeral(r -> r
+        ChatPostEphemeralResponse response = slack.methods(botToken).chatPostEphemeral(r -> r
                 .channel(randomChannelId)
                 .user(userId)
                 .iconEmoji(":wave:")
@@ -420,12 +541,12 @@ public class chat_Test {
 
         String userId = null;
 
-        ConversationsMembersResponse membersResponse = slack.methods(token)
+        ConversationsMembersResponse membersResponse = slack.methods(botToken)
                 .conversationsMembers(r -> r.channel(randomChannelId).limit(100));
         assertThat(membersResponse.getError(), is(nullValue()));
         List<String> userIds = membersResponse.getMembers();
         for (String id : userIds) {
-            User user = slack.methods(token).usersInfo(r -> r.user(id)).getUser();
+            User user = slack.methods(botToken).usersInfo(r -> r.user(id)).getUser();
             if (user.isBot() || user.isAppUser() || user.isDeleted() || user.isWorkflowBot() || user.isStranger()) {
                 continue;
             }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/conversations_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/conversations_Test.java
@@ -31,7 +31,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Slf4j
 public class conversations_Test {
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
 
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
@@ -47,7 +48,7 @@ public class conversations_Test {
         {
             ConversationsListResponse listResponse = slack.methods().conversationsList(
                     ConversationsListRequest.builder()
-                            .token(token)
+                            .token(botToken)
                             .excludeArchived(true)
                             .limit(10)
                             .types(Arrays.asList(ConversationType.PUBLIC_CHANNEL))
@@ -59,7 +60,7 @@ public class conversations_Test {
         }
 
         ConversationsCreateResponse createPublicResponse = slack.methods().conversationsCreate(r -> r
-                .token(token)
+                .token(botToken)
                 .name("test" + System.currentTimeMillis())
                 .isPrivate(false));
         assertThat(createPublicResponse.getError(), is(nullValue()));
@@ -70,7 +71,7 @@ public class conversations_Test {
         Conversation channel = createPublicResponse.getChannel();
 
         ConversationsCreateResponse createPrivateResponse = slack.methods().conversationsCreate(r -> r
-                .token(token)
+                .token(botToken)
                 .name("test" + System.currentTimeMillis())
                 .isPrivate(true));
         assertThat(createPrivateResponse.getError(), is(nullValue()));
@@ -80,7 +81,7 @@ public class conversations_Test {
 
         {
             ConversationsArchiveResponse resp = slack.methods().conversationsArchive(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(createPrivateResponse.getChannel().getId()));
             assertThat(resp.getError(), is(nullValue()));
         }
@@ -91,20 +92,20 @@ public class conversations_Test {
             assertThat(resp.getError(), is(notNullValue()));
 
             resp = slack.methods().conversationsUnarchive(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(createPrivateResponse.getChannel().getId()));
             assertThat(resp.getError(), is(nullValue()));
         }
         {
             ConversationsArchiveResponse resp = slack.methods().conversationsArchive(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(createPrivateResponse.getChannel().getId()));
             assertThat(resp.getError(), is(nullValue()));
         }
 
         {
             ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(createPublicResponse.getChannel().getId())
                     .text("This is a test message posted by unit tests for Java Slack SDK library")
                     .replyBroadcast(false));
@@ -112,7 +113,7 @@ public class conversations_Test {
             assertThat(postMessageResponse.isOk(), is(true));
 
             ChatPostMessageResponse postThread1Response = slack.methods().chatPostMessage(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(createPublicResponse.getChannel().getId())
                     .threadTs(postMessageResponse.getTs())
                     .text("[thread 1] This is a test message posted by unit tests for Java Slack SDK library")
@@ -121,7 +122,7 @@ public class conversations_Test {
             assertThat(postThread1Response.isOk(), is(true));
 
             ChatPostMessageResponse postThread2Response = slack.methods().chatPostMessage(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(createPublicResponse.getChannel().getId())
                     .threadTs(postMessageResponse.getTs())
                     .text("[thread 2] This is a test message posted by unit tests for Java Slack SDK library")
@@ -130,7 +131,7 @@ public class conversations_Test {
             assertThat(postThread2Response.isOk(), is(true));
 
             ConversationsRepliesResponse repliesResponse = slack.methods().conversationsReplies(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(createPublicResponse.getChannel().getId())
                     .ts(postMessageResponse.getTs())
                     .limit(1));
@@ -141,7 +142,7 @@ public class conversations_Test {
 
         {
             ConversationsInfoResponse infoResponse = slack.methods().conversationsInfo(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .includeNumMembers(true)
                     .includeLocale(true));
@@ -159,7 +160,7 @@ public class conversations_Test {
 
         {
             ConversationsInfoResponse infoResponse = slack.methods().conversationsInfo(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .includeNumMembers(false)
                     .includeLocale(false));
@@ -171,7 +172,7 @@ public class conversations_Test {
 
         {
             ConversationsSetPurposeResponse setPurposeResponse = slack.methods().conversationsSetPurpose(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .purpose("purpose"));
             assertThat(setPurposeResponse.getError(), is(nullValue()));
@@ -181,7 +182,7 @@ public class conversations_Test {
 
         {
             ConversationsSetTopicResponse setTopicResponse = slack.methods().conversationsSetTopic(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .topic("topic"));
             assertThat(setTopicResponse.getError(), is(nullValue()));
@@ -191,7 +192,7 @@ public class conversations_Test {
 
         {
             ConversationsHistoryResponse historyResponse = slack.methods().conversationsHistory(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .limit(2));
             assertThat(historyResponse.getError(), is(nullValue()));
@@ -203,7 +204,7 @@ public class conversations_Test {
 
         {
             ConversationsMembersResponse membersResponse = slack.methods().conversationsMembers(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .limit(2));
             assertThat(membersResponse.isOk(), is(true));
@@ -212,7 +213,7 @@ public class conversations_Test {
             assertThat(membersResponse.getResponseMetadata(), is(notNullValue()));
 
             UsersListResponse usersListResponse = slack.methods().usersList(r -> r
-                    .token(token));
+                    .token(botToken));
             String invitee_ = null;
             for (User u : usersListResponse.getMembers()) {
                 if (!"USLACKBOT".equals(u.getId())
@@ -225,14 +226,14 @@ public class conversations_Test {
             String invitee = invitee_;
 
             ConversationsInviteResponse inviteResponse = slack.methods().conversationsInvite(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .users(Arrays.asList(invitee)));
             assertThat(inviteResponse.getError(), is(nullValue()));
             assertThat(inviteResponse.isOk(), is(true));
 
             ConversationsKickResponse kickResponse = slack.methods().conversationsKick(r -> r
-                    .token(token)
+                    .token(userToken)
                     .channel(channel.getId())
                     .user(invitee));
             assertThat(kickResponse.getError(), is(nullValue()));
@@ -241,7 +242,7 @@ public class conversations_Test {
 
         {
             ConversationsLeaveResponse leaveResponse = slack.methods().conversationsLeave(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId()));
             assertThat(leaveResponse.getError(), is(nullValue()));
             assertThat(leaveResponse.isOk(), is(true));
@@ -249,7 +250,7 @@ public class conversations_Test {
 
         {
             ConversationsJoinResponse joinResponse = slack.methods().conversationsJoin(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId()));
             assertThat(joinResponse.getError(), is(nullValue()));
             assertThat(joinResponse.isOk(), is(true));
@@ -257,7 +258,7 @@ public class conversations_Test {
 
         {
             ConversationsRenameResponse renameResponse = slack.methods().conversationsRename(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .name(channel.getName() + "-1"));
             assertThat(renameResponse.getError(), is(nullValue()));
@@ -266,7 +267,7 @@ public class conversations_Test {
 
         {
             ConversationsArchiveResponse archiveResponse = slack.methods().conversationsArchive(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId()));
             assertThat(archiveResponse.getError(), is(nullValue()));
             assertThat(archiveResponse.isOk(), is(true));
@@ -274,7 +275,7 @@ public class conversations_Test {
 
         {
             ConversationsInfoResponse infoResponse = slack.methods().conversationsInfo(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId()));
             assertThat(infoResponse.getError(), is(nullValue()));
             assertThat(infoResponse.isOk(), is(true));
@@ -288,19 +289,19 @@ public class conversations_Test {
     @Test
     public void imConversation() throws IOException, SlackApiException {
 
-        UsersListResponse usersListResponse = slack.methods().usersList(r -> r.token(token));
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r.token(botToken));
         List<User> users = usersListResponse.getMembers();
         String userId = users.get(0).getId();
 
         ConversationsOpenResponse openResponse = slack.methods().conversationsOpen(r -> r
-                .token(token)
+                .token(botToken)
                 .users(Arrays.asList(userId))
                 .returnIm(true));
         assertThat(openResponse.getError(), is(nullValue()));
         assertThat(openResponse.isOk(), is(true));
 
         ConversationsMembersResponse membersResponse = slack.methods().conversationsMembers(r -> r
-                .token(token)
+                .token(botToken)
                 .channel(openResponse.getChannel().getId()));
         assertThat(membersResponse.getError(), is(nullValue()));
         assertThat(membersResponse.isOk(), is(true));
@@ -308,7 +309,7 @@ public class conversations_Test {
         assertThat(membersResponse.getMembers().isEmpty(), is(false));
 
         ConversationsCloseResponse closeResponse = slack.methods().conversationsClose(r ->
-                r.token(token).channel(openResponse.getChannel().getId()));
+                r.token(botToken).channel(openResponse.getChannel().getId()));
         assertThat(closeResponse.isOk(), is(true));
     }
 
@@ -325,13 +326,13 @@ public class conversations_Test {
 
     @Test
     public void postLongText() throws IOException, SlackApiException {
-        TestChannelGenerator channelGenerator = new TestChannelGenerator(testConfig, token);
+        TestChannelGenerator channelGenerator = new TestChannelGenerator(testConfig, botToken);
         Conversation channel = channelGenerator.createNewPublicChannel("test" + System.currentTimeMillis());
 
         // text
         {
             ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .text(longText)
                     .replyBroadcast(false));
@@ -342,7 +343,7 @@ public class conversations_Test {
         // attachments
         {
             ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .attachments(Arrays.asList(Attachment.builder().text(longText).build()))
                     .replyBroadcast(false));
@@ -353,7 +354,7 @@ public class conversations_Test {
         // blocks
         {
             ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channel.getId())
                     .blocks(Arrays.asList(
                             ContextBlock.builder().elements(Arrays.asList(
@@ -373,7 +374,7 @@ public class conversations_Test {
 
     @Test
     public void replies() throws IOException, SlackApiException {
-        TestChannelGenerator channelGenerator = new TestChannelGenerator(testConfig, token);
+        TestChannelGenerator channelGenerator = new TestChannelGenerator(testConfig, botToken);
         Conversation channel = channelGenerator.createNewPublicChannel("test" + System.currentTimeMillis());
 
         try {
@@ -381,7 +382,7 @@ public class conversations_Test {
             // first message
             {
                 ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
-                        .token(token)
+                        .token(botToken)
                         .channel(channel.getId())
                         .text(longText)
                         .replyBroadcast(false));
@@ -393,7 +394,7 @@ public class conversations_Test {
             {
                 for (int idx = 0; idx < 5; idx++) {
                     ChatPostMessageResponse postMessageResponse = slack.methods().chatPostMessage(r -> r
-                            .token(token)
+                            .token(botToken)
                             .channel(channel.getId())
                             .threadTs(threadTs)
                             .text("Say something at " + new Date())
@@ -406,7 +407,7 @@ public class conversations_Test {
             // channels.replies
             {
                 ChannelsRepliesResponse response = slack.methods().channelsReplies(r -> r
-                        .token(token)
+                        .token(botToken)
                         .threadTs(threadTs)
                         .channel(channel.getId()));
                 assertThat(response.getError(), is(nullValue()));
@@ -423,7 +424,7 @@ public class conversations_Test {
             // conversations.replies
             {
                 ConversationsRepliesResponse response = slack.methods().conversationsReplies(r -> r
-                        .token(token)
+                        .token(botToken)
                         .ts(threadTs)
                         .channel(channel.getId()));
                 assertThat(response.getError(), is(nullValue()));
@@ -444,7 +445,7 @@ public class conversations_Test {
 
     @Test
     public void longChannelName_public_ok() throws Exception {
-        TestChannelGenerator channelGenerator = new TestChannelGenerator(testConfig, token);
+        TestChannelGenerator channelGenerator = new TestChannelGenerator(testConfig, botToken);
         String channelName = "test" + System.currentTimeMillis();
         while (channelName.length() < 80) {
             channelName += "_";
@@ -455,7 +456,7 @@ public class conversations_Test {
 
     @Test
     public void longChannelName_private_ok() throws Exception {
-        TestChannelGenerator channelGenerator = new TestChannelGenerator(testConfig, token);
+        TestChannelGenerator channelGenerator = new TestChannelGenerator(testConfig, botToken);
         String channelName = "secret-" + System.currentTimeMillis();
         while (channelName.length() < 80) {
             channelName += "_";
@@ -472,7 +473,7 @@ public class conversations_Test {
         }
         ConversationsCreateResponse createPublicResponse = slack.methods().conversationsCreate(
                 ConversationsCreateRequest.builder()
-                        .token(token)
+                        .token(botToken)
                         .name(channelName)
                         .isPrivate(false)
                         .build());
@@ -487,7 +488,7 @@ public class conversations_Test {
         }
         ConversationsCreateResponse createPublicResponse = slack.methods().conversationsCreate(
                 ConversationsCreateRequest.builder()
-                        .token(token)
+                        .token(botToken)
                         .name(channelName)
                         .isPrivate(true)
                         .build());

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/dialogs_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/dialogs_Test.java
@@ -29,7 +29,7 @@ public class dialogs_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
 
     @Test
     public void open() throws IOException, SlackApiException {
@@ -61,7 +61,7 @@ public class dialogs_Test {
          * seconds of the user action.  Therefore, only an 'invalid trigger' ID response can be tested.
          */
         DialogOpenResponse dialogOpenResponse = slack.methods().dialogOpen(r -> r
-                .token(token)
+                .token(botToken)
                 .triggerId("FAKE_TRIGGER_ID")
                 .dialog(dialog));
         assertThat(dialogOpenResponse.isOk(), is(false));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/dnd_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/dnd_Test.java
@@ -20,7 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Slf4j
 public class dnd_Test {
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
@@ -32,10 +33,10 @@ public class dnd_Test {
 
     @Test
     public void dnd() throws IOException, SlackApiException {
-        List<User> members = slack.methods().usersList(r -> r.token(token).presence(true)).getMembers();
+        List<User> members = slack.methods().usersList(r -> r.token(botToken).presence(true)).getMembers();
         {
             String user = members.get(0).getId();
-            DndInfoResponse response = slack.methods().dndInfo(r -> r.token(token).user(user));
+            DndInfoResponse response = slack.methods().dndInfo(r -> r.token(botToken).user(user));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getNextDndStartTs(), is(notNullValue()));
@@ -46,7 +47,7 @@ public class dnd_Test {
             for (User member : members) {
                 users.add(member.getId());
             }
-            DndTeamInfoResponse response = slack.methods().dndTeamInfo(r -> r.token(token).users(users));
+            DndTeamInfoResponse response = slack.methods().dndTeamInfo(r -> r.token(botToken).users(users));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getUsers(), is(notNullValue()));
@@ -64,7 +65,7 @@ public class dnd_Test {
         }
         {
             DndEndDndResponse response = slack.methods().dndEndDnd(r -> r
-                    .token(token));
+                    .token(userToken));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -81,7 +82,7 @@ public class dnd_Test {
         }
         {
             DndEndSnoozeResponse response = slack.methods().dndEndSnooze(r -> r
-                    .token(token));
+                    .token(userToken));
             assertThat(response.getError(), is("snooze_not_active"));
             assertThat(response.isOk(), is(false));
         }
@@ -95,14 +96,14 @@ public class dnd_Test {
         }
         {
             DndSetSnoozeResponse response = slack.methods().dndSetSnooze(r -> r
-                    .token(token)
+                    .token(userToken)
                     .numMinutes(10));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
         {
             DndEndSnoozeResponse response = slack.methods().dndEndSnooze(r -> r
-                    .token(token));
+                    .token(userToken));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/emoji_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/emoji_Test.java
@@ -26,10 +26,21 @@ public class emoji_Test {
     }
 
     @Test
-    public void emojiList() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    public void emojiList_bot() throws IOException, SlackApiException {
+        String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
         {
-            EmojiListResponse response = slack.methods().emojiList(r -> r.token(token));
+            EmojiListResponse response = slack.methods().emojiList(r -> r.token(botToken));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+            assertThat(response.getEmoji(), is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void emojiList_user() throws IOException, SlackApiException {
+        String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+        {
+            EmojiListResponse response = slack.methods().emojiList(r -> r.token(userToken));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getEmoji(), is(notNullValue()));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/groups_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/groups_Test.java
@@ -32,10 +32,10 @@ public class groups_Test {
 
     @Test
     public void groups() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+        String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
         String name = "secret-" + System.currentTimeMillis();
-        GroupsCreateResponse creationResponse = slack.methods().groupsCreate(r -> r.token(token).name(name));
+        GroupsCreateResponse creationResponse = slack.methods().groupsCreate(r -> r.token(userToken).name(name));
         Group group = creationResponse.getGroup();
         {
             assertThat(creationResponse.getError(), is(nullValue()));
@@ -45,33 +45,33 @@ public class groups_Test {
 
         {
             GroupsListResponse response = slack.methods().groupsList(
-                    GroupsListRequest.builder().token(token).build());
+                    GroupsListRequest.builder().token(userToken).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
         {
             GroupsListResponse response = slack.methods().groupsList(
-                    GroupsListRequest.builder().token(token).excludeArchived(true).build());
+                    GroupsListRequest.builder().token(userToken).excludeArchived(true).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
             GroupsHistoryResponse response = slack.methods().groupsHistory(
-                    GroupsHistoryRequest.builder().token(token).channel(group.getId()).count(10).build());
+                    GroupsHistoryRequest.builder().token(userToken).channel(group.getId()).count(10).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
             GroupsInfoResponse response = slack.methods().groupsInfo(
-                    GroupsInfoRequest.builder().token(token).channel(group.getId()).build());
+                    GroupsInfoRequest.builder().token(userToken).channel(group.getId()).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         GroupsCreateChildResponse childCreationResponse = slack.methods().groupsCreateChild(
-                GroupsCreateChildRequest.builder().token(token).channel(group.getId()).build());
+                GroupsCreateChildRequest.builder().token(userToken).channel(group.getId()).build());
         group = childCreationResponse.getGroup();
         {
             assertThat(childCreationResponse.getError(), is(nullValue()));
@@ -81,13 +81,13 @@ public class groups_Test {
         {
             String groupId = childCreationResponse.getGroup().getId();
             ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(r -> r
-                    .token(token)
+                    .token(userToken)
                     .text("How are you?")
                     .channel(groupId));
             assertThat(postResponse.getError(), is(nullValue()));
 
             ChatPostMessageResponse replyResponse = slack.methods().chatPostMessage(r -> r
-                    .token(token)
+                    .token(userToken)
                     .threadTs(postResponse.getTs())
                     .text("Great! How are you?")
                     .channel(groupId));
@@ -95,12 +95,12 @@ public class groups_Test {
 
             String ts = postResponse.getTs();
             GroupsMarkResponse response = slack.methods().groupsMark(
-                    GroupsMarkRequest.builder().token(token).channel(group.getId()).ts(ts).build());
+                    GroupsMarkRequest.builder().token(userToken).channel(group.getId()).ts(ts).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
 
             GroupsRepliesResponse repliesResponse = slack.methods().groupsReplies(r -> r
-                    .token(token)
+                    .token(userToken)
                     .channel(groupId)
                     .threadTs(postResponse.getTs()));
             assertThat(repliesResponse.getError(), is(nullValue()));
@@ -109,26 +109,26 @@ public class groups_Test {
 
         {
             GroupsRenameResponse response = slack.methods().groupsRename(
-                    GroupsRenameRequest.builder().token(token).channel(group.getId()).name(name + "-").build());
+                    GroupsRenameRequest.builder().token(userToken).channel(group.getId()).name(name + "-").build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
             GroupsSetPurposeResponse response = slack.methods().groupsSetPurpose(
-                    GroupsSetPurposeRequest.builder().token(token).channel(group.getId()).purpose("purpose").build());
+                    GroupsSetPurposeRequest.builder().token(userToken).channel(group.getId()).purpose("purpose").build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
             GroupsSetTopicResponse response = slack.methods().groupsSetTopic(
-                    GroupsSetTopicRequest.builder().token(token).channel(group.getId()).topic("topic").build());
+                    GroupsSetTopicRequest.builder().token(userToken).channel(group.getId()).topic("topic").build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
         String userIdToInvite = null;
-        List<User> users = slack.methods().usersList(r -> r.token(token).limit(100)).getMembers();
+        List<User> users = slack.methods().usersList(r -> r.token(userToken).limit(100)).getMembers();
         for (User user : users) {
             boolean alreadyInTheGroup = false;
             for (String groupMember : group.getMembers()) {
@@ -144,7 +144,7 @@ public class groups_Test {
         }
         {
             GroupsInviteResponse response = slack.methods().groupsInvite(GroupsInviteRequest.builder()
-                    .token(token)
+                    .token(userToken)
                     .channel(group.getId())
                     .user(userIdToInvite)
                     .build());
@@ -153,7 +153,7 @@ public class groups_Test {
         }
         {
             GroupsKickResponse response = slack.methods().groupsKick(GroupsKickRequest.builder()
-                    .token(token)
+                    .token(userToken)
                     .channel(group.getId())
                     .user(userIdToInvite).build());
             assertThat(response.getError(), is(nullValue()));
@@ -161,7 +161,7 @@ public class groups_Test {
         }
         {
             GroupsOpenResponse response = slack.methods().groupsOpen(GroupsOpenRequest.builder()
-                    .token(token)
+                    .token(userToken)
                     .channel(group.getId())
                     .build());
             assertThat(response.getError(), is(nullValue()));
@@ -169,7 +169,7 @@ public class groups_Test {
         }
         {
             GroupsInviteResponse response = slack.methods().groupsInvite(GroupsInviteRequest.builder()
-                    .token(token)
+                    .token(userToken)
                     .channel(group.getId())
                     .user(userIdToInvite)
                     .build());
@@ -178,7 +178,7 @@ public class groups_Test {
         }
         {
             GroupsLeaveResponse response = slack.methods().groupsLeave(GroupsLeaveRequest.builder()
-                    .token(token)
+                    .token(userToken)
                     .channel(group.getId())
                     .build());
             // TODO: failing
@@ -187,14 +187,14 @@ public class groups_Test {
 
         {
             GroupsArchiveResponse response = slack.methods().groupsArchive(
-                    GroupsArchiveRequest.builder().token(token).channel(group.getId()).build());
+                    GroupsArchiveRequest.builder().token(userToken).channel(group.getId()).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
             GroupsUnarchiveResponse response = slack.methods().groupsUnarchive(
-                    GroupsUnarchiveRequest.builder().token(token).channel(group.getId()).build());
+                    GroupsUnarchiveRequest.builder().token(userToken).channel(group.getId()).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -202,7 +202,7 @@ public class groups_Test {
         {
             // NOTE: https://github.com/slackapi/slack-api-specs/issues/12
             GroupsCloseResponse response = slack.methods().groupsClose(
-                    GroupsCloseRequest.builder().token(token).channel(group.getId()).build());
+                    GroupsCloseRequest.builder().token(userToken).channel(group.getId()).build());
             // No error is returned but this API seems to be useless.
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
@@ -210,7 +210,7 @@ public class groups_Test {
 
         {
             GroupsArchiveResponse response = slack.methods().groupsArchive(
-                    GroupsArchiveRequest.builder().token(token).channel(group.getId()).build());
+                    GroupsArchiveRequest.builder().token(userToken).channel(group.getId()).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/im_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/im_Test.java
@@ -27,25 +27,25 @@ public class im_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @Test
     public void operations() throws Exception {
         ImListResponse listResponse = slack.methods().imList(r -> r
-                .token(token)
+                .token(userToken)
                 .limit(2));
         assertThat(listResponse.getError(), is(nullValue()));
         assertThat(listResponse.isOk(), is(true));
         assertThat(listResponse.getResponseMetadata(), is(notNullValue()));
 
         UsersListResponse usersListResponse = slack.methods().usersList(r -> r
-                .token(token)
+                .token(userToken)
                 .presence(true));
         List<User> users = usersListResponse.getMembers();
         final String userId = users.get(0).getId();
 
         ImOpenResponse openResponse = slack.methods().imOpen(r -> r
-                .token(token)
+                .token(userToken)
                 .user(userId));
         assertThat(openResponse.getError(), is(nullValue()));
         assertThat(openResponse.isOk(), is(true));
@@ -55,14 +55,14 @@ public class im_Test {
         // without ts (worked before but it gets to fail because ts is required as of Jan 2019)
         {
             ImMarkResponse markResponse = slack.methods().imMark(r -> r
-                    .token(token)
+                    .token(userToken)
                     .channel(channelId));
             assertThat(markResponse.isOk(), is(false));
             assertThat(markResponse.getError(), is("invalid_timestamp"));
         }
 
         ChatPostMessageResponse firstMessageResponse = slack.methods().chatPostMessage(r -> r
-                .token(token)
+                .token(userToken)
                 .channel(channelId)
                 .text("Hi!"));
         assertThat(firstMessageResponse.getError(), is(nullValue()));
@@ -71,7 +71,7 @@ public class im_Test {
         // with ts
         {
             ImMarkResponse markResponse = slack.methods().imMark(r -> r
-                    .token(token)
+                    .token(userToken)
                     .channel(channelId)
                     .ts(firstMessageResponse.getTs()));
             assertThat(markResponse.getError(), is(nullValue()));
@@ -79,7 +79,7 @@ public class im_Test {
         }
 
         ChatPostMessageResponse threadReplyResponse = slack.methods().chatPostMessage(r -> r
-                .token(token)
+                .token(userToken)
                 .channel(channelId)
                 .threadTs(firstMessageResponse.getTs())
                 .text("Hi!"));
@@ -87,21 +87,21 @@ public class im_Test {
         assertThat(threadReplyResponse.isOk(), is(true));
 
         ImRepliesResponse repliesResponse = slack.methods().imReplies(r -> r
-                .token(token)
+                .token(userToken)
                 .channel(channelId)
                 .threadTs(threadReplyResponse.getMessage().getThreadTs()));
         assertThat(repliesResponse.getError(), is(nullValue()));
         assertThat(repliesResponse.isOk(), is(true));
 
         ImHistoryResponse historyResponse = slack.methods().imHistory(r -> r
-                .token(token)
+                .token(userToken)
                 .channel(channelId)
                 .count(10));
         assertThat(historyResponse.getError(), is(nullValue()));
         assertThat(historyResponse.isOk(), is(true));
 
         ImCloseResponse closeResponse = slack.methods().imClose(r -> r
-                .token(token)
+                .token(userToken)
                 .channel(channelId));
         assertThat(closeResponse.getError(), is(nullValue()));
         assertThat(closeResponse.isOk(), is(true));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/mpim_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/mpim_Test.java
@@ -31,14 +31,14 @@ public class mpim_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @Test
     public void operations() throws IOException, SlackApiException {
-        MpimListResponse listResponse = slack.methods().mpimList(r -> r.token(token));
+        MpimListResponse listResponse = slack.methods().mpimList(r -> r.token(userToken));
         assertThat(listResponse.isOk(), is(true));
 
-        UsersListResponse usersListResponse = slack.methods().usersList(r -> r.token(token).presence(true));
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r.token(userToken).presence(true));
         List<User> users = usersListResponse.getMembers();
         List<String> userIds = new ArrayList<>();
         for (User u : users) {
@@ -49,44 +49,44 @@ public class mpim_Test {
             }
         }
 
-        MpimOpenResponse openResponse = slack.methods().mpimOpen(r -> r.token(token).users(userIds));
+        MpimOpenResponse openResponse = slack.methods().mpimOpen(r -> r.token(userToken).users(userIds));
         assertThat(openResponse.getError(), is(nullValue()));
         assertThat(openResponse.isOk(), is(true));
 
         String channelId = openResponse.getGroup().getId();
 
         {
-            MpimMarkResponse markResponse = slack.methods(token).mpimMark(r -> r.channel(channelId));
+            MpimMarkResponse markResponse = slack.methods(userToken).mpimMark(r -> r.channel(channelId));
             // ts is missing
             assertThat(markResponse.getError(), is("internal_error"));
         }
 
         {
-            MpimMarkResponse markResponse = slack.methods(token).mpimMark(r -> r
+            MpimMarkResponse markResponse = slack.methods(userToken).mpimMark(r -> r
                     .channel(channelId)
                     .ts(openResponse.getGroup().getLatest().getTs()));
             assertThat(markResponse.getError(), is(nullValue()));
             assertThat(markResponse.isOk(), is(true));
         }
 
-        MpimHistoryResponse historyResponse = slack.methods().mpimHistory(r -> r.token(token).channel(channelId).count(10));
+        MpimHistoryResponse historyResponse = slack.methods().mpimHistory(r -> r.token(userToken).channel(channelId).count(10));
         assertThat(historyResponse.getError(), is(nullValue()));
         assertThat(historyResponse.isOk(), is(true));
 
-        ChatPostMessageResponse parentMessage = slack.methods(token).chatPostMessage(r ->
+        ChatPostMessageResponse parentMessage = slack.methods(userToken).chatPostMessage(r ->
                 r.channel(channelId).text("Hi there"));
         assertThat(parentMessage.getError(), is(nullValue()));
 
-        ChatPostMessageResponse threadMessage = slack.methods(token).chatPostMessage(r ->
+        ChatPostMessageResponse threadMessage = slack.methods(userToken).chatPostMessage(r ->
                 r.channel(channelId).threadTs(parentMessage.getTs()).text("What's up?"));
         assertThat(threadMessage.getError(), is(nullValue()));
 
-        MpimRepliesResponse repliesResponse = slack.methods(token).mpimReplies(r ->
+        MpimRepliesResponse repliesResponse = slack.methods(userToken).mpimReplies(r ->
                 r.channel(channelId).threadTs(parentMessage.getTs()));
         assertThat(repliesResponse.getError(), is(nullValue()));
         assertThat(repliesResponse.isOk(), is(true));
 
-        MpimCloseResponse closeResponse = slack.methods().mpimClose(r -> r.token(token).channel(channelId));
+        MpimCloseResponse closeResponse = slack.methods().mpimClose(r -> r.token(userToken).channel(channelId));
         assertThat(closeResponse.getError(), is(nullValue()));
         assertThat(closeResponse.isOk(), is(true));
     }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/pins_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/pins_Test.java
@@ -32,11 +32,11 @@ public class pins_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
 
     @Test
     public void list() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token)).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(botToken)).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -46,7 +46,7 @@ public class pins_Test {
         }
 
         PinsListResponse response = slack.methods().pinsList(
-                r -> r.token(token).channel(channels.get(0)));
+                r -> r.token(botToken).channel(channels.get(0)));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getItems(), is(notNullValue()));
@@ -54,7 +54,7 @@ public class pins_Test {
 
     @Test
     public void add() throws IOException, SlackApiException {
-        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(token)).getChannels();
+        List<Channel> channels_ = slack.methods().channelsList(r -> r.token(botToken)).getChannels();
         List<String> channels = new ArrayList<>();
         for (Channel c : channels_) {
             if (c.getName().equals("random")) {
@@ -67,7 +67,7 @@ public class pins_Test {
         com.slack.api.model.File fileObj;
         {
             FilesUploadResponse response = slack.methods().filesUpload(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channels(channels)
                     .file(file)
                     .filename("sample.txt")
@@ -81,7 +81,7 @@ public class pins_Test {
         {
             // https://api.slack.com/methods/pins.add
             PinsAddResponse response = slack.methods().pinsAdd(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channels.get(0))
                     .file(fileObj.getId()));
 //            // We are phasing out support for pinning files and file comments only.
@@ -93,7 +93,7 @@ public class pins_Test {
         {
             // https://api.slack.com/methods/pins.add
             PinsRemoveResponse response = slack.methods().pinsRemove(r -> r
-                    .token(token)
+                    .token(botToken)
                     .channel(channels.get(0))
                     .file(fileObj.getId()));
             // We are phasing out support for pinning files and file comments only.
@@ -107,7 +107,7 @@ public class pins_Test {
             // as of August 2018, File object no longer contains initialComment.
             if (fileObj.getInitialComment() != null) {
                 PinsAddResponse response = slack.methods().pinsAdd(r -> r
-                        .token(token)
+                        .token(botToken)
                         .channel(channels.get(0))
                         .fileComment(fileObj.getInitialComment().getId()));
                 assertThat(response.getError(), is(nullValue()));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/reminders_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/reminders_Test.java
@@ -23,15 +23,15 @@ public class reminders_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @Test
     public void test() throws Exception {
-        RemindersListResponse list = slack.methods().remindersList(r -> r.token(token));
+        RemindersListResponse list = slack.methods().remindersList(r -> r.token(userToken));
         assertThat(list.getError(), is(nullValue()));
 
         RemindersAddResponse addResponse = slack.methods().remindersAdd(r -> r
-                .token(token)
+                .token(userToken)
                 .text("Don't forget it!")
                 .time("10"));
         assertThat(addResponse.getError(), is(nullValue()));
@@ -40,19 +40,19 @@ public class reminders_Test {
         String reminderId = addResponse.getReminder().getId();
 
         RemindersInfoResponse infoResponse = slack.methods().remindersInfo(r -> r
-                .token(token)
+                .token(userToken)
                 .reminder(reminderId));
         assertThat(infoResponse.getError(), is(nullValue()));
         assertThat(infoResponse.isOk(), is(true));
 
         RemindersCompleteResponse completeResponse = slack.methods().remindersComplete(r -> r
-                .token(token)
+                .token(userToken)
                 .reminder(reminderId));
         assertThat(completeResponse.getError(), is(nullValue()));
         assertThat(completeResponse.isOk(), is(true));
 
         RemindersDeleteResponse deleteResponse = slack.methods().remindersDelete(r -> r
-                .token(token)
+                .token(userToken)
                 .reminder(reminderId));
         assertThat(deleteResponse.getError(), is(nullValue()));
         assertThat(deleteResponse.isOk(), is(true));
@@ -61,7 +61,7 @@ public class reminders_Test {
     @Test
     public void test_async() throws Exception {
         RemindersAddResponse addResponse = slack.methodsAsync().remindersAdd(r -> r
-                .token(token)
+                .token(userToken)
                 .text("Don't forget it!")
                 .time("10"))
                 .get();
@@ -71,21 +71,21 @@ public class reminders_Test {
         String reminderId = addResponse.getReminder().getId();
 
         RemindersInfoResponse infoResponse = slack.methodsAsync().remindersInfo(r -> r
-                .token(token)
+                .token(userToken)
                 .reminder(reminderId))
                 .get();
         assertThat(infoResponse.getError(), is(nullValue()));
         assertThat(infoResponse.isOk(), is(true));
 
         RemindersCompleteResponse completeResponse = slack.methodsAsync().remindersComplete(r -> r
-                .token(token)
+                .token(userToken)
                 .reminder(reminderId))
                 .get();
         assertThat(completeResponse.getError(), is(nullValue()));
         assertThat(completeResponse.isOk(), is(true));
 
         RemindersDeleteResponse deleteResponse = slack.methodsAsync().remindersDelete(r -> r
-                .token(token)
+                .token(userToken)
                 .reminder(reminderId))
                 .get();
         assertThat(deleteResponse.getError(), is(nullValue()));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/search_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/search_Test.java
@@ -28,11 +28,18 @@ public class search_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @Test
-    public void all() throws IOException, SlackApiException {
-        SearchAllResponse response = slack.methods().searchAll(r -> r.token(token).query("test"));
+    public void all_bot() throws IOException, SlackApiException {
+        SearchAllResponse response = slack.methods().searchAll(r -> r.token(botToken).query("test"));
+        assertThat(response.getError(), is("not_allowed_token_type"));
+    }
+
+    @Test
+    public void all_user() throws IOException, SlackApiException {
+        SearchAllResponse response = slack.methods().searchAll(r -> r.token(userToken).query("test"));
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -40,7 +47,7 @@ public class search_Test {
 
     @Test
     public void all_async() throws Exception {
-        SearchAllResponse response = slack.methodsAsync().searchAll(r -> r.token(token).query("test")).get();
+        SearchAllResponse response = slack.methodsAsync().searchAll(r -> r.token(userToken).query("test")).get();
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -48,7 +55,7 @@ public class search_Test {
 
     @Test
     public void messages() throws IOException, SlackApiException {
-        SearchMessagesResponse response = slack.methods().searchMessages(r -> r.token(token).query("test"));
+        SearchMessagesResponse response = slack.methods().searchMessages(r -> r.token(userToken).query("test"));
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -61,7 +68,7 @@ public class search_Test {
 
     @Test
     public void messages_async() throws Exception {
-        SearchMessagesResponse response = slack.methodsAsync().searchMessages(r -> r.token(token).query("test")).get();
+        SearchMessagesResponse response = slack.methodsAsync().searchMessages(r -> r.token(userToken).query("test")).get();
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -74,7 +81,7 @@ public class search_Test {
 
     @Test
     public void files() throws IOException, SlackApiException {
-        SearchFilesResponse response = slack.methods().searchFiles(r -> r.token(token).query("test"));
+        SearchFilesResponse response = slack.methods().searchFiles(r -> r.token(userToken).query("test"));
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -86,7 +93,7 @@ public class search_Test {
 
     @Test
     public void files_async() throws Exception {
-        SearchFilesResponse response = slack.methodsAsync().searchFiles(r -> r.token(token).query("test")).get();
+        SearchFilesResponse response = slack.methodsAsync().searchFiles(r -> r.token(userToken).query("test")).get();
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/shared_channels_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/shared_channels_Test.java
@@ -24,7 +24,7 @@ public class shared_channels_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
 
     @Test
     public void fetchSharedChannel() throws Exception {
@@ -32,7 +32,7 @@ public class shared_channels_Test {
         if (sharedChannelId.isPresent()) {
             String channel = sharedChannelId.get();
             ConversationsInfoResponse response = slack.methods().conversationsInfo(r ->
-                    r.token(token).channel(channel));
+                    r.token(botToken).channel(channel));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.getChannel().isShared(), is(true));
             assertThat(response.getChannel().isExtShared(), is(true));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/stars_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/stars_Test.java
@@ -6,7 +6,6 @@ import com.slack.api.methods.response.files.FilesUploadResponse;
 import com.slack.api.methods.response.stars.StarsAddResponse;
 import com.slack.api.methods.response.stars.StarsListResponse;
 import com.slack.api.methods.response.stars.StarsRemoveResponse;
-import com.slack.api.model.Channel;
 import com.slack.api.model.Conversation;
 import config.Constants;
 import config.SlackTestConfig;
@@ -33,11 +32,11 @@ public class stars_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @Test
     public void list() throws IOException, SlackApiException {
-        StarsListResponse response = slack.methods().starsList(r -> r.token(token));
+        StarsListResponse response = slack.methods().starsList(r -> r.token(userToken));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getItems(), is(notNullValue()));
@@ -45,7 +44,7 @@ public class stars_Test {
 
     @Test
     public void list_async() throws Exception {
-        StarsListResponse response = slack.methodsAsync().starsList(r -> r.token(token)).get();
+        StarsListResponse response = slack.methodsAsync().starsList(r -> r.token(userToken)).get();
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
         assertThat(response.getItems(), is(notNullValue()));
@@ -53,7 +52,7 @@ public class stars_Test {
 
     @Test
     public void add() throws IOException, SlackApiException {
-        List<Conversation> channels = slack.methods().conversationsList(r -> r.token(token)).getChannels();
+        List<Conversation> channels = slack.methods().conversationsList(r -> r.token(userToken)).getChannels();
         List<String> channelIds = new ArrayList<>();
         for (Conversation c : channels) {
             if (c.getName().equals("random")) {
@@ -66,7 +65,7 @@ public class stars_Test {
         com.slack.api.model.File fileObj;
         {
             FilesUploadResponse response = slack.methods().filesUpload(r -> r
-                    .token(token)
+                    .token(userToken)
                     .channels(channelIds)
                     .file(file)
                     .filename("sample.txt")
@@ -79,7 +78,7 @@ public class stars_Test {
 
         {
             StarsAddResponse response = slack.methods().starsAdd(r -> r
-                    .token(token)
+                    .token(userToken)
                     .channel(channelIds.get(0))
                     .file(fileObj.getId()));
             assertThat(response.getError(), is(nullValue()));
@@ -87,7 +86,7 @@ public class stars_Test {
         }
         {
             StarsRemoveResponse response = slack.methods().starsRemove(r -> r
-                    .token(token)
+                    .token(userToken)
                     .channel(channelIds.get(0))
                     .file(fileObj.getId()));
             assertThat(response.getError(), is(nullValue()));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/team_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/team_Test.java
@@ -30,11 +30,12 @@ public class team_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @Test
     public void teamAccessLogs() throws Exception {
-        TeamAccessLogsResponse response = slack.methods().teamAccessLogs(r -> r.token(token));
+        TeamAccessLogsResponse response = slack.methods().teamAccessLogs(r -> r.token(userToken));
         if (response.isOk()) {
             // when you pay for this team
             assertThat(response.getError(), is(nullValue()));
@@ -48,7 +49,7 @@ public class team_Test {
 
     @Test
     public void teamAccessLogs_async() throws Exception {
-        TeamAccessLogsResponse response = slack.methodsAsync().teamAccessLogs(r -> r.token(token)).get();
+        TeamAccessLogsResponse response = slack.methodsAsync().teamAccessLogs(r -> r.token(userToken)).get();
         if (response.isOk()) {
             // when you pay for this team
             assertThat(response.getError(), is(nullValue()));
@@ -62,7 +63,7 @@ public class team_Test {
 
     @Test
     public void teamBillableInfo() throws Exception {
-        List<User> users = slack.methods().usersList(r -> r.token(token)).getMembers();
+        List<User> users = slack.methods().usersList(r -> r.token(userToken)).getMembers();
         User user = null;
         for (User u : users) {
             if (!u.isBot() && !"USLACKBOT".equals(u.getId())) {
@@ -72,7 +73,7 @@ public class team_Test {
         }
         String userId = user.getId();
         TeamBillableInfoResponse response = slack.methods().teamBillableInfo(r -> r
-                .token(token)
+                .token(userToken)
                 .user(userId));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -80,7 +81,7 @@ public class team_Test {
 
     @Test
     public void teamBillableInfo_async() throws Exception {
-        List<User> users = slack.methodsAsync().usersList(r -> r.token(token)).get().getMembers();
+        List<User> users = slack.methodsAsync().usersList(r -> r.token(userToken)).get().getMembers();
         User user = null;
         for (User u : users) {
             if (!u.isBot() && !"USLACKBOT".equals(u.getId())) {
@@ -90,7 +91,7 @@ public class team_Test {
         }
         String userId = user.getId();
         TeamBillableInfoResponse response = slack.methodsAsync().teamBillableInfo(r -> r
-                .token(token)
+                .token(userToken)
                 .user(userId))
                 .get();
         assertThat(response.getError(), is(nullValue()));
@@ -99,23 +100,23 @@ public class team_Test {
 
     @Test
     public void teamInfo() throws Exception {
-        TeamInfoResponse response = slack.methods().teamInfo(r -> r.token(token));
+        TeamInfoResponse response = slack.methods().teamInfo(r -> r.token(botToken));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 
     @Test
     public void teamInfo_async() throws Exception {
-        TeamInfoResponse response = slack.methodsAsync().teamInfo(r -> r.token(token)).get();
+        TeamInfoResponse response = slack.methodsAsync().teamInfo(r -> r.token(botToken)).get();
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 
     @Test
     public void teamIntegrationLogs() throws Exception {
-        String user = slack.methods().usersList(r -> r.token(token)).getMembers().get(0).getId();
+        String user = slack.methods().usersList(r -> r.token(userToken)).getMembers().get(0).getId();
         TeamIntegrationLogsResponse response = slack.methods().teamIntegrationLogs(r -> r
-                .token(token)
+                .token(userToken)
                 .user(user));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -123,9 +124,9 @@ public class team_Test {
 
     @Test
     public void teamIntegrationLogs_async() throws Exception {
-        String user = slack.methodsAsync().usersList(r -> r.token(token)).get().getMembers().get(0).getId();
+        String user = slack.methodsAsync().usersList(r -> r.token(userToken)).get().getMembers().get(0).getId();
         TeamIntegrationLogsResponse response = slack.methods().teamIntegrationLogs(r -> r
-                .token(token)
+                .token(userToken)
                 .user(user));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
@@ -133,14 +134,14 @@ public class team_Test {
 
     @Test
     public void teamProfileGet() throws Exception {
-        TeamProfileGetResponse response = slack.methods().teamProfileGet(r -> r.token(token));
+        TeamProfileGetResponse response = slack.methods().teamProfileGet(r -> r.token(botToken));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 
     @Test
     public void teamProfileGet_async() throws Exception {
-        TeamProfileGetResponse response = slack.methodsAsync().teamProfileGet(r -> r.token(token)).get();
+        TeamProfileGetResponse response = slack.methodsAsync().teamProfileGet(r -> r.token(botToken)).get();
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/usergroups_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/usergroups_Test.java
@@ -31,13 +31,14 @@ public class usergroups_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @Test
     public void create() throws Exception {
         String usergroupName = "usergroup-" + System.currentTimeMillis();
         UsergroupsCreateResponse response = slack.methods().usergroupsCreate(r -> r
-                .token(token)
+                .token(userToken)
                 .name(usergroupName));
         if (response.isOk()) {
             assertThat(response.getUsergroup(), is(notNullValue()));
@@ -54,25 +55,25 @@ public class usergroups_Test {
 
     @Test
     public void list() throws Exception {
-        UsergroupsListResponse response = slack.methods().usergroupsList(r -> r.token(token));
+        UsergroupsListResponse response = slack.methods().usergroupsList(r -> r.token(botToken));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 
     @Test
     public void list_async() throws Exception {
-        UsergroupsListResponse response = slack.methodsAsync().usergroupsList(r -> r.token(token)).get();
+        UsergroupsListResponse response = slack.methodsAsync().usergroupsList(r -> r.token(botToken)).get();
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
     }
 
     @Test
     public void usergroups() throws Exception {
-        UsergroupsListResponse usergroups = slack.methods().usergroupsList(r -> r.token(token));
+        UsergroupsListResponse usergroups = slack.methods().usergroupsList(r -> r.token(botToken));
         if (usergroups.isOk() && usergroups.getUsergroups().size() > 0) {
             UsergroupsUsersListResponse response = slack.methods().usergroupsUsersList(
                     UsergroupsUsersListRequest.builder()
-                            .token(token)
+                            .token(userToken)
                             .includeDisabled(false)
                             .usergroup(usergroups.getUsergroups().get(0).getId())
                             .build());
@@ -80,40 +81,40 @@ public class usergroups_Test {
         }
 
         UsergroupsCreateResponse creation = slack.methods().usergroupsCreate(r -> r
-                .token(token)
+                .token(userToken)
                 .name("usergroup-" + System.currentTimeMillis())
                 .description("Something wrong"));
         assertThat(creation.getError(), is(nullValue()));
         final Usergroup usergroup = creation.getUsergroup();
         {
             UsergroupsDisableResponse response = slack.methods().usergroupsDisable(r -> r
-                    .token(token)
+                    .token(userToken)
                     .usergroup(usergroup.getId()));
             assertThat(response.getError(), is(nullValue()));
         }
         {
             UsergroupsEnableResponse response = slack.methods().usergroupsEnable(r -> r
-                    .token(token)
+                    .token(userToken)
                     .usergroup(usergroup.getId()));
             assertThat(response.getError(), is(nullValue()));
         }
         {
             UsergroupsUpdateResponse response = slack.methods().usergroupsUpdate(r -> r
-                    .token(token)
+                    .token(userToken)
                     .usergroup(usergroup.getId())
                     .description("updated"));
             assertThat(response.getError(), is(nullValue()));
         }
         {
             UsersListResponse usersListResponse = slack.methods().usersList(r -> r
-                    .token(token)
+                    .token(userToken)
                     .limit(3));
             List<String> userIds = new ArrayList<>();
             for (User member : usersListResponse.getMembers()) {
                 userIds.add(member.getId());
             }
             UsergroupsUsersUpdateResponse response = slack.methods().usergroupsUsersUpdate(r -> r
-                    .token(token)
+                    .token(userToken)
                     .usergroup(usergroup.getId())
                     .users(userIds));
             assertThat(response.getError(), is(nullValue()));
@@ -124,7 +125,7 @@ public class usergroups_Test {
     public void users_failure() throws Exception {
         UsergroupsUsersListResponse response = slack.methods().usergroupsUsersList(
                 UsergroupsUsersListRequest.builder()
-                        .token(token)
+                        .token(botToken)
                         .includeDisabled(false)
                         .usergroup("dummy")
                         .build());

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/users_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/users_Test.java
@@ -28,7 +28,8 @@ public class users_Test {
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @AfterClass
     public static void tearDown() throws InterruptedException {
@@ -36,11 +37,22 @@ public class users_Test {
     }
 
     @Test
-    public void showUsers() throws IOException, SlackApiException {
-        UsersListResponse users = slack.methods(token).usersList(r -> r.includeLocale(true).limit(10));
+    public void showUsers_bot() throws IOException, SlackApiException {
+        UsersListResponse users = slack.methods(botToken).usersList(r -> r.includeLocale(true).limit(10));
         assertThat(users.getError(), is(nullValue()));
 
-        UsersInfoResponse usersInfo = slack.methods(token)
+        UsersInfoResponse usersInfo = slack.methods(botToken)
+                .usersInfo(r -> r.user(users.getMembers().get(0).getId()).includeLocale(true));
+        assertThat(usersInfo.getError(), is(nullValue()));
+        assertThat(usersInfo.getUser().getLocale(), is(notNullValue()));
+    }
+
+    @Test
+    public void showUsers_user() throws IOException, SlackApiException {
+        UsersListResponse users = slack.methods(userToken).usersList(r -> r.includeLocale(true).limit(10));
+        assertThat(users.getError(), is(nullValue()));
+
+        UsersInfoResponse usersInfo = slack.methods(userToken)
                 .usersInfo(r -> r.user(users.getMembers().get(0).getId()).includeLocale(true));
         assertThat(usersInfo.getError(), is(nullValue()));
         assertThat(usersInfo.getUser().getLocale(), is(notNullValue()));
@@ -48,10 +60,10 @@ public class users_Test {
 
     @Test
     public void showUsers_async() throws Exception {
-        UsersListResponse users = slack.methodsAsync(token).usersList(r -> r.includeLocale(true).limit(10)).get();
+        UsersListResponse users = slack.methodsAsync(botToken).usersList(r -> r.includeLocale(true).limit(10)).get();
         assertThat(users.getError(), is(nullValue()));
 
-        UsersInfoResponse usersInfo = slack.methodsAsync(token)
+        UsersInfoResponse usersInfo = slack.methodsAsync(botToken)
                 .usersInfo(r -> r.user(users.getMembers().get(0).getId()).includeLocale(true))
                 .get();
         assertThat(usersInfo.getError(), is(nullValue()));
@@ -59,30 +71,28 @@ public class users_Test {
     }
 
     @Test
-    public void usersScenarios() throws IOException, SlackApiException {
+    public void usersScenarios_bot() throws IOException, SlackApiException {
         {
-            UsersSetPresenceResponse response = slack.methods().usersSetPresence(r -> r.token(token).presence("away"));
+            UsersSetPresenceResponse response = slack.methods().usersSetPresence(r -> r.token(botToken).presence("away"));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
             UsersSetActiveResponse response = slack.methods().usersSetActive(
-                    UsersSetActiveRequest.builder().token(token).build());
+                    UsersSetActiveRequest.builder().token(botToken).build());
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
-            UsersIdentityResponse response = slack.methods().usersIdentity(r -> r.token(token));
-            // TODO: test preparation?
-            // {"ok":false,"error":"missing_scope","needed":"identity.basic","provided":"identify,read,post,client,apps,admin"}
-            assertThat(response.getError(), is("missing_scope"));
+            UsersIdentityResponse response = slack.methods().usersIdentity(r -> r.token(botToken));
+            assertThat(response.getError(), is("not_allowed_token_type"));
             assertThat(response.isOk(), is(false));
         }
 
         UsersListResponse usersListResponse = slack.methods().usersList(r -> r
-                .token(token)
+                .token(botToken)
                 .limit(2)
                 .presence(true));
         List<User> users = usersListResponse.getMembers();
@@ -115,14 +125,14 @@ public class users_Test {
         }
 
         {
-            UsersInfoResponse response = slack.methods().usersInfo(r -> r.token(token).user(userId));
+            UsersInfoResponse response = slack.methods().usersInfo(r -> r.token(botToken).user(userId));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getUser(), is(notNullValue()));
         }
 
         {
-            UsersGetPresenceResponse response = slack.methods().usersGetPresence(r -> r.token(token).user(userId));
+            UsersGetPresenceResponse response = slack.methods().usersGetPresence(r -> r.token(botToken).user(userId));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getPresence(), is(notNullValue()));
@@ -130,14 +140,106 @@ public class users_Test {
 
         {
             UsersConversationsResponse response = slack.methods().usersConversations(r -> r
-                    .token(token)
+                    .token(botToken)
                     .user(userId));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
 
         {
-            UsersDeletePhotoResponse response = slack.methods().usersDeletePhoto(r -> r.token(token));
+            UsersDeletePhotoResponse response = slack.methods().usersDeletePhoto(r -> r.token(botToken));
+            assertThat(response.getError(), is("not_allowed_token_type"));
+        }
+
+        File image = new File("src/test/resources/user_photo.jpg");
+        {
+            UsersSetPhotoResponse response = slack.methods().usersSetPhoto(r -> r
+                    .token(botToken)
+                    .image(image));
+            assertThat(response.getError(), is("not_allowed_token_type"));
+        }
+    }
+
+    @Test
+    public void usersScenarios_user() throws IOException, SlackApiException {
+        {
+            UsersSetPresenceResponse response = slack.methods().usersSetPresence(r -> r.token(userToken).presence("away"));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+        }
+
+        {
+            UsersSetActiveResponse response = slack.methods().usersSetActive(
+                    UsersSetActiveRequest.builder().token(userToken).build());
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+        }
+
+        {
+            UsersIdentityResponse response = slack.methods().usersIdentity(r -> r.token(userToken));
+            // TODO: test preparation?
+            // {"ok":false,"error":"missing_scope","needed":"identity.basic","provided":"identify,read,post,client,apps,admin"}
+            assertThat(response.getError(), is("missing_scope"));
+            assertThat(response.isOk(), is(false));
+        }
+
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r
+                .token(userToken)
+                .limit(2)
+                .presence(true));
+        List<User> users = usersListResponse.getMembers();
+        String userId = users.get(0).getId();
+
+        {
+            assertThat(usersListResponse.getError(), is(nullValue()));
+            assertThat(usersListResponse.isOk(), is(true));
+
+            assertThat(users, is(notNullValue()));
+            User user = users.get(0);
+            assertThat(user.getId(), is(notNullValue()));
+            assertThat(user.getName(), is(notNullValue()));
+            assertThat(user.getRealName(), is(notNullValue()));
+
+            // As of 2018/07, these APIs are no longer supported
+            // assertThat(user.getProfile().getFirstName(), is(nullValue()));
+            // assertThat(user.getProfile().getLastName(), is(nullValue()));
+            assertThat(user.getProfile().getDisplayName(), is(notNullValue()));
+            assertThat(user.getProfile().getDisplayNameNormalized(), is(notNullValue()));
+            assertThat(user.getProfile().getRealName(), is(notNullValue()));
+            assertThat(user.getProfile().getRealNameNormalized(), is(notNullValue()));
+
+            assertThat(user.getProfile().getImage24(), is(notNullValue()));
+            assertThat(user.getProfile().getImage32(), is(notNullValue()));
+            assertThat(user.getProfile().getImage48(), is(notNullValue()));
+            assertThat(user.getProfile().getImage72(), is(notNullValue()));
+            assertThat(user.getProfile().getImage192(), is(notNullValue()));
+            assertThat(user.getProfile().getImage512(), is(notNullValue()));
+        }
+
+        {
+            UsersInfoResponse response = slack.methods().usersInfo(r -> r.token(userToken).user(userId));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+            assertThat(response.getUser(), is(notNullValue()));
+        }
+
+        {
+            UsersGetPresenceResponse response = slack.methods().usersGetPresence(r -> r.token(userToken).user(userId));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+            assertThat(response.getPresence(), is(notNullValue()));
+        }
+
+        {
+            UsersConversationsResponse response = slack.methods().usersConversations(r -> r
+                    .token(userToken)
+                    .user(userId));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+        }
+
+        {
+            UsersDeletePhotoResponse response = slack.methods().usersDeletePhoto(r -> r.token(userToken));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
         }
@@ -145,7 +247,7 @@ public class users_Test {
         File image = new File("src/test/resources/user_photo.jpg");
         {
             UsersSetPhotoResponse response = slack.methods().usersSetPhoto(r -> r
-                    .token(token)
+                    .token(userToken)
                     .image(image));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
@@ -153,10 +255,9 @@ public class users_Test {
     }
 
     @Test
-    public void lookupByEMailSupported() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    public void lookupByEmailSupported_bot() throws IOException, SlackApiException {
         UsersListResponse usersListResponse = slack.methods().usersList(r -> r
-                .token(token)
+                .token(botToken)
                 .presence(true));
 
         List<User> users = usersListResponse.getMembers();
@@ -172,7 +273,35 @@ public class users_Test {
         }
 
         UsersLookupByEmailResponse response = slack.methods().usersLookupByEmail(UsersLookupByEmailRequest.builder()
-                .token(token)
+                .token(botToken)
+                .email(randomUserWhoHasEmail.getProfile().getEmail())
+                .build());
+
+        assertThat(response.getError(), is(nullValue()));
+        assertTrue(response.isOk());
+        assertEquals(randomUserWhoHasEmail.getId(), response.getUser().getId());
+    }
+
+    @Test
+    public void lookupByEmailSupported_user() throws IOException, SlackApiException {
+        UsersListResponse usersListResponse = slack.methods().usersList(r -> r
+                .token(userToken)
+                .presence(true));
+
+        List<User> users = usersListResponse.getMembers();
+        User randomUserWhoHasEmail = null;
+        for (User user : users) {
+            if (user.getProfile() != null && user.getProfile().getEmail() != null) {
+                randomUserWhoHasEmail = user;
+                break;
+            }
+        }
+        if (randomUserWhoHasEmail == null) {
+            throw new IllegalStateException("Create a non-bot user for this test case in advance.");
+        }
+
+        UsersLookupByEmailResponse response = slack.methods().usersLookupByEmail(UsersLookupByEmailRequest.builder()
+                .token(userToken)
                 .email(randomUserWhoHasEmail.getProfile().getEmail())
                 .build());
 

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/users_profile_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/users_profile_Test.java
@@ -28,13 +28,15 @@ public class users_profile_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+
     @Ignore
     @Test
     public void usersProfile() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
         {
-            UsersProfileGetResponse response = slack.methods().usersProfileGet(r -> r.token(token));
+            UsersProfileGetResponse response = slack.methods().usersProfileGet(r -> r.token(userToken));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getProfile(), is(notNullValue()));
@@ -42,7 +44,7 @@ public class users_profile_Test {
 
         {
             UsersProfileSetResponse response = slack.methods().usersProfileSet(
-                    r -> r.token(token).name("skype").value("skype-" + System.currentTimeMillis()));
+                    r -> r.token(userToken).name("skype").value("skype-" + System.currentTimeMillis()));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getProfile(), is(notNullValue()));
@@ -52,7 +54,7 @@ public class users_profile_Test {
             User.Profile profile = new User.Profile();
             profile.setSkype("skype-" + System.currentTimeMillis());
             UsersProfileSetResponse response = slack.methods().usersProfileSet(
-                    r -> r.token(token).profile(profile));
+                    r -> r.token(userToken).profile(profile));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getProfile(), is(notNullValue()));
@@ -61,10 +63,17 @@ public class users_profile_Test {
 
     @Test
     public void usersProfile_async() throws Exception {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
-
+        // user token
         {
-            UsersProfileGetResponse response = slack.methodsAsync().usersProfileGet(r -> r.token(token)).get();
+            UsersProfileGetResponse response = slack.methodsAsync().usersProfileGet(r -> r.token(userToken)).get();
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+            assertThat(response.getProfile(), is(notNullValue()));
+        }
+        // bot token
+        {
+            String userId = slack.methodsAsync().usersList(r -> r.token(botToken)).get().getMembers().get(0).getId();
+            UsersProfileGetResponse response = slack.methodsAsync().usersProfileGet(r -> r.token(botToken).user(userId)).get();
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getProfile(), is(notNullValue()));
@@ -72,7 +81,7 @@ public class users_profile_Test {
 
         {
             UsersProfileSetResponse response = slack.methodsAsync().usersProfileSet(
-                    r -> r.token(token).name("skype").value("skype-" + System.currentTimeMillis()))
+                    r -> r.token(userToken).name("skype").value("skype-" + System.currentTimeMillis()))
                     .get();
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
@@ -83,7 +92,7 @@ public class users_profile_Test {
             User.Profile profile = new User.Profile();
             profile.setSkype("skype-" + System.currentTimeMillis());
             UsersProfileSetResponse response = slack.methodsAsync().usersProfileSet(
-                    r -> r.token(token).profile(profile))
+                    r -> r.token(userToken).profile(profile))
                     .get();
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/views_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/views_Test.java
@@ -30,7 +30,7 @@ public class views_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
 
     /*
      * A view in Slack can only be opened in response to a user action such as a slash command or
@@ -44,7 +44,7 @@ public class views_Test {
         View view = View.builder().id("FAKE_ID").build();
         {
             ViewsOpenResponse response = slack.methods().viewsOpen(r -> r
-                    .token(token)
+                    .token(botToken)
                     .triggerId("FAKE_TRIGGER_ID")
                     .view(view));
             assertThat(response.isOk(), is(false));
@@ -52,7 +52,7 @@ public class views_Test {
         }
         {
             ViewsOpenResponse response = slack.methodsAsync().viewsOpen(r -> r
-                    .token(token)
+                    .token(botToken)
                     .triggerId("FAKE_TRIGGER_ID")
                     .view(view))
                     .get();
@@ -66,7 +66,7 @@ public class views_Test {
         View view = View.builder().id("FAKE_ID").build();
         {
             ViewsPushResponse response = slack.methods().viewsPush(r -> r
-                    .token(token)
+                    .token(botToken)
                     .triggerId("FAKE_TRIGGER_ID")
                     .view(view));
             assertThat(response.isOk(), is(false));
@@ -74,7 +74,7 @@ public class views_Test {
         }
         {
             ViewsPushResponse response = slack.methodsAsync().viewsPush(r -> r
-                    .token(token)
+                    .token(botToken)
                     .triggerId("FAKE_TRIGGER_ID")
                     .view(view))
                     .get();
@@ -88,7 +88,7 @@ public class views_Test {
         View view = View.builder().id("FAKE_ID").build();
         {
             ViewsUpdateResponse response = slack.methods().viewsUpdate(r -> r
-                    .token(token)
+                    .token(botToken)
                     .externalId("FAKE_EXTERNAL_ID")
                     .hash("FAKE_HASH")
                     .viewId("FAKE_VIEW_ID")
@@ -98,7 +98,7 @@ public class views_Test {
         }
         {
             ViewsUpdateResponse response = slack.methodsAsync().viewsUpdate(r -> r
-                    .token(token)
+                    .token(botToken)
                     .externalId("FAKE_EXTERNAL_ID")
                     .hash("FAKE_HASH")
                     .viewId("FAKE_VIEW_ID")
@@ -114,22 +114,22 @@ public class views_Test {
         View view = View.builder().id("FAKE_ID").build();
         {
             ViewsPublishResponse response = slack.methods().viewsPublish(r -> r
-                    .token(token)
+                    .token(botToken)
                     .userId("FAKE_USER_ID")
                     .view(view));
             assertThat(response.isOk(), is(false));
             // need to join the beta
-            assertThat(response.getError(), is("not_allowed_token_type"));
+            assertThat(response.getError(), is("invalid_arguments"));
         }
         {
             ViewsPublishResponse response = slack.methodsAsync().viewsPublish(r -> r
-                    .token(token)
+                    .token(botToken)
                     .userId("FAKE_USER_ID")
                     .view(view))
                     .get();
             assertThat(response.isOk(), is(false));
             // need to join the beta
-            assertThat(response.getError(), is("not_allowed_token_type"));
+            assertThat(response.getError(), is("invalid_arguments"));
         }
     }
 

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods_workspace_apps/WorkspaceAppApiTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods_workspace_apps/WorkspaceAppApiTest.java
@@ -37,9 +37,9 @@ public class WorkspaceAppApiTest {
 
     @Test
     public void appsPermissionsRequest() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+        String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
         AppsPermissionsRequestResponse response = slack.methods().appsPermissionsRequest(req -> req
-                .token(token)
+                .token(userToken)
                 .triggerId("dummy"));
         assertThat(response.getError(), is("not_allowed_token_type"));
         assertThat(response.isOk(), is(false));
@@ -47,18 +47,18 @@ public class WorkspaceAppApiTest {
 
     @Test
     public void appsPermissionsInfo() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+        String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
         AppsPermissionsInfoResponse response = slack.methods().appsPermissionsInfo(req -> req
-                .token(token));
+                .token(userToken));
         assertThat(response.getError(), is("not_allowed_token_type"));
         assertThat(response.isOk(), is(false));
     }
 
     @Test
     public void appsPermissionsResourcesList() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+        String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
         AppsPermissionsResourcesListResponse response = slack.methods().appsPermissionsResourcesList(AppsPermissionsResourcesListRequest.builder()
-                .token(token)
+                .token(userToken)
                 .limit(10)
                 .build());
         assertThat(response.getError(), is("not_allowed_token_type"));
@@ -67,9 +67,9 @@ public class WorkspaceAppApiTest {
 
     @Test
     public void appsPermissionsScopesList() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+        String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
         AppsPermissionsScopesListResponse response = slack.methods().appsPermissionsScopesList(AppsPermissionsScopesListRequest.builder()
-                .token(token)
+                .token(userToken)
                 .build());
         assertThat(response.getError(), is("not_allowed_token_type"));
         assertThat(response.isOk(), is(false));
@@ -77,9 +77,9 @@ public class WorkspaceAppApiTest {
 
     @Test
     public void appsPermissionsUsersList() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+        String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
         AppsPermissionsUsersListResponse response = slack.methods().appsPermissionsUsersList(AppsPermissionsUsersListRequest.builder()
-                .token(token)
+                .token(userToken)
                 .limit(10)
                 .build());
         assertThat(response.getError(), is("not_allowed_token_type"));
@@ -88,9 +88,9 @@ public class WorkspaceAppApiTest {
 
     @Test
     public void appsPermissionsUsersRequest() throws IOException, SlackApiException {
-        String token = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
+        String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
         AppsPermissionsUsersRequestResponse response = slack.methods().appsPermissionsUsersRequest(AppsPermissionsUsersRequestRequest.builder()
-                .token(token)
+                .token(userToken)
                 .triggerId("abc")
                 .user("U0000000")
                 .build());

--- a/slack-api-client/src/test/java/util/sample_json_generation/JsonDataRecorder.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/JsonDataRecorder.java
@@ -381,7 +381,7 @@ public class JsonDataRecorder {
             return null;
         }
         if (value.matches("^[\\d]+\\.[\\d]+$")) {
-            return "W000000000.000000"; // ts
+            return "0000000000.000000"; // ts
         }
         if (value.matches("^[\\d]{10}$")) {
             return "1234567890"; // epoch

--- a/slack-api-model/src/main/java/com/slack/api/model/MatchedItem.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/MatchedItem.java
@@ -34,6 +34,7 @@ public class MatchedItem {
 
     private boolean hasMore;
     private boolean sentToSelf;
+    private boolean noReactions;
 
     private String botId;
 

--- a/slack-api-model/src/main/java/com/slack/api/model/Message.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/Message.java
@@ -105,12 +105,16 @@ public class Message {
     @Data
     public static class MessageRoot {
         private String text;
+        private String user;
         private String username;
+        private String team;
         private String botId;
         private boolean mrkdwn;
         private String type;
         private String subtype;
         private String threadTs;
+
+        private BotProfile botProfile;
 
         // https://api.slack.com/messaging/retrieving#threading
         // Parent messages in a thread will no longer explicitly list their replies.

--- a/slack-api-model/src/main/java/com/slack/api/model/WarningResponseMetadata.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/WarningResponseMetadata.java
@@ -1,0 +1,11 @@
+package com.slack.api.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class WarningResponseMetadata {
+
+    private List<String> warnings;
+}


### PR DESCRIPTION
###  Summary

This pull request fixes #372. It has improved the existing tests to consider both bot/user tokens. I've fixed a few similar issues and missing fields detected by the improved tests.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
