### PR TITLE
Fix #410 Hint for a Modal Surface's Input block

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/model/block/InputBlock.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/InputBlock.java
@@ -36,7 +36,7 @@ public class InputBlock implements LayoutBlock {
      * It must be a a text object with a type of plain_text.
      * Maximum length for the text in this field is 2000 characters.
      */
-    private String hint;
+    private PlainTextObject hint;
 
     /**
      * A boolean that indicates whether the input element may be empty when a user submits the modal.

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -28,6 +28,10 @@ public class BlockKitTest {
                 "        \"type\": \"plain_text\",\n" +
                 "        \"text\": \"Label of input\"\n" +
                 "    },\n" +
+                "    \"hint\": {\n" +
+                "        \"type\": \"plain_text\",\n" +
+                "        \"text\": \"Hint of input\"\n" +
+                "    },\n" +
                 "  \"element\": {\n" +
                 "    \"type\": \"plain_text_input\",\n" +
                 "    \"action_id\": \"plain_input\",\n" +
@@ -42,6 +46,7 @@ public class BlockKitTest {
         InputBlock inputBlock = (InputBlock) message.getBlocks().get(0);
         assertThat(inputBlock.getLabel(), is(notNullValue()));
         assertThat(inputBlock.getElement(), is(notNullValue()));
+        assertThat(inputBlock.getHint(),is(notNullValue()));
     }
 
     @Test

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -242,6 +242,11 @@ public class BlocksTest {
                     "      \"type\": \"plain_text\",\n" +
                     "      \"text\": \"Choose the conversation to publish your result to:\",\n" +
                     "      \"emoji\": true\n" +
+                    "    },\n" +
+                    "    \"hint\": {\n" +
+                    "      \"type\": \"plain_text\",\n" +
+                    "      \"text\": \"Choose the conversation to publish your result to:\",\n" +
+                    "      \"emoji\": true\n" +
                     "    }\n" +
                     "  }\n" +
                     "]}";


### PR DESCRIPTION
###  Summary

This pull request fixes a bug reported at #410, where the type for hint property for input blocks is invalid.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
