### PR TITLE
Add a workaround for OpenJDK 11's bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
   # LTS version
   - jdk: openjdk11
     env: CODECOV="false"
+    env: MAVEN_OPTS=-Djdk.tls.client.protocols=TLSv1.2
     script: travis_retry ./scripts/run_no_prep_tests.sh
   # non-LTS but latest
   - jdk: openjdk14

--- a/scripts/run_no_prep_tests.sh
+++ b/scripts/run_no_prep_tests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-./mvnw clean \
+./mvnw ${MAVEN_OPTS} \
+  clean \
   test-compile \
   '-Dtest=test_locally.**.*Test' test \
   -DfailIfNoTests=false \


### PR DESCRIPTION
###  Summary

Sending HTTP requests to Slack API server on OpenJDK 11 fails due to https://bugs.openjdk.java.net/browse/JDK-8211806

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
