### PR TITLE
Fix #474 by making redirect_uri optional

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -1680,7 +1680,9 @@ public class MethodsClientImpl implements MethodsClient {
     public OAuthAccessResponse oauthAccess(OAuthAccessRequest req) throws IOException, SlackApiException {
         FormBody.Builder form = new FormBody.Builder();
         form.add("code", req.getCode());
-        form.add("redirect_uri", req.getRedirectUri());
+        if (req.getRedirectUri() != null) {
+            form.add("redirect_uri", req.getRedirectUri());
+        }
         form.add("single_channel", req.isSingleChannel() ? "1" : "0");
         String authorizationHeader = Credentials.basic(req.getClientId(), req.getClientSecret());
         return postFormWithAuthorizationHeaderAndParseResponse(form, endpointUrlPrefix + Methods.OAUTH_ACCESS, authorizationHeader, OAuthAccessResponse.class);
@@ -1695,7 +1697,9 @@ public class MethodsClientImpl implements MethodsClient {
     public OAuthV2AccessResponse oauthV2Access(OAuthV2AccessRequest req) throws IOException, SlackApiException {
         FormBody.Builder form = new FormBody.Builder();
         form.add("code", req.getCode());
-        form.add("redirect_uri", req.getRedirectUri());
+        if (req.getRedirectUri() != null) {
+            form.add("redirect_uri", req.getRedirectUri());
+        }
         String authorizationHeader = Credentials.basic(req.getClientId(), req.getClientSecret());
         return postFormWithAuthorizationHeaderAndParseResponse(form, endpointUrlPrefix + Methods.OAUTH_V2_ACCESS, authorizationHeader, OAuthV2AccessResponse.class);
     }

--- a/slack-api-client/src/test/java/test_locally/api/methods/OAuthTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/OAuthTest.java
@@ -42,6 +42,13 @@ public class OAuthTest {
     }
 
     @Test
+    public void issue_474() throws Exception {
+        assertThat(slack.methods(ValidToken).oauthAccess(r -> r.clientId("abc").clientSecret("xyz").code("xxx")).isOk(), is(true));
+        assertThat(slack.methods(ValidToken).oauthToken(r -> r.clientId("abc").clientSecret("xyz").code("xxx")).isOk(), is(true));
+        assertThat(slack.methods(ValidToken).oauthV2Access(r -> r.clientId("abc").clientSecret("xyz").code("xxx")).isOk(), is(true));
+    }
+
+    @Test
     public void test_async() throws Exception {
         assertThat(slack.methodsAsync(ValidToken).oauthAccess(r ->
                 r.clientId("abc").clientSecret("xyz").code("xxx").redirectUri("https://www.example.com"))


### PR DESCRIPTION
###  Summary

This pull request fixes #474 by making `redirect_uri` parameter optional for `oauth.access` and `oauth.v2.access` API method calls.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
