### PR TITLE
Add confirm.style in blocks

### DIFF
--- a/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
@@ -71,7 +71,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -103,7 +104,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "response_url_enabled": false
           },
@@ -135,7 +137,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "max_selected_items": 123
           },
@@ -168,7 +171,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "response_url_enabled": false,
             "filter": {
@@ -207,7 +211,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "max_selected_items": 123,
             "filter": {
@@ -247,7 +252,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -293,7 +299,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -325,7 +332,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "max_selected_items": 123
           },
@@ -361,7 +369,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -406,7 +415,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -437,7 +447,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "max_selected_items": 123
           },
@@ -470,7 +481,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -501,7 +513,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "max_selected_items": 123
           }
@@ -1233,7 +1246,8 @@
           "type": "plain_text",
           "text": "",
           "emoji": false
-        }
+        },
+        "style": ""
       },
       "url": "",
       "initial_option": {

--- a/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
@@ -47,7 +47,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -79,7 +80,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "response_url_enabled": false
           },
@@ -111,7 +113,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "max_selected_items": 123
           },
@@ -144,7 +147,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "response_url_enabled": false,
             "filter": {
@@ -183,7 +187,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "max_selected_items": 123,
             "filter": {
@@ -223,7 +228,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -269,7 +275,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -301,7 +308,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "max_selected_items": 123
           },
@@ -337,7 +345,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -382,7 +391,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -413,7 +423,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "max_selected_items": 123
           },
@@ -446,7 +457,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             }
           },
           {
@@ -477,7 +489,8 @@
                 "type": "plain_text",
                 "text": "",
                 "emoji": false
-              }
+              },
+              "style": ""
             },
             "max_selected_items": 123
           }

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -54,7 +54,8 @@
               "type": "plain_text",
               "text": "",
               "emoji": false
-            }
+            },
+            "style": ""
           }
         },
         {
@@ -86,7 +87,8 @@
               "type": "plain_text",
               "text": "",
               "emoji": false
-            }
+            },
+            "style": ""
           },
           "response_url_enabled": false
         },
@@ -119,7 +121,8 @@
               "type": "plain_text",
               "text": "",
               "emoji": false
-            }
+            },
+            "style": ""
           },
           "response_url_enabled": false,
           "filter": {
@@ -156,7 +159,8 @@
               "type": "plain_text",
               "text": "",
               "emoji": false
-            }
+            },
+            "style": ""
           }
         },
         {
@@ -202,7 +206,8 @@
               "type": "plain_text",
               "text": "",
               "emoji": false
-            }
+            },
+            "style": ""
           }
         },
         {
@@ -237,7 +242,8 @@
               "type": "plain_text",
               "text": "",
               "emoji": false
-            }
+            },
+            "style": ""
           }
         },
         {
@@ -282,7 +288,8 @@
               "type": "plain_text",
               "text": "",
               "emoji": false
-            }
+            },
+            "style": ""
           }
         },
         {
@@ -314,7 +321,8 @@
               "type": "plain_text",
               "text": "",
               "emoji": false
-            }
+            },
+            "style": ""
           }
         }
       ],

--- a/json-logs/samples/rtm/PinAddedEvent.json
+++ b/json-logs/samples/rtm/PinAddedEvent.json
@@ -62,7 +62,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -94,7 +95,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               },
               "response_url_enabled": false
             },
@@ -127,7 +129,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               },
               "response_url_enabled": false,
               "filter": {
@@ -164,7 +167,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -210,7 +214,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -245,7 +250,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -290,7 +296,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -322,7 +329,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             }
           ],

--- a/json-logs/samples/rtm/PinRemovedEvent.json
+++ b/json-logs/samples/rtm/PinRemovedEvent.json
@@ -62,7 +62,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -94,7 +95,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               },
               "response_url_enabled": false
             },
@@ -127,7 +129,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               },
               "response_url_enabled": false,
               "filter": {
@@ -164,7 +167,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -210,7 +214,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -245,7 +250,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -290,7 +296,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -322,7 +329,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             }
           ],

--- a/json-logs/samples/rtm/StarAddedEvent.json
+++ b/json-logs/samples/rtm/StarAddedEvent.json
@@ -62,7 +62,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -94,7 +95,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               },
               "response_url_enabled": false
             },
@@ -127,7 +129,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               },
               "response_url_enabled": false,
               "filter": {
@@ -164,7 +167,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -210,7 +214,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -245,7 +250,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -290,7 +296,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -322,7 +329,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             }
           ],

--- a/json-logs/samples/rtm/StarRemovedEvent.json
+++ b/json-logs/samples/rtm/StarRemovedEvent.json
@@ -61,7 +61,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -93,7 +94,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               },
               "response_url_enabled": false
             },
@@ -126,7 +128,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               },
               "response_url_enabled": false,
               "filter": {
@@ -163,7 +166,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -209,7 +213,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -244,7 +249,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -289,7 +295,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             },
             {
@@ -321,7 +328,8 @@
                   "type": "plain_text",
                   "text": "",
                   "emoji": false
-                }
+                },
+                "style": ""
               }
             }
           ],

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/ConfirmationDialogObject.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/ConfirmationDialogObject.java
@@ -17,4 +17,5 @@ public class ConfirmationDialogObject {
     private TextObject text;
     private PlainTextObject confirm;
     private PlainTextObject deny;
+    private String style;
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -5,6 +5,7 @@ import com.slack.api.model.Message;
 import com.slack.api.model.block.InputBlock;
 import com.slack.api.model.block.RichTextBlock;
 import com.slack.api.model.block.SectionBlock;
+import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.element.CheckboxesElement;
 import com.slack.api.model.block.element.RadioButtonsElement;
 import com.slack.api.model.block.element.RichTextSectionElement;
@@ -935,6 +936,33 @@ public class BlockKitTest {
         SectionBlock block = (SectionBlock) message.getBlocks().get(1);
         CheckboxesElement checkboxes2 = (CheckboxesElement) block.getAccessory();
         assertThat(checkboxes2.getActionId(), is("section-action-id"));
+    }
+
+    @Test
+    public void confirm_style() {
+        String json = "{\n" +
+                "  \"title\": {\n" +
+                "    \"type\": \"plain_text\",\n" +
+                "    \"text\": \"Are you sure?\"\n" +
+                "  },\n" +
+                "  \"text\": {\n" +
+                "    \"type\": \"mrkdwn\",\n" +
+                "    \"text\": \"Wouldn't you prefer a good game of _chess_?\"\n" +
+                "  },\n" +
+                "  \"confirm\": {\n" +
+                "    \"type\": \"plain_text\",\n" +
+                "    \"text\": \"Do it\"\n" +
+                "  },\n" +
+                "  \"deny\": {\n" +
+                "    \"type\": \"plain_text\",\n" +
+                "    \"text\": \"Stop, I've changed my mind!\"\n" +
+                "  },\n" +
+                "  \"style\":\"primary\"\n" +
+                "}";
+
+        ConfirmationDialogObject obj = GsonFactory.createSnakeCase().fromJson(json, ConfirmationDialogObject.class);
+        assertThat(obj, is(notNullValue()));
+        assertThat(obj.getStyle(), is("primary"));
     }
 
 }


### PR DESCRIPTION
###  Summary

This pull request adds `style` to `confirm` composition objects in Block Kit.
https://api.slack.com/reference/block-kit/composition-objects#confirm

Related issues/changes:
* https://github.com/slackapi/node-slack-sdk/issues/1022
* https://github.com/slackapi/python-slackclient/pull/699

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
