### PR TITLE
Bump the okhttp patch version from 4.4.0 to 4.4.1

### DIFF
--- a/json-logs/raw/status/api/v1.0.0/current.json
+++ b/json-logs/raw/status/api/v1.0.0/current.json
@@ -160,6 +160,18 @@
     {
       "date_created": "2020-03-24T17:18:02-07:00",
       "body": "We\u0027re looking into reports of access issues for some people using web browsers. Please hold tight. In the meantime, using a different type of web browser or the desktop app will hopefully get you back into your workspace."
+    },
+    {
+      "date_created": "2020-03-30T19:11:11-07:00",
+      "body": "Issue Summary: \r\n\r\nOn March 30, 2020 from 3:20 p.m. to 6:26 p.m. PDT, some customers may have experienced elevated API response times or timeouts. This was caused by an issue with a third-party provider. Once they resolved the issue, Slack API response times returned to normal."
+    },
+    {
+      "date_created": "2020-03-30T18:36:12-07:00",
+      "body": "Customers should no longer be experiencing elevated API response times or timeouts. Thank you for being patient with us, we appreciate it. \r\n\r\nIf you have any further issues, please reach out to us at feedback@slack.com."
+    },
+    {
+      "date_created": "2020-03-30T17:38:55-07:00",
+      "body": "Issues with a third-party provider are causing elevated response times in the API, leading to potential timeouts. We are monitoring the situation and working to mitigate this from our end as best we can. We apologize for the disruption."
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <okhttp.version>4.4.0</okhttp.version>
+        <okhttp.version>4.4.1</okhttp.version>
         <gson.version>2.8.6</gson.version>
         <lombok.version>1.18.12</lombok.version>
         <lombok-maven-plugin.version>1.18.10.0</lombok-maven-plugin.version>
@@ -46,7 +46,7 @@
         <junit.version>4.13</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.3.0</mockito-core.version>
+        <mockito-core.version>3.3.3</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>


### PR DESCRIPTION
###  Summary

This pull request bumps okhttp version from 4.4.0 to 4.4.1.

Here are the all changes introduced in okhttp 4.4.1. 
https://github.com/square/okhttp/compare/parent-4.4.0...parent-4.4.1

As the version includes only minor improvements and the release is 23 days ago. It's safe enough to upgrade the version. I've verified there are no failures in all the unit tests with actual Slack APIs.

This PR also upgrades the mockito version, which is used only in the tests for this library.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
