### PR TITLE
Add filter to (multi_)conversations_select (also response_url_enabled)

### DIFF
--- a/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
@@ -104,7 +104,40 @@
                 "text": "",
                 "emoji": false
               }
-            }
+            },
+            "response_url_enabled": false
+          },
+          {
+            "type": "multi_channels_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              }
+            },
+            "max_selected_items": 123
           },
           {
             "type": "conversations_select",
@@ -136,6 +169,53 @@
                 "text": "",
                 "emoji": false
               }
+            },
+            "response_url_enabled": false,
+            "filter": {
+              "include": [
+                ""
+              ],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            }
+          },
+          {
+            "type": "multi_conversations_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              }
+            },
+            "max_selected_items": 123,
+            "filter": {
+              "include": [
+                ""
+              ],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
             }
           },
           {
@@ -215,6 +295,39 @@
                 "emoji": false
               }
             }
+          },
+          {
+            "type": "multi_external_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "min_query_length": 123,
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              }
+            },
+            "max_selected_items": 123
           },
           {
             "type": "image",
@@ -297,6 +410,38 @@
             }
           },
           {
+            "type": "multi_static_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              }
+            },
+            "max_selected_items": 123
+          },
+          {
             "type": "users_select",
             "placeholder": {
               "type": "plain_text",
@@ -327,6 +472,38 @@
                 "emoji": false
               }
             }
+          },
+          {
+            "type": "multi_users_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              }
+            },
+            "max_selected_items": 123
           }
         ],
         "block_id": ""

--- a/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
@@ -80,7 +80,40 @@
                 "text": "",
                 "emoji": false
               }
-            }
+            },
+            "response_url_enabled": false
+          },
+          {
+            "type": "multi_channels_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              }
+            },
+            "max_selected_items": 123
           },
           {
             "type": "conversations_select",
@@ -112,6 +145,53 @@
                 "text": "",
                 "emoji": false
               }
+            },
+            "response_url_enabled": false,
+            "filter": {
+              "include": [
+                ""
+              ],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            }
+          },
+          {
+            "type": "multi_conversations_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              }
+            },
+            "max_selected_items": 123,
+            "filter": {
+              "include": [
+                ""
+              ],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
             }
           },
           {
@@ -191,6 +271,39 @@
                 "emoji": false
               }
             }
+          },
+          {
+            "type": "multi_external_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "min_query_length": 123,
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              }
+            },
+            "max_selected_items": 123
           },
           {
             "type": "image",
@@ -273,6 +386,38 @@
             }
           },
           {
+            "type": "multi_static_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              }
+            },
+            "max_selected_items": 123
+          },
+          {
             "type": "users_select",
             "placeholder": {
               "type": "plain_text",
@@ -303,6 +448,38 @@
                 "emoji": false
               }
             }
+          },
+          {
+            "type": "multi_users_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              }
+            },
+            "max_selected_items": 123
           }
         ],
         "block_id": ""

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -87,7 +87,8 @@
               "text": "",
               "emoji": false
             }
-          }
+          },
+          "response_url_enabled": false
         },
         {
           "type": "conversations_select",
@@ -119,6 +120,11 @@
               "text": "",
               "emoji": false
             }
+          },
+          "response_url_enabled": false,
+          "filter": {
+            "exclude_external_shared_channels": false,
+            "exclude_bot_users": false
           }
         },
         {

--- a/json-logs/samples/rtm/PinAddedEvent.json
+++ b/json-logs/samples/rtm/PinAddedEvent.json
@@ -95,7 +95,8 @@
                   "text": "",
                   "emoji": false
                 }
-              }
+              },
+              "response_url_enabled": false
             },
             {
               "type": "conversations_select",
@@ -127,6 +128,11 @@
                   "text": "",
                   "emoji": false
                 }
+              },
+              "response_url_enabled": false,
+              "filter": {
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
               }
             },
             {

--- a/json-logs/samples/rtm/PinRemovedEvent.json
+++ b/json-logs/samples/rtm/PinRemovedEvent.json
@@ -95,7 +95,8 @@
                   "text": "",
                   "emoji": false
                 }
-              }
+              },
+              "response_url_enabled": false
             },
             {
               "type": "conversations_select",
@@ -127,6 +128,11 @@
                   "text": "",
                   "emoji": false
                 }
+              },
+              "response_url_enabled": false,
+              "filter": {
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
               }
             },
             {

--- a/json-logs/samples/rtm/StarAddedEvent.json
+++ b/json-logs/samples/rtm/StarAddedEvent.json
@@ -95,7 +95,8 @@
                   "text": "",
                   "emoji": false
                 }
-              }
+              },
+              "response_url_enabled": false
             },
             {
               "type": "conversations_select",
@@ -127,6 +128,11 @@
                   "text": "",
                   "emoji": false
                 }
+              },
+              "response_url_enabled": false,
+              "filter": {
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
               }
             },
             {

--- a/json-logs/samples/rtm/StarRemovedEvent.json
+++ b/json-logs/samples/rtm/StarRemovedEvent.json
@@ -94,7 +94,8 @@
                   "text": "",
                   "emoji": false
                 }
-              }
+              },
+              "response_url_enabled": false
             },
             {
               "type": "conversations_select",
@@ -126,6 +127,11 @@
                   "text": "",
                   "emoji": false
                 }
+              },
+              "response_url_enabled": false,
+              "filter": {
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
               }
             },
             {

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ChannelsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ChannelsSelectElement.java
@@ -39,4 +39,12 @@ public class ChannelsSelectElement extends BlockElement {
      * A confirm object that defines an optional confirmation dialog that appears after a menu item is selected.
      */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * This field only works with menus in input blocks in modals.
+     * When set to true, the view_submission payload from the menu's parent view will contain a response_url.
+     * This response_url can be used for message responses.
+     * The target conversation for the message will be determined by the value of this select menu.
+     */
+    private Boolean responseUrlEnabled;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsFilter.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsFilter.java
@@ -1,0 +1,38 @@
+package com.slack.api.model.block.element;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Filter object for conversation lists
+ * Provides a way to filter the list of options in a conversations select menu or conversations multi-select menu.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ConversationsFilter {
+
+    /**
+     * Indicates which type of conversations should be included in the list.
+     * When this field is provided, any conversations that do not match will be excluded.
+     * You should provide an array of strings from the following options: im, mpim, private, and public.
+     * The array cannot be empty.
+     */
+    private List<String> include;
+
+    /**
+     * Indicates whether to exclude external shared channels from conversation lists. Defaults to false.
+     */
+    private Boolean excludeExternalSharedChannels;
+
+    /**
+     * Indicates whether to exclude bot users from conversation lists. Defaults to false.
+     */
+    private Boolean excludeBotUsers;
+
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsSelectElement.java
@@ -40,4 +40,17 @@ public class ConversationsSelectElement extends BlockElement {
      */
     private ConfirmationDialogObject confirm;
 
+    /**
+     * This field only works with menus in input blocks in modals.
+     * When set to true, the view_submission payload from the menu's parent view will contain a response_url.
+     * This response_url can be used for message responses.
+     * The target conversation for the message will be determined by the value of this select menu.
+     */
+    private Boolean responseUrlEnabled;
+
+    /**
+     * A filter object that reduces the list of available conversations using the specified criteria.
+     */
+    private ConversationsFilter filter;
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiConversationsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiConversationsSelectElement.java
@@ -49,4 +49,9 @@ public class MultiConversationsSelectElement extends BlockElement {
      */
     private Integer maxSelectedItems;
 
+    /**
+     * A filter object that reduces the list of available conversations using the specified criteria.
+     */
+    private ConversationsFilter filter;
+
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -3,9 +3,13 @@ package test_locally.api.model.block;
 import com.slack.api.model.Message;
 import com.slack.api.model.block.*;
 import com.slack.api.model.block.element.BlockElement;
+import com.slack.api.model.block.element.ChannelsSelectElement;
+import com.slack.api.model.block.element.ConversationsSelectElement;
+import com.slack.api.model.block.element.MultiConversationsSelectElement;
 import org.junit.Test;
 import test_locally.unit.GsonFactory;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static com.slack.api.model.block.Blocks.*;
@@ -15,7 +19,7 @@ import static com.slack.api.model.block.element.BlockElements.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class BlocksTest {
 
@@ -116,6 +120,196 @@ public class BlocksTest {
     public void testCheckboxes() {
         assertThat(section(s -> s.blockId("block-id").accessory(checkboxes(c -> c.actionId("foo")))), is(notNullValue()));
         assertThat(input(i -> i.element(checkboxes(c -> c.actionId("foo")))), is(notNullValue()));
+    }
+
+    @Test
+    public void testConversationsFilter() {
+        String json = "{\"blocks\":[\n" +
+                "  {\n" +
+                "    \"type\": \"input\",\n" +
+                "    \"element\": {\n" +
+                "      \"type\": \"conversations_select\",\n" +
+                "      \"placeholder\": {\n" +
+                "        \"type\": \"plain_text\",\n" +
+                "        \"text\": \"Select a conversation\",\n" +
+                "        \"emoji\": true\n" +
+                "      },\n" +
+                "      \"filter\": {\n" +
+                "        \"include\": [\n" +
+                "          \"public\",\n" +
+                "          \"mpim\"\n" +
+                "        ],\n" +
+                "        \"exclude_bot_users\": true\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"label\": {\n" +
+                "      \"type\": \"plain_text\",\n" +
+                "      \"text\": \"Choose the conversation to publish your result to:\",\n" +
+                "      \"emoji\": true\n" +
+                "    }\n" +
+                "  }\n" +
+                "]}";
+        Message message = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+        assertNotNull(message);
+        assertEquals(1, message.getBlocks().size());
+        InputBlock block = (InputBlock) message.getBlocks().get(0);
+        ConversationsSelectElement element = (ConversationsSelectElement) block.getElement();
+        assertEquals(Arrays.asList("public", "mpim"), element.getFilter().getInclude());
+        assertTrue(element.getFilter().getExcludeBotUsers());
+        assertNull(element.getFilter().getExcludeExternalSharedChannels());
+    }
+
+    @Test
+    public void testConversationsFilter_multi() {
+        String json = "{\"blocks\":[\n" +
+                "  {\n" +
+                "    \"type\": \"input\",\n" +
+                "    \"element\": {\n" +
+                "      \"type\": \"multi_conversations_select\",\n" +
+                "      \"placeholder\": {\n" +
+                "        \"type\": \"plain_text\",\n" +
+                "        \"text\": \"Select a conversation\",\n" +
+                "        \"emoji\": true\n" +
+                "      },\n" +
+                "      \"filter\": {\n" +
+                "        \"include\": [\n" +
+                "          \"public\",\n" +
+                "          \"mpim\"\n" +
+                "        ],\n" +
+                "        \"exclude_bot_users\": true\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"label\": {\n" +
+                "      \"type\": \"plain_text\",\n" +
+                "      \"text\": \"Choose the conversation to publish your result to:\",\n" +
+                "      \"emoji\": true\n" +
+                "    }\n" +
+                "  }\n" +
+                "]}";
+        Message message = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+        assertNotNull(message);
+        assertEquals(1, message.getBlocks().size());
+        InputBlock block = (InputBlock) message.getBlocks().get(0);
+        MultiConversationsSelectElement element = (MultiConversationsSelectElement) block.getElement();
+        assertEquals(Arrays.asList("public", "mpim"), element.getFilter().getInclude());
+        assertTrue(element.getFilter().getExcludeBotUsers());
+        assertNull(element.getFilter().getExcludeExternalSharedChannels());
+    }
+
+    @Test
+    public void testResponseUrlEnabled_conversations() {
+        {
+            String json = "{\"blocks\":[\n" +
+                    "  {\n" +
+                    "    \"type\": \"input\",\n" +
+                    "    \"element\": {\n" +
+                    "      \"type\": \"conversations_select\",\n" +
+                    "      \"placeholder\": {\n" +
+                    "        \"type\": \"plain_text\",\n" +
+                    "        \"text\": \"Select a conversation\",\n" +
+                    "        \"emoji\": true\n" +
+                    "      },\n" +
+                    "      \"response_url_enabled\": true\n" +
+                    "    },\n" +
+                    "    \"label\": {\n" +
+                    "      \"type\": \"plain_text\",\n" +
+                    "      \"text\": \"Choose the conversation to publish your result to:\",\n" +
+                    "      \"emoji\": true\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "]}";
+            Message message = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+            assertNotNull(message);
+            assertEquals(1, message.getBlocks().size());
+            InputBlock block = (InputBlock) message.getBlocks().get(0);
+            ConversationsSelectElement element = (ConversationsSelectElement) block.getElement();
+            assertTrue(element.getResponseUrlEnabled());
+        }
+
+        {
+            String json = "{\"blocks\":[\n" +
+                    "  {\n" +
+                    "    \"type\": \"input\",\n" +
+                    "    \"element\": {\n" +
+                    "      \"type\": \"conversations_select\",\n" +
+                    "      \"placeholder\": {\n" +
+                    "        \"type\": \"plain_text\",\n" +
+                    "        \"text\": \"Select a conversation\",\n" +
+                    "        \"emoji\": true\n" +
+                    "      }\n" +
+                    "    },\n" +
+                    "    \"label\": {\n" +
+                    "      \"type\": \"plain_text\",\n" +
+                    "      \"text\": \"Choose the conversation to publish your result to:\",\n" +
+                    "      \"emoji\": true\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "]}";
+            Message message = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+            assertNotNull(message);
+            assertEquals(1, message.getBlocks().size());
+            InputBlock block = (InputBlock) message.getBlocks().get(0);
+            ConversationsSelectElement element = (ConversationsSelectElement) block.getElement();
+            assertNull(element.getResponseUrlEnabled());
+        }
+    }
+
+    @Test
+    public void testResponseUrlEnabled_channels() {
+        {
+            String json = "{\"blocks\":[\n" +
+                    "  {\n" +
+                    "    \"type\": \"input\",\n" +
+                    "    \"element\": {\n" +
+                    "      \"type\": \"channels_select\",\n" +
+                    "      \"placeholder\": {\n" +
+                    "        \"type\": \"plain_text\",\n" +
+                    "        \"text\": \"Select a conversation\",\n" +
+                    "        \"emoji\": true\n" +
+                    "      },\n" +
+                    "      \"response_url_enabled\": true\n" +
+                    "    },\n" +
+                    "    \"label\": {\n" +
+                    "      \"type\": \"plain_text\",\n" +
+                    "      \"text\": \"Choose the conversation to publish your result to:\",\n" +
+                    "      \"emoji\": true\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "]}";
+            Message message = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+            assertNotNull(message);
+            assertEquals(1, message.getBlocks().size());
+            InputBlock block = (InputBlock) message.getBlocks().get(0);
+            ChannelsSelectElement element = (ChannelsSelectElement) block.getElement();
+            assertTrue(element.getResponseUrlEnabled());
+        }
+
+        {
+            String json = "{\"blocks\":[\n" +
+                    "  {\n" +
+                    "    \"type\": \"input\",\n" +
+                    "    \"element\": {\n" +
+                    "      \"type\": \"channels_select\",\n" +
+                    "      \"placeholder\": {\n" +
+                    "        \"type\": \"plain_text\",\n" +
+                    "        \"text\": \"Select a conversation\",\n" +
+                    "        \"emoji\": true\n" +
+                    "      }\n" +
+                    "    },\n" +
+                    "    \"label\": {\n" +
+                    "      \"type\": \"plain_text\",\n" +
+                    "      \"text\": \"Choose the conversation to publish your result to:\",\n" +
+                    "      \"emoji\": true\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "]}";
+            Message message = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+            assertNotNull(message);
+            assertEquals(1, message.getBlocks().size());
+            InputBlock block = (InputBlock) message.getBlocks().get(0);
+            ChannelsSelectElement element = (ChannelsSelectElement) block.getElement();
+            assertNull(element.getResponseUrlEnabled());
+        }
     }
 
 }

--- a/slack-app-backend/src/test/java/util/sample_json_generation/SampleObjects.java
+++ b/slack-app-backend/src/test/java/util/sample_json_generation/SampleObjects.java
@@ -60,16 +60,22 @@ public class SampleObjects {
 
     public static ConfirmationDialogObject Confirm = ConfirmationDialogObject.builder().text(TextObject).build();
 
+    public static ConversationsFilter conversationsFilter = ConversationsFilter.builder().include(Arrays.asList("")).build();
     public static List<BlockElement> BlockElements = Arrays.asList(
             initProperties(ButtonElement.builder().confirm(Confirm).build()),
             initProperties(ChannelsSelectElement.builder().confirm(Confirm).build()),
-            initProperties(ConversationsSelectElement.builder().confirm(Confirm).build()),
+            initProperties(MultiChannelsSelectElement.builder().confirm(Confirm).build()),
+            initProperties(ConversationsSelectElement.builder().confirm(Confirm).filter(conversationsFilter).build()),
+            initProperties(MultiConversationsSelectElement.builder().confirm(Confirm).filter(conversationsFilter).build()),
             initProperties(DatePickerElement.builder().confirm(Confirm).build()),
             initProperties(ExternalSelectElement.builder().confirm(Confirm).build()),
+            initProperties(MultiExternalSelectElement.builder().confirm(Confirm).build()),
             initProperties(ImageElement.builder().build()),
             initProperties(OverflowMenuElement.builder().confirm(Confirm).build()),
             initProperties(StaticSelectElement.builder().confirm(Confirm).build()),
-            initProperties(UsersSelectElement.builder().confirm(Confirm).build())
+            initProperties(MultiStaticSelectElement.builder().confirm(Confirm).build()),
+            initProperties(UsersSelectElement.builder().confirm(Confirm).build()),
+            initProperties(MultiUsersSelectElement.builder().confirm(Confirm).build())
     );
     public static List<ContextBlockElement> ContextBlockElements = Arrays.asList(
             (ContextBlockElement) initProperties(ImageElement.builder().build())


### PR DESCRIPTION
###  Summary

This pull request adds `filter` to `conversations_select` / `multi_conversations_select` elements in input blocks. In addition to that, missing `response_url_enabled` in `conversations_select` / `channels_select` elements.

References:
* https://api.slack.com/reference/block-kit/composition-objects#filter_conversations

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
