### PR TITLE
Update OAuth flow to complete with some cases

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultSuccessHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultSuccessHandler.java
@@ -30,7 +30,10 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
         if (o.getEnterprise() != null) {
             context.setEnterpriseId(o.getEnterprise().getId());
         }
-        context.setTeamId(o.getTeam().getId());
+        // "team" can be null for org-level installation
+        String teamId = o.getTeam() != null ? o.getTeam().getId() : null;
+        String teamName = o.getTeam() != null ? o.getTeam().getName() : null;
+        context.setTeamId(teamId);
         context.setBotUserId(o.getBotUserId());
         context.setBotToken(o.getAccessToken());
         context.setRequestUserId(o.getAuthedUser().getId());
@@ -40,8 +43,8 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
                 .botUserId(o.getBotUserId())
                 .botAccessToken(o.getAccessToken())
                 .enterpriseId(o.getEnterprise() != null ? o.getEnterprise().getId() : null)
-                .teamId(o.getTeam().getId())
-                .teamName(o.getTeam().getName())
+                .teamId(teamId)
+                .teamName(teamName)
                 .scope(o.getScope())
                 .botScope(o.getScope())
                 .installedAt(System.currentTimeMillis());

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,7 @@ coverage:
     project:
       default:
         threshold: 0.3%
+    patch:
+      default:
+        target: 50%
+

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/oauth/OAuthFlowOperator.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/oauth/OAuthFlowOperator.java
@@ -22,21 +22,25 @@ public class OAuthFlowOperator {
     }
 
     public OAuthAccessResponse callOAuthAccessMethod(VerificationCodePayload payload) throws IOException, SlackApiException {
-        return slack.methods().oauthAccess(OAuthAccessRequest.builder()
+        OAuthAccessRequest.OAuthAccessRequestBuilder apiRequest = OAuthAccessRequest.builder()
                 .clientId(config.getClientId())
                 .clientSecret(config.getClientSecret())
-                .code(payload.getCode())
-                .redirectUri(config.getRedirectUri())
-                .build());
+                .code(payload.getCode());
+        if (config.getRedirectUri() != null) {
+            apiRequest = apiRequest.redirectUri(config.getRedirectUri());
+        }
+        return slack.methods().oauthAccess(apiRequest.build());
     }
 
     public OAuthV2AccessResponse callOAuthV2AccessMethod(VerificationCodePayload payload) throws IOException, SlackApiException {
-        return slack.methods().oauthV2Access(OAuthV2AccessRequest.builder()
+        OAuthV2AccessRequest.OAuthV2AccessRequestBuilder apiRequest = OAuthV2AccessRequest.builder()
                 .clientId(config.getClientId())
                 .clientSecret(config.getClientSecret())
-                .code(payload.getCode())
-                .redirectUri(config.getRedirectUri())
-                .build());
+                .code(payload.getCode());
+        if (config.getRedirectUri() != null) {
+            apiRequest = apiRequest.redirectUri(config.getRedirectUri());
+        }
+        return slack.methods().oauthV2Access(apiRequest.build());
     }
 
 }


### PR DESCRIPTION
###  Summary

This pull request improves the OAuth flow handling in the following cases:
* No exception when `team` in `oauth.v2.access` response is missing
* redirect_uri is not used

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
