### PR TITLE
WIP: #494 files field in MessageEvent for supporting attachments

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageEvent.java
@@ -2,6 +2,7 @@ package com.slack.api.model.event;
 
 import com.slack.api.model.Attachment;
 import com.slack.api.model.BotProfile;
+import com.slack.api.model.File;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.Data;
 
@@ -35,6 +36,7 @@ public class MessageEvent implements Event {
     private String text;
     private List<LayoutBlock> blocks;
     private List<Attachment> attachments;
+    private List<File> files;
 
     private String ts;
 


### PR DESCRIPTION
###  Summary

Adding attachments to a slack message comes as `files` field in the slack-event. This field is absent in the MessageEvent model of the sdk. 

This fixes [494](https://github.com/slackapi/java-slack-sdk/issues/494).
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
