### PR TITLE
Move UsersLookupByEmailResponse to the right package (source code compatible)

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
@@ -90,7 +90,6 @@ import com.slack.api.methods.response.calls.CallsEndResponse;
 import com.slack.api.methods.response.calls.CallsInfoResponse;
 import com.slack.api.methods.response.calls.CallsUpdateResponse;
 import com.slack.api.methods.response.calls.participants.CallsParticipantsAddResponse;
-import com.slack.api.methods.response.channels.UsersLookupByEmailResponse;
 import com.slack.api.methods.response.chat.*;
 import com.slack.api.methods.response.chat.scheduled_messages.ChatScheduledMessagesListResponse;
 import com.slack.api.methods.response.conversations.*;

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
@@ -153,6 +153,7 @@ import com.slack.api.methods.response.usergroups.*;
 import com.slack.api.methods.response.usergroups.users.UsergroupsUsersListResponse;
 import com.slack.api.methods.response.usergroups.users.UsergroupsUsersUpdateResponse;
 import com.slack.api.methods.response.users.*;
+import com.slack.api.methods.response.users.UsersLookupByEmailResponse;
 import com.slack.api.methods.response.users.profile.UsersProfileGetResponse;
 import com.slack.api.methods.response.users.profile.UsersProfileSetResponse;
 import com.slack.api.methods.response.views.ViewsOpenResponse;

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
@@ -94,7 +94,6 @@ import com.slack.api.methods.response.calls.CallsEndResponse;
 import com.slack.api.methods.response.calls.CallsInfoResponse;
 import com.slack.api.methods.response.calls.CallsUpdateResponse;
 import com.slack.api.methods.response.calls.participants.CallsParticipantsAddResponse;
-import com.slack.api.methods.response.channels.UsersLookupByEmailResponse;
 import com.slack.api.methods.response.chat.*;
 import com.slack.api.methods.response.chat.scheduled_messages.ChatScheduledMessagesListResponse;
 import com.slack.api.methods.response.conversations.*;

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -155,6 +155,7 @@ import com.slack.api.methods.response.usergroups.*;
 import com.slack.api.methods.response.usergroups.users.UsergroupsUsersListResponse;
 import com.slack.api.methods.response.usergroups.users.UsergroupsUsersUpdateResponse;
 import com.slack.api.methods.response.users.*;
+import com.slack.api.methods.response.users.UsersLookupByEmailResponse;
 import com.slack.api.methods.response.users.profile.UsersProfileGetResponse;
 import com.slack.api.methods.response.users.profile.UsersProfileSetResponse;
 import com.slack.api.methods.response.views.ViewsOpenResponse;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/UsersLookupByEmailResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/UsersLookupByEmailResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiResponse;
 import com.slack.api.model.User;
 import lombok.Data;
 
+@Deprecated // use com.slack.api.methods.response.users.UsersLookupByEmailResponse instead
 @Data
 public class UsersLookupByEmailResponse implements SlackApiResponse {
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersLookupByEmailResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersLookupByEmailResponse.java
@@ -1,0 +1,4 @@
+package com.slack.api.methods.response.users;
+
+public class UsersLookupByEmailResponse extends com.slack.api.methods.response.channels.UsersLookupByEmailResponse {
+}

--- a/slack-api-client/src/test/java/test_locally/api/methods/FieldValidation_o_to_z_Test.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/FieldValidation_o_to_z_Test.java
@@ -1,6 +1,5 @@
 package test_locally.api.methods;
 
-import com.slack.api.methods.response.channels.UsersLookupByEmailResponse;
 import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 import com.slack.api.methods.response.oauth.OAuthTokenResponse;
 import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
@@ -455,6 +454,14 @@ public class FieldValidation_o_to_z_Test {
     @Test
     public void users_lookupByEmail() throws Exception {
         UsersLookupByEmailResponse obj = parse("users.lookupByEmail", UsersLookupByEmailResponse.class);
+        verifyIfAllGettersReturnNonNull(obj);
+    }
+
+    // NOTE: com.slack.api.methods.response.channels.UsersLookupByEmailResponse will be removed in v1.1
+    @Test
+    public void users_lookupByEmail_deprecation() throws Exception {
+        com.slack.api.methods.response.channels.UsersLookupByEmailResponse obj =
+                parse("users.lookupByEmail", com.slack.api.methods.response.channels.UsersLookupByEmailResponse.class);
         verifyIfAllGettersReturnNonNull(obj);
     }
 

--- a/slack-api-client/src/test/java/test_locally/api/methods/UsersTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/UsersTest.java
@@ -2,6 +2,7 @@ package test_locally.api.methods;
 
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
+import com.slack.api.methods.response.users.UsersLookupByEmailResponse;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -82,6 +83,17 @@ public class UsersTest {
                 .get().isOk(), is(true));
         assertThat(slack.methodsAsync(ValidToken).usersProfileSet(r -> r.user("U123").name("name").value("value"))
                 .get().isOk(), is(true));
+    }
+
+    // NOTE: we can safely remove this tests since v1.1
+    @Test
+    public void test_deprecated_UsersLookupByEmailResponse() throws Exception {
+        UsersLookupByEmailResponse response = slack.methods(ValidToken).usersLookupByEmail(r -> r.email("foo@example.com"));
+        assertThat(response.isOk(), is(true));
+        // for backward-compatibility
+        com.slack.api.methods.response.channels.UsersLookupByEmailResponse deprecatedResponse
+                = slack.methods(ValidToken).usersLookupByEmail(r -> r.email("foo@example.com"));
+        assertThat(deprecatedResponse.isOk(), is(true));
     }
 
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/users_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/users_Test.java
@@ -4,7 +4,7 @@ import com.slack.api.Slack;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.users.UsersLookupByEmailRequest;
 import com.slack.api.methods.request.users.UsersSetActiveRequest;
-import com.slack.api.methods.response.channels.UsersLookupByEmailResponse;
+import com.slack.api.methods.response.users.UsersLookupByEmailResponse;
 import com.slack.api.methods.response.users.*;
 import com.slack.api.model.User;
 import config.Constants;


### PR DESCRIPTION
###  Summary

While working on #484, I've noticed that `UsersLookupByEmailResponse` is mistakenly replaced under `channels` package 🤦 

This pull request corrects this issue without bringing any breaking changes to existing apps. We'll be removing the deprecated class under `channels` package since v1.1 release.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
