### PR TITLE
Add more supports for attachments-related params in chat.unfurl request #399

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
@@ -2,6 +2,7 @@ package com.slack.api.methods.request.chat;
 
 import com.slack.api.methods.SlackApiRequest;
 import com.slack.api.model.Action;
+import com.slack.api.model.Field;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.Builder;
 import lombok.Data;
@@ -59,13 +60,25 @@ public class ChatUnfurlRequest implements SlackApiRequest {
     // https://api.slack.com/docs/message-link-unfurling#unfurls_parameter
     @Data
     public static class UnfurlDetail {
-        private String title;
+
         private String text;
+
+        // attachments: https://api.slack.com/docs/message-attachments
         private String callbackId;
         private String attachmentType;
         private String fallback;
+        private String color;
+        private String url;
+        private String title;
+        private String titleLink;
+        private String imageUrl;
+        private String authorName;
+        private String authorIcon;
+        private String authorLink;
         private List<Action> actions;
+        private List<Field> fields;
 
+        // blocks: https://api.slack.com/reference/block-kit/blocks
         private List<LayoutBlock> blocks;
     }
 }


### PR DESCRIPTION
###  Summary

This pull request adds more support for attachments-related params in `chat.unfurl` calls. This is done for supporting the use case mentioned at #399.

<img width="400" src="https://user-images.githubusercontent.com/19658/76731670-4f891180-67a1-11ea-91e2-21a825fca27a.png">
<img width="400" src="https://user-images.githubusercontent.com/19658/76731680-54e65c00-67a1-11ea-9e6e-e4ce55701103.png">

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
