### PR TITLE
Partially reverting #441 - get @EqualsAndHashCode(callSuper = false) back for data classes

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/ActionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/ActionContext.java
@@ -14,7 +14,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class ActionContext extends Context implements ActionRespondUtility {
 
     private String triggerId;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/AttachmentActionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/AttachmentActionContext.java
@@ -15,7 +15,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class AttachmentActionContext extends Context implements SayUtility, ActionRespondUtility {
 
     private String triggerId;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/BlockSuggestionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/BlockSuggestionContext.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Setter
 @Builder
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class BlockSuggestionContext extends Context {
 
     public BlockSuggestionContext() {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DefaultContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DefaultContext.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Setter
 @Builder
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class DefaultContext extends Context {
 
     public DefaultContext() {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogCancellationContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogCancellationContext.java
@@ -12,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class DialogCancellationContext extends Context implements SayUtility, ActionRespondUtility {
 
     private String responseUrl;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSubmissionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSubmissionContext.java
@@ -18,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class DialogSubmissionContext extends Context implements SayUtility, ActionRespondUtility {
 
     private String responseUrl;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSuggestionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSuggestionContext.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Setter
 @Builder
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class DialogSuggestionContext extends Context {
 
     public DialogSuggestionContext() {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/EventContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/EventContext.java
@@ -8,7 +8,7 @@ import lombok.*;
 @Setter
 @Builder
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor
 @AllArgsConstructor
 public class EventContext extends Context implements SayUtility {

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/GlobalShortcutContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/GlobalShortcutContext.java
@@ -12,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class GlobalShortcutContext extends Context {
     private String triggerId;
 }

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/MessageShortcutContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/MessageShortcutContext.java
@@ -15,7 +15,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class MessageShortcutContext extends Context implements SayUtility, ActionRespondUtility {
 
     private String triggerId;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/OAuthCallbackContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/OAuthCallbackContext.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class OAuthCallbackContext extends Context {
 
     private String oauthCompletionUrl;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/SlashCommandContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/SlashCommandContext.java
@@ -20,7 +20,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class SlashCommandContext extends Context implements SayUtility, RespondUtility {
 
     private String triggerId;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/ViewSubmissionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/ViewSubmissionContext.java
@@ -19,7 +19,7 @@ import java.util.Map;
 @Builder
 @AllArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class ViewSubmissionContext extends Context implements InputBlockRespondUtility {
 
     private List<ViewSubmissionPayload.ResponseUrl> responseUrls;

--- a/bolt/src/test/java/test_locally/context/EqualityTest.java
+++ b/bolt/src/test/java/test_locally/context/EqualityTest.java
@@ -1,0 +1,26 @@
+package test_locally.context;
+
+import com.slack.api.bolt.context.builtin.*;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EqualityTest {
+
+    @Test
+    public void test() {
+        assertEquals(new ActionContext(), new ActionContext());
+        assertEquals(new AttachmentActionContext(), new AttachmentActionContext());
+        assertEquals(new BlockSuggestionContext(), new BlockSuggestionContext());
+        assertEquals(new DefaultContext(), new DefaultContext());
+        assertEquals(new DialogCancellationContext(), new DialogCancellationContext());
+        assertEquals(new DialogSubmissionContext(), new DialogSubmissionContext());
+        assertEquals(new DialogSuggestionContext(), new DialogSuggestionContext());
+        assertEquals(new EventContext(), new EventContext());
+        assertEquals(new GlobalShortcutContext(), new GlobalShortcutContext());
+        assertEquals(new MessageShortcutContext(), new MessageShortcutContext());
+        assertEquals(new OAuthCallbackContext(), new OAuthCallbackContext());
+        assertEquals(new SlashCommandContext(), new SlashCommandContext());
+        assertEquals(new ViewSubmissionContext(), new ViewSubmissionContext());
+    }
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditApiErrorResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditApiErrorResponse.java
@@ -1,6 +1,7 @@
 package com.slack.api.audit;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditApiErrorResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditApiErrorResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.audit;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class AuditApiErrorResponse implements AuditApiResponse {
 
     private boolean ok;

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditApiException.java
@@ -8,6 +8,7 @@ import okhttp3.Response;
 
 @Data
 @Slf4j
+@EqualsAndHashCode(callSuper = false)
 public class AuditApiException extends Exception {
 
     private final Response response;

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditApiException.java
@@ -3,6 +3,7 @@ package com.slack.api.audit;
 import com.slack.api.SlackConfig;
 import com.slack.api.util.json.GsonFactory;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
@@ -2,6 +2,7 @@ package com.slack.api.audit.response;
 
 import com.slack.api.audit.AuditApiResponse;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class ActionsResponse implements AuditApiResponse {
     private boolean ok;
     private String warning;

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import com.slack.api.audit.AuditApiResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class LogsResponse implements AuditApiResponse {
     private boolean ok;
     private String warning;

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
@@ -2,6 +2,7 @@ package com.slack.api.audit.response;
 
 import com.slack.api.audit.AuditApiResponse;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class SchemasResponse implements AuditApiResponse {
     private boolean ok;
     private String warning;

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsCompletionException.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsCompletionException.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 
 @Data
 @Slf4j
+@EqualsAndHashCode(callSuper = false)
 public class MethodsCompletionException extends RuntimeException {
 
     private final IOException ioException;

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsCompletionException.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsCompletionException.java
@@ -1,6 +1,7 @@
 package com.slack.api.methods;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiException.java
@@ -3,6 +3,7 @@ package com.slack.api.methods;
 import com.slack.api.SlackConfig;
 import com.slack.api.util.json.GsonFactory;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiException.java
@@ -8,6 +8,7 @@ import okhttp3.Response;
 
 @Data
 @Slf4j
+@EqualsAndHashCode(callSuper = false)
 public class SlackApiException extends Exception {
 
     private final Response response;

--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiErrorResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiErrorResponse.java
@@ -2,6 +2,7 @@ package com.slack.api.scim;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiErrorResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiErrorResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class SCIMApiErrorResponse implements SCIMApiResponse {
 
     @SerializedName("Errors")

--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiException.java
@@ -3,6 +3,7 @@ package com.slack.api.scim;
 import com.slack.api.SlackConfig;
 import com.slack.api.util.json.GsonFactory;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 

--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiException.java
@@ -8,6 +8,7 @@ import okhttp3.Response;
 
 @Data
 @Slf4j
+@EqualsAndHashCode(callSuper = false)
 public class SCIMApiException extends Exception {
 
     private final Response response;

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsCreateResponse.java
@@ -5,5 +5,6 @@ import com.slack.api.scim.model.Group;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class GroupsCreateResponse extends Group implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsCreateResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.scim.response;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.model.Group;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsDeleteResponse.java
@@ -4,5 +4,6 @@ import com.slack.api.scim.SCIMApiResponse;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class GroupsDeleteResponse implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsDeleteResponse.java
@@ -2,6 +2,7 @@ package com.slack.api.scim.response;
 
 import com.slack.api.scim.SCIMApiResponse;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsPatchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsPatchResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.scim.response;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.model.Group;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsPatchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsPatchResponse.java
@@ -5,5 +5,6 @@ import com.slack.api.scim.model.Group;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class GroupsPatchResponse extends Group implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsReadResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsReadResponse.java
@@ -5,5 +5,6 @@ import com.slack.api.scim.model.Group;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class GroupsReadResponse extends Group implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsReadResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsReadResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.scim.response;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.model.Group;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsSearchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsSearchResponse.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class GroupsSearchResponse implements SCIMApiResponse {
     private Integer totalResults;
     private Integer itemsPerPage;

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsSearchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsSearchResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.model.Group;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsUpdateResponse.java
@@ -5,5 +5,6 @@ import com.slack.api.scim.model.Group;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class GroupsUpdateResponse extends Group implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/GroupsUpdateResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.scim.response;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.model.Group;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/ServiceProviderConfigsGetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/ServiceProviderConfigsGetResponse.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class ServiceProviderConfigsGetResponse implements SCIMApiResponse {
 
     private List<AuthenticationScheme> authenticationSchemes;

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/ServiceProviderConfigsGetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/ServiceProviderConfigsGetResponse.java
@@ -2,6 +2,7 @@ package com.slack.api.scim.response;
 
 import com.slack.api.scim.SCIMApiResponse;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersCreateResponse.java
@@ -5,5 +5,6 @@ import com.slack.api.scim.model.User;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class UsersCreateResponse extends User implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersCreateResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.scim.response;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.model.User;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersDeleteResponse.java
@@ -4,5 +4,6 @@ import com.slack.api.scim.SCIMApiResponse;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class UsersDeleteResponse implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersDeleteResponse.java
@@ -2,6 +2,7 @@ package com.slack.api.scim.response;
 
 import com.slack.api.scim.SCIMApiResponse;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersPatchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersPatchResponse.java
@@ -5,5 +5,6 @@ import com.slack.api.scim.model.User;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class UsersPatchResponse extends User implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersPatchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersPatchResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.scim.response;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.model.User;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersReadResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersReadResponse.java
@@ -5,5 +5,6 @@ import com.slack.api.scim.model.User;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class UsersReadResponse extends User implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersReadResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersReadResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.scim.response;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.model.User;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersSearchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersSearchResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.model.User;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersSearchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersSearchResponse.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import java.util.List;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class UsersSearchResponse implements SCIMApiResponse {
     private Integer totalResults;
     private Integer itemsPerPage;

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersUpdateResponse.java
@@ -5,5 +5,6 @@ import com.slack.api.scim.model.User;
 import lombok.Data;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class UsersUpdateResponse extends User implements SCIMApiResponse {
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/response/UsersUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/response/UsersUpdateResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.scim.response;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.model.User;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/status/v1/LegacyStatusApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/status/v1/LegacyStatusApiException.java
@@ -6,6 +6,7 @@ import okhttp3.Response;
 
 @Data
 @Slf4j
+@EqualsAndHashCode(callSuper = false)
 public class LegacyStatusApiException extends Exception {
 
     private final Response response;

--- a/slack-api-client/src/main/java/com/slack/api/status/v1/LegacyStatusApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/status/v1/LegacyStatusApiException.java
@@ -1,6 +1,7 @@
 package com.slack.api.status.v1;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 

--- a/slack-api-client/src/main/java/com/slack/api/status/v2/StatusApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/status/v2/StatusApiException.java
@@ -6,6 +6,7 @@ import okhttp3.Response;
 
 @Data
 @Slf4j
+@EqualsAndHashCode(callSuper = false)
 public class StatusApiException extends Exception {
 
     private final Response response;

--- a/slack-api-client/src/main/java/com/slack/api/status/v2/StatusApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/status/v2/StatusApiException.java
@@ -1,6 +1,7 @@
 package com.slack.api.status.v2;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 

--- a/slack-api-client/src/test/java/test_locally/api/audit/EqualityTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/audit/EqualityTest.java
@@ -1,0 +1,35 @@
+package test_locally.api.audit;
+
+import com.slack.api.audit.AuditApiErrorResponse;
+import com.slack.api.audit.AuditApiException;
+import com.slack.api.audit.response.ActionsResponse;
+import com.slack.api.audit.response.LogsResponse;
+import com.slack.api.audit.response.SchemasResponse;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EqualityTest {
+
+    @Test
+    public void test() {
+        Request request = new Request.Builder()
+                .url("https://www.example.com/")
+                .build();
+        Response response = new Response.Builder()
+                .request(request)
+                .code(200)
+                .protocol(Protocol.HTTP_1_1)
+                .message("")
+                .build();
+
+        assertEquals(new AuditApiErrorResponse(), new AuditApiErrorResponse());
+        assertEquals(new AuditApiException(response, "test"), new AuditApiException(response, "test"));
+        assertEquals(new ActionsResponse(), new ActionsResponse());
+        assertEquals(new LogsResponse(), new LogsResponse());
+        assertEquals(new SchemasResponse(), new SchemasResponse());
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/methods/EqualityTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/EqualityTest.java
@@ -1,0 +1,29 @@
+package test_locally.api.methods;
+
+import com.slack.api.methods.MethodsCompletionException;
+import com.slack.api.methods.SlackApiException;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EqualityTest {
+
+    @Test
+    public void test() {
+        Request request = new Request.Builder()
+                .url("https://www.example.com/")
+                .build();
+        Response response = new Response.Builder()
+                .request(request)
+                .code(200)
+                .protocol(Protocol.HTTP_1_1)
+                .message("")
+                .build();
+
+        assertEquals(new MethodsCompletionException(null, null, null), new MethodsCompletionException(null, null, null));
+        assertEquals(new SlackApiException(response, ""), new SlackApiException(response, ""));
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/scim/EqualityTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim/EqualityTest.java
@@ -1,0 +1,46 @@
+package test_locally.api.scim;
+
+import com.slack.api.scim.SCIMApiErrorResponse;
+import com.slack.api.scim.SCIMApiException;
+import com.slack.api.scim.response.*;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EqualityTest {
+
+    @Test
+    public void test() {
+        Request request = new Request.Builder()
+                .url("https://www.example.com/")
+                .build();
+        Response response = new Response.Builder()
+                .request(request)
+                .code(200)
+                .protocol(Protocol.HTTP_1_1)
+                .message("")
+                .build();
+
+        assertEquals(new SCIMApiErrorResponse(), new SCIMApiErrorResponse());
+        assertEquals(new SCIMApiException(response, ""), new SCIMApiException(response, ""));
+
+        assertEquals(new GroupsCreateResponse(), new GroupsCreateResponse());
+        assertEquals(new GroupsDeleteResponse(), new GroupsDeleteResponse());
+        assertEquals(new GroupsPatchResponse(), new GroupsPatchResponse());
+        assertEquals(new GroupsReadResponse(), new GroupsReadResponse());
+        assertEquals(new GroupsSearchResponse(), new GroupsSearchResponse());
+        assertEquals(new GroupsUpdateResponse(), new GroupsUpdateResponse());
+
+        assertEquals(new ServiceProviderConfigsGetResponse(), new ServiceProviderConfigsGetResponse());
+
+        assertEquals(new UsersCreateResponse(), new UsersCreateResponse());
+        assertEquals(new UsersDeleteResponse(), new UsersDeleteResponse());
+        assertEquals(new UsersPatchResponse(), new UsersPatchResponse());
+        assertEquals(new UsersReadResponse(), new UsersReadResponse());
+        assertEquals(new UsersSearchResponse(), new UsersSearchResponse());
+        assertEquals(new UsersUpdateResponse(), new UsersUpdateResponse());
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/status/EqualityTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/status/EqualityTest.java
@@ -1,0 +1,29 @@
+package test_locally.api.status;
+
+import com.slack.api.status.v1.LegacyStatusApiException;
+import com.slack.api.status.v2.StatusApiException;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EqualityTest {
+
+    @Test
+    public void test() {
+        Request request = new Request.Builder()
+                .url("https://www.example.com/")
+                .build();
+        Response response = new Response.Builder()
+                .request(request)
+                .code(200)
+                .protocol(Protocol.HTTP_1_1)
+                .message("")
+                .build();
+
+        assertEquals(new LegacyStatusApiException(response, ""), new LegacyStatusApiException(response, ""));
+        assertEquals(new StatusApiException(response, ""), new StatusApiException(response, ""));
+    }
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/block/UnknownBlockElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/UnknownBlockElement.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class UnknownBlockElement extends BlockElement {
     private String type;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/UnknownBlockElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/UnknownBlockElement.java
@@ -1,10 +1,7 @@
 package com.slack.api.model.block;
 
 import com.slack.api.model.block.element.BlockElement;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Data
 @Builder

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/MarkdownTextObject.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/MarkdownTextObject.java
@@ -1,9 +1,6 @@
 package com.slack.api.model.block.composition;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/messaging/composition-objects#text
@@ -12,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class MarkdownTextObject extends TextObject {
     public static final String TYPE = "mrkdwn";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/PlainTextObject.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/PlainTextObject.java
@@ -1,9 +1,6 @@
 package com.slack.api.model.block.composition;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/messaging/composition-objects#text
@@ -12,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class PlainTextObject extends TextObject {
     public static final String TYPE = "plain_text";
 

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/UnknownTextObject.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/UnknownTextObject.java
@@ -1,9 +1,6 @@
 package com.slack.api.model.block.composition;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/messaging/composition-objects#text
@@ -12,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class UnknownTextObject extends TextObject {
     private String type;
     private String text;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ButtonElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ButtonElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/block-kit/block-elements#button
@@ -14,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class ButtonElement extends BlockElement {
     public static final String TYPE = "button";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ChannelsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ChannelsSelectElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/block-kit/block-elements#channel_select
@@ -14,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class ChannelsSelectElement extends BlockElement {
     public static final String TYPE = "channels_select";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/CheckboxesElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/CheckboxesElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.OptionObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -16,6 +13,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class CheckboxesElement extends BlockElement {
     public static final String TYPE = "checkboxes";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsSelectElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/block-kit/block-elements#conversation_select
@@ -14,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class ConversationsSelectElement extends BlockElement {
     public static final String TYPE = "conversations_select";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/DatePickerElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/DatePickerElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/block-kit/block-elements#datepicker
@@ -14,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class DatePickerElement extends BlockElement {
     public static final String TYPE = "datepicker";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ExternalSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ExternalSelectElement.java
@@ -3,10 +3,7 @@ package com.slack.api.model.block.element;
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.OptionObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/block-kit/block-elements#external_select
@@ -15,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class ExternalSelectElement extends BlockElement {
     public static final String TYPE = "external_select";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ImageElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ImageElement.java
@@ -1,10 +1,7 @@
 package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.ContextBlockElement;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/block-kit/block-elements#image
@@ -13,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class ImageElement extends BlockElement implements ContextBlockElement {
     public static final String TYPE = "image";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiChannelsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiChannelsSelectElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -16,6 +13,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class MultiChannelsSelectElement extends BlockElement {
     public static final String TYPE = "multi_channels_select";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiConversationsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiConversationsSelectElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -16,6 +13,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class MultiConversationsSelectElement extends BlockElement {
     public static final String TYPE = "multi_conversations_select";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiExternalSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiExternalSelectElement.java
@@ -3,10 +3,7 @@ package com.slack.api.model.block.element;
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.OptionObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -17,6 +14,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class MultiExternalSelectElement extends BlockElement {
     public static final String TYPE = "multi_external_select";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiStaticSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiStaticSelectElement.java
@@ -4,10 +4,7 @@ import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.OptionGroupObject;
 import com.slack.api.model.block.composition.OptionObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -18,6 +15,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class MultiStaticSelectElement extends BlockElement {
     public static final String TYPE = "multi_static_select";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiUsersSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiUsersSelectElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -16,6 +13,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class MultiUsersSelectElement extends BlockElement {
     public static final String TYPE = "multi_users_select";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/OverflowMenuElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/OverflowMenuElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.OptionObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -16,6 +13,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class OverflowMenuElement extends BlockElement {
     public static final String TYPE = "overflow";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/PlainTextInputElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/PlainTextInputElement.java
@@ -1,10 +1,7 @@
 package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/block-kit/block-elements#input
@@ -13,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class PlainTextInputElement extends BlockElement {
     public static final String TYPE = "plain_text_input";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RadioButtonsElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RadioButtonsElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.OptionObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -16,6 +13,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class RadioButtonsElement extends BlockElement {
     public static final String TYPE = "radio_buttons";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextListElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextListElement.java
@@ -1,9 +1,6 @@
 package com.slack.api.model.block.element;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +12,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class RichTextListElement extends BlockElement implements RichTextElement {
 
     public static final String TYPE = "rich_text_list";

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextPreformattedElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextPreformattedElement.java
@@ -1,9 +1,6 @@
 package com.slack.api.model.block.element;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +12,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class RichTextPreformattedElement extends BlockElement implements RichTextElement {
 
     public static final String TYPE = "rich_text_preformatted";

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextQuoteElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextQuoteElement.java
@@ -1,9 +1,6 @@
 package com.slack.api.model.block.element;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +12,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class RichTextQuoteElement extends BlockElement implements RichTextElement {
 
     public static final String TYPE = "rich_text_quote";

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextSectionElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextSectionElement.java
@@ -1,9 +1,6 @@
 package com.slack.api.model.block.element;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +12,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class RichTextSectionElement extends BlockElement implements RichTextElement {
     public static final String TYPE = "rich_text_section";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextUnknownElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextUnknownElement.java
@@ -1,14 +1,12 @@
 package com.slack.api.model.block.element;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class RichTextUnknownElement extends BlockElement implements RichTextElement {
     private String type;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/StaticSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/StaticSelectElement.java
@@ -4,10 +4,7 @@ import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.OptionGroupObject;
 import com.slack.api.model.block.composition.OptionObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -18,6 +15,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class StaticSelectElement extends BlockElement {
     public static final String TYPE = "static_select";
     private final String type = TYPE;

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/UsersSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/UsersSelectElement.java
@@ -2,10 +2,7 @@ package com.slack.api.model.block.element;
 
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.PlainTextObject;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * https://api.slack.com/reference/block-kit/block-elements#users_select
@@ -14,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class UsersSelectElement extends BlockElement {
     public static final String TYPE = "users_select";
     private final String type = TYPE;

--- a/slack-api-model/src/test/java/test_locally/api/model/ModelsTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/ModelsTest.java
@@ -247,33 +247,4 @@ public class ModelsTest {
         assertNotNull(checkboxes);
     }
 
-    @Test
-    public void equality() {
-        assertEquals(new MarkdownTextObject(), new MarkdownTextObject());
-        assertEquals(new PlainTextObject(), new PlainTextObject());
-        assertEquals(new UnknownTextObject(), new UnknownTextObject());
-        assertEquals(new ButtonElement(), new ButtonElement());
-        assertEquals(new ChannelsSelectElement(), new ChannelsSelectElement());
-        assertEquals(new CheckboxesElement(), new CheckboxesElement());
-        assertEquals(new ConversationsSelectElement(), new ConversationsSelectElement());
-        assertEquals(new DatePickerElement(), new DatePickerElement());
-        assertEquals(new ExternalSelectElement(), new ExternalSelectElement());
-        assertEquals(new ImageElement(), new ImageElement());
-        assertEquals(new MultiChannelsSelectElement(), new MultiChannelsSelectElement());
-        assertEquals(new MultiConversationsSelectElement(), new MultiConversationsSelectElement());
-        assertEquals(new MultiExternalSelectElement(), new MultiExternalSelectElement());
-        assertEquals(new MultiStaticSelectElement(), new MultiStaticSelectElement());
-        assertEquals(new MultiUsersSelectElement(), new MultiUsersSelectElement());
-        assertEquals(new OverflowMenuElement(), new OverflowMenuElement());
-        assertEquals(new PlainTextInputElement(), new PlainTextInputElement());
-        assertEquals(new RadioButtonsElement(), new RadioButtonsElement());
-        assertEquals(new RichTextListElement(), new RichTextListElement());
-        assertEquals(new RichTextPreformattedElement(), new RichTextPreformattedElement());
-        assertEquals(new RichTextQuoteElement(), new RichTextQuoteElement());
-        assertEquals(new RichTextSectionElement(), new RichTextSectionElement());
-        assertEquals(new RichTextUnknownElement(), new RichTextUnknownElement());
-        assertEquals(new StaticSelectElement(), new StaticSelectElement());
-        assertEquals(new UsersSelectElement(), new UsersSelectElement());
-    }
-
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/block/EqualityTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/EqualityTest.java
@@ -1,0 +1,44 @@
+package test_locally.api.model.block;
+
+import com.slack.api.model.block.UnknownBlockElement;
+import com.slack.api.model.block.composition.MarkdownTextObject;
+import com.slack.api.model.block.composition.PlainTextObject;
+import com.slack.api.model.block.composition.UnknownTextObject;
+import com.slack.api.model.block.element.*;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EqualityTest {
+
+    @Test
+    public void equality() {
+        assertEquals(new UnknownTextObject(), new UnknownTextObject());
+        assertEquals(new MarkdownTextObject(), new MarkdownTextObject());
+        assertEquals(new PlainTextObject(), new PlainTextObject());
+
+        assertEquals(new UnknownBlockElement(), new UnknownBlockElement());
+        assertEquals(new ButtonElement(), new ButtonElement());
+        assertEquals(new ChannelsSelectElement(), new ChannelsSelectElement());
+        assertEquals(new CheckboxesElement(), new CheckboxesElement());
+        assertEquals(new ConversationsSelectElement(), new ConversationsSelectElement());
+        assertEquals(new DatePickerElement(), new DatePickerElement());
+        assertEquals(new ExternalSelectElement(), new ExternalSelectElement());
+        assertEquals(new ImageElement(), new ImageElement());
+        assertEquals(new MultiChannelsSelectElement(), new MultiChannelsSelectElement());
+        assertEquals(new MultiConversationsSelectElement(), new MultiConversationsSelectElement());
+        assertEquals(new MultiExternalSelectElement(), new MultiExternalSelectElement());
+        assertEquals(new MultiStaticSelectElement(), new MultiStaticSelectElement());
+        assertEquals(new MultiUsersSelectElement(), new MultiUsersSelectElement());
+        assertEquals(new OverflowMenuElement(), new OverflowMenuElement());
+        assertEquals(new PlainTextInputElement(), new PlainTextInputElement());
+        assertEquals(new RadioButtonsElement(), new RadioButtonsElement());
+        assertEquals(new RichTextListElement(), new RichTextListElement());
+        assertEquals(new RichTextPreformattedElement(), new RichTextPreformattedElement());
+        assertEquals(new RichTextQuoteElement(), new RichTextQuoteElement());
+        assertEquals(new RichTextSectionElement(), new RichTextSectionElement());
+        assertEquals(new RichTextUnknownElement(), new RichTextUnknownElement());
+        assertEquals(new StaticSelectElement(), new StaticSelectElement());
+        assertEquals(new UsersSelectElement(), new UsersSelectElement());
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/views/response/ViewSubmissionResponse.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/views/response/ViewSubmissionResponse.java
@@ -13,6 +13,7 @@ import java.util.Map;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class ViewSubmissionResponse {
 
     private String responseAction; // push, update, errors, (no value to close)

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/views/response/ViewSubmissionResponse.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/views/response/ViewSubmissionResponse.java
@@ -2,10 +2,7 @@ package com.slack.api.app_backend.views.response;
 
 import com.slack.api.model.view.View;
 import com.slack.api.util.json.GsonFactory;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.Map;
 


### PR DESCRIPTION
###  Summary

This pull request partially reverts #441 (this PR was really amazing). 

As having `@EqualsAndHashCode(callSuper = false)` annotation in `@Data` classes was intentional (I totally forgot it when reviewing the PR), the commit to remove them should be reverted. See also: https://github.com/slackapi/java-slack-sdk/pull/441#issuecomment-622642389

cc @eamelink 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
