### PR TITLE
Fix #396 by using only daemon threads

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java
@@ -1,11 +1,11 @@
 package com.slack.api.methods.impl;
 
 import com.slack.api.methods.MethodsConfig;
+import com.slack.api.util.thread.ExecutorServiceFactory;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public class ThreadPools {
 
@@ -32,7 +32,8 @@ public class ThreadPools {
             }
             ExecutorService teamExecutor = allTeams.get(teamId);
             if (teamExecutor == null) {
-                teamExecutor = Executors.newFixedThreadPool(customPoolSize);
+                String threadGroupName = "slack-methods-" + config.getExecutorName() + "-" + teamId;
+                teamExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, customPoolSize);
                 allTeams.put(teamId, teamExecutor);
             }
             return teamExecutor;
@@ -40,7 +41,9 @@ public class ThreadPools {
         } else {
             ExecutorService defaultExecutor = ALL_DEFAULT.get(executorName);
             if (defaultExecutor == null) {
-                defaultExecutor = Executors.newFixedThreadPool(config.getDefaultThreadPoolSize());
+                String threadGroupName = "slack-methods-" + config.getExecutorName();
+                int poolSize = config.getDefaultThreadPoolSize();
+                defaultExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, poolSize);
                 ALL_DEFAULT.put(config.getExecutorName(), defaultExecutor);
             }
             return defaultExecutor;

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/MemoryMetricsDatastore.java
@@ -24,8 +24,7 @@ public class MemoryMetricsDatastore implements MetricsDatastore {
 
     public MemoryMetricsDatastore(int numberOfNodes) {
         this.numberOfNodes = numberOfNodes;
-        String threadGroupName = "slack-methods-metrics-memory";
-        this.cleanerExecutor = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(threadGroupName);
+        this.cleanerExecutor = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(getThreadGroupName());
         this.cleanerExecutor.scheduleAtFixedRate(new MaintenanceJob(this), 1000, 50, TimeUnit.MILLISECONDS);
     }
 
@@ -33,6 +32,10 @@ public class MemoryMetricsDatastore implements MetricsDatastore {
     protected void finalize() throws Throwable {
         cleanerExecutor.shutdown();
         super.finalize();
+    }
+
+    public String getThreadGroupName() {
+        return "slack-methods-metrics-memory:" + Integer.toHexString(hashCode());
     }
 
     // -----------------------------------------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/MemoryMetricsDatastore.java
@@ -7,6 +7,7 @@ import com.slack.api.methods.metrics.LastMinuteRequests;
 import com.slack.api.methods.metrics.MetricsDatastore;
 import com.slack.api.methods.metrics.WaitingMessageIds;
 import com.slack.api.util.json.GsonFactory;
+import com.slack.api.util.thread.ExecutorServiceFactory;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -23,7 +24,8 @@ public class MemoryMetricsDatastore implements MetricsDatastore {
 
     public MemoryMetricsDatastore(int numberOfNodes) {
         this.numberOfNodes = numberOfNodes;
-        this.cleanerExecutor = Executors.newSingleThreadScheduledExecutor();
+        String threadGroupName = "slack-methods-metrics-memory";
+        this.cleanerExecutor = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(threadGroupName);
         this.cleanerExecutor.scheduleAtFixedRate(new MaintenanceJob(this), 1000, 50, TimeUnit.MILLISECONDS);
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/RedisMetricsDatastore.java
@@ -24,8 +24,7 @@ public class RedisMetricsDatastore implements MetricsDatastore {
     public RedisMetricsDatastore(String appName, JedisPool jedisPool) {
         this.appName = appName;
         this.jedisPool = jedisPool;
-        String threadGroupName = "slack-methods-metrics-redis";
-        this.cleanerExecutor = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(threadGroupName);
+        this.cleanerExecutor = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(getThreadGroupName());
         this.cleanerExecutor.scheduleAtFixedRate(new MaintenanceJob(this), 1000, 50, TimeUnit.MILLISECONDS);
     }
 
@@ -38,6 +37,10 @@ public class RedisMetricsDatastore implements MetricsDatastore {
         this.cleanerExecutor.shutdown();
         this.jedisPool.destroy();
         super.finalize();
+    }
+
+    public String getThreadGroupName() {
+        return "slack-methods-metrics-redis:" + this.appName;
     }
 
     private void addToStatsKeyIndices(Jedis jedis, String statsKey) {

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/RedisMetricsDatastore.java
@@ -4,11 +4,11 @@ import com.slack.api.methods.MethodsStats;
 import com.slack.api.methods.impl.AsyncRateLimitQueue;
 import com.slack.api.methods.metrics.LastMinuteRequests;
 import com.slack.api.methods.metrics.MetricsDatastore;
+import com.slack.api.util.thread.ExecutorServiceFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 import java.util.*;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -24,7 +24,8 @@ public class RedisMetricsDatastore implements MetricsDatastore {
     public RedisMetricsDatastore(String appName, JedisPool jedisPool) {
         this.appName = appName;
         this.jedisPool = jedisPool;
-        this.cleanerExecutor = Executors.newSingleThreadScheduledExecutor();
+        String threadGroupName = "slack-methods-metrics-redis";
+        this.cleanerExecutor = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(threadGroupName);
         this.cleanerExecutor.scheduleAtFixedRate(new MaintenanceJob(this), 1000, 50, TimeUnit.MILLISECONDS);
     }
 

--- a/slack-api-client/src/test/java/test_locally/api/methods/AuthTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/AuthTest.java
@@ -2,11 +2,6 @@ package test_locally.api.methods;
 
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
-import com.slack.api.methods.MethodsConfig;
-import com.slack.api.methods.impl.AsyncRateLimitExecutor;
-import com.slack.api.methods.metrics.MetricsDatastore;
-import com.slack.api.methods.metrics.impl.MemoryMetricsDatastore;
-import com.slack.api.methods.metrics.impl.RedisMetricsDatastore;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,8 +9,6 @@ import util.MockSlackApiServer;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static util.MockSlackApi.ValidToken;
 
 public class AuthTest {

--- a/slack-api-client/src/test/java/test_locally/api/methods/MethodsClientImplTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/MethodsClientImplTest.java
@@ -14,7 +14,8 @@ import util.MockSlackApiServer;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static util.MockSlackApi.ValidToken;
 
 public class MethodsClientImplTest {

--- a/slack-api-client/src/test/java/test_locally/api/methods/MethodsConfigTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/MethodsConfigTest.java
@@ -11,6 +11,7 @@ public class MethodsConfigTest {
     public void immutable_singleton_setCustomThreadPoolSizes() {
         MethodsConfig.DEFAULT_SINGLETON.setCustomThreadPoolSizes(Collections.emptyMap());
     }
+
     @Test(expected = UnsupportedOperationException.class)
     public void immutable_singleton_setMetricsDatastore() {
         MethodsConfig.DEFAULT_SINGLETON.setMetricsDatastore(null);

--- a/slack-api-client/src/test/java/test_locally/api/methods/MigrationTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/MigrationTest.java
@@ -4,7 +4,6 @@ import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import util.MockSlackApiServer;
 

--- a/slack-api-client/src/test/java/test_locally/api/methods/metrics/MemoryMetricsDatastoreTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/metrics/MemoryMetricsDatastoreTest.java
@@ -7,8 +7,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static com.slack.api.methods.MethodsConfig.DEFAULT_SINGLETON_EXECUTOR_NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class MemoryMetricsDatastoreTest {
 
@@ -50,5 +49,12 @@ public class MemoryMetricsDatastoreTest {
                 DEFAULT_SINGLETON_EXECUTOR_NAME, null, "chat.postMessage", "id");
         datastore.deleteFromWaitingMessageIds(
                 DEFAULT_SINGLETON_EXECUTOR_NAME, null, "chat.postMessage", "id");
+    }
+
+    @Test
+    public void threadGroupName() {
+        MemoryMetricsDatastore datastore1 = new MemoryMetricsDatastore(1);
+        MemoryMetricsDatastore datastore2 = new MemoryMetricsDatastore(1);
+        assertNotEquals(datastore1.getThreadGroupName(), datastore2.getThreadGroupName());
     }
 }

--- a/slack-api-client/src/test/java/test_locally/api/methods/metrics/RedisMetricsDatastoreTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/metrics/RedisMetricsDatastoreTest.java
@@ -6,6 +6,7 @@ import com.slack.api.SlackConfig;
 import com.slack.api.methods.AsyncMethodsClient;
 import com.slack.api.methods.MethodsConfig;
 import com.slack.api.methods.MethodsStats;
+import com.slack.api.methods.metrics.impl.MemoryMetricsDatastore;
 import com.slack.api.methods.metrics.impl.RedisMetricsDatastore;
 import org.junit.After;
 import org.junit.Before;
@@ -16,8 +17,7 @@ import util.MockSlackApiServer;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static util.MockSlackApi.ValidToken;
 
 public class RedisMetricsDatastoreTest {
@@ -97,5 +97,14 @@ public class RedisMetricsDatastoreTest {
         datastore.updateCurrentQueueSize(executor, "T123", "auth.test");
         datastore.updateNumberOfLastMinuteRequests(executor, "T123", "auth.test");
         datastore.setRateLimitedMethodRetryEpochMillis(executor, "T123", "auth.test", 123456L);
+    }
+
+    @Test
+    public void threadGroupName() {
+        RedisMetricsDatastore datastore1 = new RedisMetricsDatastore("app1", jedisPool);
+        RedisMetricsDatastore datastore2 = new RedisMetricsDatastore("app2", jedisPool);
+        assertEquals("slack-methods-metrics-redis:app1", datastore1.getThreadGroupName());
+        assertEquals("slack-methods-metrics-redis:app2", datastore2.getThreadGroupName());
+        assertNotEquals(datastore1.getThreadGroupName(), datastore2.getThreadGroupName());
     }
 }

--- a/slack-api-client/src/test/java/test_locally/api/status/LegacyApiTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/status/LegacyApiTest.java
@@ -64,6 +64,7 @@ public class LegacyApiTest {
             resp.setContentType("application/json");
         }
     }
+
     int port = PortProvider.getPort(LegacyApiTest.class.getName());
     Server server = new Server(port);
 

--- a/slack-api-client/src/test/java/test_locally/api/util/SlackHttpClientTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/util/SlackHttpClientTest.java
@@ -8,8 +8,8 @@ import okhttp3.FormBody;
 import okhttp3.Response;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SlackHttpClientTest {
 

--- a/slack-api-client/src/test/java/test_locally/snippet/Issue396.java
+++ b/slack-api-client/src/test/java/test_locally/snippet/Issue396.java
@@ -1,0 +1,10 @@
+package test_locally.snippet;
+
+import com.slack.api.SlackConfig;
+
+// https://github.com/slackapi/java-slack-sdk/issues/396
+public class Issue396 {
+    public static void main(String args[]) {
+        SlackConfig a = SlackConfig.DEFAULT;
+    }
+}

--- a/slack-api-client/src/test/java/test_with_remote_apis/UnnecessaryChannelsCleanerTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/UnnecessaryChannelsCleanerTest.java
@@ -1,9 +1,7 @@
 package test_with_remote_apis;
 
 import com.slack.api.Slack;
-import com.slack.api.methods.response.channels.ChannelsArchiveResponse;
 import com.slack.api.methods.response.conversations.ConversationsArchiveResponse;
-import com.slack.api.model.Channel;
 import com.slack.api.model.Conversation;
 import com.slack.api.model.ConversationType;
 import config.Constants;

--- a/slack-api-client/src/test/java/util/sample_json_generation/JsonDataRecordingListener.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/JsonDataRecordingListener.java
@@ -1,12 +1,12 @@
 package util.sample_json_generation;
 
 import com.slack.api.util.http.listener.HttpResponseListener;
+import com.slack.api.util.thread.ExecutorServiceFactory;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static java.util.stream.Collectors.joining;
 
@@ -14,7 +14,8 @@ import static java.util.stream.Collectors.joining;
 public class JsonDataRecordingListener extends HttpResponseListener {
 
     private final CopyOnWriteArrayList<String> remaining = new CopyOnWriteArrayList<>();
-    private final ExecutorService executorService = Executors.newFixedThreadPool(5);
+    private final String threadGroupName = "slack-unit-test-JsonDataRecordingListener";
+    private final ExecutorService executorService = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, 5);
 
     public boolean isAllDone() {
         if (remaining.size() > 0) {

--- a/slack-api-model/src/main/java/com/slack/api/util/thread/DaemonThreadFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/thread/DaemonThreadFactory.java
@@ -1,0 +1,19 @@
+package com.slack.api.util.thread;
+
+import java.util.concurrent.ThreadFactory;
+
+public class DaemonThreadFactory implements ThreadFactory {
+    private final ThreadGroup threadGroup;
+
+    public DaemonThreadFactory(String threadGroupName) {
+        this.threadGroup = new ThreadGroup(threadGroupName);
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(threadGroup, r);
+        t.setDaemon(true);
+        t.setName(t.getThreadGroup().getName() + "-worker-" + t.getId());
+        return t;
+    }
+}

--- a/slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java
@@ -1,0 +1,19 @@
+package com.slack.api.util.thread;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class ExecutorServiceFactory {
+
+    private ExecutorServiceFactory() {
+    }
+
+    public static ExecutorService createDaemonThreadPoolExecutor(String threadGroupName, int poolSize) {
+        return Executors.newFixedThreadPool(poolSize, new DaemonThreadFactory(threadGroupName));
+    }
+
+    public static ScheduledExecutorService createDaemonThreadScheduledExecutor(String threadGroupName) {
+        return Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory(threadGroupName));
+    }
+}

--- a/slack-api-model/src/test/java/test_locally/util/DaemonThreadFactoryTest.java
+++ b/slack-api-model/src/test/java/test_locally/util/DaemonThreadFactoryTest.java
@@ -1,0 +1,25 @@
+package test_locally.util;
+
+import com.slack.api.util.thread.DaemonThreadFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Slf4j
+public class DaemonThreadFactoryTest {
+
+    @Test
+    public void test() throws InterruptedException {
+        DaemonThreadFactory factory = new DaemonThreadFactory("awesome-group");
+        Thread thread = factory.newThread(() -> log.info("This is a test"));
+        thread.start();
+
+        thread.join();
+
+        assertTrue(thread.isDaemon());
+        assertFalse(thread.isAlive());
+    }
+
+}

--- a/slack-api-model/src/test/java/test_locally/util/ExecutorServiceFactoryTest.java
+++ b/slack-api-model/src/test/java/test_locally/util/ExecutorServiceFactoryTest.java
@@ -1,0 +1,37 @@
+package test_locally.util;
+
+import com.slack.api.util.thread.ExecutorServiceFactory;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertTrue;
+
+public class ExecutorServiceFactoryTest {
+
+    @Test
+    public void createDaemonThreadScheduledExecutor() throws InterruptedException {
+        ScheduledExecutorService service = ExecutorServiceFactory.createDaemonThreadScheduledExecutor("test");
+        AtomicBoolean isDaemon = new AtomicBoolean(false);
+        service.schedule(() -> isDaemon.set(Thread.currentThread().isDaemon()), 1, TimeUnit.MILLISECONDS);
+
+        Thread.sleep(50L);
+
+        assertTrue(isDaemon.get());
+    }
+
+    @Test
+    public void createDaemonThreadPoolExecutor() throws InterruptedException {
+        ExecutorService service = ExecutorServiceFactory.createDaemonThreadPoolExecutor("test", 3);
+
+        AtomicBoolean isDaemon = new AtomicBoolean(false);
+        service.submit(() -> isDaemon.set(Thread.currentThread().isDaemon()));
+
+        Thread.sleep(50L);
+
+        assertTrue(isDaemon.get());
+    }
+}


### PR DESCRIPTION
###  Summary

This pull request fixes #396 by improving the thread executor management across this SDK.

I've changed all the code generating `ExecutorService` and `ScheduledExecutorService` with the newly added utilities, `DaemonThreadFactory ` and `ExecutorServiceFactory `.

```bash
$ grep "Executors.new" -R */src/main/java
slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java:        return Executors.newFixedThreadPool(poolSize, new DaemonThreadFactory(threadGroupName));
slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java:        return Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory(threadGroupName));

$ grep "ExecutorService" -R */src/main/java
slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java:        final ExecutorService executorService = teamId != null ? ThreadPools.getOrCreate(config, teamId) : ThreadPools.getDefault(config);
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:import com.slack.api.util.thread.ExecutorServiceFactory;
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:import java.util.concurrent.ExecutorService;
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:    private static final ConcurrentMap<String, ExecutorService> ALL_DEFAULT = new ConcurrentHashMap<>();
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:    private static final ConcurrentMap<String, ConcurrentMap<String, ExecutorService>> TEAM_CUSTOM = new ConcurrentHashMap<>();
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:    public static ExecutorService getDefault(MethodsConfig config) {
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:    public static ExecutorService getOrCreate(MethodsConfig config, String teamId) {
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:            ConcurrentMap<String, ExecutorService> allTeams = TEAM_CUSTOM.get(executorName);
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:            ExecutorService teamExecutor = allTeams.get(teamId);
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:                teamExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, customPoolSize);
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:            ExecutorService defaultExecutor = ALL_DEFAULT.get(executorName);
slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java:                defaultExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, poolSize);
slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/MemoryMetricsDatastore.java:import com.slack.api.util.thread.ExecutorServiceFactory;
slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/MemoryMetricsDatastore.java:    private final ScheduledExecutorService cleanerExecutor;
slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/MemoryMetricsDatastore.java:        this.cleanerExecutor = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(threadGroupName);
slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/RedisMetricsDatastore.java:import com.slack.api.util.thread.ExecutorServiceFactory;
slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/RedisMetricsDatastore.java:import java.util.concurrent.ScheduledExecutorService;
slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/RedisMetricsDatastore.java:    private final ScheduledExecutorService cleanerExecutor;
slack-api-client/src/main/java/com/slack/api/methods/metrics/impl/RedisMetricsDatastore.java:        this.cleanerExecutor = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(threadGroupName);
slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java:import java.util.concurrent.ExecutorService;
slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java:import java.util.concurrent.ScheduledExecutorService;
slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java:public class ExecutorServiceFactory {
slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java:    private ExecutorServiceFactory() {
slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java:    public static ExecutorService createDaemonThreadPoolExecutor(String threadGroupName, int poolSize) {
slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java:    public static ScheduledExecutorService createDaemonThreadScheduledExecutor(String threadGroupName) {
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
