### PR TITLE
Fix #468 by implementing short-time cache for authorization middleware

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -70,8 +70,17 @@ public class AppConfig {
     private boolean oAuthCallbackEnabled = false;
 
 
+    /**
+     * Returns true if auth.test call result cache in SingleTeamAuthorization or MultiTeamsAuthorization middleware
+     * is enabled. The default is false.
+     */
     @Builder.Default
     private boolean authTestCacheEnabled = false;
+
+    /**
+     * Returns the millisecond value to keep cached auth.test response in cache.
+     * Negative value indicates the cache is permanent. The default is 3000 milliseconds.
+     */
     @Builder.Default
     private long authTestCacheExpirationMillis = 3000L;
 

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -69,6 +69,12 @@ public class AppConfig {
     @Builder.Default
     private boolean oAuthCallbackEnabled = false;
 
+
+    @Builder.Default
+    private boolean authTestCacheEnabled = false;
+    @Builder.Default
+    private long authTestCacheExpirationMillis = 3000L;
+
     @Builder.Default
     // https://api.slack.com/authentication/migration
     private boolean classicAppPermissionsEnabled = false;

--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/MultiTeamsAuthorization.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/MultiTeamsAuthorization.java
@@ -11,13 +11,18 @@ import com.slack.api.bolt.request.RequestType;
 import com.slack.api.bolt.response.Responder;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.auth.AuthTestResponse;
 import com.slack.api.model.block.LayoutBlock;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static com.slack.api.bolt.middleware.MiddlewareOps.isNoAuthRequiredRequest;
 import static com.slack.api.bolt.response.ResponseTypes.ephemeral;
@@ -30,6 +35,16 @@ public class MultiTeamsAuthorization implements Middleware {
 
     private final AppConfig config;
     private final InstallationService installationService;
+
+    @Data
+    @AllArgsConstructor
+    static class CachedAuthTestResponse {
+        private AuthTestResponse response;
+        private long cachedMillis;
+    }
+
+    // token -> auth.test response
+    private final ConcurrentMap<String, CachedAuthTestResponse> tokenToAuthTestCache = new ConcurrentHashMap<>();
 
     private boolean alwaysRequestUserTokenNeeded;
 
@@ -110,7 +125,7 @@ public class MultiTeamsAuthorization implements Middleware {
 
         try {
             String token = botToken != null ? botToken : userToken;
-            AuthTestResponse authTestResponse = context.client().authTest(r -> r.token(token));
+            AuthTestResponse authTestResponse = callAuthTest(token, config, context.client());
             if (authTestResponse.isOk()) {
                 context.setBotToken(botToken);
                 context.setRequestUserToken(userToken);
@@ -128,6 +143,24 @@ public class MultiTeamsAuthorization implements Middleware {
             return buildError(503, null, e, null);
         } catch (SlackApiException e) {
             return buildError(503, null, null, e);
+        }
+    }
+
+    protected AuthTestResponse callAuthTest(String token, AppConfig config, MethodsClient client) throws IOException, SlackApiException {
+        if (config.isAuthTestCacheEnabled()) {
+            CachedAuthTestResponse cachedResponse = tokenToAuthTestCache.get(token);
+            if (cachedResponse != null) {
+                long millisToExpire = cachedResponse.getCachedMillis() + config.getAuthTestCacheExpirationMillis();
+                if (millisToExpire > System.currentTimeMillis()) {
+                    return cachedResponse.getResponse();
+                }
+            }
+            AuthTestResponse response = client.authTest(r -> r.token(token));
+            CachedAuthTestResponse newCache = new CachedAuthTestResponse(response, System.currentTimeMillis());
+            tokenToAuthTestCache.put(token, newCache);
+            return response;
+        } else {
+            return client.authTest(r -> r.token(token));
         }
     }
 

--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/SingleTeamAuthorization.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/SingleTeamAuthorization.java
@@ -8,8 +8,14 @@ import com.slack.api.bolt.model.Installer;
 import com.slack.api.bolt.request.Request;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.auth.AuthTestResponse;
 import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.slack.api.bolt.middleware.MiddlewareOps.isNoAuthRequiredRequest;
 
@@ -21,6 +27,9 @@ public class SingleTeamAuthorization implements Middleware {
 
     private final AppConfig appConfig;
     private final InstallationService installationService;
+
+    private Optional<AuthTestResponse> cachedAuthTestResponse = Optional.empty();
+    private AtomicLong lastCachedMillis = new AtomicLong(0L);
 
     public SingleTeamAuthorization(AppConfig appConfig, InstallationService installationService) {
         this.appConfig = appConfig;
@@ -34,7 +43,7 @@ public class SingleTeamAuthorization implements Middleware {
         }
 
         Context context = req.getContext();
-        AuthTestResponse authResult = context.client().authTest(r -> r.token(appConfig.getSingleTeamBotToken()));
+        AuthTestResponse authResult = callAuthTest(appConfig, context.client());
         if (authResult.isOk()) {
             if (context.getBotToken() == null) {
                 context.setBotToken(appConfig.getSingleTeamBotToken());
@@ -72,4 +81,20 @@ public class SingleTeamAuthorization implements Middleware {
                     .build();
         }
     }
+
+    protected AuthTestResponse callAuthTest(AppConfig config, MethodsClient client) throws IOException, SlackApiException {
+        if (config.isAuthTestCacheEnabled()) {
+            long millisToExpire = lastCachedMillis.get() + config.getAuthTestCacheExpirationMillis();
+            if (cachedAuthTestResponse.isPresent() && millisToExpire > System.currentTimeMillis()) {
+                return cachedAuthTestResponse.get();
+            }
+            AuthTestResponse response = client.authTest(r -> r.token(config.getSingleTeamBotToken()));
+            cachedAuthTestResponse = Optional.of(response); // response here is not null for sure
+            lastCachedMillis.set(System.currentTimeMillis());
+            return response;
+        } else {
+            return client.authTest(r -> r.token(config.getSingleTeamBotToken()));
+        }
+    }
+
 }

--- a/bolt/src/test/java/test_locally/app/MultiTeamsAuthTestCacheTest.java
+++ b/bolt/src/test/java/test_locally/app/MultiTeamsAuthTestCacheTest.java
@@ -13,6 +13,7 @@ import com.slack.api.bolt.request.RequestHeaders;
 import com.slack.api.bolt.request.builtin.GlobalShortcutRequest;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.methods.MethodsConfig;
 import com.slack.api.methods.SlackApiException;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.server.Server;
@@ -43,6 +44,12 @@ import static org.junit.Assert.fail;
 public class MultiTeamsAuthTestCacheTest {
 
     static SlackConfig config = new SlackConfig();
+    static {
+        MethodsConfig methodsConfig = new MethodsConfig();
+        methodsConfig.setStatsEnabled(false); // To skip TeamIdCache requests
+        config.setMethodsConfig(methodsConfig);
+    }
+
     static Slack slack = Slack.getInstance(config);
     static CountdownAuthTestServer server = new CountdownAuthTestServer();
 
@@ -192,7 +199,7 @@ public class MultiTeamsAuthTestCacheTest {
             @Override
             protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
                 String token = req.getHeader("Authorization").replaceFirst("Bearer ", "");
-                int count = remaining.computeIfAbsent(token, (t) -> new AtomicInteger(2)).getAndDecrement();
+                int count = remaining.computeIfAbsent(token, (t) -> new AtomicInteger(1)).getAndDecrement();
                 if (count <= 0) {
                     resp.setStatus(500);
                     return;

--- a/bolt/src/test/java/test_locally/app/MultiTeamsAuthTestCacheTest.java
+++ b/bolt/src/test/java/test_locally/app/MultiTeamsAuthTestCacheTest.java
@@ -1,0 +1,234 @@
+package test_locally.app;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.app_backend.SlackSignature;
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.model.Bot;
+import com.slack.api.bolt.model.Installer;
+import com.slack.api.bolt.model.builtin.DefaultBot;
+import com.slack.api.bolt.model.builtin.DefaultInstaller;
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.builtin.GlobalShortcutRequest;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.methods.SlackApiException;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import util.PortProvider;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@Slf4j
+public class MultiTeamsAuthTestCacheTest {
+
+    static SlackConfig config = new SlackConfig();
+    static Slack slack = Slack.getInstance(config);
+    static CountdownAuthTestServer server = new CountdownAuthTestServer();
+
+    final String secret = "foo-bar-baz";
+    final SlackSignature.Generator generator = new SlackSignature.Generator(secret);
+
+    String realPayload = "{\"type\":\"shortcut\",\"token\":\"legacy-fixed-value\",\"action_ts\":\"123.123\",\"team\":{\"id\":\"T123\",\"domain\":\"seratch-test\"},\"user\":{\"id\":\"U123\",\"username\":\"seratch\",\"team_id\":\"T123\"},\"callback_id\":\"test-global-shortcut\",\"trigger_id\":\"123.123.123\"}\n";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        server.start();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void cacheEnabled() throws Exception {
+        App app = buildApp(true);
+        app.globalShortcut("test-global-shortcut", (req, ctx) -> ctx.ack());
+
+        String requestBody = "payload=" + URLEncoder.encode(realPayload, "UTF-8");
+
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(requestBody, rawHeaders, timestamp);
+
+        GlobalShortcutRequest req = new GlobalShortcutRequest(requestBody, realPayload, new RequestHeaders(rawHeaders));
+        assertEquals("seratch", req.getPayload().getUser().getUsername()); // a bit different from message_actions payload
+
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(300L);
+        response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(300L);
+        response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(3000L);
+
+        response = app.run(req);
+        assertEquals(503L, response.getStatusCode().longValue());
+    }
+
+    @Test
+    public void cacheDisabled() throws Exception {
+        App app = buildApp(false);
+        app.globalShortcut("test-global-shortcut", (req, ctx) -> ctx.ack());
+
+        String requestBody = "payload=" + URLEncoder.encode(realPayload, "UTF-8");
+
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(requestBody, rawHeaders, timestamp);
+
+        GlobalShortcutRequest req = new GlobalShortcutRequest(requestBody, realPayload, new RequestHeaders(rawHeaders));
+        assertEquals("seratch", req.getPayload().getUser().getUsername()); // a bit different from message_actions payload
+
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        response = app.run(req);
+        assertEquals(503L, response.getStatusCode().longValue());
+    }
+
+    App buildApp(boolean authTestCacheEnabled) {
+        App app = new App(AppConfig.builder()
+                .authTestCacheEnabled(authTestCacheEnabled)
+                .signingSecret(secret)
+                .clientId("test")
+                .clientSecret("test-test")
+                .slack(slack)
+                .build());
+        app.service(new InstallationService() {
+            @Override
+            public boolean isHistoricalDataEnabled() {
+                return false;
+            }
+
+            @Override
+            public void setHistoricalDataEnabled(boolean isHistoricalDataEnabled) {
+            }
+
+            @Override
+            public void saveInstallerAndBot(Installer installer) {
+            }
+
+            @Override
+            public void deleteBot(Bot bot) {
+            }
+
+            @Override
+            public void deleteInstaller(Installer installer) {
+            }
+
+            @Override
+            public Bot findBot(String enterpriseId, String teamId) {
+                DefaultBot bot = new DefaultBot();
+                bot.setTeamId("T111");
+                bot.setBotAccessToken("B111");
+                bot.setBotUserId("U111");
+                bot.setInstalledAt(System.currentTimeMillis());
+                bot.setBotAccessToken("xoxb-1234567890-123456789012-12345678901234567890" + authTestCacheEnabled);
+                return bot;
+            }
+
+            @Override
+            public Installer findInstaller(String enterpriseId, String teamId, String userId) {
+                return null;
+            }
+        });
+        return app;
+    }
+
+    void setRequestHeaders(String requestBody, Map<String, List<String>> rawHeaders, String timestamp) {
+        rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP, Arrays.asList(timestamp));
+        rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_SIGNATURE, Arrays.asList(generator.generate(timestamp, requestBody)));
+    }
+
+    public static class CountdownAuthTestServer {
+
+        static String ok = "{\n" +
+                "  \"ok\": true,\n" +
+                "  \"url\": \"https://java-slack-sdk-test.slack.com/\",\n" +
+                "  \"team\": \"java-slack-sdk-test\",\n" +
+                "  \"user\": \"test_user\",\n" +
+                "  \"team_id\": \"T1234567\",\n" +
+                "  \"user_id\": \"U1234567\",\n" +
+                "  \"bot_id\": \"B12345678\",\n" +
+                "  \"enterprise_id\": \"E12345678\"\n" +
+                "}";
+
+        @WebServlet
+        public static class CountdownAuthTestMockEndpoint extends HttpServlet {
+
+            private ConcurrentMap<String, AtomicInteger> remaining = new ConcurrentHashMap<>();
+
+            @Override
+            protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+                String token = req.getHeader("Authorization").replaceFirst("Bearer ", "");
+                int count = remaining.computeIfAbsent(token, (t) -> new AtomicInteger(2)).getAndDecrement();
+                if (count <= 0) {
+                    resp.setStatus(500);
+                    return;
+                }
+                resp.setStatus(200);
+                resp.setContentType("application/json");
+                resp.getWriter().write(ok);
+            }
+        }
+
+        private final int port;
+        private final Server server;
+
+        public CountdownAuthTestServer() {
+            this(PortProvider.getPort(CountdownAuthTestServer.class.getName()));
+        }
+
+        public CountdownAuthTestServer(int port) {
+            this.port = port;
+            server = new Server(this.port);
+            ServletHandler handler = new ServletHandler();
+            server.setHandler(handler);
+            handler.addServletWithMapping(CountdownAuthTestMockEndpoint.class, "/*");
+        }
+
+        public String getMethodsEndpointPrefix() {
+            return "http://localhost:" + port + "/api/";
+        }
+
+        public void start() throws Exception {
+            server.start();
+        }
+
+        public void stop() throws Exception {
+            server.stop();
+        }
+    }
+
+}

--- a/bolt/src/test/java/test_locally/app/SingleTeamAuthTestCacheTest.java
+++ b/bolt/src/test/java/test_locally/app/SingleTeamAuthTestCacheTest.java
@@ -1,0 +1,196 @@
+package test_locally.app;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.app_backend.SlackSignature;
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.builtin.GlobalShortcutRequest;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.methods.SlackApiException;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import util.PortProvider;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@Slf4j
+public class SingleTeamAuthTestCacheTest {
+
+    static SlackConfig config = new SlackConfig();
+    static Slack slack = Slack.getInstance(config);
+    static CountdownAuthTestServer server = new CountdownAuthTestServer();
+
+    final String secret = "foo-bar-baz";
+    final SlackSignature.Generator generator = new SlackSignature.Generator(secret);
+
+    String realPayload = "{\"type\":\"shortcut\",\"token\":\"legacy-fixed-value\",\"action_ts\":\"123.123\",\"team\":{\"id\":\"T123\",\"domain\":\"seratch-test\"},\"user\":{\"id\":\"U123\",\"username\":\"seratch\",\"team_id\":\"T123\"},\"callback_id\":\"test-global-shortcut\",\"trigger_id\":\"123.123.123\"}\n";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        server.start();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void cacheEnabled() throws Exception {
+        App app = buildApp(true);
+        app.globalShortcut("test-global-shortcut", (req, ctx) -> ctx.ack());
+
+        String requestBody = "payload=" + URLEncoder.encode(realPayload, "UTF-8");
+
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(requestBody, rawHeaders, timestamp);
+
+        GlobalShortcutRequest req = new GlobalShortcutRequest(requestBody, realPayload, new RequestHeaders(rawHeaders));
+        assertEquals("seratch", req.getPayload().getUser().getUsername()); // a bit different from message_actions payload
+
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(300L);
+        response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(300L);
+        response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(3000L);
+        try {
+            app.run(req);
+            fail("Exception expected here");
+        } catch (SlackApiException e) {
+            assertEquals(500, e.getResponse().code());
+        }
+    }
+
+    @Test
+    public void cacheDisabled() throws Exception {
+        App app = buildApp(false);
+        app.globalShortcut("test-global-shortcut", (req, ctx) -> ctx.ack());
+
+        String requestBody = "payload=" + URLEncoder.encode(realPayload, "UTF-8");
+
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(requestBody, rawHeaders, timestamp);
+
+        GlobalShortcutRequest req = new GlobalShortcutRequest(requestBody, realPayload, new RequestHeaders(rawHeaders));
+        assertEquals("seratch", req.getPayload().getUser().getUsername()); // a bit different from message_actions payload
+
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        try {
+            app.run(req);
+            fail("Exception expected here");
+        } catch (SlackApiException e) {
+            assertEquals(500, e.getResponse().code());
+        }
+    }
+
+    App buildApp(boolean authTestCacheEnabled) {
+        return new App(AppConfig.builder()
+                .authTestCacheEnabled(authTestCacheEnabled)
+                .signingSecret(secret)
+                .singleTeamBotToken("xoxb-1234567890-123456789012-12345678901234567890" + authTestCacheEnabled)
+                .slack(slack)
+                .build());
+    }
+
+    void setRequestHeaders(String requestBody, Map<String, List<String>> rawHeaders, String timestamp) {
+        rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP, Arrays.asList(timestamp));
+        rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_SIGNATURE, Arrays.asList(generator.generate(timestamp, requestBody)));
+    }
+
+    public static class CountdownAuthTestServer {
+
+        static String ok = "{\n" +
+                "  \"ok\": true,\n" +
+                "  \"url\": \"https://java-slack-sdk-test.slack.com/\",\n" +
+                "  \"team\": \"java-slack-sdk-test\",\n" +
+                "  \"user\": \"test_user\",\n" +
+                "  \"team_id\": \"T1234567\",\n" +
+                "  \"user_id\": \"U1234567\",\n" +
+                "  \"bot_id\": \"B12345678\",\n" +
+                "  \"enterprise_id\": \"E12345678\"\n" +
+                "}";
+
+        @WebServlet
+        public static class CountdownAuthTestMockEndpoint extends HttpServlet {
+
+            private ConcurrentMap<String, AtomicInteger> remaining = new ConcurrentHashMap<>();
+
+            @Override
+            protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+                String token = req.getHeader("Authorization").replaceFirst("Bearer ", "");
+                int count = remaining.computeIfAbsent(token, (t) -> new AtomicInteger(2)).getAndDecrement();
+                if (count <= 0) {
+                    resp.setStatus(500);
+                    return;
+                }
+                resp.setStatus(200);
+                resp.setContentType("application/json");
+                resp.getWriter().write(ok);
+            }
+        }
+
+        private final int port;
+        private final Server server;
+
+        public CountdownAuthTestServer() {
+            this(PortProvider.getPort(CountdownAuthTestServer.class.getName()));
+        }
+
+        public CountdownAuthTestServer(int port) {
+            this.port = port;
+            server = new Server(this.port);
+            ServletHandler handler = new ServletHandler();
+            server.setHandler(handler);
+            handler.addServletWithMapping(CountdownAuthTestMockEndpoint.class, "/*");
+        }
+
+        public String getMethodsEndpointPrefix() {
+            return "http://localhost:" + port + "/api/";
+        }
+
+        public void start() throws Exception {
+            server.start();
+        }
+
+        public void stop() throws Exception {
+            server.stop();
+        }
+    }
+
+}

--- a/bolt/src/test/java/test_locally/app/SingleTeamAuthTestCacheTest.java
+++ b/bolt/src/test/java/test_locally/app/SingleTeamAuthTestCacheTest.java
@@ -101,6 +101,45 @@ public class SingleTeamAuthTestCacheTest {
     }
 
     @Test
+    public void permanentCacheEnabled() throws Exception {
+        App app = new App(AppConfig.builder()
+                .authTestCacheEnabled(true)
+                .authTestCacheExpirationMillis(-1L)
+                .signingSecret(secret)
+                .singleTeamBotToken("xoxb-1234567890-123456789012-12345678901234567890-permanent")
+                .slack(slack)
+                .build());
+        app.globalShortcut("test-global-shortcut", (req, ctx) -> ctx.ack());
+
+        String requestBody = "payload=" + URLEncoder.encode(realPayload, "UTF-8");
+
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(requestBody, rawHeaders, timestamp);
+
+        GlobalShortcutRequest req = new GlobalShortcutRequest(requestBody, realPayload, new RequestHeaders(rawHeaders));
+        assertEquals("seratch", req.getPayload().getUser().getUsername()); // a bit different from message_actions payload
+
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(300L);
+        response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(300L);
+        response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(3000L);
+        response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+    }
+
+    @Test
     public void cacheDisabled() throws Exception {
         App app = buildApp(false);
         app.globalShortcut("test-global-shortcut", (req, ctx) -> ctx.ack());

--- a/bolt/src/test/java/test_locally/app/SingleTeamAuthTestCacheTest.java
+++ b/bolt/src/test/java/test_locally/app/SingleTeamAuthTestCacheTest.java
@@ -8,6 +8,7 @@ import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.request.RequestHeaders;
 import com.slack.api.bolt.request.builtin.GlobalShortcutRequest;
 import com.slack.api.bolt.response.Response;
+import com.slack.api.methods.MethodsConfig;
 import com.slack.api.methods.SlackApiException;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.server.Server;
@@ -38,6 +39,11 @@ import static org.junit.Assert.fail;
 public class SingleTeamAuthTestCacheTest {
 
     static SlackConfig config = new SlackConfig();
+    static {
+        MethodsConfig methodsConfig = new MethodsConfig();
+        methodsConfig.setStatsEnabled(false); // To skip TeamIdCache requests
+        config.setMethodsConfig(methodsConfig);
+    }
     static Slack slack = Slack.getInstance(config);
     static CountdownAuthTestServer server = new CountdownAuthTestServer();
 
@@ -154,7 +160,7 @@ public class SingleTeamAuthTestCacheTest {
             @Override
             protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
                 String token = req.getHeader("Authorization").replaceFirst("Bearer ", "");
-                int count = remaining.computeIfAbsent(token, (t) -> new AtomicInteger(2)).getAndDecrement();
+                int count = remaining.computeIfAbsent(token, (t) -> new AtomicInteger(1)).getAndDecrement();
                 if (count <= 0) {
                     resp.setStatus(500);
                     return;


### PR DESCRIPTION
###  Summary

This pull request fixes #468 by introducing new options as below.

* AppConfig#authTestCacheEnabled (default: false)
* AppConfig#authTestCacheExpirationMillis (default: 3000)

The default behavior won't be changed. Only when a Bolt app turns the flag on, the cache will be enabled. 

The cache layer doesn't support distributed cache implementations (e.g., the ones using Memcached, Redis) by design. As mentioned in #468, the purpose of this cache is to reduce the number of `auth.test` API calls in Bolt apps that tend to receive lots of incoming requests from Slack in a short time of period.

TODO: Update document when releasing v1.1

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
