### PR TITLE
Add missing field to chat.scheduledMessages.list

### DIFF
--- a/json-logs/samples/api/chat.scheduleMessage.json
+++ b/json-logs/samples/api/chat.scheduleMessage.json
@@ -132,6 +132,12 @@
     "blocks": [
       {
         "type": "",
+        "block_id": "",
+        "text": {
+          "type": "",
+          "text": "",
+          "emoji": false
+        },
         "elements": [
           {
             "type": "",
@@ -207,7 +213,6 @@
             "image_bytes": 12345
           }
         ],
-        "block_id": "",
         "fallback": "",
         "image_url": "",
         "image_width": 12345,
@@ -215,11 +220,6 @@
         "image_bytes": 12345,
         "alt_text": "",
         "title": {
-          "type": "",
-          "text": "",
-          "emoji": false
-        },
-        "text": {
           "type": "",
           "text": "",
           "emoji": false

--- a/json-logs/samples/api/chat.scheduledMessages.list.json
+++ b/json-logs/samples/api/chat.scheduledMessages.list.json
@@ -5,7 +5,8 @@
       "id": "Q00000000",
       "channel_id": "C00000000",
       "post_at": 12345,
-      "date_created": 12345
+      "date_created": 12345,
+      "text": ""
     }
   ],
   "response_metadata": {

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/scheduled_messages/ChatScheduledMessagesListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/scheduled_messages/ChatScheduledMessagesListResponse.java
@@ -22,6 +22,7 @@ public class ChatScheduledMessagesListResponse implements SlackApiResponse {
     public static class ScheduledMessage {
         private String id;
         private String channelId;
+        private String text;
         private Integer postAt;
         private Integer dateCreated;
     }


### PR DESCRIPTION
###  Summary

It's a pretty minor fix but this pull request adds a missing field in `ChatScheduledMessagesListResponse` detected by a unit test.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
