### PR TITLE
Add style to rich_text emoji elements

### DIFF
--- a/json-logs/samples/api/im.history.json
+++ b/json-logs/samples/api/im.history.json
@@ -23,7 +23,132 @@
       ],
       "subscribed": false,
       "user": "U00000000",
-      "bot_link": ""
+      "bot_link": "",
+      "client_msg_id": "",
+      "team": "T00000000",
+      "edited": {
+        "user": "U00000000",
+        "ts": "0000000000.000000"
+      },
+      "blocks": [
+        {
+          "type": "",
+          "elements": [
+            {
+              "type": "",
+              "text": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                }
+              },
+              "placeholder": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "initial_channel": "",
+              "response_url_enabled": false,
+              "initial_conversation": "",
+              "filter": {
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "initial_date": "",
+              "initial_option": {
+                "text": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "min_query_length": 12345,
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 12345,
+              "image_height": 12345,
+              "image_bytes": 12345,
+              "initial_user": ""
+            },
+            {
+              "type": "",
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 12345,
+              "image_height": 12345,
+              "image_bytes": 12345
+            }
+          ],
+          "block_id": "",
+          "fallback": "",
+          "image_url": "",
+          "image_width": 12345,
+          "image_height": 12345,
+          "image_bytes": 12345,
+          "alt_text": "",
+          "title": {
+            "type": "",
+            "text": "",
+            "emoji": false
+          },
+          "text": {
+            "type": "",
+            "text": "",
+            "emoji": false
+          },
+          "fields": [
+            {
+              "type": "",
+              "text": "",
+              "emoji": false,
+              "verbatim": false
+            }
+          ],
+          "accessory": {
+            "type": "",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 12345,
+            "image_height": 12345,
+            "image_bytes": 12345
+          }
+        }
+      ]
     }
   ],
   "has_more": false,

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextSectionElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextSectionElement.java
@@ -65,6 +65,7 @@ public class RichTextSectionElement extends BlockElement implements RichTextElem
         private final String type = TYPE;
         private String name;
         private Integer skinTone;
+        private TextStyle style;
     }
 
     @Data

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -625,6 +625,48 @@ public class BlockKitTest {
         }
     }
 
+    @Test
+    public void richText_emoji_with_style() {
+        String json = "{\n" +
+                "  \"blocks\": [\n" +
+                "    {\n" +
+                "      \"type\": \"rich_text\",\n" +
+                "      \"block_id\": \"UiW\",\n" +
+                "      \"elements\": [\n" +
+                "        {\n" +
+                "          \"type\": \"rich_text_section\",\n" +
+                "          \"elements\": [\n" +
+                "            {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"text\": \"This is a text part.\"\n" +
+                "            },\n" +
+                "            {\n" +
+                "              \"type\": \"emoji\",\n" +
+                "              \"name\": \"house\",\n" +
+                "              \"style\": {\n" +
+                "                \"bold\": true\n," +
+                "                \"strike\": true" +
+                "              }\n" +
+                "            },\n" +
+                "            {\n" +
+                "              \"type\": \"link\",\n" +
+                "              \"url\": \"https://medium.com/slack-developer-blog\",\n" +
+                "              \"text\": \"Slack Platform Blog\",\n" +
+                "              \"style\": {\n" +
+                "                \"bold\": true\n," +
+                "                \"strike\": true" +
+                "              }\n" +
+                "            }\n" +
+                "          ]\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+        Message message = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+        assertThat(message, is(notNullValue()));
+    }
+
     String unknownBlocksJson = "{blocks: [{\n" +
             "  \"type\": \"unknown_block\",\n" +
             "  \"block_id\": \"input123\",\n" +


### PR DESCRIPTION
###  Summary

This pull request adds the `style` property to `emoji` rich text element. I've detected this missing field by running all the tests including the ones under `test_with_remote_apis` packages.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
