### PR TITLE
Fix #491 Append OAuth redirect URI to Slack OAuth URL

### DIFF
--- a/bolt/src/test/java/test_locally/AppTest.java
+++ b/bolt/src/test/java/test_locally/AppTest.java
@@ -39,6 +39,20 @@ public class AppTest {
     }
 
     @Test
+    public void getOauthInstallationUrl_v1_with_redirect_uri() {
+        AppConfig config = AppConfig.builder()
+            .signingSecret("secret")
+            .clientId("123")
+            .scope("commands,chat:write")
+            .classicAppPermissionsEnabled(true)
+            .redirectUri("https://my.app/oauth/callback")
+            .build();
+        App app = new App(config);
+        String url = app.getOauthInstallationUrl("state-value");
+        assertEquals("https://slack.com/oauth/authorize?client_id=123&scope=commands,chat:write&state=state-value&redirect_uri=https%3A%2F%2Fmy.app%2Foauth%2Fcallback", url);
+    }
+
+    @Test
     public void getOauthInstallationUrl_v2() {
         AppConfig config = AppConfig.builder()
                 .signingSecret("secret")
@@ -49,6 +63,20 @@ public class AppTest {
         App app = new App(config);
         String url = app.getOauthInstallationUrl("state-value");
         assertEquals("https://slack.com/oauth/v2/authorize?client_id=123&scope=commands,chat:write&user_scope=search:read&state=state-value", url);
+    }
+
+    @Test
+    public void getOauthInstallationUrl_v2_with_redirect_uri() {
+        AppConfig config = AppConfig.builder()
+            .signingSecret("secret")
+            .clientId("123")
+            .scope("commands,chat:write")
+            .userScope("search:read")
+            .redirectUri("https://my.app/oauth/callback")
+            .build();
+        App app = new App(config);
+        String url = app.getOauthInstallationUrl("state-value");
+        assertEquals("https://slack.com/oauth/v2/authorize?client_id=123&scope=commands,chat:write&user_scope=search:read&state=state-value&redirect_uri=https%3A%2F%2Fmy.app%2Foauth%2Fcallback", url);
     }
 
     @Test


### PR DESCRIPTION
###  Summary

This PR appends a `redirect_uri` query param value based on the redirect URI specified in a given `AppConfig`, if such a value is set. This change enables Bolt application developers who need to configure their Slack applications with multiple OAuth redirect URIs to be explicit about where the OAuth callback should return to their Bolt application.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
