### PR TITLE
Bump AWS SDK's patch versions

### DIFF
--- a/bolt-aws-lambda/pom.xml
+++ b/bolt-aws-lambda/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <aws-lambda-core.version>1.2.0</aws-lambda-core.version>
+        <aws-lambda-core.version>1.2.1</aws-lambda-core.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <quarkus.version>1.4.1.Final</quarkus.version>
+        <quarkus.version>1.4.2.Final</quarkus.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.7.RELEASE</spring-boot.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,6 @@ url: https://slack.dev
 
 sdkLatestVersion: 1.0.6
 kotlinVersion: 1.3.72
-springBootVersion: 2.2.6.RELEASE
-quarkusVersion: 1.4.1.Final
+springBootVersion: 2.2.7.RELEASE
+quarkusVersion: 1.4.2.Final
 helidonVersion: 1.4.4

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <lombok-maven-plugin.version>1.18.10.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.774</aws.s3.version>
+        <aws.s3.version>1.11.778</aws.s3.version>
         <junit.version>4.13</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
###  Summary

* aws-lambda-core from 1.2.0 to 1.2.1
* aws-sdk-s3 from 1.11.774 to 1.11.778

Also, this commit upgrades Spring Boot, Quakus but they're just for examples and docs.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
