### PR TITLE
Add the latest OpenJDK build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,19 @@ cache:
 install:
   - echo 'skipped'
 matrix:
+  # LTS version
   - jdk: openjdk8
     env: CODECOV="true"
     script: travis_retry ./scripts/run_no_prep_tests.sh
+  # LTS version
   - jdk: openjdk11
     env: CODECOV="false"
     script: travis_retry ./scripts/run_no_prep_tests.sh
+  # non-LTS but latest
+  - jdk: openjdk14
+    env: CODECOV="false"
+    script: travis_retry ./scripts/run_no_prep_tests.sh
+  # To detect duplicated classes
   - jdk: openjdk8
     script:
       - travis_retry ./mvnw install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true --no-transfer-progress


### PR DESCRIPTION
###  Summary

This pull request adds the build settings with the latest OpenJDK. 

The OpenJDK 14 is still in beta and it's not the next LTS (Long Term Support) version (the next LTS is 17). That being said, having the builds with the latest JDK would be safer and we may be able to contribute to the OpenJDK community by detecting the issues affecting this SDK.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
