### PR TITLE
Fix null name for middleware in Kotlin debug logging

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -813,7 +813,12 @@ public class App {
             Middleware current,
             LinkedList<Middleware> remaining) throws Exception {
         if (log.isDebugEnabled()) {
-            log.debug("Start running a middleware (name: {})", current.getClass().getCanonicalName());
+            String middlewareName = current.getClass().getCanonicalName();
+            if (middlewareName == null) {
+                // In Kotlin, `app.use { req, resp, chain -> chain.next(req) }` doesn't have its class name here
+                middlewareName = current.toString();
+            }
+            log.debug("Start running a middleware (name: {})", middlewareName);
         }
         if (remaining.isEmpty()) {
             return current.apply(request, response, (req) -> runHandler(req));


### PR DESCRIPTION
###  Summary

This pull request fixes a minor issue about debug logging in Kotlin. When a Bolt app has the following middleware, the name of the middleware in debug logging can be null.

```kotlin
app.use { req, resp, chain ->
  chain.next(req)
}
```

```
INFO [main] com.slack.api.bolt.jetty.SlackAppServer ⚡️ Bolt app is running!
DEBUG [qtp392781299-35] com.slack.api.bolt.App Start running a middleware (name: com.slack.api.bolt.middleware.builtin.SSLCheck)
DEBUG [qtp392781299-35] com.slack.api.bolt.App Start running a middleware (name: com.slack.api.bolt.middleware.builtin.RequestVerification)
DEBUG [qtp392781299-35] com.slack.api.app_backend.SlackSignature$Verifier Request verification (timestamp: 1583645612, body: xxx, signature: v0=yyy)
DEBUG [qtp392781299-35] com.slack.api.bolt.App Start running a middleware (name: com.slack.api.bolt.middleware.builtin.SingleTeamAuthorization)
DEBUG [qtp392781299-35] com.slack.api.bolt.App Start running a middleware (name: com.slack.api.bolt.middleware.builtin.IgnoringSelfEvents)
DEBUG [qtp392781299-35] com.slack.api.bolt.App Start running a middleware (name: null)
DEBUG [qtp392781299-35] com.slack.api.bolt.App Start running the main handler (request type: Command)
```

This pull request adds a fallback for the case where the class name is null.

```
DEBUG [qtp392781299-35] com.slack.api.bolt.App Start running a middleware (name: examples.middleware.AppKt$main$1@449ee45a)
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
