### PR TITLE
Add view builder extension function for Block Kit DSL

### DIFF
--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/view/Extensions.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/view/Extensions.kt
@@ -1,0 +1,9 @@
+package com.slack.api.model.kotlin_extension.view
+
+import com.slack.api.model.kotlin_extension.block.dsl.LayoutBlockDsl
+import com.slack.api.model.kotlin_extension.block.withBlocks
+import com.slack.api.model.view.View.ViewBuilder
+
+fun ViewBuilder.blocks(builder: LayoutBlockDsl.() -> Unit): ViewBuilder {
+    return this.blocks(withBlocks(builder))
+}

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/view/ViewBuilderExtensionTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/view/ViewBuilderExtensionTest.kt
@@ -1,0 +1,49 @@
+package test_locally.view
+
+import com.slack.api.model.block.Blocks.*
+import com.slack.api.model.block.composition.BlockCompositions.*
+import com.slack.api.model.kotlin_extension.view.blocks
+import com.slack.api.model.view.Views.view
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class ViewBuilderExtensionTest {
+    @Test
+    fun `View builder extension works`() {
+        val view = view {
+            it.type("home")
+                .blocks {
+                    section {
+                        markdownText("**Welcome to your home screen!**")
+                    }
+                    divider()
+                    section {
+                        markdownText(":clock3: Your next event starts in **10** minutes.")
+                        fields {
+                            plainText(":pushpin: Location: Large Conference Room", emoji = true)
+                            plainText(":hourglass_flowing_sand: Duration: 30 minutes", emoji = true)
+                        }
+                    }
+                }
+        }
+
+        val expected = view {
+            it.type("home")
+                    .blocks(asBlocks(
+                            section { thisSection ->
+                                thisSection.text(markdownText { mt -> mt.text("**Welcome to your home screen!**")})
+                            },
+                            divider(),
+                            section { thisSection ->
+                                thisSection.text(markdownText { mt -> mt.text(":clock3: Your next event starts in **10** minutes.") })
+                                        .fields(asSectionFields(
+                                                plainText { pt -> pt.text(":pushpin: Location: Large Conference Room").emoji(true) },
+                                                plainText { pt -> pt.text(":hourglass_flowing_sand: Duration: 30 minutes").emoji(true) }
+                                        ))
+                            }
+                    ))
+        }
+
+        assertEquals(expected.toString(), view.toString(), "$expected \n$view")
+    }
+}


### PR DESCRIPTION
###  Summary

This PR adds an extension function on the `View.ViewBuilder` in the `slack-api-model` Kotlin extension package so we can use `.blocks { }` on the view builder for the new Block Kit DSL.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
