### PR TITLE
Update composition.OptionObject to have mrkdwn for some cases

### DIFF
--- a/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.slack.api.model.*;
 import com.slack.api.model.block.*;
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
+import com.slack.api.model.block.composition.OptionObject;
 import com.slack.api.model.block.composition.PlainTextObject;
 import com.slack.api.model.block.composition.TextObject;
 import com.slack.api.model.block.element.BlockElement;
@@ -65,6 +66,11 @@ public class SampleObjects {
 
     public static TextObject TextObject = initProperties(PlainTextObject.builder().build());
 
+    public static OptionObject Option = initProperties(OptionObject.builder()
+            .text(TextObject)
+            .description(PlainTextObject.builder().build())
+            .build());
+
     public static ConfirmationDialogObject Confirm = ConfirmationDialogObject.builder().text(TextObject).build();
 
     public static List<BlockElement> BlockElements = asElements(
@@ -72,10 +78,10 @@ public class SampleObjects {
             initProperties(channelsSelect(c -> c.confirm(Confirm))),
             initProperties(conversationsSelect(c -> c.confirm(Confirm))),
             initProperties(datePicker(d -> d.confirm(Confirm))),
-            initProperties(externalSelect(e -> e.confirm(Confirm))),
+            initProperties(externalSelect(e -> e.initialOption(Option).confirm(Confirm))),
             initProperties(com.slack.api.model.block.element.BlockElements.image(i -> i)),
             initProperties(overflowMenu(o -> o.confirm(Confirm))),
-            initProperties(staticSelect(s -> s.confirm(Confirm))),
+            initProperties(staticSelect(s -> s.initialOption(Option).confirm(Confirm))),
             initProperties(usersSelect(u -> u.confirm(Confirm)))
     );
     public static List<ContextBlockElement> ContextBlockElements = asContextElements(

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/BlockCompositions.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/BlockCompositions.java
@@ -66,7 +66,7 @@ public class BlockCompositions {
         return configurator.configure(OptionObject.builder()).build();
     }
 
-    public static OptionObject option(PlainTextObject text, String value) {
+    public static OptionObject option(TextObject text, String value) {
         return OptionObject.builder().text(text).value(value).build();
     }
 

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/OptionObject.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/OptionObject.java
@@ -15,18 +15,22 @@ import lombok.NoArgsConstructor;
 public class OptionObject {
 
     /**
-     * The formatting to use for this text object. Can be one of plain_text or mrkdwn.
+     * A text object that defines the text shown in the option on the menu.
+     * Overflow, select, and multi-select menus can only use plain_text objects,
+     * while radio buttons and checkboxes can use mrkdwn text objects.
+     * Maximum length for the text in this field is 75 characters.
      */
-    private PlainTextObject text;
+    private TextObject text;
 
     /**
-     * The text for the block. This field accepts any of the standard text formatting markup when type is mrkdwn.
+     * The string value that will be passed to your app when this option is chosen.
+     * Maximum length for this field is 75 characters.
      */
     private String value;
 
     /**
-     * A plain_text https://api.slack.com/reference/block-kit/composition-objects#text
-     * only text object that defines a line of descriptive text shown below the text field beside the radio button.
+     * A plain_text only text object that defines a line of descriptive text shown
+     * below the text field beside the radio button.
      * Maximum length for the text object within this field is 75 characters.
      */
     private PlainTextObject description;
@@ -38,6 +42,7 @@ public class OptionObject {
      * <p>
      * Maximum length for this field is 3000 characters.
      * If you're using url, you'll still receive an interaction payload and will need to send an acknowledgement response.
+     * A URL to load in the user's browser when the option is clicked.
      */
     private String url;
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/ModelsTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/ModelsTest.java
@@ -12,6 +12,7 @@ import com.slack.api.model.event.MessageEvent;
 import com.slack.api.model.view.ViewState;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -229,6 +230,21 @@ public class ModelsTest {
 
         ConfirmationDialogObject confirmationDialog = confirmationDialog(r -> r.text(markdownText("foo")));
         assertNotNull(confirmationDialog);
+    }
+
+    @Test
+    public void blockCompositions_radio_buttons_checkboxes() {
+        MarkdownTextObject mto = markdownText(r -> r.text("foo").verbatim(false));
+        assertNotNull(mto);
+
+        OptionObject opt = option(mto, "value");
+        assertNotNull(opt);
+
+        RadioButtonsElement radioButtons = radioButtons(r -> r.actionId("a").initialOption(opt).options(Arrays.asList(opt)));
+        assertNotNull(radioButtons);
+
+        CheckboxesElement checkboxes = checkboxes(r -> r.actionId("a").initialOptions(Arrays.asList(opt)).options(Arrays.asList(opt)));
+        assertNotNull(checkboxes);
     }
 
 }

--- a/slack-app-backend/src/test/java/test_locally/sample_json_generation/InteractiveMessagesPayloadDumpTest.java
+++ b/slack-app-backend/src/test/java/test_locally/sample_json_generation/InteractiveMessagesPayloadDumpTest.java
@@ -55,6 +55,7 @@ public class InteractiveMessagesPayloadDumpTest {
         action.getConfirm().setDeny(new PlainTextObject());
         action.getConfirm().setTitle(new PlainTextObject());
         action.getConfirm().setText(new PlainTextObject());
+        action.setInitialOption(SampleObjects.Option);
         List<BlockActionPayload.Action> actions = Arrays.asList(action);
         return BlockActionPayload.builder()
                 .team(new BlockActionPayload.Team())

--- a/slack-app-backend/src/test/java/util/sample_json_generation/SampleObjects.java
+++ b/slack-app-backend/src/test/java/util/sample_json_generation/SampleObjects.java
@@ -3,10 +3,7 @@ package util.sample_json_generation;
 import com.google.gson.JsonElement;
 import com.slack.api.model.*;
 import com.slack.api.model.block.*;
-import com.slack.api.model.block.composition.ConfirmationDialogObject;
-import com.slack.api.model.block.composition.MarkdownTextObject;
-import com.slack.api.model.block.composition.PlainTextObject;
-import com.slack.api.model.block.composition.TextObject;
+import com.slack.api.model.block.composition.*;
 import com.slack.api.model.block.element.*;
 import com.slack.api.util.json.GsonFactory;
 
@@ -58,6 +55,11 @@ public class SampleObjects {
 
     public static TextObject TextObject = initProperties(PlainTextObject.builder().build());
 
+    public static OptionObject Option = initProperties(OptionObject.builder()
+            .text(TextObject)
+            .description(PlainTextObject.builder().build())
+            .build());
+
     public static ConfirmationDialogObject Confirm = ConfirmationDialogObject.builder().text(TextObject).build();
 
     public static ConversationsFilter conversationsFilter = ConversationsFilter.builder().include(Arrays.asList("")).build();
@@ -68,11 +70,11 @@ public class SampleObjects {
             initProperties(ConversationsSelectElement.builder().confirm(Confirm).filter(conversationsFilter).build()),
             initProperties(MultiConversationsSelectElement.builder().confirm(Confirm).filter(conversationsFilter).build()),
             initProperties(DatePickerElement.builder().confirm(Confirm).build()),
-            initProperties(ExternalSelectElement.builder().confirm(Confirm).build()),
+            initProperties(ExternalSelectElement.builder().initialOption(Option).confirm(Confirm).build()),
             initProperties(MultiExternalSelectElement.builder().confirm(Confirm).build()),
             initProperties(ImageElement.builder().build()),
             initProperties(OverflowMenuElement.builder().confirm(Confirm).build()),
-            initProperties(StaticSelectElement.builder().confirm(Confirm).build()),
+            initProperties(StaticSelectElement.builder().initialOption(Option).confirm(Confirm).build()),
             initProperties(MultiStaticSelectElement.builder().confirm(Confirm).build()),
             initProperties(UsersSelectElement.builder().confirm(Confirm).build()),
             initProperties(MultiUsersSelectElement.builder().confirm(Confirm).build())


### PR DESCRIPTION
###  Summary

This pull request changes the type of `option.text` in Block elements to accept not only `plain_text` but `mrkdwn` for `radion_buttons` and `checkboxes`. As the `TextObject` is a super type of `PlainTextObject`, this change is backward-compatible for both source and binary compatibility.

Reference: https://api.slack.com/reference/block-kit/composition-objects#option

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
