### PR TITLE
Add skin_tone attribute to emoji element in rich_text blocks

### DIFF
--- a/json-logs/samples/api/channels.history.json
+++ b/json-logs/samples/api/channels.history.json
@@ -1112,7 +1112,8 @@
           "count": 12345
         }
       ],
-      "parent_user_id": "U00000000"
+      "parent_user_id": "U00000000",
+      "client_msg_id": ""
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -314,7 +314,9 @@
       "browsers_seen_initial_activity_education": false,
       "browsers_dismissed_initial_saved_education": false,
       "browsers_seen_initial_saved_education": false,
-      "saved_view": ""
+      "saved_view": "",
+      "ia_slackbot_survey_timestamp_48h": 12345,
+      "ia_slackbot_survey_timestamp_7d": 12345
     },
     "created": 12345,
     "manual_presence": ""

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextSectionElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextSectionElement.java
@@ -64,6 +64,7 @@ public class RichTextSectionElement extends BlockElement implements RichTextElem
         public static final String TYPE = "emoji";
         private final String type = TYPE;
         private String name;
+        private Integer skinTone;
     }
 
     @Data

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -1,11 +1,10 @@
 package test_locally.api.model.block;
 
-import com.slack.api.model.block.ActionsBlock;
-import com.slack.api.model.block.Blocks;
-import com.slack.api.model.block.ContextBlock;
-import com.slack.api.model.block.ContextBlockElement;
+import com.slack.api.model.Message;
+import com.slack.api.model.block.*;
 import com.slack.api.model.block.element.BlockElement;
 import org.junit.Test;
+import test_locally.unit.GsonFactory;
 
 import java.util.List;
 
@@ -16,6 +15,7 @@ import static com.slack.api.model.block.element.BlockElements.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 
 public class BlocksTest {
 
@@ -72,6 +72,39 @@ public class BlocksTest {
                 .blockId("block-id")
                 .elements(asElements(button(b -> b.value("v"))))
         ), is(notNullValue()));
+    }
+
+    String richTextSkinTone = "{ \"blocks\": [\n" +
+            "  {\n" +
+            "    \"type\": \"rich_text\",\n" +
+            "    \"block_id\": \"b123\",\n" +
+            "    \"elements\": [\n" +
+            "      {\n" +
+            "        \"type\": \"rich_text_section\",\n" +
+            "        \"elements\": [\n" +
+            "          {\n" +
+            "            \"type\": \"text\",\n" +
+            "            \"text\": \"Hello\"\n" +
+            "          },\n" +
+            "          {\n" +
+            "            \"type\": \"emoji\",\n" +
+            "            \"name\": \"wave\",\n" +
+            "            \"skin_tone\": 3\n" +
+            "          },\n" +
+            "          {\n" +
+            "            \"type\": \"emoji\",\n" +
+            "            \"name\": \"rocket\"\n" +
+            "          }\n" +
+            "        ]\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  }\n" +
+            "]}";
+
+    @Test
+    public void testRichTextSkinToneEmoji() {
+        Message message = GsonFactory.createSnakeCase().fromJson(richTextSkinTone, Message.class);
+        assertNotNull(message);
     }
 
     @Test


### PR DESCRIPTION
###  Summary

This pull request adds a missing field `skin_tone` in the `emoji` element in `rich_text` blocks. Refer to [this changelog](https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less) to learn what `rich_text` blocks are.


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
