### PR TITLE
Dependency updates in v1.1 (tl;dr - okhttp 4.7 to 4.8, micronaut 1.3 to 2.0)

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,7 +10,8 @@
     </parent>
 
     <properties>
-        <helidon.version>1.4.4</helidon.version>
+        <!--- TODO: upgrade to helidon 2.0 -->
+        <helidon.version>1.4.5</helidon.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,8 +10,8 @@
     </parent>
 
     <properties>
-        <micronaut.version>1.3.6</micronaut.version>
-        <micronaut-test-junit5.version>1.2.0.RC5</micronaut-test-junit5.version>
+        <micronaut.version>2.0.0</micronaut.version>
+        <micronaut-test-junit5.version>1.2.0</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>
 

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <quarkus.version>1.5.1.Final</quarkus.version>
+        <quarkus.version>1.6.0.Final</quarkus.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,5 +9,6 @@ url: https://slack.dev
 sdkLatestVersion: 1.0.11
 kotlinVersion: 1.3.72
 springBootVersion: 2.3.1.RELEASE
-quarkusVersion: 1.5.1.Final
-helidonVersion: 1.4.4
+compatibleMicronautVersion: 2.x
+quarkusVersion: 1.6.0.Final
+helidonVersion: 1.4.5

--- a/docs/guides/ja/supported-web-frameworks.md
+++ b/docs/guides/ja/supported-web-frameworks.md
@@ -166,6 +166,7 @@ ngrok http 3000 --subdomain {あなたのサブドメイン}
 ありふれた Servlet での実行環境ではなく、[Micronaut](https://micronaut.io/) を使いたい場合、**bolt-micronaut** というライブラリだけを追加します（**bolt** ライブラリもこれの依存ライブラリとして自動で解決されます）。**bolt-jetty** は必要ないので注意してください。以下は Maven の例ですが、もちろん Gradle でも同様です。
 
 ```xml
+<!-- Micronaut {{ site.compatibleMicronautVersion }} と互換性があります -->
 <dependency>
   <groupId>com.slack.api</groupId>
   <artifactId>bolt-micronaut</artifactId>

--- a/docs/guides/supported-web-frameworks.md
+++ b/docs/guides/supported-web-frameworks.md
@@ -167,6 +167,7 @@ ngrok http 3000 --subdomain {your-favorite-one}
 If you prefer [Micronaut](https://micronaut.io/) rather than commonplace Servlet environments, add **bolt-micronaut**, NOT **bolt-jetty**. As the **bolt** dependency will be automatically resolved as the **bolt-micronaut**'s dependency, you don't need to add it. Needless to say, that's the same for Gradle projects.
 
 ```xml
+<!-- Compatible with Micronaut {{ site.compatibleMicronautVersion }} -->
 <dependency>
   <groupId>com.slack.api</groupId>
   <artifactId>bolt-micronaut</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,18 +38,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <okhttp.version>4.7.2</okhttp.version>
+        <okhttp.version>4.8.0</okhttp.version>
         <gson.version>2.8.6</gson.version>
         <lombok.version>1.18.12</lombok.version>
         <lombok-maven-plugin.version>1.18.10.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
         <kotlin.version>1.3.72</kotlin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.805</aws.s3.version>
+        <aws.s3.version>1.11.820</aws.s3.version>
         <junit.version>4.13</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.3.3</mockito-core.version>
+        <mockito-core.version>3.4.0</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>


### PR DESCRIPTION
###  Summary

We don't upgrade Helidon SE to 2.0 as there are some incompatibilities and the necessity to build in JDK 11.

* [slack-api-client] okhttp 4.7.2 to 4.8.0 https://github.com/square/okhttp/compare/parent-4.7.2...parent-4.8.0
* [bolt-micronaut] Micronaut 1.3 to 2.0
* [bolt-helidon] Helido SE 1.4.4 to 1.4.5 (we don't support 2.0 this time)
* AWS S3 SDK to the latest patch version

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
