### PR TITLE
version 1.1.0 release

### DIFF
--- a/bolt-aws-lambda/pom.xml
+++ b/bolt-aws-lambda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-aws-lambda</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-docker-examples/echo-command-app/build.gradle
+++ b/bolt-docker-examples/echo-command-app/build.gradle
@@ -10,7 +10,7 @@ repositories {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("com.slack.api:bolt-jetty:1.0.11")
+    implementation("com.slack.api:bolt-jetty:1.1.0")
     implementation("ch.qos.logback:logback-classic:1.2.3")
     implementation('net.logstash.logback:logstash-logback-encoder:6.2')
 }

--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-helidon</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-jetty/pom.xml
+++ b/bolt-jetty/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-jetty</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-kotlin-examples/pom.xml
+++ b/bolt-kotlin-examples/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-kotlin-examples</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>
@@ -17,7 +17,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-micronaut</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <dependencyManagement>

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>
@@ -21,7 +21,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-quarkus-examples</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-servlet/pom.xml
+++ b/bolt-servlet/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-servlet</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-spring-boot-examples</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt/pom.xml
+++ b/bolt/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt/src/main/java/com/slack/api/bolt/meta/BoltLibraryVersion.java
+++ b/bolt/src/main/java/com/slack/api/bolt/meta/BoltLibraryVersion.java
@@ -5,7 +5,7 @@ public final class BoltLibraryVersion {
     }
 
     public static final String get() {
-        return "1.1.0-SNAPSHOT";
+        return "1.1.0";
     }
 }
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,7 +6,7 @@ markdown: kramdown
 baseurl: /java-slack-sdk
 url: https://slack.dev
 
-sdkLatestVersion: 1.0.11
+sdkLatestVersion: 1.1.0
 kotlinVersion: 1.3.72
 springBootVersion: 2.3.1.RELEASE
 compatibleMicronautVersion: 2.x

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-sdk-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <name>Java Slack SDK Project</name>
@@ -62,6 +62,7 @@
         <maven-versions-plugin.version>2.7</maven-versions-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+        <dokka.version>0.10.1</dokka.version>
     </properties>
 
     <licenses>

--- a/slack-api-client-kotlin-extension/pom.xml
+++ b/slack-api-client-kotlin-extension/pom.xml
@@ -5,18 +5,26 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-api-client-kotlin-extension</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
     </properties>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jcenter</id>
+            <name>JCenter</name>
+            <url>https://jcenter.bintray.com/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <dependency>
@@ -70,6 +78,21 @@
                         <phase>test-compile</phase>
                         <goals>
                             <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>${dokka.version}</version>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>dokka</goal>
+                            <goal>javadoc</goal>
+                            <goal>javadocJar</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-api-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/slack-api-client/src/main/java/com/slack/api/meta/SlackApiClientLibraryVersion.java
+++ b/slack-api-client/src/main/java/com/slack/api/meta/SlackApiClientLibraryVersion.java
@@ -5,7 +5,7 @@ public final class SlackApiClientLibraryVersion {
     }
 
     public static final String get() {
-        return "1.1.0-SNAPSHOT";
+        return "1.1.0";
     }
 }
 

--- a/slack-api-model-kotlin-extension/pom.xml
+++ b/slack-api-model-kotlin-extension/pom.xml
@@ -6,13 +6,21 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-api-model-kotlin-extension</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jcenter</id>
+            <name>JCenter</name>
+            <url>https://jcenter.bintray.com/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -73,6 +81,21 @@
                         <phase>test-compile</phase>
                         <goals>
                             <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>${dokka.version}</version>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>dokka</goal>
+                            <goal>javadoc</goal>
+                            <goal>javadocJar</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/slack-api-model/pom.xml
+++ b/slack-api-model/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-api-model</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
     
     <dependencies>

--- a/slack-api-model/src/main/java/com/slack/api/meta/SlackApiModelLibraryVersion.java
+++ b/slack-api-model/src/main/java/com/slack/api/meta/SlackApiModelLibraryVersion.java
@@ -5,7 +5,7 @@ public final class SlackApiModelLibraryVersion {
     }
 
     public static final String get() {
-        return "1.1.0-SNAPSHOT";
+        return "1.1.0";
     }
 }
 

--- a/slack-app-backend/pom.xml
+++ b/slack-app-backend/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-app-backend</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <dependencies>


### PR DESCRIPTION
We're going to release a new minor version - v1.1.0 within a few days.

## New Features

### Block Kit Kotlin DSL

Block Kit Kotlin DSL is a huge addition since this release. The new optional modules enable Kotlin developers to use much smoother and more intuitive DSLs for constructing rich messages, modal views, and Home tabs. Refer to the document pages and examples in the repository for details.

```kotlin
import com.slack.api.Slack
import com.slack.api.model.block.Blocks.*
import com.slack.api.model.kotlin_extension.request.chat.blocks

val slack = Slack.getInstance()
val token = System.getenv("SLACK_BOT_TOKEN")
val response = slack.methods(token).chatPostMessage { it
  .channel("C1234567")
  .blocks {
    section {
      // "text" fields can be constructed via plainText() and markdownText()
      markdownText("*Please select a restaurant:*")
    }
    divider()
    actions {
      // To align with the JSON structure, you could put the elements { } block around the buttons but for brevity it can be omitted
      // The same is true for things such as the section block's "accessory" container
      button {
        // For instances where only plain text is acceptable, the field's name can be filled with plain text inputs
        text("Farmhouse", emoji = true)
        value("farmhouse")
      }
      button {
        text("Kin Khao", emoji = true)
        value("kin-khao")
      }
    }
  }
}
```

Related issues/PRs: #428 #469 #501 #503 #504 #513

### http.proxyHost / http.proxyPort support in all Slack API clients

In v1.0.x versions, `slack-api-client` users have to manually extract `http.proxyHost` and `http.proxyPort` from system properties, concatenate those into a single string value, and then call `SlackConfig#setProxyUrl(String)` with the generated URL.

As those system properties are the standard ones, `SlackConfig` started supporting them out-of-the-box since v1.1.0. It works this way: 1) automatically read them, 2) build the proxy URL that consists of the value, and set it as the default value of `proxyUrl` when the properties exist. 

In the case a developer explicitly gives a `proxyUrl` value, the URL must be prioritized over the host + port in system properties.

Related issues/PRs: #500 #499

### Short-time cache for Bolt authorization

Bolt for Java used to excessively call `auth.test` every time the app receives an incoming request from the Slack API server. I
t's the safest way to always ensure if the underlying token is valid but it can be a not-small overhead for the app's response time. We've introduced the following options to enable Bolt apps to have a short-time cache for the `auth.test` API calls.

* `AppConfig#authTestCacheEnabled` (default: false)
* `AppConfig#authTestCacheExpirationMillis` (default: 3000)

The default behavior won't be changed. Only when a Bolt app turns the flag on, the cache will be enabled. 

The cache layer doesn't support distributed cache implementations (e.g., the ones using Memcached, Redis) by design. As mentioned in #468, the purpose of this cache is to reduce the number of `auth.test` API calls in Bolt apps that tend to receive lots of incoming requests from Slack in a short time of period.

Related issues/PRs: #502 #468

### A bunch of new APIs

As of July 13, the `slack-api-client` module supports all the public Web APIs.

* admin.usergroups.addTeams
* admin.conversations.restrictAccess.*
* calls.participants.remove
* conversations.mark

## Changes

* [kotlin-extension] #428 #469 #501 #503 #504 #513 Add Kotlin DSL modules for constructing Block Kit payloads - thanks @emanguy @seratch
* [bolt] #502 #468 short-time cache for authorization middleware - thanks @eamelink @seratch
* [slack-api-client] #508 Bump okhttp version from 4.7.2 to 4.8.0 - thanks @seratch
* [slack-api-client] #500 #499 Add proxy system properties support (http.proxyHost / http.proxyPort) - thanks @seratch
* [slack-api-client] #512 Redact authorization header from debug logging outputs - thanks @seratch
* [slack-api-client] #507 Add admin.conversations.restrictAccess.* APIs - thanks @seratch
* [slack-api-client] #509 Add conversations.mark API - thanks @seratch
* [slack-api-client] #505 Add calls.participants.remove, admin.usergroups.addTeams API - thanks @seratch
* [slack-app-backend] #494 #496 Add file_share message events & files in message_changed events - thanks @Hariprasad-Ramakrishnan @seratch
* [bolt-micronaut] #508 Bump micronaut from 1.3 to 2.0 - thanks @seratch

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
