### PR TITLE
Fix block element equality

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/ActionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/ActionContext.java
@@ -14,7 +14,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class ActionContext extends Context implements ActionRespondUtility {
 
     private String triggerId;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/AttachmentActionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/AttachmentActionContext.java
@@ -15,7 +15,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class AttachmentActionContext extends Context implements SayUtility, ActionRespondUtility {
 
     private String triggerId;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/BlockSuggestionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/BlockSuggestionContext.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Setter
 @Builder
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class BlockSuggestionContext extends Context {
 
     public BlockSuggestionContext() {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DefaultContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DefaultContext.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Setter
 @Builder
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class DefaultContext extends Context {
 
     public DefaultContext() {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogCancellationContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogCancellationContext.java
@@ -12,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class DialogCancellationContext extends Context implements SayUtility, ActionRespondUtility {
 
     private String responseUrl;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSubmissionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSubmissionContext.java
@@ -18,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class DialogSubmissionContext extends Context implements SayUtility, ActionRespondUtility {
 
     private String responseUrl;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSuggestionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSuggestionContext.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Setter
 @Builder
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class DialogSuggestionContext extends Context {
 
     public DialogSuggestionContext() {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/EventContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/EventContext.java
@@ -8,7 +8,7 @@ import lombok.*;
 @Setter
 @Builder
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
 public class EventContext extends Context implements SayUtility {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/GlobalShortcutContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/GlobalShortcutContext.java
@@ -12,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class GlobalShortcutContext extends Context {
     private String triggerId;
 }

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/MessageShortcutContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/MessageShortcutContext.java
@@ -15,7 +15,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class MessageShortcutContext extends Context implements SayUtility, ActionRespondUtility {
 
     private String triggerId;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/OAuthCallbackContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/OAuthCallbackContext.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class OAuthCallbackContext extends Context {
 
     private String oauthCompletionUrl;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/SlashCommandContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/SlashCommandContext.java
@@ -20,7 +20,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class SlashCommandContext extends Context implements SayUtility, RespondUtility {
 
     private String triggerId;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/ViewSubmissionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/ViewSubmissionContext.java
@@ -19,7 +19,7 @@ import java.util.Map;
 @Builder
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode
 public class ViewSubmissionContext extends Context implements InputBlockRespondUtility {
 
     private List<ViewSubmissionPayload.ResponseUrl> responseUrls;

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditApiErrorResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditApiErrorResponse.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class AuditApiErrorResponse implements AuditApiResponse {
 
     private boolean ok;

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditApiException.java
@@ -9,7 +9,6 @@ import okhttp3.Response;
 
 @Data
 @Slf4j
-@EqualsAndHashCode(callSuper = false)
 public class AuditApiException extends Exception {
 
     private final Response response;

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
@@ -7,7 +7,6 @@ import lombok.EqualsAndHashCode;
 import java.util.List;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class ActionsResponse implements AuditApiResponse {
     private boolean ok;
     private String warning;

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
@@ -9,7 +9,6 @@ import lombok.EqualsAndHashCode;
 import java.util.List;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class LogsResponse implements AuditApiResponse {
     private boolean ok;
     private String warning;

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
@@ -7,7 +7,6 @@ import lombok.EqualsAndHashCode;
 import java.util.List;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class SchemasResponse implements AuditApiResponse {
     private boolean ok;
     private String warning;

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsCompletionException.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsCompletionException.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 
 @Data
 @Slf4j
-@EqualsAndHashCode(callSuper = false)
 public class MethodsCompletionException extends RuntimeException {
 
     private final IOException ioException;

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiException.java
@@ -9,7 +9,6 @@ import okhttp3.Response;
 
 @Data
 @Slf4j
-@EqualsAndHashCode(callSuper = false)
 public class SlackApiException extends Exception {
 
     private final Response response;

--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiErrorResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiErrorResponse.java
@@ -5,7 +5,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class SCIMApiErrorResponse implements SCIMApiResponse {
 
     @SerializedName("Errors")

--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiException.java
@@ -9,7 +9,6 @@ import okhttp3.Response;
 
 @Data
 @Slf4j
-@EqualsAndHashCode(callSuper = false)
 public class SCIMApiException extends Exception {
 
     private final Response response;

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsCreateResponse.java
@@ -6,6 +6,5 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class GroupsCreateResponse extends Group implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsDeleteResponse.java
@@ -5,6 +5,5 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class GroupsDeleteResponse implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsPatchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsPatchResponse.java
@@ -6,6 +6,5 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class GroupsPatchResponse extends Group implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsReadResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsReadResponse.java
@@ -6,6 +6,5 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class GroupsReadResponse extends Group implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsSearchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsSearchResponse.java
@@ -9,7 +9,6 @@ import lombok.EqualsAndHashCode;
 import java.util.List;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class GroupsSearchResponse implements SCIMApiResponse {
     private Integer totalResults;
     private Integer itemsPerPage;

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsUpdateResponse.java
@@ -6,6 +6,5 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class GroupsUpdateResponse extends Group implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/ServiceProviderConfigsGetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/ServiceProviderConfigsGetResponse.java
@@ -7,7 +7,6 @@ import lombok.EqualsAndHashCode;
 import java.util.List;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class ServiceProviderConfigsGetResponse implements SCIMApiResponse {
 
     private List<AuthenticationScheme> authenticationSchemes;

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersCreateResponse.java
@@ -6,6 +6,5 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class UsersCreateResponse extends User implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersDeleteResponse.java
@@ -5,6 +5,5 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class UsersDeleteResponse implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersPatchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersPatchResponse.java
@@ -6,6 +6,5 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class UsersPatchResponse extends User implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersReadResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersReadResponse.java
@@ -6,6 +6,5 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class UsersReadResponse extends User implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersSearchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersSearchResponse.java
@@ -9,7 +9,6 @@ import lombok.EqualsAndHashCode;
 import java.util.List;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class UsersSearchResponse implements SCIMApiResponse {
     private Integer totalResults;
     private Integer itemsPerPage;

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersUpdateResponse.java
@@ -6,6 +6,5 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
 public class UsersUpdateResponse extends User implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/status/v1/LegacyStatusApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/status/v1/LegacyStatusApiException.java
@@ -7,7 +7,6 @@ import okhttp3.Response;
 
 @Data
 @Slf4j
-@EqualsAndHashCode(callSuper = false)
 public class LegacyStatusApiException extends Exception {
 
     private final Response response;

--- a/slack-api-client/src/main/java/com/slack/api/status/v2/StatusApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/status/v2/StatusApiException.java
@@ -7,7 +7,6 @@ import okhttp3.Response;
 
 @Data
 @Slf4j
-@EqualsAndHashCode(callSuper = false)
 public class StatusApiException extends Exception {
 
     private final Response response;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/UnknownBlockElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/UnknownBlockElement.java
@@ -7,7 +7,6 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public class UnknownBlockElement extends BlockElement {
     private String type;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/MarkdownTextObject.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/MarkdownTextObject.java
@@ -7,7 +7,6 @@ import lombok.*;
  */
 @Data
 @Builder
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class MarkdownTextObject extends TextObject {

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/PlainTextObject.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/PlainTextObject.java
@@ -6,7 +6,6 @@ import lombok.*;
  * https://api.slack.com/reference/messaging/composition-objects#text
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/UnknownTextObject.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/UnknownTextObject.java
@@ -6,7 +6,6 @@ import lombok.*;
  * https://api.slack.com/reference/messaging/composition-objects#text
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ButtonElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ButtonElement.java
@@ -8,7 +8,6 @@ import lombok.*;
  * https://api.slack.com/reference/block-kit/block-elements#button
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ChannelsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ChannelsSelectElement.java
@@ -8,7 +8,6 @@ import lombok.*;
  * https://api.slack.com/reference/block-kit/block-elements#channel_select
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/CheckboxesElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/CheckboxesElement.java
@@ -10,7 +10,6 @@ import java.util.List;
  * https://api.slack.com/reference/block-kit/block-elements#checkboxes
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsSelectElement.java
@@ -8,7 +8,6 @@ import lombok.*;
  * https://api.slack.com/reference/block-kit/block-elements#conversation_select
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/DatePickerElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/DatePickerElement.java
@@ -8,7 +8,6 @@ import lombok.*;
  * https://api.slack.com/reference/block-kit/block-elements#datepicker
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ExternalSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ExternalSelectElement.java
@@ -9,7 +9,6 @@ import lombok.*;
  * https://api.slack.com/reference/block-kit/block-elements#external_select
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ImageElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ImageElement.java
@@ -7,7 +7,6 @@ import lombok.*;
  * https://api.slack.com/reference/block-kit/block-elements#image
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiChannelsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiChannelsSelectElement.java
@@ -10,7 +10,6 @@ import java.util.List;
  * https://api.slack.com/reference/block-kit/block-elements#channel_multi_select
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiConversationsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiConversationsSelectElement.java
@@ -10,7 +10,6 @@ import java.util.List;
  * https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiExternalSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiExternalSelectElement.java
@@ -11,7 +11,6 @@ import java.util.List;
  * https://api.slack.com/reference/block-kit/block-elements#external_multi_select
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiStaticSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiStaticSelectElement.java
@@ -12,7 +12,6 @@ import java.util.List;
  * https://api.slack.com/reference/block-kit/block-elements#multi_select
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiUsersSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiUsersSelectElement.java
@@ -10,7 +10,6 @@ import java.util.List;
  * https://api.slack.com/reference/block-kit/block-elements#users_multi_select
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/OverflowMenuElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/OverflowMenuElement.java
@@ -10,7 +10,6 @@ import java.util.List;
  * https://api.slack.com/reference/block-kit/block-elements#overflow
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/PlainTextInputElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/PlainTextInputElement.java
@@ -7,7 +7,6 @@ import lombok.*;
  * https://api.slack.com/reference/block-kit/block-elements#input
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RadioButtonsElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RadioButtonsElement.java
@@ -10,7 +10,6 @@ import java.util.List;
  * https://api.slack.com/reference/block-kit/block-elements#radio
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextListElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextListElement.java
@@ -9,7 +9,6 @@ import java.util.List;
  * https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextPreformattedElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextPreformattedElement.java
@@ -9,7 +9,6 @@ import java.util.List;
  * https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextQuoteElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextQuoteElement.java
@@ -9,7 +9,6 @@ import java.util.List;
  * https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextSectionElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextSectionElement.java
@@ -9,7 +9,6 @@ import java.util.List;
  * https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextUnknownElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextUnknownElement.java
@@ -3,7 +3,6 @@ package com.slack.api.model.block.element;
 import lombok.*;
 
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/StaticSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/StaticSelectElement.java
@@ -12,7 +12,6 @@ import java.util.List;
  * https://api.slack.com/reference/messaging/block-elements#static-select
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/UsersSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/UsersSelectElement.java
@@ -8,7 +8,6 @@ import lombok.*;
  * https://api.slack.com/reference/block-kit/block-elements#users_select
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/slack-api-model/src/test/java/test_locally/api/model/ModelsTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/ModelsTest.java
@@ -247,4 +247,33 @@ public class ModelsTest {
         assertNotNull(checkboxes);
     }
 
+    @Test
+    public void equality() {
+        assertEquals(new MarkdownTextObject(), new MarkdownTextObject());
+        assertEquals(new PlainTextObject(), new PlainTextObject());
+        assertEquals(new UnknownTextObject(), new UnknownTextObject());
+        assertEquals(new ButtonElement(), new ButtonElement());
+        assertEquals(new ChannelsSelectElement(), new ChannelsSelectElement());
+        assertEquals(new CheckboxesElement(), new CheckboxesElement());
+        assertEquals(new ConversationsSelectElement(), new ConversationsSelectElement());
+        assertEquals(new DatePickerElement(), new DatePickerElement());
+        assertEquals(new ExternalSelectElement(), new ExternalSelectElement());
+        assertEquals(new ImageElement(), new ImageElement());
+        assertEquals(new MultiChannelsSelectElement(), new MultiChannelsSelectElement());
+        assertEquals(new MultiConversationsSelectElement(), new MultiConversationsSelectElement());
+        assertEquals(new MultiExternalSelectElement(), new MultiExternalSelectElement());
+        assertEquals(new MultiStaticSelectElement(), new MultiStaticSelectElement());
+        assertEquals(new MultiUsersSelectElement(), new MultiUsersSelectElement());
+        assertEquals(new OverflowMenuElement(), new OverflowMenuElement());
+        assertEquals(new PlainTextInputElement(), new PlainTextInputElement());
+        assertEquals(new RadioButtonsElement(), new RadioButtonsElement());
+        assertEquals(new RichTextListElement(), new RichTextListElement());
+        assertEquals(new RichTextPreformattedElement(), new RichTextPreformattedElement());
+        assertEquals(new RichTextQuoteElement(), new RichTextQuoteElement());
+        assertEquals(new RichTextSectionElement(), new RichTextSectionElement());
+        assertEquals(new RichTextUnknownElement(), new RichTextUnknownElement());
+        assertEquals(new StaticSelectElement(), new StaticSelectElement());
+        assertEquals(new UsersSelectElement(), new UsersSelectElement());
+    }
+
 }

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/views/response/ViewSubmissionResponse.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/views/response/ViewSubmissionResponse.java
@@ -10,7 +10,6 @@ import java.util.Map;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public class ViewSubmissionResponse {
 
     private String responseAction; // push, update, errors, (no value to close)


### PR DESCRIPTION
###  Summary

Block elements should be compared structurally, but their `@EqualsAndHashCode`  annotation had `callSuper  = true`. The super class however (typically `ButtonElement`) doesn't have `equals` overridden for structural equality. So two structurally identical elements would not be considered equal by `.equals()`.

In other words,  this was failing:

    assertEquals(new ButtonElement(), new ButtonElement())

The first commit in this PR fixes that, by removing the `callSuper = flag` from the `@EqualsAndHashCode` annotation, so that these elements are considered equals when they are structurally equivalent. 

Two additional commits that don't change anything, but just clean up a  bit of code:
 - First one removes `@EqualsAndHashCode` when there's already `@Data`, which includes  that.
- Last one removes `callSuper = false` from the remaining `@EqualsAndHashCode` annotations, since it's the default value.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
