### PR TITLE
Bump dependency patch versions (2020-03-07)

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <helidon.version>1.4.1</helidon.version>
+        <helidon.version>1.4.2</helidon.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-kotlin-examples/pom.xml
+++ b/bolt-kotlin-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <kotlin.version>1.3.61</kotlin.version>
+        <kotlin.version>1.3.70</kotlin.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.2.4.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.5.RELEASE</spring-boot.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,7 +7,7 @@ baseurl: /java-slack-sdk
 url: https://slack.dev
 
 sdkLatestVersion: 1.0.0-RC1
-kotlinVersion: 1.3.61
-springBootVersion: 2.2.2.RELEASE
+kotlinVersion: 1.3.70
+springBootVersion: 2.2.5.RELEASE
 quarkusVersion: 1.2.1.Final
-helidonVersion: 1.4.1
+helidonVersion: 1.4.2

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <lombok-maven-plugin.version>1.18.10.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.728</aws.s3.version>
+        <aws.s3.version>1.11.739</aws.s3.version>
         <junit.version>4.13</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <javax.websocket-api.version>1.1</javax.websocket-api.version>
-        <tyrus-standalone-client.version>1.15</tyrus-standalone-client.version>
+        <tyrus-standalone-client.version>1.16</tyrus-standalone-client.version>
         <jedis.version>3.2.0</jedis.version>
         <jedis-mock.version>0.1.16</jedis-mock.version>
     </properties>


### PR DESCRIPTION
###  Summary

This pull request upgrades the patch versions of these libraries.

* AWS Java SDK - S3 for `bolt` project
* Helidon SE core libraries for `bolt-helidon` project
* Tyrus WebSocket Client for `slack-api-client` project (specifically for RTM client)

The following will be affecting only the examples and docs.

* Kotlin language
* Spring Boot

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
