### PR TITLE
Fix #409 by adding valid response structure - user.groups

### DIFF
--- a/json-logs/samples/scim/v1/Groups.json
+++ b/json-logs/samples/scim/v1/Groups.json
@@ -1,10 +1,22 @@
 {
-  "totalResults": 12345,
-  "itemsPerPage": 12345,
-  "startIndex": 12345,
   "schemas": [
     ""
   ],
+  "id": "S00000000",
+  "displayName": "",
+  "members": [
+    {
+      "value": "W00000000",
+      "display": ""
+    }
+  ],
+  "meta": {
+    "created": "",
+    "location": "https://www.example.com/"
+  },
+  "totalResults": 12345,
+  "itemsPerPage": 12345,
+  "startIndex": 12345,
   "Resources": [
     {
       "schemas": [
@@ -57,9 +69,5 @@
         "location": "https://www.example.com/"
       }
     }
-  ],
-  "Errors": {
-    "description": "",
-    "code": 12345
-  }
+  ]
 }

--- a/json-logs/samples/scim/v1/Users.json
+++ b/json-logs/samples/scim/v1/Users.json
@@ -1,10 +1,42 @@
 {
-  "totalResults": 12345,
-  "itemsPerPage": 12345,
-  "startIndex": 12345,
   "schemas": [
     ""
   ],
+  "id": "W00000000",
+  "externalId": "",
+  "meta": {
+    "created": "",
+    "location": "https://www.example.com/"
+  },
+  "userName": "",
+  "nickName": "",
+  "name": {
+    "givenName": "",
+    "familyName": ""
+  },
+  "displayName": "",
+  "profileUrl": "https://www.example.com/",
+  "title": "",
+  "timezone": "",
+  "active": false,
+  "emails": [
+    {
+      "value": "",
+      "primary": false
+    }
+  ],
+  "photos": [
+    {
+      "value": "https://www.example.com/",
+      "type": ""
+    }
+  ],
+  "groups": [
+    ""
+  ],
+  "totalResults": 12345,
+  "itemsPerPage": 12345,
+  "startIndex": 12345,
   "Resources": [
     {
       "schemas": [
@@ -42,16 +74,8 @@
       ],
       "groups": [
         {
-          "schemas": [
-            "urn:scim:schemas:core:1.0",
-            "urn:scim:schemas:extension:enterprise:1.0"
-          ],
-          "id": "",
-          "displayName": "",
-          "meta": {
-            "created": "",
-            "location": ""
-          }
+          "value": "",
+          "display": ""
         }
       ],
       "addresses": [
@@ -82,41 +106,5 @@
         "manager": {}
       }
     }
-  ],
-  "Errors": {
-    "description": "",
-    "code": 12345
-  },
-  "id": "W00000000",
-  "externalId": "",
-  "meta": {
-    "created": "",
-    "location": "https://www.example.com/"
-  },
-  "userName": "",
-  "nickName": "",
-  "name": {
-    "givenName": "",
-    "familyName": ""
-  },
-  "displayName": "",
-  "profileUrl": "https://www.example.com/",
-  "title": "",
-  "timezone": "",
-  "active": false,
-  "emails": [
-    {
-      "value": "",
-      "primary": false
-    }
-  ],
-  "photos": [
-    {
-      "value": "https://www.example.com/",
-      "type": ""
-    }
-  ],
-  "groups": [
-    ""
   ]
 }

--- a/json-logs/samples/scim/v1/Users/00000000000.json
+++ b/json-logs/samples/scim/v1/Users/00000000000.json
@@ -34,16 +34,8 @@
   ],
   "groups": [
     {
-      "schemas": [
-        "urn:scim:schemas:core:1.0",
-        "urn:scim:schemas:extension:enterprise:1.0"
-      ],
-      "id": "",
-      "displayName": "",
-      "meta": {
-        "created": "",
-        "location": ""
-      }
+      "value": "",
+      "display": ""
     }
   ],
   "addresses": [

--- a/slack-api-client/src/main/java/com/slack/api/scim/model/Group.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/model/Group.java
@@ -24,5 +24,6 @@ public class Group {
     @Data
     public static class Member {
         private String value;
+        private String display;
     }
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/model/User.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/model/User.java
@@ -105,4 +105,10 @@ public class User {
         }
     }
 
+    @Data
+    public static class Group {
+        private String value;
+        private String display;
+    }
+
 }

--- a/slack-api-client/src/test/java/util/sample_json_generation/JsonDataRecorder.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/JsonDataRecorder.java
@@ -197,14 +197,12 @@ public class JsonDataRecorder {
             User.Role sampleObject = ObjectInitializer.initProperties(new User.Role());
             objects.add(GsonFactory.createCamelCase(config).toJsonTree(sampleObject));
         }
-        if (resourceObj.get("groups") == null) {
-            resourceObj.add("groups", new JsonArray());
-        }
-        {
-            JsonArray objects = resourceObj.get("groups").getAsJsonArray();
-            clearAllElements(objects);
-            Group sampleObject = ObjectInitializer.initProperties(new Group());
-            objects.add(GsonFactory.createCamelCase(config).toJsonTree(sampleObject));
+        if (resourceObj.get("groups") != null) {
+            JsonArray groups = new JsonArray();
+            User.Group group = new User.Group();
+            ObjectInitializer.initProperties(group);
+            groups.add(GsonFactory.createCamelCase(config).toJsonTree(group));
+            resourceObj.add("groups", groups);
         }
     }
 


### PR DESCRIPTION
###  Summary

This pull request fixes #409 by correcting the response attribute `user.groups`. I've added a unit test to verify the behavior in the case and fixed the response class accordingly.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
