### PR TITLE
FIxes false detection of subtypes when the subtype is embedded under a sub document

### DIFF
--- a/slack-api-client/src/test/java/test_locally/api/rtm/RTMEventsDispatcherImplTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/rtm/RTMEventsDispatcherImplTest.java
@@ -1,5 +1,7 @@
 package test_locally.api.rtm;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.slack.api.model.event.Event;
 import com.slack.api.model.event.MessageEvent;
 import com.slack.api.rtm.RTMEventHandler;
@@ -15,8 +17,23 @@ public class RTMEventsDispatcherImplTest {
 
     @Test
     public void eventDetection() {
-        String type = RTMEventsDispatcherImpl.detectEventType("{\"type\": \"hello\"}");
+        JsonObject jsonMessage = JsonParser.parseString("{\"type\": \"hello\"}").getAsJsonObject();
+        String type = RTMEventsDispatcherImpl.detectEventType(jsonMessage);
         assertThat(type, is("hello"));
+    }
+
+    @Test
+    public void eventSubtypeDetection() {
+        JsonObject jsonMessage = JsonParser.parseString("{ \"type\": \"message\", \"subtype\": \"bot_message\" }").getAsJsonObject();
+        String subtype = RTMEventsDispatcherImpl.detectEventSubType(jsonMessage);
+        assertThat(subtype, is("bot_message"));
+    }
+
+    @Test
+    public void eventInnerSubtypeDetection() {
+        JsonObject jsonMessage = JsonParser.parseString("{\"type\": \"pin_added\", \"item\": { \"type\": \"message\", \"subtype\": \"bot_message\" } }").getAsJsonObject();
+        String subtype = RTMEventsDispatcherImpl.detectEventSubType(jsonMessage);
+        assertThat(subtype, is(""));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Gaspard Petit <gaspard.petit@eidosmontreal.com>

###  Summary

Currently, this:
```
{
 "type": "pin_added",
  "item": {
    "type": "message"
    "type": "bot_message"
  }
}
```

Is detected as a `pin_added.bot_message` type.subtype`. This PR fixes it so that the type and subtype detection are done on a parsed json document instead of a raw text string.

This would also fix detection of type if the field appeared after an embedded type field, ex:

```
{
  "item": {
    "type": "message"
  },
 "type": "pin_added"
}
```
would currently be detected as a "message" event. I have never see such messages from Slack however, it seems like `type` comes first, but I'm not sure there are any guarantee about this.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
