### PR TITLE
Add more tests for Kotlin extensions

### DIFF
--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/HomeTemplateTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/HomeTemplateTest.kt
@@ -1,6 +1,7 @@
 package test_locally.block
 
 import com.google.gson.JsonElement
+import com.slack.api.model.kotlin_extension.block.element.ButtonStyle
 import com.slack.api.model.kotlin_extension.block.withBlocks
 import com.slack.api.util.json.GsonFactory
 import org.junit.Test
@@ -12,7 +13,7 @@ class HomeTemplateTest {
     val gson = GsonFactory.createSnakeCase()
 
     @Test
-    fun projetTracker() {
+    fun projectTracker() {
         val blocks = withBlocks {
             section {
                 markdownText("*Here's what you can do with Project Tracker:*")
@@ -186,6 +187,382 @@ class HomeTemplateTest {
 					"value": "new_configuration"
 				}
 			]
+		}
+	]
+}
+        """.trimIndent()
+        val json = gson.fromJson(original, JsonElement::class.java)
+        val expected = json.asJsonObject["blocks"]
+        val actual = gson.toJsonTree(blocks)
+        assertEquals(expected, actual, "\n" + expected.toString() + "\n" + actual.toString())
+    }
+
+    @Test
+    fun calendar() {
+        val blocks = withBlocks {
+            section {
+                markdownText("*Today, 22 October*")
+                accessory {
+                    button {
+                        text("Manage App Settings", emoji = true)
+                        value("settings")
+                    }
+                }
+            }
+            actions {
+                elements {
+                    datePicker {
+                        initialDate("2019-10-22")
+                        placeholder("Select a date", emoji = true)
+                    }
+                }
+            }
+            divider()
+            section {
+                markdownText("*<fakelink.toUrl.com|Marketing weekly sync>*\n11:30am — 12:30pm  |  SF500 · 7F · Saturn (5)\nStatus: ✅ Going")
+                accessory {
+                    overflowMenu {
+                        options {
+                            option {
+                                plainText("View Event Details", emoji = true)
+                                value("view_event_details")
+                            }
+                            option {
+                                plainText("Change Response", emoji = true)
+                                value("change_response")
+                            }
+                        }
+                    }
+                }
+            }
+            actions {
+                elements {
+                    button {
+                        text("Join Video Call", emoji = true)
+                        style(ButtonStyle.PRIMARY)
+                        value("join")
+                    }
+                }
+            }
+            divider()
+            section {
+                markdownText("*<fakelink.toUrl.com|Design review w/ Platform leads>*\n1:30pm — 2:00pm  |  SF500 · 4F · Finch (4)")
+                accessory {
+                    overflowMenu {
+                        options {
+                            option {
+                                plainText("View Event Details", emoji = true)
+                                value("view_event_details")
+                            }
+                            option {
+                                plainText("Change Response", emoji = true)
+                                value("change_response")
+                            }
+                        }
+                    }
+                }
+            }
+            actions {
+                elements {
+                    staticSelect {
+                        placeholder("Going?", emoji = true)
+                        options {
+                            option {
+                                plainText("Going", emoji = true)
+                                value("going")
+                            }
+                            option {
+                                plainText("Maybe", emoji = true)
+                                value("maybe")
+                            }
+                            option {
+                                plainText("Not going", emoji = true)
+                                value("decline")
+                            }
+                        }
+                    }
+                }
+            }
+            divider()
+            section {
+                markdownText("*<fakelink.toUrl.com|Presentation write-up>*\n4:00pm — 5:30pm  |  SF500 · 7F · Saturn (5)\nStatus: ✅ Going")
+                accessory {
+                    overflowMenu {
+                        options {
+                            option {
+                                plainText("View Event Details", emoji = true)
+                                value("view_event_details")
+                            }
+                            option {
+                                plainText("Change Response", emoji = true)
+                                value("change_response")
+                            }
+                        }
+                    }
+                }
+            }
+            actions {
+                elements {
+                    button {
+                        text("Join Video Call", emoji = true)
+                        style(ButtonStyle.PRIMARY)
+                        value("join")
+                    }
+                }
+            }
+            divider()
+            context {
+                elements {
+                    image("https://api.slack.com/img/blocks/bkb_template_images/placeholder.png", altText = "placeholder")
+                }
+            }
+            context {
+                elements {
+                    markdownText("Past events")
+                }
+            }
+            section {
+                markdownText("*Marketing team breakfast*\n8:30am — 9:30am  |  SF500 · 7F · Saturn (5)")
+            }
+            divider()
+            section {
+                markdownText("*Coffee chat w/ candidate*\n10:30am — 11:00am  |  SF500 · 10F · Cafe")
+            }
+        }
+        val original = """
+{
+	"type": "home",
+	"blocks": [
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Today, 22 October*"
+			},
+			"accessory": {
+				"type": "button",
+				"text": {
+					"type": "plain_text",
+					"text": "Manage App Settings",
+					"emoji": true
+				},
+				"value": "settings"
+			}
+		},
+		{
+			"type": "actions",
+			"elements": [
+				{
+					"type": "datepicker",
+					"initial_date": "2019-10-22",
+					"placeholder": {
+						"type": "plain_text",
+						"text": "Select a date",
+						"emoji": true
+					}
+				}
+			]
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*<fakelink.toUrl.com|Marketing weekly sync>*\n11:30am — 12:30pm  |  SF500 · 7F · Saturn (5)\nStatus: ✅ Going"
+			},
+			"accessory": {
+				"type": "overflow",
+				"options": [
+					{
+						"text": {
+							"type": "plain_text",
+							"text": "View Event Details",
+							"emoji": true
+						},
+						"value": "view_event_details"
+					},
+					{
+						"text": {
+							"type": "plain_text",
+							"text": "Change Response",
+							"emoji": true
+						},
+						"value": "change_response"
+					}
+				]
+			}
+		},
+		{
+			"type": "actions",
+			"elements": [
+				{
+					"type": "button",
+					"text": {
+						"type": "plain_text",
+						"text": "Join Video Call",
+						"emoji": true
+					},
+					"style": "primary",
+					"value": "join"
+				}
+			]
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*<fakelink.toUrl.com|Design review w/ Platform leads>*\n1:30pm — 2:00pm  |  SF500 · 4F · Finch (4)"
+			},
+			"accessory": {
+				"type": "overflow",
+				"options": [
+					{
+						"text": {
+							"type": "plain_text",
+							"text": "View Event Details",
+							"emoji": true
+						},
+						"value": "view_event_details"
+					},
+					{
+						"text": {
+							"type": "plain_text",
+							"text": "Change Response",
+							"emoji": true
+						},
+						"value": "change_response"
+					}
+				]
+			}
+		},
+		{
+			"type": "actions",
+			"elements": [
+				{
+					"type": "static_select",
+					"placeholder": {
+						"type": "plain_text",
+						"text": "Going?",
+						"emoji": true
+					},
+					"options": [
+						{
+							"text": {
+								"type": "plain_text",
+								"text": "Going",
+								"emoji": true
+							},
+							"value": "going"
+						},
+						{
+							"text": {
+								"type": "plain_text",
+								"text": "Maybe",
+								"emoji": true
+							},
+							"value": "maybe"
+						},
+						{
+							"text": {
+								"type": "plain_text",
+								"text": "Not going",
+								"emoji": true
+							},
+							"value": "decline"
+						}
+					]
+				}
+			]
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*<fakelink.toUrl.com|Presentation write-up>*\n4:00pm — 5:30pm  |  SF500 · 7F · Saturn (5)\nStatus: ✅ Going"
+			},
+			"accessory": {
+				"type": "overflow",
+				"options": [
+					{
+						"text": {
+							"type": "plain_text",
+							"text": "View Event Details",
+							"emoji": true
+						},
+						"value": "view_event_details"
+					},
+					{
+						"text": {
+							"type": "plain_text",
+							"text": "Change Response",
+							"emoji": true
+						},
+						"value": "change_response"
+					}
+				]
+			}
+		},
+		{
+			"type": "actions",
+			"elements": [
+				{
+					"type": "button",
+					"text": {
+						"type": "plain_text",
+						"text": "Join Video Call",
+						"emoji": true
+					},
+					"style": "primary",
+					"value": "join"
+				}
+			]
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "context",
+			"elements": [
+				{
+					"type": "image",
+					"image_url": "https://api.slack.com/img/blocks/bkb_template_images/placeholder.png",
+					"alt_text": "placeholder"
+				}
+			]
+		},
+		{
+			"type": "context",
+			"elements": [
+				{
+					"type": "mrkdwn",
+					"text": "Past events"
+				}
+			]
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Marketing team breakfast*\n8:30am — 9:30am  |  SF500 · 7F · Saturn (5)"
+			}
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Coffee chat w/ candidate*\n10:30am — 11:00am  |  SF500 · 10F · Cafe"
+			}
 		}
 	]
 }

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/MessageTemplateTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/MessageTemplateTest.kt
@@ -42,7 +42,8 @@ class MessageTemplateTest {
                 }
             }
         }
-        val original = """{
+        val original = """
+{
 	"blocks": [
 		{
 			"type": "section",
@@ -98,6 +99,274 @@ class MessageTemplateTest {
 					},
 					"style": "danger",
 					"value": "click_me_123"
+				}
+			]
+		}
+	]
+}
+"""
+        val json = gson.fromJson(original, JsonElement::class.java)
+        val expected = json.asJsonObject["blocks"]
+        val actual = gson.toJsonTree(blocks)
+        assertEquals(expected, actual, "\n" + expected.toString() + "\n" + actual.toString())
+    }
+
+    @Test
+    fun notification() {
+        val blocks = withBlocks {
+            section {
+                plainText("Looks like you have a scheduling conflict with this event:", emoji = true)
+            }
+            divider()
+            section {
+                markdownText("*<fakeLink.toUserProfiles.com|Iris / Zelda 1-1>*\nTuesday, January 21 4:00-4:30pm\nBuilding 2 - Havarti Cheese (3)\n2 guests")
+                accessory {
+                    image(imageUrl = "https://api.slack.com/img/blocks/bkb_template_images/notifications.png", altText = "calendar thumbnail")
+                }
+            }
+            context {
+                elements {
+                    image(imageUrl = "https://api.slack.com/img/blocks/bkb_template_images/notificationsWarningIcon.png", altText = "notifications warning icon")
+                }
+                markdownText("*Conflicts with Team Huddle: 4:15-4:30pm*")
+            }
+            divider()
+            section {
+                markdownText("*Propose a new time:*")
+            }
+            section {
+                markdownText("*Today - 4:30-5pm*\nEveryone is available: @iris, @zelda")
+                accessory {
+                    button {
+                        text(text = "Choose", emoji = true)
+                        value("click_me_123")
+                    }
+                }
+            }
+            section {
+                markdownText("*Tomorrow - 4-4:30pm*\nEveryone is available: @iris, @zelda")
+                accessory {
+                    button {
+                        text(text = "Choose", emoji = true)
+                        value("click_me_123")
+                    }
+                }
+            }
+            section {
+                markdownText("*Tomorrow - 6-6:30pm*\nSome people aren't available: @iris, ~@zelda~")
+                accessory {
+                    button {
+                        text(text = "Choose", emoji = true)
+                        value("click_me_123")
+                    }
+                }
+            }
+            section {
+                markdownText("*<fakelink.ToMoreTimes.com|Show more times>*")
+            }
+        }
+        val original = """
+{
+	"blocks": [
+		{
+			"type": "section",
+			"text": {
+				"type": "plain_text",
+				"text": "Looks like you have a scheduling conflict with this event:",
+				"emoji": true
+			}
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*<fakeLink.toUserProfiles.com|Iris / Zelda 1-1>*\nTuesday, January 21 4:00-4:30pm\nBuilding 2 - Havarti Cheese (3)\n2 guests"
+			},
+			"accessory": {
+				"type": "image",
+				"image_url": "https://api.slack.com/img/blocks/bkb_template_images/notifications.png",
+				"alt_text": "calendar thumbnail"
+			}
+		},
+		{
+			"type": "context",
+			"elements": [
+				{
+					"type": "image",
+					"image_url": "https://api.slack.com/img/blocks/bkb_template_images/notificationsWarningIcon.png",
+					"alt_text": "notifications warning icon"
+				},
+				{
+					"type": "mrkdwn",
+					"text": "*Conflicts with Team Huddle: 4:15-4:30pm*"
+				}
+			]
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Propose a new time:*"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Today - 4:30-5pm*\nEveryone is available: @iris, @zelda"
+			},
+			"accessory": {
+				"type": "button",
+				"text": {
+					"type": "plain_text",
+					"text": "Choose",
+					"emoji": true
+				},
+				"value": "click_me_123"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Tomorrow - 4-4:30pm*\nEveryone is available: @iris, @zelda"
+			},
+			"accessory": {
+				"type": "button",
+				"text": {
+					"type": "plain_text",
+					"text": "Choose",
+					"emoji": true
+				},
+				"value": "click_me_123"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Tomorrow - 6-6:30pm*\nSome people aren't available: @iris, ~@zelda~"
+			},
+			"accessory": {
+				"type": "button",
+				"text": {
+					"type": "plain_text",
+					"text": "Choose",
+					"emoji": true
+				},
+				"value": "click_me_123"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*<fakelink.ToMoreTimes.com|Show more times>*"
+			}
+		}
+	]
+}
+"""
+        val json = gson.fromJson(original, JsonElement::class.java)
+        val expected = json.asJsonObject["blocks"]
+        val actual = gson.toJsonTree(blocks)
+        assertEquals(expected, actual, "\n" + expected.toString() + "\n" + actual.toString())
+    }
+
+    @Test
+    fun onboarding() {
+        val blocks = withBlocks {
+            section {
+                markdownText("Hey there \uD83D\uDC4B I'm TaskBot. I'm here to help you create and manage tasks in Slack.\nThere are two ways to quickly create tasks:")
+            }
+            section {
+                markdownText("*1️⃣ Use the `/task` command*. Type `/task` followed by a short description of your tasks and I'll ask for a due date (if applicable). Try it out by using the `/task` command in this channel.")
+            }
+            section {
+                markdownText("*2️⃣ Use the _Create a Task_ action.* If you want to create a task from a message, select `Create a Task` in a message's context menu. Try it out by selecting the _Create a Task_ action for this message (shown below).")
+            }
+            image {
+                title("image1", true)
+                imageUrl("https://api.slack.com/img/blocks/bkb_template_images/onboardingComplex.jpg")
+                altText("image1")
+            }
+            section {
+                markdownText("➕ To start tracking your team's tasks, *add me to a channel* and I'll introduce myself. I'm usually added to a team or project channel. Type `/invite @TaskBot` from the channel or pick a channel on the right.")
+                accessory {
+                    conversationsSelect {
+                        placeholder("Select a channel...", true)
+                    }
+                }
+            }
+            divider()
+            context {
+                markdownText("\uD83D\uDC40 View all tasks with `/task list`\n❓Get help at any time with `/task help` or type *help* in a DM with me")
+            }
+        }
+        val original = """
+{
+	"blocks": [
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "Hey there 👋 I'm TaskBot. I'm here to help you create and manage tasks in Slack.\nThere are two ways to quickly create tasks:"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*1️⃣ Use the `/task` command*. Type `/task` followed by a short description of your tasks and I'll ask for a due date (if applicable). Try it out by using the `/task` command in this channel."
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*2️⃣ Use the _Create a Task_ action.* If you want to create a task from a message, select `Create a Task` in a message's context menu. Try it out by selecting the _Create a Task_ action for this message (shown below)."
+			}
+		},
+		{
+			"type": "image",
+			"title": {
+				"type": "plain_text",
+				"text": "image1",
+				"emoji": true
+			},
+			"image_url": "https://api.slack.com/img/blocks/bkb_template_images/onboardingComplex.jpg",
+			"alt_text": "image1"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "➕ To start tracking your team's tasks, *add me to a channel* and I'll introduce myself. I'm usually added to a team or project channel. Type `/invite @TaskBot` from the channel or pick a channel on the right."
+			},
+			"accessory": {
+				"type": "conversations_select",
+				"placeholder": {
+					"type": "plain_text",
+					"text": "Select a channel...",
+					"emoji": true
+				}
+			}
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "context",
+			"elements": [
+				{
+					"type": "mrkdwn",
+					"text": "👀 View all tasks with `/task list`\n❓Get help at any time with `/task help` or type *help* in a DM with me"
 				}
 			]
 		}

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/ModalTemplateTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/ModalTemplateTest.kt
@@ -312,4 +312,227 @@ class ModalTemplateTest {
         assertEquals(expected, actual, "\n" + expected.toString() + "\n" + actual.toString())
     }
 
+    @Test
+    fun listOfInformation() {
+        val blocks = withBlocks {
+            section {
+                markdownText(":tada: You're all set! This is your booking summary.")
+            }
+            divider()
+            section {
+                fields {
+                    markdownText("*Attendee*\nKatie Chen")
+                    markdownText("*Date*\nOct 22-23")
+                }
+            }
+            context {
+                elements {
+                    markdownText(":house: Accommodation")
+                }
+            }
+            divider()
+            section {
+                markdownText("*Redwood Suite*\n*Share with 2 other person.* Studio home. Modern bathroom. TV. Heating. Full kitchen. Patio with lounge chairs and campfire style fire pit and grill.")
+                accessory {
+                    image(imageUrl = "https://api.slack.com/img/blocks/bkb_template_images/redwood-suite.png", altText = "Redwood Suite")
+                }
+            }
+            context {
+                elements {
+                    markdownText(":fork_and_knife: Food & Dietary restrictions")
+                }
+            }
+            divider()
+            section {
+                markdownText("*All-rounder*\nYou eat most meats, seafood, dairy and vegetables.")
+            }
+            context {
+                markdownText(":woman-running: Activities")
+            }
+            divider()
+            section {
+                markdownText("*Winery tour and tasting*")
+                fields {
+                    plainText("Wednesday, Oct 22 2019, 2pm-5pm", emoji = true)
+                    plainText("Hosted by Sandra Mullens", emoji = true)
+                }
+            }
+            section {
+                markdownText("*Sunrise hike to Mount Amazing*")
+                fields {
+                    plainText("Thursday, Oct 23 2019, 5:30am", emoji = true)
+                    plainText("Hosted by Jordan Smith", emoji = true)
+                }
+            }
+            section {
+                markdownText("*Design systems brainstorm*")
+                fields {
+                    plainText("Thursday, Oct 23 2019, 11a", emoji = true)
+                    plainText("Hosted by Mary Lee", emoji = true)
+                }
+            }
+        }
+        val original = """
+{
+	"type": "modal",
+	"submit": {
+		"type": "plain_text",
+		"text": "Submit",
+		"emoji": true
+	},
+	"close": {
+		"type": "plain_text",
+		"text": "Cancel",
+		"emoji": true
+	},
+	"title": {
+		"type": "plain_text",
+		"text": "Your itinerary",
+		"emoji": true
+	},
+	"blocks": [
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": ":tada: You're all set! This is your booking summary."
+			}
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"fields": [
+				{
+					"type": "mrkdwn",
+					"text": "*Attendee*\nKatie Chen"
+				},
+				{
+					"type": "mrkdwn",
+					"text": "*Date*\nOct 22-23"
+				}
+			]
+		},
+		{
+			"type": "context",
+			"elements": [
+				{
+					"type": "mrkdwn",
+					"text": ":house: Accommodation"
+				}
+			]
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Redwood Suite*\n*Share with 2 other person.* Studio home. Modern bathroom. TV. Heating. Full kitchen. Patio with lounge chairs and campfire style fire pit and grill."
+			},
+			"accessory": {
+				"type": "image",
+				"image_url": "https://api.slack.com/img/blocks/bkb_template_images/redwood-suite.png",
+				"alt_text": "Redwood Suite"
+			}
+		},
+		{
+			"type": "context",
+			"elements": [
+				{
+					"type": "mrkdwn",
+					"text": ":fork_and_knife: Food & Dietary restrictions"
+				}
+			]
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*All-rounder*\nYou eat most meats, seafood, dairy and vegetables."
+			}
+		},
+		{
+			"type": "context",
+			"elements": [
+				{
+					"type": "mrkdwn",
+					"text": ":woman-running: Activities"
+				}
+			]
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Winery tour and tasting*"
+			},
+			"fields": [
+				{
+					"type": "plain_text",
+					"text": "Wednesday, Oct 22 2019, 2pm-5pm",
+					"emoji": true
+				},
+				{
+					"type": "plain_text",
+					"text": "Hosted by Sandra Mullens",
+					"emoji": true
+				}
+			]
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Sunrise hike to Mount Amazing*"
+			},
+			"fields": [
+				{
+					"type": "plain_text",
+					"text": "Thursday, Oct 23 2019, 5:30am",
+					"emoji": true
+				},
+				{
+					"type": "plain_text",
+					"text": "Hosted by Jordan Smith",
+					"emoji": true
+				}
+			]
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*Design systems brainstorm*"
+			},
+			"fields": [
+				{
+					"type": "plain_text",
+					"text": "Thursday, Oct 23 2019, 11a",
+					"emoji": true
+				},
+				{
+					"type": "plain_text",
+					"text": "Hosted by Mary Lee",
+					"emoji": true
+				}
+			]
+		}
+	]
+}
+        """.trimIndent()
+        val json = gson.fromJson(original, JsonElement::class.java)
+        val expected = json.asJsonObject["blocks"]
+        val actual = gson.toJsonTree(blocks)
+        assertEquals(expected, actual, "\n" + expected.toString() + "\n" + actual.toString())
+    }
+
 }


### PR DESCRIPTION
###  Summary

As part of the final verifications for the v1.1 release, I've written more unit tests for Block Kit Kotlin DSL using templates taken from Block Kit Builder. Those tests didn't detect any bugs but having them would be beneficial for learners.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
