### PR TITLE
Add proxyUrl in api client config document

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
 _site
 .env
 .jekyll-metadata
+vendor/

--- a/docs/guides/ja/web-api-basics.md
+++ b/docs/guides/ja/web-api-basics.md
@@ -392,6 +392,7 @@ Slack slack = Slack.getInstance(config);
 
 |名称|型|説明（デフォルト値）|
 |-|-|-|
+|**proxyUrl**|**String**|全ての Slack への通信にプロキシサーバーを有効にしたい場合、`http://localhost:8888` のような完全な URL を表現する文字列の値を指定します。 (デフォルト値: null)|
 |**prettyResponseLoggingEnabled**|**boolean**|このフラグが true のとき Slack API から受け取ったレスポンスボディの JSON データを整形した上でデバッグレベルでログ出力します （デフォルト値: `false`）|
 |**failOnUnknownProperties**|**boolean**|このフラグが true のとき JSON パーサーは Slack API レスポンス内に未知のプロパティを検知したときに例外を throw します （デフォルト値: `false`）|
 |**tokenExistenceVerificationEnabled**|**boolean**|このフラグが true のとき **MethodsClient** はトークンが未設定の状態で API 呼び出しをしようとするとその前に例外を throw します （デフォルト値: `false`）|

--- a/docs/guides/web-api-basics.md
+++ b/docs/guides/web-api-basics.md
@@ -391,6 +391,7 @@ Here is the list of available customizable options.
 
 |Name|Type|Description (Default Value)|
 |-|-|-|
+|**proxyUrl**|**String**|If you enable a proxy server for all outgoing requests to Slack, you can set a single string value representing an absolute URL such as `http://localhost:8888`. (default: null)|
 |**prettyResponseLoggingEnabled**|**boolean**|If this flag is set as true, the logger prints the whole response JSON data from Slack APIs in a prettified format. (default: `false`)|
 |**failOnUnknownProperties**|**boolean**|If this flag is set as true, JSON parser throws an exception when detecting an uknown property in a Slack API response. (default: `false`)|
 |**tokenExistenceVerificationEnabled**|**boolean**|If this flag is set as true, **MethodsClient** throws exceptions when detecting missing token for API calls. (default: `false`)|


### PR DESCRIPTION
###  Summary

This pull request adds `proxyUrl` part in `SlackConfig` document page - https://slack.dev/java-slack-sdk/guides/web-api-basics#customize-your-slack-api-clients

<img width="500"  src="https://user-images.githubusercontent.com/19658/85378088-0a7d3400-b575-11ea-816a-7430bce318ff.png">

🇯🇵 
<img width="500" src="https://user-images.githubusercontent.com/19658/85378098-0e10bb00-b575-11ea-8ee2-c0a5f2eab53d.png">


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
