### PR TITLE
Add app.message/app.botMessage handlers

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/EventRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/EventRequest.java
@@ -69,6 +69,10 @@ public class EventRequest extends Request<EventContext> {
     }
 
     public String getEventTypeAndSubtype() {
-        return eventType + ":" + eventSubtype;
+        if (eventSubtype == null) {
+            return eventType;
+        } else {
+            return eventType + ":" + eventSubtype;
+        }
     }
 }

--- a/bolt/src/test/java/samples/MessagesSample.java
+++ b/bolt/src/test/java/samples/MessagesSample.java
@@ -1,0 +1,30 @@
+package samples;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import lombok.extern.slf4j.Slf4j;
+import samples.util.ResourceLoader;
+import samples.util.TestSlackAppServer;
+
+@Slf4j
+public class MessagesSample {
+
+    public static void main(String[] args) throws Exception {
+        AppConfig config = ResourceLoader.loadAppConfig();
+        App app = new App(config);
+
+        app.message("posted by a user", (event, ctx) -> {
+            ctx.say("You're right. This is a message by a user <@" + event.getEvent().getUser() + "> !");
+            return ctx.ack();
+        });
+        app.botMessage("posted by a bot", (event, ctx) -> {
+            String botId = event.getEvent().getBotId();
+            String userId = ctx.client().botsInfo(r -> r.bot(botId)).getBot().getUserId();
+            ctx.say("You're right. This is a message by a bot user <@" + userId + "> !");
+            return ctx.ack();
+        });
+        TestSlackAppServer server = new TestSlackAppServer(app);
+        server.start();
+    }
+
+}

--- a/bolt/src/test/java/test_locally/app/EventTest.java
+++ b/bolt/src/test/java/test_locally/app/EventTest.java
@@ -1,0 +1,145 @@
+package test_locally.app;
+
+import com.google.gson.Gson;
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.app_backend.SlackSignature;
+import com.slack.api.app_backend.events.payload.EventsApiPayload;
+import com.slack.api.app_backend.events.payload.MessageBotPayload;
+import com.slack.api.app_backend.events.payload.MessagePayload;
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.builtin.EventRequest;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.model.event.MessageBotEvent;
+import com.slack.api.model.event.MessageEvent;
+import com.slack.api.util.json.GsonFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import util.AuthTestMockServer;
+import util.MockSlackApiServer;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+@Slf4j
+public class EventTest {
+
+    MockSlackApiServer server = new MockSlackApiServer();
+    SlackConfig config = new SlackConfig();
+    Slack slack = Slack.getInstance(config);
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    final Gson gson = GsonFactory.createSnakeCase();
+    final String secret = "foo-bar-baz";
+    final SlackSignature.Generator generator = new SlackSignature.Generator(secret);
+
+    @Test
+    public void user() throws Exception {
+        App app = buildApp();
+        AtomicBoolean userMessageReceived = new AtomicBoolean(false);
+        app.event(MessageEvent.class, (req, ctx) -> {
+            userMessageReceived.set(req.getEvent().getUser().equals("U123"));
+            return ctx.ack();
+        });
+        AtomicBoolean botMessageReceived = new AtomicBoolean(false);
+        app.event(MessageBotEvent.class, (req, ctx) -> {
+            botMessageReceived.set(req.getEvent().getBotId().equals("B123"));
+            return ctx.ack();
+        });
+
+        EventsApiPayload<MessageEvent> payload = buildUserMessagePayload();
+
+        String requestBody = gson.toJson(payload);
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(requestBody, rawHeaders, timestamp);
+
+        EventRequest req = new EventRequest(requestBody, new RequestHeaders(rawHeaders));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+        assertTrue(userMessageReceived.get());
+        assertFalse(botMessageReceived.get());
+    }
+
+    @Test
+    public void bot() throws Exception {
+        App app = buildApp();
+        AtomicBoolean userMessageReceived = new AtomicBoolean(false);
+        app.event(MessageEvent.class, (req, ctx) -> {
+            userMessageReceived.set(req.getEvent().getUser().equals("U123"));
+            return ctx.ack();
+        });
+        AtomicBoolean botMessageReceived = new AtomicBoolean(false);
+        app.event(MessageBotEvent.class, (req, ctx) -> {
+            botMessageReceived.set(req.getEvent().getBotId().equals("B123"));
+            return ctx.ack();
+        });
+
+        EventsApiPayload<MessageBotEvent> payload = buildUserBotMessagePayload();
+
+        String requestBody = gson.toJson(payload);
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(requestBody, rawHeaders, timestamp);
+
+        EventRequest req = new EventRequest(requestBody, new RequestHeaders(rawHeaders));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        assertFalse(userMessageReceived.get());
+        assertTrue(botMessageReceived.get());
+    }
+
+    App buildApp() {
+        return new App(AppConfig.builder()
+                .signingSecret(secret)
+                .singleTeamBotToken(AuthTestMockServer.ValidToken)
+                .slack(slack)
+                .build());
+    }
+
+    void setRequestHeaders(String requestBody, Map<String, List<String>> rawHeaders, String timestamp) {
+        rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP, Arrays.asList(timestamp));
+        rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_SIGNATURE, Arrays.asList(generator.generate(timestamp, requestBody)));
+    }
+
+    EventsApiPayload<MessageEvent> buildUserMessagePayload() {
+        EventsApiPayload<MessageEvent> payload = new MessagePayload();
+        MessageEvent event = new MessageEvent();
+        event.setUser("U123");
+        event.setText("This is a message sent by a user.");
+        payload.setEvent(event);
+        payload.setTeamId("T123");
+        return payload;
+    }
+
+    EventsApiPayload<MessageBotEvent> buildUserBotMessagePayload() {
+        EventsApiPayload<MessageBotEvent> payload = new MessageBotPayload();
+        MessageBotEvent event = new MessageBotEvent();
+        event.setBotId("B123");
+        event.setText("This is a message sent by a bot user.");
+        payload.setEvent(event);
+        payload.setTeamId("T123");
+        return payload;
+    }
+
+}

--- a/bolt/src/test/java/test_locally/app/MessageTest.java
+++ b/bolt/src/test/java/test_locally/app/MessageTest.java
@@ -1,0 +1,290 @@
+package test_locally.app;
+
+import com.google.gson.Gson;
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.app_backend.SlackSignature;
+import com.slack.api.app_backend.events.payload.EventsApiPayload;
+import com.slack.api.app_backend.events.payload.MessageBotPayload;
+import com.slack.api.app_backend.events.payload.MessagePayload;
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.builtin.EventRequest;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.model.event.MessageBotEvent;
+import com.slack.api.model.event.MessageEvent;
+import com.slack.api.util.json.GsonFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import util.AuthTestMockServer;
+import util.MockSlackApiServer;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+@Slf4j
+public class MessageTest {
+
+    MockSlackApiServer server = new MockSlackApiServer();
+    SlackConfig config = new SlackConfig();
+    Slack slack = Slack.getInstance(config);
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    final Gson gson = GsonFactory.createSnakeCase();
+    final String secret = "foo-bar-baz";
+    final SlackSignature.Generator generator = new SlackSignature.Generator(secret);
+
+    @Test
+    public void user() throws Exception {
+        App app = buildApp();
+        AtomicBoolean userMessageReceived = new AtomicBoolean(false);
+        app.message("sent by a user", (req, ctx) -> {
+            userMessageReceived.set(req.getEvent().getUser().equals("U123"));
+            return ctx.ack();
+        });
+        AtomicBoolean botMessageReceived = new AtomicBoolean(false);
+        app.botMessage("sent by a user", (req, ctx) -> {
+            botMessageReceived.set(req.getEvent().getBotId().equals("B123"));
+            return ctx.ack();
+        });
+
+        EventsApiPayload<MessageEvent> payload = buildUserMessagePayload();
+
+        EventRequest req = buildRequest(gson.toJson(payload));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+        assertTrue(userMessageReceived.get());
+        assertFalse(botMessageReceived.get());
+    }
+
+    @Test
+    public void user_word_matching() throws Exception {
+        App app = buildApp();
+        AtomicBoolean userMessageReceived = new AtomicBoolean(false);
+        app.message("sent by a user...", (req, ctx) -> {
+            userMessageReceived.set(req.getEvent().getUser().equals("U123"));
+            return ctx.ack();
+        });
+        AtomicBoolean botMessageReceived = new AtomicBoolean(false);
+        app.botMessage("sent by a user...", (req, ctx) -> {
+            botMessageReceived.set(req.getEvent().getBotId().equals("B123"));
+            return ctx.ack();
+        });
+
+        EventsApiPayload<MessageEvent> payload = buildUserMessagePayload();
+        payload.getEvent().setText("This is a message sent by a user... is it really correct?");
+
+        EventRequest req = buildRequest(gson.toJson(payload));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+        assertTrue(userMessageReceived.get());
+        assertFalse(botMessageReceived.get());
+    }
+
+    @Test
+    public void user_word_not_matching() throws Exception {
+        App app = buildApp();
+        AtomicBoolean userMessageReceived = new AtomicBoolean(false);
+        app.message("sent by a user, is it really correct?", (req, ctx) -> {
+            userMessageReceived.set(req.getEvent().getUser().equals("U123"));
+            return ctx.ack();
+        });
+        AtomicBoolean botMessageReceived = new AtomicBoolean(false);
+        app.botMessage("sent by a user, is it really correct?", (req, ctx) -> {
+            botMessageReceived.set(req.getEvent().getBotId().equals("B123"));
+            return ctx.ack();
+        });
+
+        EventsApiPayload<MessageEvent> payload = buildUserMessagePayload();
+        payload.getEvent().setText("This is a message sent by a user... is it really correct?");
+
+        EventRequest req = buildRequest(gson.toJson(payload));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+        assertFalse(userMessageReceived.get());
+        assertFalse(botMessageReceived.get());
+    }
+
+    @Test
+    public void user_regexp_matching() throws Exception {
+        Pattern pattern = Pattern.compile("^.*sent by a user\\.\\.\\..*$");
+        App app = buildApp();
+        AtomicBoolean userMessageReceived = new AtomicBoolean(false);
+        app.message(pattern, (req, ctx) -> {
+            userMessageReceived.set(req.getEvent().getUser().equals("U123"));
+            return ctx.ack();
+        });
+        AtomicBoolean botMessageReceived = new AtomicBoolean(false);
+        app.botMessage(pattern, (req, ctx) -> {
+            botMessageReceived.set(req.getEvent().getBotId().equals("B123"));
+            return ctx.ack();
+        });
+
+        EventsApiPayload<MessageEvent> payload = buildUserMessagePayload();
+        payload.getEvent().setText("This is a message sent by a user... is it really correct?");
+
+        EventRequest req = buildRequest(gson.toJson(payload));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+        assertTrue(userMessageReceived.get());
+        assertFalse(botMessageReceived.get());
+    }
+
+    @Test
+    public void user_regexp_not_matching() throws Exception {
+        Pattern pattern = Pattern.compile("^.*sent by a user, is it really correct\\?.*$");
+        App app = buildApp();
+        AtomicBoolean userMessageReceived = new AtomicBoolean(false);
+        app.message(pattern, (req, ctx) -> {
+            userMessageReceived.set(req.getEvent().getUser().equals("U123"));
+            return ctx.ack();
+        });
+        AtomicBoolean botMessageReceived = new AtomicBoolean(false);
+        app.botMessage(pattern, (req, ctx) -> {
+            botMessageReceived.set(req.getEvent().getBotId().equals("B123"));
+            return ctx.ack();
+        });
+
+        EventsApiPayload<MessageEvent> payload = buildUserMessagePayload();
+        payload.getEvent().setText("This is a message sent by a user... is it really correct?");
+
+        EventRequest req = buildRequest(gson.toJson(payload));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+        assertFalse(userMessageReceived.get());
+        assertFalse(botMessageReceived.get());
+    }
+
+    @Test
+    public void user_skipped() throws Exception {
+        App app = buildApp();
+        AtomicBoolean userMessageReceived = new AtomicBoolean(false);
+        app.message("posted by a user", (req, ctx) -> {
+            userMessageReceived.set(req.getEvent().getUser().equals("U123"));
+            return ctx.ack();
+        });
+        AtomicBoolean botMessageReceived = new AtomicBoolean(false);
+        app.botMessage("posted by a user", (req, ctx) -> {
+            botMessageReceived.set(req.getEvent().getBotId().equals("B123"));
+            return ctx.ack();
+        });
+
+        EventsApiPayload<MessageEvent> payload = buildUserMessagePayload();
+
+        EventRequest req = buildRequest(gson.toJson(payload));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+        assertFalse(userMessageReceived.get());
+        assertFalse(botMessageReceived.get());
+    }
+
+    @Test
+    public void bot() throws Exception {
+        App app = buildApp();
+        AtomicBoolean userMessageReceived = new AtomicBoolean(false);
+        app.message("sent by a bot user", (req, ctx) -> {
+            userMessageReceived.set(req.getEvent().getUser().equals("U123"));
+            return ctx.ack();
+        });
+        AtomicBoolean botMessageReceived = new AtomicBoolean(false);
+        app.botMessage("sent by a bot user", (req, ctx) -> {
+            botMessageReceived.set(req.getEvent().getBotId().equals("B123"));
+            return ctx.ack();
+        });
+
+        EventsApiPayload<MessageBotEvent> payload = buildUserBotMessagePayload();
+
+        EventRequest req = buildRequest(gson.toJson(payload));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        assertFalse(userMessageReceived.get());
+        assertTrue(botMessageReceived.get());
+    }
+
+    @Test
+    public void bot_skipped() throws Exception {
+        App app = buildApp();
+        AtomicBoolean userMessageReceived = new AtomicBoolean(false);
+        app.message("posted by a bot user", (req, ctx) -> {
+            userMessageReceived.set(req.getEvent().getUser().equals("U123"));
+            return ctx.ack();
+        });
+        AtomicBoolean botMessageReceived = new AtomicBoolean(false);
+        app.botMessage("posted by a bot user", (req, ctx) -> {
+            botMessageReceived.set(req.getEvent().getBotId().equals("B123"));
+            return ctx.ack();
+        });
+
+        EventsApiPayload<MessageBotEvent> payload = buildUserBotMessagePayload();
+
+        EventRequest req = buildRequest(gson.toJson(payload));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        assertFalse(userMessageReceived.get());
+        assertFalse(botMessageReceived.get());
+    }
+
+    App buildApp() {
+        return new App(AppConfig.builder()
+                .signingSecret(secret)
+                .singleTeamBotToken(AuthTestMockServer.ValidToken)
+                .slack(slack)
+                .build());
+    }
+
+    void setRequestHeaders(String requestBody, Map<String, List<String>> rawHeaders, String timestamp) {
+        rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP, Arrays.asList(timestamp));
+        rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_SIGNATURE, Arrays.asList(generator.generate(timestamp, requestBody)));
+    }
+
+    private EventRequest buildRequest(String s) {
+        String requestBody = s;
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(requestBody, rawHeaders, timestamp);
+
+        return new EventRequest(requestBody, new RequestHeaders(rawHeaders));
+    }
+
+    EventsApiPayload<MessageEvent> buildUserMessagePayload() {
+        EventsApiPayload<MessageEvent> payload = new MessagePayload();
+        MessageEvent event = new MessageEvent();
+        event.setUser("U123");
+        event.setText("This is a message sent by a user.");
+        payload.setEvent(event);
+        payload.setTeamId("T123");
+        return payload;
+    }
+
+    EventsApiPayload<MessageBotEvent> buildUserBotMessagePayload() {
+        EventsApiPayload<MessageBotEvent> payload = new MessageBotPayload();
+        MessageBotEvent event = new MessageBotEvent();
+        event.setBotId("B123");
+        event.setText("This is a message sent by a bot user.");
+        payload.setEvent(event);
+        payload.setTeamId("T123");
+        return payload;
+    }
+
+}

--- a/bolt/src/test/java/test_locally/docs/AppHomeTest.java
+++ b/bolt/src/test/java/test_locally/docs/AppHomeTest.java
@@ -10,8 +10,8 @@ import org.junit.Test;
 import java.time.ZonedDateTime;
 
 import static com.slack.api.model.block.Blocks.*;
-import static com.slack.api.model.block.composition.BlockCompositions.*;
-import static com.slack.api.model.view.Views.*;
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+import static com.slack.api.model.view.Views.view;
 
 public class AppHomeTest {
 

--- a/bolt/src/test/java/test_locally/docs/AuditLogsApiTest.java
+++ b/bolt/src/test/java/test_locally/docs/AuditLogsApiTest.java
@@ -1,10 +1,12 @@
 package test_locally.docs;
 
 import com.slack.api.Slack;
-import com.slack.api.audit.*;
+import com.slack.api.audit.Actions;
+import com.slack.api.audit.AuditApiException;
+import com.slack.api.audit.AuditClient;
+import com.slack.api.audit.response.ActionsResponse;
 import com.slack.api.audit.response.LogsResponse;
 import com.slack.api.audit.response.SchemasResponse;
-import com.slack.api.audit.response.ActionsResponse;
 
 import java.io.IOException;
 

--- a/bolt/src/test/java/test_locally/docs/BasicsTest.java
+++ b/bolt/src/test/java/test_locally/docs/BasicsTest.java
@@ -12,8 +12,10 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import static com.slack.api.model.block.Blocks.*;
-import static com.slack.api.model.block.composition.BlockCompositions.*;
-import static com.slack.api.model.block.element.BlockElements.*;
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static com.slack.api.model.block.element.BlockElements.asElements;
+import static com.slack.api.model.block.element.BlockElements.button;
 import static java.util.stream.Collectors.joining;
 
 public class BasicsTest {
@@ -123,7 +125,7 @@ public class BasicsTest {
                     resp.getHeaders().put("content-type", Arrays.asList(resp.getContentType()));
                     // dump all the headers as a single string
                     String headers = resp.getHeaders().entrySet().stream()
-                            .map(e -> e.getKey() +  ": " + e.getValue() + "\n").collect(joining());
+                            .map(e -> e.getKey() + ": " + e.getValue() + "\n").collect(joining());
 
                     // set an ephemeral message with useful information
                     DebugResponseBody body = new DebugResponseBody();

--- a/bolt/src/test/java/test_locally/docs/EventsApiTest.java
+++ b/bolt/src/test/java/test_locally/docs/EventsApiTest.java
@@ -2,14 +2,13 @@ package test_locally.docs;
 
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
-import org.junit.Test;
-import com.slack.api.methods.response.chat.ChatPostMessageResponse;
-import com.slack.api.model.event.ReactionAddedEvent;
-
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.response.chat.ChatGetPermalinkResponse;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.methods.response.reactions.ReactionsAddResponse;
 import com.slack.api.model.event.MessageEvent;
+import com.slack.api.model.event.ReactionAddedEvent;
+import org.junit.Test;
 
 import java.util.regex.Pattern;
 

--- a/bolt/src/test/java/test_locally/docs/InteractiveComponentsTest.java
+++ b/bolt/src/test/java/test_locally/docs/InteractiveComponentsTest.java
@@ -1,13 +1,15 @@
 package test_locally.docs;
 
+import com.slack.api.app_backend.interactive_components.response.Option;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.model.block.composition.PlainTextObject;
 import org.junit.Test;
-import com.slack.api.app_backend.interactive_components.response.Option;
-import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+
 import java.util.Arrays;
 import java.util.List;
+
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
 import static java.util.stream.Collectors.toList;
 
 

--- a/bolt/src/test/java/test_locally/docs/OAuthTest.java
+++ b/bolt/src/test/java/test_locally/docs/OAuthTest.java
@@ -57,7 +57,12 @@ public class OAuthTest {
         });
     }
 
-    static String renderCompletionPageHtml(String queryString) { return null; }
-    static String renderCancellationPageHtml(String queryString) { return null; }
+    static String renderCompletionPageHtml(String queryString) {
+        return null;
+    }
+
+    static String renderCancellationPageHtml(String queryString) {
+        return null;
+    }
 
 }

--- a/bolt/src/test/java/test_locally/docs/SCIMApiTest.java
+++ b/bolt/src/test/java/test_locally/docs/SCIMApiTest.java
@@ -1,10 +1,15 @@
 package test_locally.docs;
 
 import com.slack.api.Slack;
-import com.slack.api.scim.*;
-import com.slack.api.scim.model.*;
-import com.slack.api.scim.response.*;
-import com.slack.api.scim.request.*;
+import com.slack.api.scim.SCIMApiException;
+import com.slack.api.scim.SCIMClient;
+import com.slack.api.scim.model.Group;
+import com.slack.api.scim.model.User;
+import com.slack.api.scim.request.GroupsPatchRequest;
+import com.slack.api.scim.response.GroupsSearchResponse;
+import com.slack.api.scim.response.UsersCreateResponse;
+import com.slack.api.scim.response.UsersReadResponse;
+import com.slack.api.scim.response.UsersSearchResponse;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/bolt/src/test/java/test_locally/middleware/IgnoringSelfEventsTest.java
+++ b/bolt/src/test/java/test_locally/middleware/IgnoringSelfEventsTest.java
@@ -10,14 +10,12 @@ import com.slack.api.bolt.request.RequestHeaders;
 import com.slack.api.bolt.request.builtin.EventRequest;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.methods.MethodsClient;
-import com.slack.api.methods.SlackApiException;
 import com.slack.api.model.event.MemberJoinedChannelEvent;
 import com.slack.api.model.event.MessageEvent;
 import com.slack.api.util.json.GsonFactory;
 import org.junit.Test;
 import util.MockSlackApiServer;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/bolt/src/test/java/test_locally/middleware/MultiTeamsAuthorizationTest.java
+++ b/bolt/src/test/java/test_locally/middleware/MultiTeamsAuthorizationTest.java
@@ -8,7 +8,6 @@ import com.slack.api.app_backend.events.payload.MessagePayload;
 import com.slack.api.app_backend.events.payload.UrlVerificationPayload;
 import com.slack.api.app_backend.interactive_components.payload.BlockActionPayload;
 import com.slack.api.bolt.AppConfig;
-import com.slack.api.bolt.context.builtin.ActionContext;
 import com.slack.api.bolt.context.builtin.EventContext;
 import com.slack.api.bolt.middleware.MiddlewareChain;
 import com.slack.api.bolt.middleware.builtin.MultiTeamsAuthorization;
@@ -35,7 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -264,7 +264,7 @@ public class MultiTeamsAuthorizationTest {
         } finally {
             slackApiServer.stop();
         }
-   }
+    }
 
     @Test
     public void valid_and_installer() throws Exception {

--- a/bolt/src/test/java/test_locally/service/AmazonS3InstallationServiceTest.java
+++ b/bolt/src/test/java/test_locally/service/AmazonS3InstallationServiceTest.java
@@ -132,6 +132,7 @@ public class AmazonS3InstallationServiceTest {
         public AWSCredentials credentials() {
             return getCredentials();
         }
+
         public AmazonS3 s3() {
             return createS3Client();
         }

--- a/bolt/src/test/java/test_locally/service/FileInstallationServiceTest.java
+++ b/bolt/src/test/java/test_locally/service/FileInstallationServiceTest.java
@@ -10,7 +10,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 
 public class FileInstallationServiceTest {
 
@@ -68,9 +67,11 @@ public class FileInstallationServiceTest {
 
     static class MyInstaller extends DefaultInstaller {
         Bot bot;
+
         MyInstaller(Bot bot) {
             this.bot = bot;
         }
+
         @Override
         public Bot toBot() {
             return bot;

--- a/bolt/src/test/java/test_locally/servlet/ServletAdapterOpsTest.java
+++ b/bolt/src/test/java/test_locally/servlet/ServletAdapterOpsTest.java
@@ -5,7 +5,6 @@ import com.slack.api.bolt.servlet.ServletAdapterOps;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Arrays;

--- a/bolt/src/test/java/test_locally/servlet/SlackAppServletTest.java
+++ b/bolt/src/test/java/test_locally/servlet/SlackAppServletTest.java
@@ -10,7 +10,6 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.*;
 import java.util.Collections;
 

--- a/bolt/src/test/java/test_locally/servlet/SlackOAuthAppServletTest.java
+++ b/bolt/src/test/java/test_locally/servlet/SlackOAuthAppServletTest.java
@@ -3,7 +3,6 @@ package test_locally.servlet;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.service.OAuthStateService;
-import com.slack.api.bolt.servlet.SlackAppServlet;
 import com.slack.api.bolt.servlet.SlackOAuthAppServlet;
 import org.junit.Test;
 
@@ -135,4 +134,5 @@ public class SlackOAuthAppServletTest {
         servlet.service(req, resp);
 
         verify(resp, times(1)).setStatus(500);
-    }}
+    }
+}

--- a/docs/guides/bolt-basics.md
+++ b/docs/guides/bolt-basics.md
@@ -32,6 +32,8 @@ Here is the list of the available methods to dispatch events.
 |Method|Constraints (value: type)|Description|
 |-|-|-|
 |**app.event**|event type: **Class\<Event\>**|[**Events API**]({{ site.url | append: site.baseurl }}/guides/events-api): Responds to any kinds of bot/user events you subscribe.|
+|**app.message**|keyword: **String** \| **Pattern**|[**Events API**]({{ site.url | append: site.baseurl }}/guides/events-api): Responds to messages posted by a user only when the text in messages matches the given keyword or regular expressions.|
+|**app.botMessage**|keyword: **String** \| **Pattern**|[**Events API**]({{ site.url | append: site.baseurl }}/guides/events-api): Responds to messages posted by a bot user only when the text in messages matches the given keyword or regular expressions.|
 |**app.command**|command name: **String** \| **Pattern**|[**Slash Commands**]({{ site.url | append: site.baseurl }}/guides/slash-commands): Responds to slash command invocations in the workspace.|
 |**app.messageAction**|callback_id: **String** \| **Pattern**|[**Actions**]({{ site.url | append: site.baseurl }}/guides/actions): Responds to user actions in message menus.|
 |**app.blockAction**|action_id: **String** \| **Pattern**|[**Interactive Components**]({{ site.url | append: site.baseurl }}/guides/interactive-components): Responds to user actions (e.g., click a button, choose an item from select menus, radio buttons, etc.) in **blocks**. These events can be triggered in all the surfaces (messages, modals, and Home tabs).|

--- a/docs/guides/ja/bolt-basics.md
+++ b/docs/guides/ja/bolt-basics.md
@@ -32,6 +32,8 @@ app.command("/echo", (req, ctx) -> {
 |メソッド|ディスパッチの条件 (値: 型)|説明|
 |-|-|-|
 |**app.event**|イベントデータ型: **Class\<Event\>**|[**イベント API**]({{ site.url | append: site.baseurl }}/guides/ja/events-api): 購読しているあらゆる bot/user events に応答します。|
+|**app.message**|キーワード: **String** \| **Pattern**|[**イベント API**]({{ site.url | append: site.baseurl }}/guides/ja/events-api): ユーザーからのメッセージ投稿で指定のキーワード・正規表現にマッチする bot/user events に応答します。|
+|**app.botMessage**|キーワード: **String** \| **Pattern**|[**イベント API**]({{ site.url | append: site.baseurl }}/guides/ja/events-api): ボットユーザーからのメッセージ投稿で指定のキーワード・正規表現にマッチする bot/user events に応答します。|
 |**app.command**|コマンド名: **String** \| **Pattern**|[**スラッシュコマンド**]({{ site.url | append: site.baseurl }}/guides/ja/slash-commands): スラッシュコマンドの実行に応答します。|
 |**app.messageAction**|callback_id: **String** \| **Pattern**|[**アクション**]({{ site.url | append: site.baseurl }}/guides/ja/actions): メッセージメニューのアクション実行に応答します。|
 |**app.blockAction**|action_id: **String** \| **Pattern**|[**インタラクティブコンポーネント**]({{ site.url | append: site.baseurl }}/guides/ja/interactive-components): **blocks** 内でのボタンクリック、セレクトメニューからの選択、ラジオボタン選択などユーザクアションに応答します。これらのイベントは全てのインターフェース（メッセージ、モーダル、Home タブ）で発火します。|


### PR DESCRIPTION
###  Summary

This pull request adds `app.message`/`app.botMessage` handlers to `App` class in Bolt for Java. Merging this fixes #381 .

While working on this, I've noticed there are some rooms for improvements regarding the keyword matching patterns. Specifically, some keywords, including special characters in regular expressions, didn't properly work with the current implementation. This pull request fixes the issue as well. Plus, I've refactored the internal key name for handlers from `app_mention:null`/`message:bot_message` to `app_metion`/`message:bot_message`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).