### PR TITLE
Upgrade dependencies' patch versions (2020-04-02)

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <helidon.version>1.4.2</helidon.version>
+        <helidon.version>1.4.4</helidon.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-jetty/pom.xml
+++ b/bolt-jetty/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <jetty.version>9.4.24.v20191120</jetty.version>
+        <jetty.version>9.4.27.v20200227</jetty.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-kotlin-examples/pom.xml
+++ b/bolt-kotlin-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <kotlin.version>1.3.70</kotlin.version>
+        <kotlin.version>1.3.71</kotlin.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.version>1.3.2</micronaut.version>
+        <micronaut.version>1.3.3</micronaut.version>
         <micronaut-test-junit5.version>1.1.5</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <quarkus.version>1.2.1.Final</quarkus.version>
+        <quarkus.version>1.3.1.Final</quarkus.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.2.5.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <lombok-maven-plugin.version>1.18.10.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.739</aws.s3.version>
+        <aws.s3.version>1.11.757</aws.s3.version>
         <junit.version>4.13</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
###  Summary

This pull request upgrades only patch versions of this SDK's dependencies. For the SDK users, only the following updates may affect.

* Jetty HTTP Server 9.4.24 -> 9.4.27
* Micronaut 1.3.2 -> 1.3.3
* Helidon SE 1.4.1 -> 1.4.2
* (provided scope) AWS S3 SDK 1.11.739 -> 1.11.757

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).