### PR TITLE
Fix #415 attachments payload's validity issue

### DIFF
--- a/json-logs/samples/api/im.history.json
+++ b/json-logs/samples/api/im.history.json
@@ -21,7 +21,9 @@
           "ts": ""
         }
       ],
-      "subscribed": false
+      "subscribed": false,
+      "user": "U00000000",
+      "bot_link": ""
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -800,6 +800,7 @@
   "url": "",
   "is_europe": false,
   "accept_tos_url": "https://www.example.com/",
+  "channels_with_use_case": {},
   "error": "",
   "needed": "",
   "provided": ""

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/conversations_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/conversations_Test.java
@@ -416,7 +416,9 @@ public class conversations_Test {
                 List<Message> messages = response.getMessages();
                 Message firstMessage = messages.get(0);
                 assertThat(firstMessage.getReplyUsersCount(), is(1));
-                assertThat(firstMessage.getReplies().size(), is(5));
+                // NOTE: As of April 2020, this field is no longer available
+                // assertThat(firstMessage.getReplies().size(), is(5));
+                assertThat(firstMessage.getReplies(), is(nullValue()));
                 assertThat(firstMessage.getReplyCount(), is(5));
                 assertThat(firstMessage.getLatestReply(), is(messages.get(5).getTs()));
             }
@@ -433,7 +435,9 @@ public class conversations_Test {
                 List<Message> messages = response.getMessages();
                 Message firstMessage = messages.get(0);
                 assertThat(firstMessage.getReplyUsersCount(), is(1));
-                assertThat(firstMessage.getReplies().size(), is(5));
+                // NOTE: As of April 2020, this field is no longer available
+                // assertThat(firstMessage.getReplies().size(), is(5));
+                assertThat(firstMessage.getReplies(), is(nullValue()));
                 assertThat(firstMessage.getReplyCount(), is(5));
                 assertThat(firstMessage.getLatestReply(), is(messages.get(5).getTs()));
             }

--- a/slack-api-model/src/main/java/com/slack/api/model/Attachment.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/Attachment.java
@@ -4,7 +4,6 @@ import com.google.gson.annotations.SerializedName;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -190,8 +189,7 @@ public class Attachment {
     /**
      * Fields are defined as an array, and hashes contained within it will be displayed in a table inside the message attachment.
      */
-    @Builder.Default
-    private List<Field> fields = new ArrayList<>();
+    private List<Field> fields;
 
     /**
      * A valid URL to an image file that will be displayed inside a message attachment.
@@ -259,14 +257,12 @@ public class Attachment {
      * in attachments</a> are not formatted. To enable formatting on attachment fields, add the
      * name of the field (as defined in the API) in this list.
      */
-    @Builder.Default
-    private List<String> mrkdwnIn = new ArrayList<>();
+    private List<String> mrkdwnIn;
 
     /**
      * Actions are defined as an array, and hashes contained within it will be displayed in as buttons in the message attachment.
      */
-    @Builder.Default
-    private List<Action> actions = new ArrayList<>();
+    private List<Action> actions;
 
     private List<LayoutBlock> blocks;
 

--- a/slack-app-backend/src/test/java/test_locally/app_backend/outgoing_webhooks/WebhookResponseTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/outgoing_webhooks/WebhookResponseTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNull;
 
 public class WebhookResponseTest {
@@ -64,7 +65,7 @@ public class WebhookResponseTest {
         assertThat(attachmentResponse.getTitle(), is("Slack API Documentation"));
         assertThat(attachmentResponse.getTitleLink(), is("https://api.slack.com/"));
         assertThat(attachmentResponse.getText(), is("This is an *attachment*."));
-        assertThat(attachmentResponse.getFields().size(), is(0));
+        assertThat(attachmentResponse.getFields(), is(nullValue()));
         assertNull(attachmentResponse.getImageUrl());
         assertNull(attachmentResponse.getImageWidth());
         assertNull(attachmentResponse.getImageHeight());
@@ -78,8 +79,8 @@ public class WebhookResponseTest {
         assertThat(attachmentResponse.getFooter(), is("footer"));
         assertNull(attachmentResponse.getFooterIcon());
         assertNull(attachmentResponse.getTs());
-        assertThat(attachmentResponse.getMrkdwnIn().size(), is(0));
-        assertThat(attachmentResponse.getActions().size(), is(0));
+        assertThat(attachmentResponse.getMrkdwnIn(), is(nullValue()));
+        assertThat(attachmentResponse.getActions(), is(nullValue()));
         assertNull(attachmentResponse.getBlocks());
         assertNull(attachmentResponse.getFilename());
         assertNull(attachmentResponse.getSize());


### PR DESCRIPTION
###  Summary

This pull request fixes #415 where posting a message with attachments gets an error response from the server-side saying the attachments are invalid.

```json
{
  "ok": false,
  "error": "invalid_attachments",
  "response_metadata": {
    "messages": [
      "[ERROR] invalid_keys"
    ]
  }
}
```

The reason of the error is that an attachment payload this library generates contains empty arrays for `fields`, `mrkdwnIn`, and `actions` by default. This pull request removes those default values from an attachment initialization.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
