### PR TITLE
Get rid of the reflection API usage for response_url access

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/request/Request.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/Request.java
@@ -70,6 +70,8 @@ public abstract class Request<CTX extends Context> {
 
     public abstract RequestHeaders getHeaders();
 
+    public abstract String getResponseUrl();
+
     /**
      * Verifies if the signature is valid.
      *

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/AttachmentActionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/AttachmentActionRequest.java
@@ -55,6 +55,11 @@ public class AttachmentActionRequest extends Request<AttachmentActionContext> {
         return this.headers;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return getPayload() != null ? getPayload().getResponseUrl() : null;
+    }
+
     public AttachmentActionPayload getPayload() {
         return payload;
     }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/BlockActionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/BlockActionRequest.java
@@ -57,4 +57,8 @@ public class BlockActionRequest extends Request<ActionContext> {
         return payload;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return getPayload() != null ? getPayload().getResponseUrl() : null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/BlockSuggestionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/BlockSuggestionRequest.java
@@ -53,4 +53,8 @@ public class BlockSuggestionRequest extends Request<BlockSuggestionContext> {
         return payload;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogCancellationRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogCancellationRequest.java
@@ -57,4 +57,8 @@ public class DialogCancellationRequest extends Request<DialogCancellationContext
         return payload;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return getPayload() != null ? getPayload().getResponseUrl() : null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogSubmissionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogSubmissionRequest.java
@@ -57,4 +57,8 @@ public class DialogSubmissionRequest extends Request<DialogSubmissionContext> {
         return payload;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return getPayload() != null ? getPayload().getResponseUrl() : null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogSuggestionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogSuggestionRequest.java
@@ -53,4 +53,8 @@ public class DialogSuggestionRequest extends Request<DialogSuggestionContext> {
         return payload;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/EventRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/EventRequest.java
@@ -75,4 +75,9 @@ public class EventRequest extends Request<EventContext> {
             return eventType + ":" + eventSubtype;
         }
     }
+
+    @Override
+    public String getResponseUrl() {
+        return null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/MessageActionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/MessageActionRequest.java
@@ -59,4 +59,8 @@ public class MessageActionRequest extends Request<MessageActionContext> {
         return payload;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return getPayload() != null ? getPayload().getResponseUrl() : null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/OAuthCallbackRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/OAuthCallbackRequest.java
@@ -60,4 +60,8 @@ public class OAuthCallbackRequest extends Request<OAuthCallbackContext> {
         return payload;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/OAuthStartRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/OAuthStartRequest.java
@@ -41,4 +41,8 @@ public class OAuthStartRequest extends Request<OAuthCallbackContext> {
         return this.headers;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/OutgoingWebhooksRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/OutgoingWebhooksRequest.java
@@ -53,4 +53,9 @@ public class OutgoingWebhooksRequest extends Request<OutgoingWebhooksContext> {
     public WebhookPayload getPayload() {
         return payload;
     }
+
+    @Override
+    public String getResponseUrl() {
+        return null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/SSLCheckRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/SSLCheckRequest.java
@@ -50,4 +50,9 @@ public class SSLCheckRequest extends Request<DefaultContext> {
     public SSLCheckPayload getPayload() {
         return payload;
     }
+
+    @Override
+    public String getResponseUrl() {
+        return null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/SlashCommandRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/SlashCommandRequest.java
@@ -56,4 +56,9 @@ public class SlashCommandRequest extends Request<SlashCommandContext> {
     public SlashCommandPayload getPayload() {
         return payload;
     }
+
+    @Override
+    public String getResponseUrl() {
+        return getPayload() != null ? getPayload().getResponseUrl() : null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/UrlVerificationRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/UrlVerificationRequest.java
@@ -50,4 +50,9 @@ public class UrlVerificationRequest extends Request<DefaultContext> {
     public String getChallenge() {
         return this.challenge;
     }
+
+    @Override
+    public String getResponseUrl() {
+        return null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewClosedRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewClosedRequest.java
@@ -54,4 +54,8 @@ public class ViewClosedRequest extends Request<DefaultContext> {
         return payload;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewSubmissionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewSubmissionRequest.java
@@ -54,4 +54,8 @@ public class ViewSubmissionRequest extends Request<ViewSubmissionContext> {
         return payload;
     }
 
+    @Override
+    public String getResponseUrl() {
+        return null;
+    }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/response/ResponseTypes.java
+++ b/bolt/src/main/java/com/slack/api/bolt/response/ResponseTypes.java
@@ -1,0 +1,10 @@
+package com.slack.api.bolt.response;
+
+public class ResponseTypes {
+
+    private ResponseTypes() {}
+
+    public static final String ephemeral = "ephemeral";
+    public static final String inChannel = "in_channel";
+
+}

--- a/bolt/src/test/java/test_locally/middleware/MiddlewareOpsTest.java
+++ b/bolt/src/test/java/test_locally/middleware/MiddlewareOpsTest.java
@@ -1,0 +1,45 @@
+package test_locally.middleware;
+
+import com.slack.api.bolt.middleware.MiddlewareOps;
+import com.slack.api.bolt.request.RequestType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MiddlewareOpsTest {
+
+    @Test
+    public void needAuth() {
+        assertFalse(MiddlewareOps.isNoAuthRequiredRequest(RequestType.ViewSubmission));
+        assertFalse(MiddlewareOps.isNoAuthRequiredRequest(RequestType.ViewClosed));
+        assertFalse(MiddlewareOps.isNoAuthRequiredRequest(RequestType.BlockAction));
+        assertFalse(MiddlewareOps.isNoAuthRequiredRequest(RequestType.BlockSuggestion));
+        assertFalse(MiddlewareOps.isNoAuthRequiredRequest(RequestType.Command));
+    }
+
+    @Test
+    public void doesNotNeedAuth() {
+        assertTrue(MiddlewareOps.isNoAuthRequiredRequest(RequestType.SSLCheck));
+        assertTrue(MiddlewareOps.isNoAuthRequiredRequest(RequestType.OAuthCallback));
+        assertTrue(MiddlewareOps.isNoAuthRequiredRequest(RequestType.OAuthStart));
+        assertTrue(MiddlewareOps.isNoAuthRequiredRequest(RequestType.UrlVerification));
+    }
+
+    @Test
+    public void needSignatureVerification() {
+        assertFalse(MiddlewareOps.isNoSlackSignatureRequest(RequestType.ViewSubmission));
+        assertFalse(MiddlewareOps.isNoSlackSignatureRequest(RequestType.ViewClosed));
+        assertFalse(MiddlewareOps.isNoSlackSignatureRequest(RequestType.BlockAction));
+        assertFalse(MiddlewareOps.isNoSlackSignatureRequest(RequestType.BlockSuggestion));
+        assertFalse(MiddlewareOps.isNoSlackSignatureRequest(RequestType.Command));
+    }
+
+    @Test
+    public void doesNotNeedSignatureVerification() {
+        assertTrue(MiddlewareOps.isNoSlackSignatureRequest(RequestType.SSLCheck));
+        assertTrue(MiddlewareOps.isNoSlackSignatureRequest(RequestType.OAuthCallback));
+        assertTrue(MiddlewareOps.isNoSlackSignatureRequest(RequestType.OAuthStart));
+    }
+
+}


### PR DESCRIPTION
###  Summary

This pull request improves the internals by getting rid of the reflection API usage. Depending on reflection APIs potentially can be a portability issue or a blocker for the case a developer dynamically creates a `Request` instance for testing purposes.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
