### PR TITLE
v1.0.11 release

### DIFF
--- a/bolt-aws-lambda/pom.xml
+++ b/bolt-aws-lambda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-aws-lambda</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-docker-examples/echo-command-app/build.gradle
+++ b/bolt-docker-examples/echo-command-app/build.gradle
@@ -10,7 +10,7 @@ repositories {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("com.slack.api:bolt-jetty:1.0.10")
+    implementation("com.slack.api:bolt-jetty:1.0.11")
     implementation("ch.qos.logback:logback-classic:1.2.3")
     implementation('net.logstash.logback:logstash-logback-encoder:6.2')
 }

--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-helidon</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-jetty/pom.xml
+++ b/bolt-jetty/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-jetty</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-kotlin-examples/pom.xml
+++ b/bolt-kotlin-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-kotlin-examples</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <properties>
@@ -17,7 +17,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-micronaut</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <dependencyManagement>

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <properties>
@@ -21,7 +21,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-quarkus-examples</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-servlet/pom.xml
+++ b/bolt-servlet/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-servlet</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.3.0.RELEASE</spring-boot.version>
+        <spring-boot.version>2.3.1.RELEASE</spring-boot.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-spring-boot-examples</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt/pom.xml
+++ b/bolt/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt/src/main/java/com/slack/api/bolt/meta/BoltLibraryVersion.java
+++ b/bolt/src/main/java/com/slack/api/bolt/meta/BoltLibraryVersion.java
@@ -5,7 +5,7 @@ public final class BoltLibraryVersion {
     }
 
     public static final String get() {
-        return "1.0.11-SNAPSHOT";
+        return "1.0.11";
     }
 }
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,7 +6,7 @@ markdown: kramdown
 baseurl: /java-slack-sdk
 url: https://slack.dev
 
-sdkLatestVersion: 1.0.10
+sdkLatestVersion: 1.0.11
 kotlinVersion: 1.3.72
 springBootVersion: 2.3.1.RELEASE
 quarkusVersion: 1.5.1.Final

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,6 @@ url: https://slack.dev
 
 sdkLatestVersion: 1.0.10
 kotlinVersion: 1.3.72
-springBootVersion: 2.3.0.RELEASE
+springBootVersion: 2.3.1.RELEASE
 quarkusVersion: 1.5.1.Final
 helidonVersion: 1.4.4

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <lombok-maven-plugin.version>1.18.10.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.801</aws.s3.version>
+        <aws.s3.version>1.11.805</aws.s3.version>
         <junit.version>4.13</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-sdk-parent</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>pom</packaging>
 
     <name>Java Slack SDK Project</name>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-api-client</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/slack-api-client/src/main/java/com/slack/api/meta/SlackApiClientLibraryVersion.java
+++ b/slack-api-client/src/main/java/com/slack/api/meta/SlackApiClientLibraryVersion.java
@@ -5,7 +5,7 @@ public final class SlackApiClientLibraryVersion {
     }
 
     public static final String get() {
-        return "1.0.11-SNAPSHOT";
+        return "1.0.11";
     }
 }
 

--- a/slack-api-model/pom.xml
+++ b/slack-api-model/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-api-model</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
     
     <dependencies>

--- a/slack-api-model/src/main/java/com/slack/api/meta/SlackApiModelLibraryVersion.java
+++ b/slack-api-model/src/main/java/com/slack/api/meta/SlackApiModelLibraryVersion.java
@@ -5,7 +5,7 @@ public final class SlackApiModelLibraryVersion {
     }
 
     public static final String get() {
-        return "1.0.11-SNAPSHOT";
+        return "1.0.11";
     }
 }
 

--- a/slack-app-backend/pom.xml
+++ b/slack-app-backend/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.0.11-SNAPSHOT</version>
+        <version>1.0.11</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-app-backend</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.11</version>
     <packaging>jar</packaging>
 
     <dependencies>


### PR DESCRIPTION
###  Summary

We're going to release a new patch version within a few days (possibly within 24 hours).

* [slack-app-backend] #489 #490 Fix Event type extraction failure in slack-app-backend (no effect to Bolt) - Thanks @lgrammel @seratch
* [bolt] #491 #492 Append OAuth redirect URI to Slack OAuth URL - Thanks @timrourke

Here is the list of all issues/pull requests included in this release.
https://github.com/slackapi/java-slack-sdk/milestone/5?closed=1

For other maintainers' information, running the following script updates all the version strings. As some are not part of build settings, we use [a tiny script to do all](https://github.com/slackapi/java-slack-sdk/blob/v1.0.10/scripts/set_version.sh).

```bash
./scripts/set_version.sh 1.0.11
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
