### PR TITLE
Remove unused / deprecated methods

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMClient.java
@@ -72,16 +72,6 @@ public interface SCIMClient {
 
     UsersDeleteResponse deleteUser(RequestConfigurator<UsersDeleteRequest.UsersDeleteRequestBuilder> req) throws IOException, SCIMApiException;
 
-    // ---
-
-    // Use deleteUser instead
-    @Deprecated
-    UsersDeleteResponse delete(UsersDeleteRequest req) throws IOException, SCIMApiException;
-
-    // Use deleteUser instead
-    @Deprecated
-    UsersDeleteResponse delete(RequestConfigurator<UsersDeleteRequest.UsersDeleteRequestBuilder> req) throws IOException, SCIMApiException;
-
     // --------------------
     // Groups
     // --------------------

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/SCIMClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/SCIMClientImpl.java
@@ -125,18 +125,6 @@ public class SCIMClientImpl implements SCIMClient {
         return deleteUser(req.configure(UsersDeleteRequest.builder()).build());
     }
 
-    @Deprecated
-    @Override
-    public UsersDeleteResponse delete(UsersDeleteRequest req) throws IOException, SCIMApiException {
-        return deleteUser(req);
-    }
-
-    @Deprecated
-    @Override
-    public UsersDeleteResponse delete(RequestConfigurator<UsersDeleteRequest.UsersDeleteRequestBuilder> req) throws IOException, SCIMApiException {
-        return deleteUser(req);
-    }
-
     @Override
     public GroupsSearchResponse searchGroups(GroupsSearchRequest req) throws IOException, SCIMApiException {
         Map<String, String> query = new HashMap<>();

--- a/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
@@ -17,6 +17,8 @@ import java.util.Map;
 @Slf4j
 public class SlackHttpClient implements AutoCloseable {
 
+    private static final MediaType MEDIA_TYPE_APPLICATION_JSON = MediaType.parse("application/json; charset=utf-8");
+
     private final OkHttpClient okHttpClient;
 
     private SlackConfig config = SlackConfig.DEFAULT;
@@ -91,56 +93,29 @@ public class SlackHttpClient implements AutoCloseable {
         return okHttpClient.newCall(request).execute();
     }
 
-    // Use postJsonBody instead
-    @Deprecated
-    public Response postJsonPostRequest(String url, Object obj) throws IOException {
-        return postJsonBody(url, obj);
-    }
-
     public Response postJsonBody(String url, Object obj) throws IOException {
-        RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), toSnakeCaseJsonString(obj));
+        RequestBody body = RequestBody.create(toSnakeCaseJsonString(obj), MEDIA_TYPE_APPLICATION_JSON);
         Request request = new Request.Builder().url(url).post(body).build();
-        return okHttpClient.newCall(request).execute();
-    }
-
-    public Response postJsonBodyWithBearerHeader(String url, String token, Object obj) throws IOException {
-        String bearerHeaderValue = "Bearer " + token;
-        RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), toSnakeCaseJsonString(obj));
-        Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).post(body).build();
-        return okHttpClient.newCall(request).execute();
-    }
-
-    public Response patchJsonBodyWithBearerHeader(String url, String token, Object obj) throws IOException {
-        String bearerHeaderValue = "Bearer " + token;
-        RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), toSnakeCaseJsonString(obj));
-        Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).patch(body).build();
-        return okHttpClient.newCall(request).execute();
-    }
-
-    public Response putJsonBodyWithBearerHeader(String url, String token, Object obj) throws IOException {
-        String bearerHeaderValue = "Bearer " + token;
-        RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), toSnakeCaseJsonString(obj));
-        Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).put(body).build();
         return okHttpClient.newCall(request).execute();
     }
 
     public Response postCamelCaseJsonBodyWithBearerHeader(String url, String token, Object obj) throws IOException {
         String bearerHeaderValue = "Bearer " + token;
-        RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), toCamelCaseJsonString(obj));
+        RequestBody body = RequestBody.create(toCamelCaseJsonString(obj), MEDIA_TYPE_APPLICATION_JSON);
         Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).post(body).build();
         return okHttpClient.newCall(request).execute();
     }
 
     public Response patchCamelCaseJsonBodyWithBearerHeader(String url, String token, Object obj) throws IOException {
         String bearerHeaderValue = "Bearer " + token;
-        RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), toCamelCaseJsonString(obj));
+        RequestBody body = RequestBody.create(toCamelCaseJsonString(obj), MEDIA_TYPE_APPLICATION_JSON);
         Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).patch(body).build();
         return okHttpClient.newCall(request).execute();
     }
 
     public Response putCamelCaseJsonBodyWithBearerHeader(String url, String token, Object obj) throws IOException {
         String bearerHeaderValue = "Bearer " + token;
-        RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), toCamelCaseJsonString(obj));
+        RequestBody body = RequestBody.create(toCamelCaseJsonString(obj), MEDIA_TYPE_APPLICATION_JSON);
         Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).put(body).build();
         return okHttpClient.newCall(request).execute();
     }


### PR DESCRIPTION
###  Summary

This pull request brings the following changes.

* Remove `delete` methods from **SCIMClient** (it has been deprecated since the time this used to be jslack - new users don't need the deprecations any more)
* Remove `postJsonBodyWithBearerHeader` methods from **MethodsClient** as they're not used at all in this library and users can implement the same logic pretty easily
* Address internal deprecation warnings in **MethodsClient**

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
