### PR TITLE
Update the message event examples in documents

### DIFF
--- a/docs/guides/bolt-basics.md
+++ b/docs/guides/bolt-basics.md
@@ -33,7 +33,6 @@ Here is the list of the available methods to dispatch events.
 |-|-|-|
 |**app.event**|event type: **Class\<Event\>**|[**Events API**]({{ site.url | append: site.baseurl }}/guides/events-api): Responds to any kinds of bot/user events you subscribe.|
 |**app.message**|keyword: **String** \| **Pattern**|[**Events API**]({{ site.url | append: site.baseurl }}/guides/events-api): Responds to messages posted by a user only when the text in messages matches the given keyword or regular expressions.|
-|**app.botMessage**|keyword: **String** \| **Pattern**|[**Events API**]({{ site.url | append: site.baseurl }}/guides/events-api): Responds to messages posted by a bot user only when the text in messages matches the given keyword or regular expressions.|
 |**app.command**|command name: **String** \| **Pattern**|[**Slash Commands**]({{ site.url | append: site.baseurl }}/guides/slash-commands): Responds to slash command invocations in the workspace.|
 |**app.messageAction**|callback_id: **String** \| **Pattern**|[**Actions**]({{ site.url | append: site.baseurl }}/guides/actions): Responds to user actions in message menus.|
 |**app.blockAction**|action_id: **String** \| **Pattern**|[**Interactive Components**]({{ site.url | append: site.baseurl }}/guides/interactive-components): Responds to user actions (e.g., click a button, choose an item from select menus, radio buttons, etc.) in **blocks**. These events can be triggered in all the surfaces (messages, modals, and Home tabs).|

--- a/docs/guides/events-api.md
+++ b/docs/guides/events-api.md
@@ -130,19 +130,8 @@ app.message(sdk, (payload, ctx) -> {
 If matching an exact word in a text message works for you, the code looks much simpler as below.
 
 ```java
-app.message("seratch", (payload, ctx) -> {
-  return ctx.ack();
-});
-```
-
-To do the similar with `message` events from bot users, use an `app.botMessage` listener. There is a difference between [`message` event payloads without any subtype](https://api.slack.com/events/message) and [`message` event payloads with their subtype](https://api.slack.com/events/message/bot_message). As Java is a statically typed language, these events are distinguished by the subtype.
-
-```java
-app.botMessage("seratch", (payload, ctx) -> {
-  return ctx.ack();
-});
-
-app.botMessage(Pattern.compile("^.*seratch.*$"), (payload, ctx) -> {
+app.message(":wave:", (payload, ctx) -> {
+  ctx.say("Hello, <@" + payload.getEvent().getUser() + ">");
   return ctx.ack();
 });
 ```

--- a/docs/guides/ja/bolt-basics.md
+++ b/docs/guides/ja/bolt-basics.md
@@ -33,7 +33,6 @@ app.command("/echo", (req, ctx) -> {
 |-|-|-|
 |**app.event**|イベントデータ型: **Class\<Event\>**|[**イベント API**]({{ site.url | append: site.baseurl }}/guides/ja/events-api): 購読しているあらゆる bot/user events に応答します。|
 |**app.message**|キーワード: **String** \| **Pattern**|[**イベント API**]({{ site.url | append: site.baseurl }}/guides/ja/events-api): ユーザーからのメッセージ投稿で指定のキーワード・正規表現にマッチする bot/user events に応答します。|
-|**app.botMessage**|キーワード: **String** \| **Pattern**|[**イベント API**]({{ site.url | append: site.baseurl }}/guides/ja/events-api): ボットユーザーからのメッセージ投稿で指定のキーワード・正規表現にマッチする bot/user events に応答します。|
 |**app.command**|コマンド名: **String** \| **Pattern**|[**スラッシュコマンド**]({{ site.url | append: site.baseurl }}/guides/ja/slash-commands): スラッシュコマンドの実行に応答します。|
 |**app.messageAction**|callback_id: **String** \| **Pattern**|[**アクション**]({{ site.url | append: site.baseurl }}/guides/ja/actions): メッセージメニューのアクション実行に応答します。|
 |**app.blockAction**|action_id: **String** \| **Pattern**|[**インタラクティブコンポーネント**]({{ site.url | append: site.baseurl }}/guides/ja/interactive-components): **blocks** 内でのボタンクリック、セレクトメニューからの選択、ラジオボタン選択などユーザクアションに応答します。これらのイベントは全てのサーフェスエリア（メッセージ、モーダル、Home タブ）で発火します。|

--- a/docs/guides/ja/events-api.md
+++ b/docs/guides/ja/events-api.md
@@ -131,19 +131,8 @@ app.message(sdk, (payload, ctx) -> {
 もし固定のキーワードを含むだけのパターンであれば、コードはもっとシンプルです。以下では指定されたキーワードをそのまま一部に含んでいるメッセージにマッチします。
 
 ```java
-app.message("seratch", (payload, ctx) -> {
-  return ctx.ack();
-});
-```
-
-同じことをボットユーザーからのメッセージにも行いたい場合は `app.botMessage` リスナーを使います。 [subtype を持たない `message` イベント](https://api.slack.com/events/message)と [subtype が `bot_message` の `message` イベント](https://api.slack.com/events/message/bot_message)は、ペイロードのデータ構造が異なるため、静的型付け言語である Java の Bolt 実装ではこの二つを明確に区別しています。
-
-```java
-app.botMessage("seratch", (payload, ctx) -> {
-  return ctx.ack();
-});
-
-app.botMessage(Pattern.compile("^.*seratch.*$"), (payload, ctx) -> {
+app.message(":wave:", (payload, ctx) -> {
+  ctx.say("Hello, <@" + payload.getEvent().getUser() + ">");
   return ctx.ack();
 });
 ```

--- a/json-logs/samples/events/MessagePayload.json
+++ b/json-logs/samples/events/MessagePayload.json
@@ -17,6 +17,19 @@
     "type": "message",
     "channel": "",
     "user": "",
+    "bot_profile": {
+      "id": "",
+      "deleted": false,
+      "name": "",
+      "updated": 123,
+      "app_id": "",
+      "icons": {
+        "image_36": "",
+        "image_48": "",
+        "image_72": ""
+      },
+      "team_id": ""
+    },
     "text": "",
     "blocks": [
       {

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -3,6 +3,19 @@
   "type": "message",
   "channel": "",
   "user": "",
+  "bot_profile": {
+    "id": "",
+    "deleted": false,
+    "name": "",
+    "updated": 123,
+    "app_id": "",
+    "icons": {
+      "image_36": "",
+      "image_48": "",
+      "image_72": ""
+    },
+    "team_id": ""
+  },
   "text": "",
   "blocks": [
     {

--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageEvent.java
@@ -1,6 +1,7 @@
 package com.slack.api.model.event;
 
 import com.slack.api.model.Attachment;
+import com.slack.api.model.BotProfile;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.Data;
 
@@ -26,6 +27,7 @@ public class MessageEvent implements Event {
     private final String type = TYPE_NAME;
     private String channel;
     private String user;
+    private BotProfile botProfile;
 
     private String text;
     private List<LayoutBlock> blocks;


### PR DESCRIPTION
###  Summary

This pull request brings the following changes.

* Update Bolt message event example to be compatible with Bolt for JS
* Add bot_profile to message events
* Remove app.botMessage handler from the document to avoid unnecessary confusion

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
