### PR TITLE
Fix #489 Event type extraction failure in slack-app-backend (no effect to Bolt)

### DIFF
--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/EventTypeExtractorImpl.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/EventTypeExtractorImpl.java
@@ -1,100 +1,39 @@
 package com.slack.api.app_backend.events;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class EventTypeExtractorImpl implements EventTypeExtractor {
 
     @Override
     public String extractEventType(String json) {
-        StringBuilder sb = new StringBuilder();
-        char[] chars = json.toCharArray();
-        boolean isInsideEventData = false;
-        for (int idx = 0; idx < (chars.length - 7); idx++) {
-            if (!isInsideEventData && chars[idx] == '"'
-                    && chars[idx + 1] == 'e'
-                    && chars[idx + 2] == 'v'
-                    && chars[idx + 3] == 'e'
-                    && chars[idx + 4] == 'n'
-                    && chars[idx + 5] == 't'
-                    && chars[idx + 6] == '"'
-                    && chars[idx + 7] == ':') {
-                idx = idx + 8;
-                isInsideEventData = true;
-            }
-
-            if (isInsideEventData && chars[idx] == '"'
-                    && chars[idx + 1] == 't'
-                    && chars[idx + 2] == 'y'
-                    && chars[idx + 3] == 'p'
-                    && chars[idx + 4] == 'e'
-                    && chars[idx + 5] == '"'
-                    && chars[idx + 6] == ':') {
-                idx = idx + 7;
-                int doubleQuoteCount = 0;
-                boolean isPreviousCharEscape = false;
-                while (doubleQuoteCount < 2 && idx < chars.length) {
-                    char c = chars[idx];
-                    if (c == '"' && !isPreviousCharEscape) {
-                        doubleQuoteCount++;
-                    } else {
-                        if (doubleQuoteCount == 1) {
-                            sb.append(c);
-                        }
-                    }
-                    isPreviousCharEscape = c == '\\';
-                    idx++;
-                }
-                break;
-            }
-        }
-        return sb.toString();
+        return extractFieldUnderEvent(json, "type");
     }
 
     @Override
     public String extractEventSubtype(String json) {
-        StringBuilder sb = new StringBuilder();
-        char[] chars = json.toCharArray();
-        boolean isInsideEventData = false;
-        for (int idx = 0; idx < (chars.length - 7); idx++) {
-            if (!isInsideEventData && chars[idx] == '"'
-                    && chars[idx + 1] == 'e'
-                    && chars[idx + 2] == 'v'
-                    && chars[idx + 3] == 'e'
-                    && chars[idx + 4] == 'n'
-                    && chars[idx + 5] == 't'
-                    && chars[idx + 6] == '"'
-                    && chars[idx + 7] == ':') {
-                idx = idx + 8;
-                isInsideEventData = true;
-            }
+        return extractFieldUnderEvent(json, "subtype");
+    }
 
-            if (isInsideEventData && chars[idx] == '"'
-                    && chars[idx + 1] == 's'
-                    && chars[idx + 2] == 'u'
-                    && chars[idx + 3] == 'b'
-                    && chars[idx + 4] == 't'
-                    && chars[idx + 5] == 'y'
-                    && chars[idx + 6] == 'p'
-                    && chars[idx + 7] == 'e'
-                    && chars[idx + 8] == '"'
-                    && chars[idx + 9] == ':') {
-                idx = idx + 10;
-                int doubleQuoteCount = 0;
-                boolean isPreviousCharEscape = false;
-                while (doubleQuoteCount < 2 && idx < chars.length) {
-                    char c = chars[idx];
-                    if (c == '"' && !isPreviousCharEscape) {
-                        doubleQuoteCount++;
-                    } else {
-                        if (doubleQuoteCount == 1) {
-                            sb.append(c);
-                        }
+    private static String extractFieldUnderEvent(String json, String fieldName) {
+        try {
+            JsonElement root = JsonParser.parseString(json);
+            if (root != null && root.isJsonObject() && root.getAsJsonObject().has("event")) {
+                JsonElement event = root.getAsJsonObject().get("event");
+                if (event.isJsonObject() && event.getAsJsonObject().has(fieldName)) {
+                    JsonElement eventType = event.getAsJsonObject().get(fieldName);
+                    if (eventType.isJsonPrimitive()) {
+                        return eventType.getAsString();
                     }
-                    isPreviousCharEscape = c == '\\';
-                    idx++;
                 }
-                break;
             }
+        } catch (JsonSyntaxException e) {
+            log.debug("Failed to parse {} as a JSON data", json, e);
         }
-        return sb.toString();
+        return "";
     }
 
 }

--- a/slack-app-backend/src/test/java/test_locally/app_backend/events/EventTypeDetectorImplTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/events/EventTypeDetectorImplTest.java
@@ -12,6 +12,26 @@ public class EventTypeDetectorImplTest {
     private EventTypeExtractor eventTypeExtractor = new EventTypeExtractorImpl();
 
     @Test
+    public void notFound() {
+        {
+            String eventType = eventTypeExtractor.extractEventType("{}");
+            assertThat(eventType, is(""));
+        }
+        {
+            String eventType = eventTypeExtractor.extractEventType("{\"event\": {}}");
+            assertThat(eventType, is(""));
+        }
+        {
+            String eventType = eventTypeExtractor.extractEventSubtype("{}");
+            assertThat(eventType, is(""));
+        }
+        {
+            String eventType = eventTypeExtractor.extractEventSubtype("{\"event\": {}}");
+            assertThat(eventType, is(""));
+        }
+    }
+
+    @Test
     public void detect_goodbye() {
         String payload = "{\n" +
                 "        \"token\": \"XXYYZZ\",\n" +
@@ -49,6 +69,51 @@ public class EventTypeDetectorImplTest {
                 "        ],\n" +
                 "        \"event_id\": \"Ev08MFMKH6\",\n" +
                 "        \"event_time\": 1234567890\n" +
+                "}";
+        String eventType = eventTypeExtractor.extractEventType(payload);
+        assertThat(eventType, is("message"));
+    }
+
+    @Test
+    public void issue_489() {
+        String payload = "{\n" +
+                "  \"authed_users\": [\n" +
+                "    \"RETRACTED\"\n" +
+                "  ],\n" +
+                "  \"event_id\": \"RETRACTED\",\n" +
+                "  \"api_app_id\": \"RETRACTED\",\n" +
+                "  \"team_id\": \"RETRACTED\",\n" +
+                "  \"event\": {\n" +
+                "    \"client_msg_id\": \"b5ac4998-4526-4d0b-8bb0-7bd614c1b774\",\n" +
+                "    \"blocks\": [\n" +
+                "      {\n" +
+                "        \"elements\": [\n" +
+                "          {\n" +
+                "            \"elements\": [\n" +
+                "              {\n" +
+                "                \"text\": \"test\",\n" +
+                "                \"type\": \"text\"\n" +
+                "              }\n" +
+                "            ],\n" +
+                "            \"type\": \"rich_text_section\"\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"type\": \"rich_text\",\n" +
+                "        \"block_id\": \"Ws3Y\"\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"event_ts\": \"1592257234.003200\",\n" +
+                "    \"channel\": \"RETRACTED\",\n" +
+                "    \"text\": \"test\",\n" +
+                "    \"team\": \"RETRACTED\",\n" +
+                "    \"type\": \"message\",\n" +
+                "    \"channel_type\": \"channel\",\n" +
+                "    \"user\": \"RETRACTED\",\n" +
+                "    \"ts\": \"1592257234.003200\"\n" +
+                "  },\n" +
+                "  \"type\": \"event_callback\",\n" +
+                "  \"event_time\": 1592257234,\n" +
+                "  \"token\": \"RETRACTED\"\n" +
                 "}";
         String eventType = eventTypeExtractor.extractEventType(payload);
         assertThat(eventType, is("message"));


### PR DESCRIPTION
###  Summary

This pull request fixes #489 affecting only the users that directly use the **slack-app-backend** library. Bolt for Java does the extraction in a different way. 

Manipulating string values in a bit naive way (yes, I wrote the code!) may cause similar issues in the future. So, I've changed the implementation to simply rely on [Gson](https://github.com/google/gson) as with Bolt's approach.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
