### PR TITLE
Add more unit tests & fix a minor issue in SingleTeamAuthorization

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/SingleTeamAuthorization.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/SingleTeamAuthorization.java
@@ -49,14 +49,15 @@ public class SingleTeamAuthorization implements Middleware {
                                     "enterprise_id: {}, team_id: {}, user_id: {}",
                             context.getEnterpriseId(), context.getTeamId(), context.getRequestUserId()
                     );
-                }
-                Installer installer = installationService.findInstaller(
-                        context.getEnterpriseId(),
-                        context.getTeamId(),
-                        context.getRequestUserId()
-                );
-                if (installer != null) {
-                    context.setRequestUserToken(installer.getInstallerUserAccessToken());
+                } else {
+                    Installer installer = installationService.findInstaller(
+                            context.getEnterpriseId(),
+                            context.getTeamId(),
+                            context.getRequestUserId()
+                    );
+                    if (installer != null) {
+                        context.setRequestUserToken(installer.getInstallerUserAccessToken());
+                    }
                 }
             }
 

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/AttachmentActionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/AttachmentActionRequest.java
@@ -22,13 +22,15 @@ public class AttachmentActionRequest extends Request<AttachmentActionContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, AttachmentActionPayload.class);
-        getContext().setResponseUrl(payload.getResponseUrl());
-        getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
-        getContext().setTeamId(payload.getTeam().getId());
-        if (payload.getChannel() != null) {
-            getContext().setChannelId(payload.getChannel().getId());
+        if (payload != null) {
+            getContext().setResponseUrl(payload.getResponseUrl());
+            getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
+            getContext().setTeamId(payload.getTeam().getId());
+            if (payload.getChannel() != null) {
+                getContext().setChannelId(payload.getChannel().getId());
+            }
+            getContext().setRequestUserId(payload.getUser().getId());
         }
-        getContext().setRequestUserId(payload.getUser().getId());
     }
 
     private AttachmentActionContext context = new AttachmentActionContext();

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/BlockActionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/BlockActionRequest.java
@@ -22,11 +22,13 @@ public class BlockActionRequest extends Request<ActionContext> {
         this.requestBody = requestBody;
         this.headers = headers;
         this.payload = GsonFactory.createSnakeCase().fromJson(payloadBody, BlockActionPayload.class);
-        getContext().setResponseUrl(payload.getResponseUrl());
-        getContext().setTriggerId(payload.getTriggerId());
-        getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
-        getContext().setTeamId(payload.getTeam().getId());
-        getContext().setRequestUserId(payload.getUser().getId());
+        if (this.payload != null) {
+            getContext().setResponseUrl(payload.getResponseUrl());
+            getContext().setTriggerId(payload.getTriggerId());
+            getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
+            getContext().setTeamId(payload.getTeam().getId());
+            getContext().setRequestUserId(payload.getUser().getId());
+        }
     }
 
     private ActionContext context = new ActionContext();

--- a/bolt/src/test/java/test_locally/middleware/LegacyRequestVerificationTest.java
+++ b/bolt/src/test/java/test_locally/middleware/LegacyRequestVerificationTest.java
@@ -4,6 +4,9 @@ import com.slack.api.bolt.middleware.MiddlewareChain;
 import com.slack.api.bolt.middleware.builtin.LegacyRequestVerification;
 import com.slack.api.bolt.request.RequestHeaders;
 import com.slack.api.bolt.request.builtin.BlockActionRequest;
+import com.slack.api.bolt.request.builtin.OutgoingWebhooksRequest;
+import com.slack.api.bolt.request.builtin.SSLCheckRequest;
+import com.slack.api.bolt.request.builtin.SlashCommandRequest;
 import com.slack.api.bolt.response.Response;
 import org.junit.Test;
 
@@ -27,6 +30,56 @@ public class LegacyRequestVerificationTest {
         String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
         RequestHeaders headers = new RequestHeaders(rawHeaders);
         BlockActionRequest req = new BlockActionRequest(requestBody, payload, headers);
+        Response resp = new Response();
+        Response result = middleware.apply(req, resp, chain);
+        assertEquals(200L, result.getStatusCode().longValue());
+    }
+
+    @Test
+    public void validRequest_ssl_check() throws Exception {
+        String requestBody = "token=valid&ssl_check=1";
+        LegacyRequestVerification middleware = new LegacyRequestVerification("valid");
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        RequestHeaders headers = new RequestHeaders(rawHeaders);
+        SSLCheckRequest req = new SSLCheckRequest(requestBody, headers);
+        Response resp = new Response();
+        Response result = middleware.apply(req, resp, chain);
+        assertEquals(200L, result.getStatusCode().longValue());
+    }
+
+    String slashCommandPayload = "token=gIkuvaNzQIHg97ATvDxqgjtO" +
+            "&team_id=T0001" +
+            "&team_domain=example" +
+            "&enterprise_id=E0001" +
+            "&enterprise_name=Globular%20Construct%20Inc" +
+            "&channel_id=C2147483705" +
+            "&channel_name=test" +
+            "&user_id=U2147483697" +
+            "&user_name=Steve" +
+            "&command=/weather" +
+            "&text=94070" +
+            "&response_url=https://hooks.slack.com/commands/1234/5678" +
+            "&trigger_id=13345224609.738474920.8088930838d88f008e0";
+
+    @Test
+    public void validRequest_command() throws Exception {
+        String requestBody = slashCommandPayload;
+        LegacyRequestVerification middleware = new LegacyRequestVerification("gIkuvaNzQIHg97ATvDxqgjtO");
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        RequestHeaders headers = new RequestHeaders(rawHeaders);
+        SlashCommandRequest req = new SlashCommandRequest(requestBody, headers);
+        Response resp = new Response();
+        Response result = middleware.apply(req, resp, chain);
+        assertEquals(200L, result.getStatusCode().longValue());
+    }
+
+    @Test
+    public void validRequest_going_webhooks() throws Exception {
+        String requestBody = "token=gIkuvaNzQIHg97ATvDxqgjtO&trigger_word=hello";
+        LegacyRequestVerification middleware = new LegacyRequestVerification("gIkuvaNzQIHg97ATvDxqgjtO");
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        RequestHeaders headers = new RequestHeaders(rawHeaders);
+        OutgoingWebhooksRequest req = new OutgoingWebhooksRequest(requestBody, headers);
         Response resp = new Response();
         Response result = middleware.apply(req, resp, chain);
         assertEquals(200L, result.getStatusCode().longValue());

--- a/bolt/src/test/java/test_locally/middleware/SingleTeamAuthorizationTest.java
+++ b/bolt/src/test/java/test_locally/middleware/SingleTeamAuthorizationTest.java
@@ -9,6 +9,8 @@ import com.slack.api.bolt.middleware.builtin.SingleTeamAuthorization;
 import com.slack.api.bolt.request.RequestHeaders;
 import com.slack.api.bolt.request.builtin.EventRequest;
 import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.bolt.service.builtin.FileInstallationService;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.response.auth.AuthTestResponse;
 import com.slack.api.model.event.MessageEvent;
@@ -33,6 +35,91 @@ public class SingleTeamAuthorizationTest {
 
     @Test
     public void valid() throws Exception {
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        RequestHeaders headers = new RequestHeaders(rawHeaders);
+        MessagePayload payload = new MessagePayload();
+        payload.setType("message");
+        payload.setTeamId("T123");
+        MessageEvent event = new MessageEvent();
+        event.setUser("U123BOT");
+        event.setTs("123.123");
+        event.setText("foo");
+        payload.setEvent(event);
+
+        MethodsClient client = mock(MethodsClient.class);
+        AuthTestResponse authTestResult = new AuthTestResponse();
+        authTestResult.setOk(true);
+        when(client.authTest(any(RequestConfigurator.class))).thenReturn(authTestResult);
+
+        EventRequest req = new EventRequest(GsonFactory.createSnakeCase().toJson(payload), headers) {
+            @Override
+            public EventContext getContext() {
+                EventContext context = new EventContext() {
+                    @Override
+                    public MethodsClient client() {
+                        return client;
+                    }
+                };
+                return context;
+            }
+        };
+        req.getContext().setBotToken("xoxb-123");
+        req.getContext().setBotUserId("U123BOT");
+        req.getContext().setRequestUserId("U123");
+        Response resp = new Response();
+        Response result = middleware.apply(req, resp, chain);
+        assertEquals(200L, result.getStatusCode().longValue());
+    }
+
+    @Test
+    public void valid_plus_user_token() throws Exception {
+        AppConfig config = new AppConfig();
+        config.setAlwaysRequestUserTokenNeeded(true);
+        InstallationService service = new FileInstallationService(config);
+        SingleTeamAuthorization middleware = new SingleTeamAuthorization(config, service);
+
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        RequestHeaders headers = new RequestHeaders(rawHeaders);
+        MessagePayload payload = new MessagePayload();
+        payload.setType("message");
+        payload.setTeamId("T123");
+        MessageEvent event = new MessageEvent();
+        event.setUser("U123BOT");
+        event.setTs("123.123");
+        event.setText("foo");
+        payload.setEvent(event);
+
+        MethodsClient client = mock(MethodsClient.class);
+        AuthTestResponse authTestResult = new AuthTestResponse();
+        authTestResult.setOk(true);
+        when(client.authTest(any(RequestConfigurator.class))).thenReturn(authTestResult);
+
+        EventRequest req = new EventRequest(GsonFactory.createSnakeCase().toJson(payload), headers) {
+            @Override
+            public EventContext getContext() {
+                EventContext context = new EventContext() {
+                    @Override
+                    public MethodsClient client() {
+                        return client;
+                    }
+                };
+                return context;
+            }
+        };
+        req.getContext().setBotToken("xoxb-123");
+        req.getContext().setBotUserId("U123BOT");
+        req.getContext().setRequestUserId("U123");
+        Response resp = new Response();
+        Response result = middleware.apply(req, resp, chain);
+        assertEquals(200L, result.getStatusCode().longValue());
+    }
+
+    @Test
+    public void valid_plus_user_token_without_InstallationService() throws Exception {
+        AppConfig config = new AppConfig();
+        config.setAlwaysRequestUserTokenNeeded(true);
+        SingleTeamAuthorization middleware = new SingleTeamAuthorization(config, null);
+
         Map<String, List<String>> rawHeaders = new HashMap<>();
         RequestHeaders headers = new RequestHeaders(rawHeaders);
         MessagePayload payload = new MessagePayload();

--- a/bolt/src/test/java/test_locally/request/BlockActionRequestTest.java
+++ b/bolt/src/test/java/test_locally/request/BlockActionRequestTest.java
@@ -1,0 +1,107 @@
+package test_locally.request;
+
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.builtin.BlockActionRequest;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class BlockActionRequestTest {
+
+    @Test
+    public void test_null_payload() {
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String signature = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
+        String requestBody = "payload=";
+        String remoteAddress = "127.0.0.1";
+        rawHeaders.put("X-Slack-Signature", Arrays.asList(signature));
+        RequestHeaders headers = new RequestHeaders(rawHeaders);
+        BlockActionRequest request = new BlockActionRequest(requestBody, null, headers);
+        request.setClientIpAddress(remoteAddress);
+
+        assertEquals(remoteAddress, request.getClientIpAddress());
+        assertEquals(0, request.getQueryString().size());
+        assertEquals(requestBody, request.getRequestBodyAsString());
+        assertEquals(1, request.getHeaders().getNames().size());
+        assertEquals("x-slack-signature", request.getHeaders().getNames().iterator().next());
+        assertEquals(signature, request.getHeaders().getFirstValue("X-Slack-Signature"));
+    }
+
+    String payload = "{\n" +
+            "  \"type\": \"block_actions\",\n" +
+            "  \"team\": {\n" +
+            "    \"id\": \"T9TK3CUKW\",\n" +
+            "    \"domain\": \"example\"\n" +
+            "  },\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"UA8RXUSPL\",\n" +
+            "    \"username\": \"jtorrance\",\n" +
+            "    \"team_id\": \"T9TK3CUKW\"\n" +
+            "  },\n" +
+            "  \"api_app_id\": \"AABA1ABCD\",\n" +
+            "  \"token\": \"9s8d9as89d8as9d8as989\",\n" +
+            "  \"container\": {\n" +
+            "    \"type\": \"message_attachment\",\n" +
+            "    \"message_ts\": \"1548261231.000200\",\n" +
+            "    \"attachment_id\": 1,\n" +
+            "    \"channel_id\": \"CBR2V3XEX\",\n" +
+            "    \"is_ephemeral\": false,\n" +
+            "    \"is_app_unfurl\": false\n" +
+            "  },\n" +
+            "  \"trigger_id\": \"12321423423.333649436676.d8c1bb837935619ccad0f624c448ffb3\",\n" +
+            "  \"channel\": {\n" +
+            "    \"id\": \"CBR2V3XEX\",\n" +
+            "    \"name\": \"review-updates\"\n" +
+            "  },\n" +
+            "  \"message\": {\n" +
+            "    \"bot_id\": \"BAH5CA16Z\",\n" +
+            "    \"type\": \"message\",\n" +
+            "    \"text\": \"This content can't be displayed.\",\n" +
+            "    \"user\": \"UAJ2RU415\",\n" +
+            "    \"ts\": \"1548261231.000200\"\n" +
+            "  },\n" +
+            "  \"response_url\": \"https://hooks.slack.com/actions/AABA1ABCD/1232321423432/D09sSasdasdAS9091209\",\n" +
+            "  \"actions\": [\n" +
+            "    {\n" +
+            "      \"action_id\": \"WaXA\",\n" +
+            "      \"block_id\": \"=qXel\",\n" +
+            "      \"text\": {\n" +
+            "        \"type\": \"plain_text\",\n" +
+            "        \"text\": \"View\",\n" +
+            "        \"emoji\": true\n" +
+            "      },\n" +
+            "      \"value\": \"click_me_123\",\n" +
+            "      \"type\": \"button\",\n" +
+            "      \"action_ts\": \"1548426417.840180\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    @Test
+    public void test_validPayload_single_workspace_mode() throws UnsupportedEncodingException {
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String signature = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
+        String requestBody = "payload=" + URLEncoder.encode(payload, "UTF-8");
+        String remoteAddress = "127.0.0.1";
+        rawHeaders.put("X-Slack-Signature", Arrays.asList(signature));
+        RequestHeaders headers = new RequestHeaders(rawHeaders);
+        BlockActionRequest request = new BlockActionRequest(requestBody, payload, headers);
+        request.setClientIpAddress(remoteAddress);
+        request.updateContext(AppConfig.builder().singleTeamBotToken("xoxb-123-123").build());
+
+        assertEquals(remoteAddress, request.getClientIpAddress());
+        assertEquals(0, request.getQueryString().size());
+        assertEquals(requestBody, request.getRequestBodyAsString());
+        assertEquals(1, request.getHeaders().getNames().size());
+        assertEquals("x-slack-signature", request.getHeaders().getNames().iterator().next());
+        assertEquals(signature, request.getHeaders().getFirstValue("X-Slack-Signature"));
+    }
+}

--- a/bolt/src/test/java/test_locally/request/LegacyRequestsTest.java
+++ b/bolt/src/test/java/test_locally/request/LegacyRequestsTest.java
@@ -1,0 +1,135 @@
+package test_locally.request;
+
+import com.google.gson.Gson;
+import com.slack.api.app_backend.dialogs.payload.DialogCancellationPayload;
+import com.slack.api.app_backend.dialogs.payload.DialogSubmissionPayload;
+import com.slack.api.app_backend.dialogs.payload.DialogSuggestionPayload;
+import com.slack.api.app_backend.interactive_components.payload.AttachmentActionPayload;
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.RequestType;
+import com.slack.api.bolt.request.builtin.*;
+import com.slack.api.util.json.GsonFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class LegacyRequestsTest {
+
+    Gson gson = GsonFactory.createSnakeCase();
+    RequestHeaders requestHeaders = new RequestHeaders(Collections.emptyMap());
+
+    String attachmentActionPayloadString;
+    AttachmentActionRequest attachmentActionRequest;
+
+    String dialogCancellationPayloadString;
+    DialogCancellationRequest dialogCancellationRequest;
+
+    String dialogSuggestionPayloadString;
+    DialogSuggestionRequest dialogSuggestionRequest;
+
+    String dialogSubmissionPayloadString;
+    DialogSubmissionRequest dialogSubmissionRequest;
+
+    String webhookPayloadString;
+    OutgoingWebhooksRequest webhooksRequest;
+
+    @Before
+    public void setup() throws UnsupportedEncodingException {
+        AttachmentActionPayload attachmentActionPayload = new AttachmentActionPayload();
+        attachmentActionPayload.setTeam(new AttachmentActionPayload.Team());
+        attachmentActionPayload.setUser(new AttachmentActionPayload.User());
+        attachmentActionPayload.setChannel(new AttachmentActionPayload.Channel());
+        attachmentActionPayloadString = gson.toJson(attachmentActionPayload);
+        attachmentActionRequest = new AttachmentActionRequest(
+                "payload=" + URLEncoder.encode(attachmentActionPayloadString, "UTF-8"),
+                attachmentActionPayloadString,
+                requestHeaders
+        );
+
+        DialogCancellationPayload dialogCancellationPayload = new DialogCancellationPayload();
+        dialogCancellationPayload.setTeam(new DialogCancellationPayload.Team());
+        dialogCancellationPayload.setUser(new DialogCancellationPayload.User());
+        dialogCancellationPayload.setChannel(new DialogCancellationPayload.Channel());
+        dialogCancellationPayloadString = gson.toJson(dialogCancellationPayload);
+        dialogCancellationRequest = new DialogCancellationRequest(
+                "payload=" + URLEncoder.encode(dialogCancellationPayloadString, "UTF-8"),
+                dialogCancellationPayloadString,
+                requestHeaders
+        );
+
+        DialogSuggestionPayload dialogSuggestionPayload = new DialogSuggestionPayload();
+        dialogSuggestionPayload.setTeam(new DialogSuggestionPayload.Team());
+        dialogSuggestionPayload.setUser(new DialogSuggestionPayload.User());
+        dialogSuggestionPayload.setChannel(new DialogSuggestionPayload.Channel());
+        dialogSuggestionPayloadString = gson.toJson(dialogSuggestionPayload);
+        dialogSuggestionRequest = new DialogSuggestionRequest(
+                "payload=" + URLEncoder.encode(dialogSuggestionPayloadString, "UTF-8"),
+                dialogSuggestionPayloadString,
+                requestHeaders
+        );
+
+        DialogSubmissionPayload dialogSubmissionPayload = new DialogSubmissionPayload();
+        dialogSubmissionPayload.setTeam(new DialogSubmissionPayload.Team());
+        dialogSubmissionPayload.setUser(new DialogSubmissionPayload.User());
+        dialogSubmissionPayload.setChannel(new DialogSubmissionPayload.Channel());
+        dialogSubmissionPayloadString = gson.toJson(dialogSuggestionPayload);
+        dialogSubmissionRequest = new DialogSubmissionRequest(
+                "payload=" + URLEncoder.encode(dialogSubmissionPayloadString, "UTF-8"),
+                dialogSubmissionPayloadString,
+                requestHeaders
+        );
+
+        webhookPayloadString = "token=123&trigger_word=hello";
+        webhooksRequest = new OutgoingWebhooksRequest(webhookPayloadString, requestHeaders);
+    }
+
+    @Test
+    public void getRequestType() {
+        assertEquals(RequestType.AttachmentAction, attachmentActionRequest.getRequestType());
+        assertEquals(RequestType.DialogCancellation, dialogCancellationRequest.getRequestType());
+        assertEquals(RequestType.DialogSuggestion, dialogSuggestionRequest.getRequestType());
+        assertEquals(RequestType.DialogSubmission, dialogSubmissionRequest.getRequestType());
+        assertEquals(RequestType.OutgoingWebhooks, webhooksRequest.getRequestType());
+    }
+
+    @Test
+    public void getRequestBodyAsString() throws UnsupportedEncodingException {
+        assertEquals(
+                "payload=" + URLEncoder.encode(attachmentActionPayloadString, "UTF-8"),
+                attachmentActionRequest.getRequestBodyAsString());
+        assertEquals(
+                "payload=" + URLEncoder.encode(dialogCancellationPayloadString, "UTF-8"),
+                dialogCancellationRequest.getRequestBodyAsString());
+        assertEquals(
+                "payload=" + URLEncoder.encode(dialogSuggestionPayloadString, "UTF-8"),
+                dialogSuggestionRequest.getRequestBodyAsString());
+        assertEquals(
+                "payload=" + URLEncoder.encode(dialogSubmissionPayloadString, "UTF-8"),
+                dialogSubmissionRequest.getRequestBodyAsString());
+        assertEquals(webhookPayloadString, webhooksRequest.getRequestBodyAsString());
+    }
+
+    @Test
+    public void getHeaders() {
+        assertEquals(requestHeaders, attachmentActionRequest.getHeaders());
+        assertEquals(requestHeaders, dialogCancellationRequest.getHeaders());
+        assertEquals(requestHeaders, dialogSuggestionRequest.getHeaders());
+        assertEquals(requestHeaders, dialogSubmissionRequest.getHeaders());
+        assertEquals(requestHeaders, webhooksRequest.getHeaders());
+    }
+
+    @Test
+    public void getPayload() {
+        assertNotNull(attachmentActionRequest.getPayload());
+        assertNotNull(dialogCancellationRequest.getPayload());
+        assertNotNull(dialogSuggestionRequest.getPayload());
+        assertNotNull(dialogSubmissionRequest.getPayload());
+        assertNotNull(webhooksRequest.getPayload());
+    }
+}

--- a/bolt/src/test/java/test_locally/request/WebEndpointRequestTest.java
+++ b/bolt/src/test/java/test_locally/request/WebEndpointRequestTest.java
@@ -1,0 +1,33 @@
+package test_locally.request;
+
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.WebEndpointRequest;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class WebEndpointRequestTest {
+
+    @Test
+    public void test() {
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String signature = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
+        String query = "foo=bar";
+        String remoteAddress = "127.0.0.1";
+        rawHeaders.put("X-Slack-Signature", Arrays.asList(signature));
+        RequestHeaders headers = new RequestHeaders(rawHeaders);
+        WebEndpointRequest request = new WebEndpointRequest(query, null, headers);
+        request.setClientIpAddress(remoteAddress);
+
+        assertEquals(remoteAddress, request.getClientIpAddress());
+        assertEquals(query, request.getQueryString());
+        assertEquals(1, request.getHeaders().getNames().size());
+        assertEquals("x-slack-signature", request.getHeaders().getNames().iterator().next());
+        assertEquals(signature, request.getHeaders().getFirstValue("X-Slack-Signature"));
+    }
+}

--- a/bolt/src/test/java/test_locally/response/ResponderTest.java
+++ b/bolt/src/test/java/test_locally/response/ResponderTest.java
@@ -1,0 +1,34 @@
+package test_locally.response;
+
+import com.slack.api.Slack;
+import com.slack.api.app_backend.interactive_components.response.ActionResponse;
+import com.slack.api.bolt.response.Responder;
+import com.slack.api.webhook.WebhookResponse;
+import org.junit.Test;
+import util.WebhookMockServer;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResponderTest {
+
+    @Test
+    public void test() throws Exception {
+        WebhookMockServer slackApiServer = new WebhookMockServer();
+        slackApiServer.start();
+        Slack slack = Slack.getInstance();
+        Responder responder = new Responder(slack, slackApiServer.getWebhookUrl());
+        try {
+            ActionResponse body = ActionResponse.builder().text("Hi").build();
+            WebhookResponse response = responder.send(body);
+            assertEquals(200L, response.getCode().longValue());
+
+            WebhookResponse actionResponse = responder.sendToAction(r -> r.text("Hi"));
+            assertEquals(200L, actionResponse.getCode().longValue());
+
+            WebhookResponse commandResponse = responder.sendToCommand(r -> r.text("Hi"));
+            assertEquals(200L, commandResponse.getCode().longValue());
+        } finally {
+            slackApiServer.stop();
+        }
+    }
+}

--- a/bolt/src/test/java/test_locally/response/ResponseTest.java
+++ b/bolt/src/test/java/test_locally/response/ResponseTest.java
@@ -1,0 +1,22 @@
+package test_locally.response;
+
+import com.slack.api.bolt.response.Response;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ResponseTest {
+
+    @Test
+    public void ok() {
+        Map<String, String> obj = new HashMap<>();
+        obj.put("error", "invalid_arguments");
+        Response response = Response.ok(obj);
+        assertNotNull(response);
+        assertEquals(200L, response.getStatusCode().longValue());
+    }
+}

--- a/bolt/src/test/java/test_locally/servlet/ServletAdapterOpsTest.java
+++ b/bolt/src/test/java/test_locally/servlet/ServletAdapterOpsTest.java
@@ -1,0 +1,39 @@
+package test_locally.servlet;
+
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.servlet.ServletAdapterOps;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+public class ServletAdapterOpsTest {
+
+    @Test
+    public void writeResponse() throws IOException {
+        HttpServletResponse httpResponse = mock(HttpServletResponse.class);
+        PrintWriter writer = mock(PrintWriter.class);
+        when(httpResponse.getWriter()).thenReturn(writer);
+        Response boltResponse = new Response();
+        boltResponse.setStatusCode(404);
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Set-Cookie", Arrays.asList("foo=bar"));
+        boltResponse.setHeaders(headers);
+        boltResponse.setBody("This is a message for you!");
+
+        ServletAdapterOps.writeResponse(httpResponse, boltResponse);
+
+        verify(httpResponse, times(1)).setStatus(404);
+        verify(httpResponse, times(1)).addHeader("Set-Cookie", "foo=bar");
+        verify(httpResponse, times(1)).getWriter();
+        verify(writer, times(1)).write("This is a message for you!");
+    }
+}

--- a/bolt/src/test/java/test_locally/servlet/SlackAppServletTest.java
+++ b/bolt/src/test/java/test_locally/servlet/SlackAppServletTest.java
@@ -1,0 +1,93 @@
+package test_locally.servlet;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.servlet.SlackAppServlet;
+import org.junit.Test;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.*;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class SlackAppServletTest {
+
+    @Test
+    public void instantiation() {
+        App app = new App(AppConfig.builder().singleTeamBotToken("xoxb-xxx").signingSecret("secret").build());
+        SlackAppServlet servlet = new SlackAppServlet(app);
+        assertEquals(app, servlet.getApp());
+    }
+
+    String slashCommandPayload = "token=gIkuvaNzQIHg97ATvDxqgjtO" +
+            "&team_id=T0001" +
+            "&team_domain=example" +
+            "&enterprise_id=E0001" +
+            "&enterprise_name=Globular%20Construct%20Inc" +
+            "&channel_id=C2147483705" +
+            "&channel_name=test" +
+            "&user_id=U2147483697" +
+            "&user_name=Steve" +
+            "&command=/weather" +
+            "&text=94070" +
+            "&response_url=https://hooks.slack.com/commands/1234/5678" +
+            "&trigger_id=13345224609.738474920.8088930838d88f008e0";
+
+    static class SimpleServletInputStream extends ServletInputStream {
+        final ByteArrayInputStream body;
+
+        SimpleServletInputStream(String body) {
+            this.body = new ByteArrayInputStream(body.getBytes());
+        }
+
+        @Override
+        public boolean isFinished() {
+            return body.available() == 0;
+        }
+
+        @Override
+        public boolean isReady() {
+            return body.available() > 0;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+
+        @Override
+        public int read() {
+            return body.read();
+        }
+    }
+
+    @Test
+    public void errorHandler() throws ServletException, IOException {
+        AppConfig config = AppConfig.builder().singleTeamBotToken("xoxb-xxx").signingSecret("secret").build();
+        App app = new App(config, Collections.emptyList()); // bypass the built-in middleware
+        app.command("/weather", (req, ctx) -> {
+            throw new RuntimeException("Something is wrong!");
+        });
+        SlackAppServlet servlet = new SlackAppServlet(app);
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getMethod()).thenReturn("POST");
+        ServletInputStream body = new SimpleServletInputStream(slashCommandPayload);
+        when(req.getInputStream()).thenReturn(body);
+        when(req.getReader()).thenReturn(new BufferedReader(new InputStreamReader(body)));
+        when(req.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
+
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        PrintWriter writer = mock(PrintWriter.class);
+        when(resp.getWriter()).thenReturn(writer);
+
+        servlet.service(req, resp);
+
+        verify(resp, times(1)).setStatus(500);
+    }
+}

--- a/bolt/src/test/java/test_locally/servlet/SlackOAuthAppServletTest.java
+++ b/bolt/src/test/java/test_locally/servlet/SlackOAuthAppServletTest.java
@@ -1,0 +1,138 @@
+package test_locally.servlet;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.service.OAuthStateService;
+import com.slack.api.bolt.servlet.SlackAppServlet;
+import com.slack.api.bolt.servlet.SlackOAuthAppServlet;
+import org.junit.Test;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.*;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class SlackOAuthAppServletTest {
+
+    @Test
+    public void instantiation() {
+        App app = new App(AppConfig.builder().singleTeamBotToken("xoxb-xxx").signingSecret("secret").build());
+        SlackOAuthAppServlet servlet = new SlackOAuthAppServlet(app);
+        assertEquals(app, servlet.getApp());
+    }
+
+    String slashCommandPayload = "token=gIkuvaNzQIHg97ATvDxqgjtO" +
+            "&team_id=T0001" +
+            "&team_domain=example" +
+            "&enterprise_id=E0001" +
+            "&enterprise_name=Globular%20Construct%20Inc" +
+            "&channel_id=C2147483705" +
+            "&channel_name=test" +
+            "&user_id=U2147483697" +
+            "&user_name=Steve" +
+            "&command=/weather" +
+            "&text=94070" +
+            "&response_url=https://hooks.slack.com/commands/1234/5678" +
+            "&trigger_id=13345224609.738474920.8088930838d88f008e0";
+
+    static class SimpleServletInputStream extends ServletInputStream {
+        final ByteArrayInputStream body;
+
+        SimpleServletInputStream(String body) {
+            this.body = new ByteArrayInputStream(body.getBytes());
+        }
+
+        @Override
+        public boolean isFinished() {
+            return body.available() == 0;
+        }
+
+        @Override
+        public boolean isReady() {
+            return body.available() > 0;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+
+        @Override
+        public int read() {
+            return body.read();
+        }
+    }
+
+    @Test
+    public void oauthStart() throws ServletException, IOException {
+        AppConfig config = AppConfig.builder()
+                .signingSecret("secret")
+                .clientId("123.123")
+                .clientSecret("secret")
+                .oauthStartPath("/start")
+                .build();
+        App app = new App(config, Collections.emptyList()).asOAuthApp(true); // bypass the built-in middleware
+        SlackOAuthAppServlet servlet = new SlackOAuthAppServlet(app);
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getMethod()).thenReturn("GET");
+        when(req.getRequestURI()).thenReturn("/start");
+        ServletInputStream body = new SimpleServletInputStream("");
+        when(req.getInputStream()).thenReturn(body);
+        when(req.getReader()).thenReturn(new BufferedReader(new InputStreamReader(body)));
+        when(req.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
+
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        PrintWriter writer = mock(PrintWriter.class);
+        when(resp.getWriter()).thenReturn(writer);
+
+        servlet.service(req, resp);
+
+        verify(resp, times(1)).setStatus(302);
+    }
+
+    @Test
+    public void oauthStart_error() throws ServletException, IOException {
+        AppConfig config = AppConfig.builder()
+                .signingSecret("secret")
+                .clientId("123.123")
+                .clientSecret("secret")
+                .oauthStartPath("/start")
+                .build();
+        App app = new App(config, Collections.emptyList()).asOAuthApp(true); // bypass the built-in middleware
+        app.service(new OAuthStateService() {
+            @Override
+            public void addNewStateToDatastore(String state) throws Exception {
+                throw new Exception("Something is wrong!");
+            }
+
+            @Override
+            public boolean isAvailableInDatabase(String state) {
+                return false;
+            }
+
+            @Override
+            public void deleteStateFromDatastore(String state) {
+            }
+        });
+        SlackOAuthAppServlet servlet = new SlackOAuthAppServlet(app);
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getMethod()).thenReturn("GET");
+        when(req.getRequestURI()).thenReturn("/start");
+        ServletInputStream body = new SimpleServletInputStream("");
+        when(req.getInputStream()).thenReturn(body);
+        when(req.getReader()).thenReturn(new BufferedReader(new InputStreamReader(body)));
+        when(req.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
+
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        PrintWriter writer = mock(PrintWriter.class);
+        when(resp.getWriter()).thenReturn(writer);
+
+        servlet.service(req, resp);
+
+        verify(resp, times(1)).setStatus(500);
+    }}


### PR DESCRIPTION
###  Summary

This pull request adds more unit tests to the `bolt` project. Also, I've fixed a very minor issue in `SingleTeamAuthorization` where a NullPointerException potentially occurs only when `AppConfig#isAlwaysRequestUserTokenNeeded()` is `true` plus `InstallationService` is null (this is actually an invalid setting).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
