### PR TITLE
Adding support and check for the event subtypes

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/rtm/RTMEventHandler.java
+++ b/slack-api-client/src/main/java/com/slack/api/rtm/RTMEventHandler.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Type;
 public abstract class RTMEventHandler<E extends Event> {
 
     private String cachedEventName;
+    private String cachedEventSubName;
     private Class<E> cachedClazz;
 
     /**
@@ -31,6 +32,26 @@ public abstract class RTMEventHandler<E extends Event> {
             return cachedEventName;
         } catch (Exception e) {
             throw new IllegalStateException("A static field TYPE_NAME in " + clazz.getCanonicalName() + " is required");
+        }
+    }
+
+    /**
+     * Returns the subtype value of the event (e.g., MessageEvent.TYPE_NAME)
+     */
+    public String getEventSubType()
+    {
+        if (cachedEventSubName != null) {
+            return cachedEventSubName;
+        }
+        Class<E> clazz = getEventClass();
+        try {
+            Field field = clazz.getField("SUBTYPE_NAME");
+            field.setAccessible(true);
+            cachedEventSubName = (String) field.get(null);
+            return cachedEventSubName;
+        } catch (Exception e) {
+            cachedEventSubName = "";
+            return cachedEventSubName;
         }
     }
 
@@ -70,5 +91,4 @@ public abstract class RTMEventHandler<E extends Event> {
     public void acceptUntypedObject(Object event) {
         handle((E) event);
     }
-
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/event/Event.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/Event.java
@@ -5,9 +5,7 @@ import java.io.Serializable;
 public interface Event extends Serializable {
 
     String getType();
-
     default String getSubtype() {
-        return null;
+        return "";
     }
-
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/event/Event.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/Event.java
@@ -5,7 +5,9 @@ import java.io.Serializable;
 public interface Event extends Serializable {
 
     String getType();
+
     default String getSubtype() {
-        return "";
+        return null;
     }
+
 }


### PR DESCRIPTION
Signed-off-by: Gaspard Petit <gaspard.petit@eidosmontreal.com>

###  Summary
Right now the RTM client does not consider the subtype when deserializing messages and dispatching them. This results in class conversion exceptions when multiple handlers are registered for different events of the same types, ex. MessageEvent and MessageChangedEvents. Both receive the notification possibly with the wrong object type.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
