### PR TITLE
Fix #525 by correcting the structure of details in LogsResponse (Audit Logs API)

### DIFF
--- a/json-logs/samples/audit/v1/logs.json
+++ b/json-logs/samples/audit/v1/logs.json
@@ -20,6 +20,51 @@
           "name": "",
           "email": "",
           "team": "E00000000"
+        },
+        "usergroup": {
+          "id": "S00000000",
+          "name": ""
+        },
+        "channel": {
+          "id": "C00000000",
+          "privacy": "",
+          "name": "",
+          "is_shared": false,
+          "is_org_shared": false,
+          "teams_shared_with": [
+            "T00000000",
+            ""
+          ]
+        },
+        "enterprise": {
+          "id": "E00000000",
+          "name": "",
+          "domain": ""
+        },
+        "workspace": {
+          "id": "T00000000",
+          "name": "",
+          "domain": ""
+        },
+        "file": {
+          "id": "F00000000",
+          "name": "",
+          "filetype": "",
+          "title": ""
+        },
+        "app": {
+          "id": "A00000000",
+          "name": "",
+          "is_distributed": false,
+          "is_directory_approved": false,
+          "is_workflow_app": false,
+          "scopes": [
+            ""
+          ]
+        },
+        "workflow": {
+          "id": "12345",
+          "name": ""
         }
       },
       "context": {
@@ -31,6 +76,73 @@
         },
         "ua": "",
         "ip_address": ""
+      },
+      "details": {
+        "channels": [
+          "C00000000"
+        ],
+        "type": "",
+        "is_workflow": false,
+        "shared_to": "T00000000",
+        "reason": "",
+        "mobile_only": false,
+        "web_only": false,
+        "expires_on": 12345,
+        "name": "",
+        "kicker": {
+          "id": "W00000000",
+          "name": "",
+          "email": "",
+          "team": "T00000000",
+          "type": "",
+          "user": {
+            "id": "W00000000",
+            "name": "",
+            "email": "",
+            "team": "E00000000"
+          }
+        },
+        "inviter": {
+          "id": "W00000000",
+          "name": "",
+          "email": "",
+          "team": "E00000000",
+          "type": "",
+          "user": {
+            "id": "W00000000",
+            "name": "",
+            "email": "",
+            "team": "E00000000"
+          }
+        },
+        "is_internal_integration": false,
+        "app_owner_id": "W00000000",
+        "bot_scopes": [
+          ""
+        ],
+        "new_version_id": "12345",
+        "trigger": "",
+        "new_scopes": [
+          ""
+        ],
+        "previous_scopes": [
+          ""
+        ],
+        "granular_bot_token": false,
+        "origin_team": "T00000000",
+        "target_team": "T00000000",
+        "scopes": [
+          ""
+        ],
+        "resolution": "",
+        "app_previously_resolved": false,
+        "admin_app_id": "",
+        "new_value": [
+          "C00000000"
+        ],
+        "previous_value": [
+          ""
+        ]
       }
     }
   ],

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditApiErrorResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditApiErrorResponse.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class AuditApiErrorResponse implements AuditApiResponse {
+    private transient String rawBody;
 
     private boolean ok;
     private String warning;

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditApiException.java
@@ -44,6 +44,7 @@ public class AuditApiException extends Exception {
         AuditApiErrorResponse parsedErrorResponse = null;
         try {
             parsedErrorResponse = GsonFactory.createSnakeCase(config).fromJson(responseBody, AuditApiErrorResponse.class);
+            parsedErrorResponse.setRawBody(responseBody);
         } catch (Exception e) {
             if (log.isDebugEnabled()) {
                 String responseToPrint = responseBody.length() > 1000 ? responseBody.subSequence(0, 1000) + " ..." : responseBody;

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditApiResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditApiResponse.java
@@ -24,4 +24,7 @@ public interface AuditApiResponse {
 
     void setProvided(String provided);
 
+    String getRawBody();
+
+    void setRawBody(String rawBody);
 }

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditClient.java
@@ -25,6 +25,8 @@ public interface AuditClient {
 
     String ENDPOINT_URL_PREFIX = "https://api.slack.com/audit/v1/";
 
+    AuditClient attachRawBody(boolean attachRawBody);
+
     SchemasResponse getSchemas() throws IOException, AuditApiException;
 
     SchemasResponse getSchemas(SchemasRequest req) throws IOException, AuditApiException;

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/AuditClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/AuditClientImpl.java
@@ -25,6 +25,7 @@ public class AuditClientImpl implements AuditClient {
 
     private final SlackHttpClient slackHttpClient;
     private final String token;
+    private boolean attachRawBody = false;
 
     public AuditClientImpl(SlackHttpClient slackHttpClient) {
         this(slackHttpClient, null);
@@ -41,6 +42,12 @@ public class AuditClientImpl implements AuditClient {
 
     public void setEndpointUrlPrefix(String endpointUrlPrefix) {
         this.endpointUrlPrefix = endpointUrlPrefix;
+    }
+
+    @Override
+    public AuditClient attachRawBody(boolean attachRawBody) {
+        this.attachRawBody = attachRawBody;
+        return this;
     }
 
     @Override
@@ -125,7 +132,9 @@ public class AuditClientImpl implements AuditClient {
         slackHttpClient.runHttpResponseListeners(response, body);
         if (response.isSuccessful()) {
             T apiResponse = GsonFactory.createSnakeCase(slackHttpClient.getConfig()).fromJson(body, clazz);
-            apiResponse.setRawBody(body);
+            if (attachRawBody) {
+                apiResponse.setRawBody(body);
+            }
             return apiResponse;
         } else {
             throw new AuditApiException(slackHttpClient.getConfig(), response, body);

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/AuditClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/AuditClientImpl.java
@@ -3,6 +3,7 @@ package com.slack.api.audit.impl;
 import com.slack.api.RequestConfigurator;
 import com.slack.api.audit.AuditApiException;
 import com.slack.api.audit.AuditApiRequest;
+import com.slack.api.audit.AuditApiResponse;
 import com.slack.api.audit.AuditClient;
 import com.slack.api.audit.request.ActionsRequest;
 import com.slack.api.audit.request.LogsRequest;
@@ -114,16 +115,18 @@ public class AuditClientImpl implements AuditClient {
         }
     }
 
-    private <T> T doGet(String url, Map<String, String> query, String token, Class<T> clazz) throws IOException, AuditApiException {
+    private <T extends AuditApiResponse> T doGet(String url, Map<String, String> query, String token, Class<T> clazz) throws IOException, AuditApiException {
         Response response = slackHttpClient.get(url, query, token);
         return parseJsonResponseAndRunListeners(response, clazz);
     }
 
-    private <T> T parseJsonResponseAndRunListeners(Response response, Class<T> clazz) throws IOException, AuditApiException {
+    private <T extends AuditApiResponse> T parseJsonResponseAndRunListeners(Response response, Class<T> clazz) throws IOException, AuditApiException {
         String body = response.body().string();
         slackHttpClient.runHttpResponseListeners(response, body);
         if (response.isSuccessful()) {
-            return GsonFactory.createSnakeCase(slackHttpClient.getConfig()).fromJson(body, clazz);
+            T apiResponse = GsonFactory.createSnakeCase(slackHttpClient.getConfig()).fromJson(body, clazz);
+            apiResponse.setRawBody(body);
+            return apiResponse;
         } else {
             throw new AuditApiException(slackHttpClient.getConfig(), response, body);
         }

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
@@ -9,6 +9,8 @@ import java.util.List;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class ActionsResponse implements AuditApiResponse {
+    private transient String rawBody;
+
     private boolean ok;
     private String warning;
     private String error;

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
@@ -7,10 +7,13 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class LogsResponse implements AuditApiResponse {
+    private transient String rawBody;
+
     private boolean ok;
     private String warning;
     private String error;
@@ -56,6 +59,7 @@ public class LogsResponse implements AuditApiResponse {
         private Enterprise enterprise;
         private File file;
         private Channel channel;
+        private Workflow workflow;
     }
 
     @Data
@@ -66,6 +70,8 @@ public class LogsResponse implements AuditApiResponse {
         private Boolean distributed;
         @SerializedName("is_directory_approved")
         private Boolean directoryApproved;
+        @SerializedName("is_workflow_app")
+        private Boolean workflowApp;
         private List<String> scopes;
     }
 
@@ -110,6 +116,12 @@ public class LogsResponse implements AuditApiResponse {
     }
 
     @Data
+    public static class Workflow {
+        private String id;
+        private String name;
+    }
+
+    @Data
     public static class Context {
         private Location location;
         private String ua;
@@ -124,40 +136,78 @@ public class LogsResponse implements AuditApiResponse {
         private String domain;
     }
 
+    /**
+     * The data structure for new_value, previous_value is greatly flexible.
+     * This class supports multiple patterns for those.
+     */
+    @Data
+    public static class DetailsChangedValue {
+        // e.g., ["C111", "C222"]
+        private List<String> stringValues;
+        // e.g., {"type": ["TOPLEVEL_ADMINS_AND_OWNERS_AND_SELECTED"]}
+        private Map<String, List<String>> namedStringValues;
+    }
+
     @Data
     public static class Details {
-        @SerializedName("is_internal_integration")
-        private Boolean internalIntegration;
+        private String type;
         private String appOwnerId;
+        private List<String> scopes; // app_scopes_expanded
+        private List<String> botScopes;
         private List<String> newScopes;
         private List<String> previousScopes;
-        private String type;
         private Inviter inviter;
-        private String newValue;
-        private String previousValue;
+        private DetailsChangedValue newValue; // pref.who_can_manage_shared_channels etc
+        private DetailsChangedValue previousValue; // pref.who_can_manage_shared_channels etc
         private Kicker kicker;
         private String installerUserId;
         private Boolean appPreviouslyApproved;
         private List<String> oldScopes;
         private String name;
         private String botId;
+        private List<String> channels;
         private List<Permission> permissions;
+        private String sharedTo; // channel_workspaces_updated
+        private String reason;
+        @SerializedName("is_internal_integration")
+        private Boolean internalIntegration;
+        @SerializedName("is_workflow")
+        private Boolean workflow; // user_channel_join
+        private Boolean mobileOnly; // user_session_reset_by_admin
+        private Boolean webOnly; // user_session_reset_by_admin
+        private Integer expiresOn; // guest_expiration_set
+        private String newVersionId; // workflow_published
+        private String trigger; // workflow_published
+        private Boolean granularBotToken; // app_scopes_expanded
+        private String originTeam; // external_shared_channel_invite_approved
+        private String targetTeam; // external_shared_channel_invite_approved
+        private String resolution; // app_approved
+        private Boolean appPreviouslyResolved; // app_approved
+        private String adminAppId; // app_approved
     }
 
     @Data
     public static class Inviter {
         private String type;
+
         private User user;
+
         private String id;
         private String name;
         private String email;
+        private String team;
     }
 
     @Data
     public static class Kicker {
+        private String type;
+
+        private User user;
+
         private String id;
         private String name;
         private String email;
+        private String team;
     }
 
     @Data

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
@@ -9,6 +9,8 @@ import java.util.List;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class SchemasResponse implements AuditApiResponse {
+    private transient String rawBody;
+
     private boolean ok;
     private String warning;
     private String error;

--- a/slack-api-client/src/main/java/com/slack/api/util/json/GsonAuditLogsDetailsChangedValueFactory.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/json/GsonAuditLogsDetailsChangedValueFactory.java
@@ -42,9 +42,7 @@ public class GsonAuditLogsDetailsChangedValueFactory implements JsonDeserializer
                     namedValues.put(name, parseStringArray(value));
                 } else {
                     if (failOnUnknownProperties) {
-                        // unsupported result
-                        String message = "Unsupported value (" + name + " -> " + value + ") here is detected. " +
-                                "Please report at https://github.com/slackapi/java-slack-sdk/issues";
+                        String message = "A non-array value (" + value + ") for " + name + " is detected. " + REPORT_THIS;
                         throw new JsonParseException(message);
                     }
                 }
@@ -52,8 +50,7 @@ public class GsonAuditLogsDetailsChangedValueFactory implements JsonDeserializer
             return result;
         } else {
             if (failOnUnknownProperties) {
-                // unsupported result
-                String message = "Unsupported whole value (" + json + ") is detected. " + REPORT_THIS;
+                String message = "The whole value (" + json + ") is unsupported. " + REPORT_THIS;
                 throw new JsonParseException(message);
             }
         }
@@ -67,8 +64,7 @@ public class GsonAuditLogsDetailsChangedValueFactory implements JsonDeserializer
                 values.add(elem.getAsString());
             } else {
                 if (failOnUnknownProperties) {
-                    // unsupported value
-                    String message = "The value (" + elem + ") here are not yet supported. " + REPORT_THIS;
+                    String message = "An unexpected element (" + elem + ") in an array is detected. " + REPORT_THIS;
                     throw new JsonParseException(message);
                 }
             }

--- a/slack-api-client/src/main/java/com/slack/api/util/json/GsonAuditLogsDetailsChangedValueFactory.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/json/GsonAuditLogsDetailsChangedValueFactory.java
@@ -1,0 +1,102 @@
+package com.slack.api.util.json;
+
+import com.google.gson.*;
+import com.slack.api.audit.response.LogsResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+public class GsonAuditLogsDetailsChangedValueFactory implements JsonDeserializer<LogsResponse.DetailsChangedValue>, JsonSerializer<LogsResponse.DetailsChangedValue> {
+
+    private static final String REPORT_THIS = "Please report this issue at https://github.com/slackapi/java-slack-sdk/issues";
+
+    private final boolean failOnUnknownProperties;
+
+    public GsonAuditLogsDetailsChangedValueFactory() {
+        this(false);
+    }
+
+    public GsonAuditLogsDetailsChangedValueFactory(boolean failOnUnknownProperties) {
+        this.failOnUnknownProperties = failOnUnknownProperties;
+    }
+
+    @Override
+    public LogsResponse.DetailsChangedValue deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        LogsResponse.DetailsChangedValue result = new LogsResponse.DetailsChangedValue();
+        if (json.isJsonArray()) {
+            result.setStringValues(parseStringArray(json));
+            return result;
+        } else if (json.isJsonObject()) {
+            Map<String, List<String>> namedValues = new HashMap<>();
+            result.setNamedStringValues(namedValues);
+            JsonObject obj = json.getAsJsonObject();
+            for (String name : obj.keySet()) {
+                JsonElement value = obj.get(name);
+                if (value.isJsonArray()) {
+                    namedValues.put(name, parseStringArray(value));
+                } else {
+                    if (failOnUnknownProperties) {
+                        // unsupported result
+                        String message = "Unsupported value (" + name + " -> " + value + ") here is detected. " +
+                                "Please report at https://github.com/slackapi/java-slack-sdk/issues";
+                        throw new JsonParseException(message);
+                    }
+                }
+            }
+            return result;
+        } else {
+            if (failOnUnknownProperties) {
+                // unsupported result
+                String message = "Unsupported whole value (" + json + ") is detected. " + REPORT_THIS;
+                throw new JsonParseException(message);
+            }
+        }
+        return result;
+    }
+
+    private List<String> parseStringArray(JsonElement json) throws JsonParseException {
+        List<String> values = new ArrayList<>();
+        for (JsonElement elem : json.getAsJsonArray()) {
+            if (elem.isJsonPrimitive()) {
+                values.add(elem.getAsString());
+            } else {
+                if (failOnUnknownProperties) {
+                    // unsupported value
+                    String message = "The value (" + elem + ") here are not yet supported. " + REPORT_THIS;
+                    throw new JsonParseException(message);
+                }
+            }
+        }
+        return values;
+    }
+
+    @Override
+    public JsonElement serialize(LogsResponse.DetailsChangedValue src, Type typeOfSrc, JsonSerializationContext context) {
+        if (src.getStringValues() != null) {
+            JsonArray array = new JsonArray();
+            for (String value : src.getStringValues()) {
+                array.add(value);
+            }
+            return array;
+        } else if (src.getNamedStringValues() != null) {
+            JsonObject json = new JsonObject();
+            for (Map.Entry<String, List<String>> each : src.getNamedStringValues().entrySet()) {
+                JsonArray array = new JsonArray();
+                for (String value : each.getValue()) {
+                    array.add(value);
+                }
+                json.add(each.getKey(), array);
+            }
+            return json;
+        } else {
+            log.warn("Unsupported field in LogsResponse.DetailsChangedValue is detected ({})", src);
+            return JsonNull.INSTANCE;
+        }
+    }
+}

--- a/slack-api-client/src/main/java/com/slack/api/util/json/GsonFactory.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/json/GsonFactory.java
@@ -4,6 +4,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.slack.api.SlackConfig;
+import com.slack.api.audit.response.LogsResponse;
 import com.slack.api.model.block.ContextBlockElement;
 import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.model.block.composition.TextObject;
@@ -28,6 +29,7 @@ public class GsonFactory {
                 .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory())
                 .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory())
                 .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory())
+                .registerTypeAdapter(LogsResponse.DetailsChangedValue.class, new GsonAuditLogsDetailsChangedValueFactory())
                 .create();
     }
 
@@ -35,14 +37,17 @@ public class GsonFactory {
      * Most of the Slack APIs' key naming is snake-cased.
      */
     public static Gson createSnakeCase(SlackConfig config) {
+        boolean failOnUnknownProps = config.isFailOnUnknownProperties();
         GsonBuilder gsonBuilder = new GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory(config.isFailOnUnknownProperties()))
-                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory(config.isFailOnUnknownProperties()))
-                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory(config.isFailOnUnknownProperties()))
-                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory(config.isFailOnUnknownProperties()))
-                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory(config.isFailOnUnknownProperties()));
-        if (config.isFailOnUnknownProperties() || config.isLibraryMaintainerMode()) {
+                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory(failOnUnknownProps))
+                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory(failOnUnknownProps))
+                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory(failOnUnknownProps))
+                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory(failOnUnknownProps))
+                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory(failOnUnknownProps))
+                .registerTypeAdapter(LogsResponse.DetailsChangedValue.class,
+                        new GsonAuditLogsDetailsChangedValueFactory(failOnUnknownProps));
+        if (failOnUnknownProps || config.isLibraryMaintainerMode()) {
             gsonBuilder = gsonBuilder.registerTypeAdapterFactory(new UnknownPropertyDetectionAdapterFactory());
         }
         if (config.isPrettyResponseLoggingEnabled()) {
@@ -55,13 +60,16 @@ public class GsonFactory {
      * Mainly used for SCIM APIs.
      */
     public static Gson createCamelCase(SlackConfig config) {
+        boolean failOnUnknownProps = config.isFailOnUnknownProperties();
         GsonBuilder gsonBuilder = new GsonBuilder()
-                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory(config.isFailOnUnknownProperties()))
-                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory(config.isFailOnUnknownProperties()))
-                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory(config.isFailOnUnknownProperties()))
-                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory(config.isFailOnUnknownProperties()))
-                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory(config.isFailOnUnknownProperties()));
-        if (config.isFailOnUnknownProperties() || config.isLibraryMaintainerMode()) {
+                .registerTypeAdapter(LayoutBlock.class, new GsonLayoutBlockFactory(failOnUnknownProps))
+                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory(failOnUnknownProps))
+                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory(failOnUnknownProps))
+                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory(failOnUnknownProps))
+                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory(failOnUnknownProps))
+                .registerTypeAdapter(LogsResponse.DetailsChangedValue.class,
+                        new GsonAuditLogsDetailsChangedValueFactory(failOnUnknownProps));
+        if (failOnUnknownProps || config.isLibraryMaintainerMode()) {
             gsonBuilder = gsonBuilder.registerTypeAdapterFactory(new UnknownPropertyDetectionAdapterFactory());
         }
         if (config.isPrettyResponseLoggingEnabled()) {

--- a/slack-api-client/src/test/java/config/SlackTestConfig.java
+++ b/slack-api-client/src/test/java/config/SlackTestConfig.java
@@ -48,6 +48,7 @@ public class SlackTestConfig {
     static {
         CONFIG.setLibraryMaintainerMode(true);
         CONFIG.setPrettyResponseLoggingEnabled(true);
+        CONFIG.setFailOnUnknownProperties(true);
         CONFIG.getHttpClientResponseHandlers().add(JSON_DATA_RECORDING_LISTENER);
     }
 

--- a/slack-api-client/src/test/java/test_locally/api/audit/FieldsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/audit/FieldsTest.java
@@ -20,7 +20,7 @@ public class FieldsTest {
     public void actions() throws Exception {
         String json = reader.readWholeAsString("/v1/actions.json");
         ActionsResponse obj = GsonFactory.createSnakeCase().fromJson(json, ActionsResponse.class);
-        verifyIfAllGettersReturnNonNull(obj);
+        verifyIfAllGettersReturnNonNull(obj, "getRawBody", "getWarning");
         verifyIfAllGettersReturnNonNullRecursively(obj.getActions());
     }
 
@@ -28,7 +28,7 @@ public class FieldsTest {
     public void logs() throws Exception {
         String json = reader.readWholeAsString("/v1/logs.json");
         LogsResponse obj = GsonFactory.createSnakeCase().fromJson(json, LogsResponse.class);
-        verifyIfAllGettersReturnNonNull(obj);
+        verifyIfAllGettersReturnNonNull(obj, "getRawBody", "getWarning");
         verifyIfAllGettersReturnNonNullRecursively(obj.getResponseMetadata(), "getMessages", "getWarnings");
         verifyIfAllGettersReturnNonNull(obj.getEntries().get(0), "getDetails");
         verifyIfAllGettersReturnNonNullRecursively(obj.getEntries().get(0).getActor());
@@ -46,7 +46,7 @@ public class FieldsTest {
     public void schemas() throws Exception {
         String json = reader.readWholeAsString("/v1/schemas.json");
         SchemasResponse obj = GsonFactory.createSnakeCase().fromJson(json, SchemasResponse.class);
-        verifyIfAllGettersReturnNonNull(obj);
+        verifyIfAllGettersReturnNonNull(obj, "getRawBody", "getWarning");
         verifyIfAllGettersReturnNonNullRecursively(obj.getSchemas().get(0));
     }
 }

--- a/slack-api-client/src/test/java/test_locally/api/util/json/GsonAuditLogsDetailsChangedValueFactoryTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/util/json/GsonAuditLogsDetailsChangedValueFactoryTest.java
@@ -1,0 +1,258 @@
+package test_locally.api.util.json;
+
+import com.google.gson.Gson;
+import com.slack.api.audit.response.LogsResponse;
+import com.slack.api.util.json.GsonFactory;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+public class GsonAuditLogsDetailsChangedValueFactoryTest {
+
+    String array_json = "{\n" +
+            "  \"entries\": [\n" +
+            "    {\n" +
+            "      \"id\": \"1df9d306-f268-49ae-8680-b0c6241f14f3\",\n" +
+            "      \"date_create\": 1595748462,\n" +
+            "      \"action\": \"pref.enterprise_default_channels\",\n" +
+            "      \"actor\": {\n" +
+            "        \"type\": \"user\",\n" +
+            "        \"user\": {\n" +
+            "          \"id\": \"W111\",\n" +
+            "          \"name\": \"Alice\",\n" +
+            "          \"email\": \"foo@example.com\",\n" +
+            "          \"team\": \"T111\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"entity\": {\n" +
+            "        \"type\": \"workspace\",\n" +
+            "        \"workspace\": {\n" +
+            "          \"id\": \"T222\",\n" +
+            "          \"name\": \"Test Workspace\",\n" +
+            "          \"domain\": \"ws-domain\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"context\": {\n" +
+            "        \"location\": {\n" +
+            "          \"type\": \"workspace\",\n" +
+            "          \"id\": \"T222\",\n" +
+            "          \"name\": \"Test Workspace\",\n" +
+            "          \"domain\": \"ws-domain\"\n" +
+            "        },\n" +
+            "        \"ua\": \"\",\n" +
+            "        \"ip_address\": \"127.0.0.1\"\n" +
+            "      },\n" +
+            "      \"details\": {\n" +
+            "        \"new_value\": [\n" +
+            "          \"C111\"\n" +
+            "        ]\n" +
+            "      }\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"id\": \"abb8bb0d-9c67-43ed-813d-9fd1fa86e198\",\n" +
+            "      \"date_create\": 1595748461,\n" +
+            "      \"action\": \"pref.enterprise_default_channels\",\n" +
+            "      \"actor\": {\n" +
+            "        \"type\": \"user\",\n" +
+            "        \"user\": {\n" +
+            "          \"id\": \"W111\",\n" +
+            "          \"name\": \"Alice\",\n" +
+            "          \"email\": \"foo@example.com\",\n" +
+            "          \"team\": \"T111\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"entity\": {\n" +
+            "        \"type\": \"enterprise\",\n" +
+            "        \"enterprise\": {\n" +
+            "          \"id\": \"E111\",\n" +
+            "          \"name\": \"Org Name\",\n" +
+            "          \"domain\": \"org-domain\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"context\": {\n" +
+            "        \"location\": {\n" +
+            "          \"type\": \"enterprise\",\n" +
+            "          \"id\": \"E111\",\n" +
+            "          \"name\": \"Org Name\",\n" +
+            "          \"domain\": \"org-domain\"\n" +
+            "        },\n" +
+            "        \"ua\": \"xxx\",\n" +
+            "        \"ip_address\": \"1.1.1.1\"\n" +
+            "      },\n" +
+            "      \"details\": {\n" +
+            "        \"new_value\": [\n" +
+            "          \"C111\"\n" +
+            "        ],\n" +
+            "        \"previous_value\": []\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"response_metadata\": {\n" +
+            "    \"next_cursor\": \"\"\n" +
+            "  }\n" +
+            "}";
+
+    String key_value_json = "{\n" +
+            "  \"entries\": [\n" +
+            "    {\n" +
+            "      \"id\": \"989a4b83-f447-4cf9-b64c-8baa3731418d\",\n" +
+            "      \"date_create\": 1595748397,\n" +
+            "      \"action\": \"pref.who_can_manage_ext_shared_channels\",\n" +
+            "      \"actor\": {\n" +
+            "        \"type\": \"user\",\n" +
+            "        \"user\": {\n" +
+            "          \"id\": \"W111\",\n" +
+            "          \"name\": \"Alice\",\n" +
+            "          \"email\": \"foo@example.com\",\n" +
+            "          \"team\": \"T111\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"entity\": {\n" +
+            "        \"type\": \"enterprise\",\n" +
+            "        \"enterprise\": {\n" +
+            "          \"id\": \"E111\",\n" +
+            "          \"name\": \"Org Name\",\n" +
+            "          \"domain\": \"org-domain\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"context\": {\n" +
+            "        \"location\": {\n" +
+            "          \"type\": \"enterprise\",\n" +
+            "          \"id\": \"E111\",\n" +
+            "          \"name\": \"Org Name\",\n" +
+            "          \"domain\": \"org-domain\"\n" +
+            "        },\n" +
+            "        \"ua\": \"xxx\",\n" +
+            "        \"ip_address\": \"1.1.1.1\"\n" +
+            "      },\n" +
+            "      \"details\": {\n" +
+            "        \"new_value\": {\n" +
+            "          \"type\": [\n" +
+            "            \"TOPLEVEL_ADMINS_AND_OWNERS_AND_SELECTED\"\n" +
+            "          ]\n" +
+            "        },\n" +
+            "        \"previous_value\": {\n" +
+            "          \"type\": [\n" +
+            "            \"ORG_ADMINS_AND_OWNERS\"\n" +
+            "          ]\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"id\": \"1b2c5e5e-1d1c-40fb-8f8f-31250574f131\",\n" +
+            "      \"date_create\": 1595748397,\n" +
+            "      \"action\": \"pref.who_can_manage_ext_shared_channels\",\n" +
+            "      \"actor\": {\n" +
+            "        \"type\": \"user\",\n" +
+            "        \"user\": {\n" +
+            "          \"id\": \"W111\",\n" +
+            "          \"name\": \"Alice\",\n" +
+            "          \"email\": \"foo@example.com\",\n" +
+            "          \"team\": \"T111\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"entity\": {\n" +
+            "        \"type\": \"enterprise\",\n" +
+            "        \"enterprise\": {\n" +
+            "          \"id\": \"E111\",\n" +
+            "          \"name\": \"Org Name\",\n" +
+            "          \"domain\": \"org-domain\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"context\": {\n" +
+            "        \"location\": {\n" +
+            "          \"type\": \"enterprise\",\n" +
+            "          \"id\": \"E111\",\n" +
+            "          \"name\": \"Org Name\",\n" +
+            "          \"domain\": \"org-domain\"\n" +
+            "        },\n" +
+            "        \"ua\": \"xxx\",\n" +
+            "        \"ip_address\": \"1.1.1.1\"\n" +
+            "      },\n" +
+            "      \"details\": {\n" +
+            "        \"new_value\": {\n" +
+            "          \"type\": [\n" +
+            "            \"TOPLEVEL_ADMINS_AND_OWNERS_AND_SELECTED\"\n" +
+            "          ]\n" +
+            "        },\n" +
+            "        \"previous_value\": {\n" +
+            "          \"type\": [\n" +
+            "            \"ORG_ADMINS_AND_OWNERS\"\n" +
+            "          ]\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"response_metadata\": {\n" +
+            "    \"next_cursor\": \"\"\n" +
+            "  }\n" +
+            "}";
+
+    @Test
+    public void deserialize_array() {
+        LogsResponse response = GsonFactory.createSnakeCase().fromJson(array_json, LogsResponse.class);
+        assertThat(response.getEntries().size(), is(2));
+        assertThat(response.getEntries().get(0).getDetails().getNewValue().toString(),
+                is("LogsResponse.DetailsChangedValue(" +
+                        "stringValues=[C111], " +
+                        "namedStringValues=null)"));
+    }
+
+    @Test
+    public void deserialize_object() {
+        LogsResponse response = GsonFactory.createSnakeCase().fromJson(key_value_json, LogsResponse.class);
+        assertThat(response.getEntries().size(), is(2));
+        assertThat(response.getEntries().get(0).getDetails().getNewValue().toString(),
+                is("LogsResponse.DetailsChangedValue(" +
+                        "stringValues=null, " +
+                        "namedStringValues={type=[TOPLEVEL_ADMINS_AND_OWNERS_AND_SELECTED]})"));
+    }
+
+    @Test
+    public void serialize_array() {
+        Gson gson = GsonFactory.createSnakeCase();
+        LogsResponse response = new LogsResponse();
+        response.setRawBody("raw");
+        LogsResponse.Entry entry = new LogsResponse.Entry();
+        LogsResponse.Details details = new LogsResponse.Details();
+        LogsResponse.DetailsChangedValue changedValue = new LogsResponse.DetailsChangedValue();
+        changedValue.setStringValues(Arrays.asList("C111", "C222"));
+        details.setNewValue(changedValue);
+        details.setPreviousValue(changedValue);
+        entry.setDetails(details);
+        List<LogsResponse.Entry> entries = Arrays.asList(entry);
+        response.setEntries(entries);
+        String json = gson.toJson(response);
+        assertThat(json, is("{\"ok\":false,\"entries\":[{\"details\":{" +
+                "\"new_value\":[\"C111\",\"C222\"]," +
+                "\"previous_value\":[\"C111\",\"C222\"]" +
+                "}}]}"));
+    }
+
+    @Test
+    public void serialize_object() {
+        Gson gson = GsonFactory.createSnakeCase();
+        LogsResponse response = new LogsResponse();
+        response.setRawBody("raw");
+        LogsResponse.Entry entry = new LogsResponse.Entry();
+        LogsResponse.Details details = new LogsResponse.Details();
+        LogsResponse.DetailsChangedValue changedValue = new LogsResponse.DetailsChangedValue();
+        Map<String, List<String>> namedValues = new HashMap<>();
+        namedValues.put("type", Arrays.asList("TOPLEVEL_ADMINS_AND_OWNERS_AND_SELECTED"));
+        changedValue.setNamedStringValues(namedValues);
+        details.setNewValue(changedValue);
+        details.setPreviousValue(changedValue);
+        entry.setDetails(details);
+        List<LogsResponse.Entry> entries = Arrays.asList(entry);
+        response.setEntries(entries);
+        String json = gson.toJson(response);
+        assertThat(json, is("{\"ok\":false,\"entries\":[{\"details\":{" +
+                "\"new_value\":{\"type\":[\"TOPLEVEL_ADMINS_AND_OWNERS_AND_SELECTED\"]}," +
+                "\"previous_value\":{\"type\":[\"TOPLEVEL_ADMINS_AND_OWNERS_AND_SELECTED\"]}" +
+                "}}]}"));
+    }
+
+}

--- a/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
@@ -243,4 +243,26 @@ public class ApiTest {
         }
     }
 
+    @Test
+    public void attachBody() throws Exception {
+        if (orgAdminUserToken != null) {
+            // false (default)
+            LogsResponse response = slack.audit(orgAdminUserToken).getLogs(req -> req
+                    .limit(1)
+                    .action(Actions.User.user_login)
+            );
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.getEntries().size(), is(not(0)));
+            assertThat(response.getRawBody(), is(nullValue())); // null
+            // true
+            response = slack.audit(orgAdminUserToken).attachRawBody(true).getLogs(req -> req
+                    .limit(1)
+                    .action(Actions.User.user_login)
+            );
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.getEntries().size(), is(not(0)));
+            assertThat(response.getRawBody(), is(notNullValue())); // non-null
+        }
+    }
+
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
@@ -13,11 +13,13 @@ import org.junit.AfterClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
@@ -179,6 +181,65 @@ public class ApiTest {
             );
             assertThat(cursor, not(equalTo(response.getResponseMetadata().getNextCursor())));
             assertThat(response, is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getLogs_all_actions() throws Exception {
+        if (orgAdminUserToken != null) {
+            verifyAllActions(orgAdminUserToken, Actions.WorkspaceOrOrg.class);
+            verifyAllActions(orgAdminUserToken, Actions.User.class);
+            verifyAllActions(orgAdminUserToken, Actions.File.class);
+            verifyAllActions(orgAdminUserToken, Actions.Channel.class);
+            verifyAllActions(orgAdminUserToken, Actions.App.class);
+        }
+    }
+
+    static void verifyAllActions(String token, Class<?> clazz) throws Exception {
+        List<Field> fields = Arrays.stream(clazz.getDeclaredFields())
+                .filter(f -> Modifier.isStatic(f.getModifiers()) && Modifier.isPublic(f.getModifiers()))
+                .collect(toList());
+        for (Field f : fields) {
+            String action = String.valueOf(f.get(clazz));
+            try {
+                LogsResponse response = slack.audit(token).getLogs(req -> req.limit(500).action(action));
+                assertThat(response.getError(), is(nullValue()));
+            } catch (AuditApiException e) {
+                if (e.getResponse().code() == 400) {
+                    log.info("{} seems to be no longer supported", action);
+                }
+            }
+            Thread.sleep(30); // To avoid rate limiting errors
+        }
+    }
+
+    @Test
+    public void getLogs_issue_525()
+            throws IOException, AuditApiException {
+        if (orgAdminUserToken != null) {
+            LogsResponse response = slack.audit(orgAdminUserToken).getLogs(req -> req
+                    .limit(10)
+                    .action(Actions.WorkspaceOrOrg.pref_enterprise_default_channels));
+
+            assertThat(response.getEntries().size(), is(not(0)));
+
+            for (LogsResponse.Entry entry : response.getEntries()) {
+                assertThat(entry.getDetails().getNewValue(), is(notNullValue()));
+                assertThat(entry.getDetails().getNewValue().getStringValues(), is(notNullValue()));
+                assertThat(entry.getDetails().getNewValue().getNamedStringValues(), is(nullValue()));
+            }
+
+            response = slack.audit(orgAdminUserToken).getLogs(req -> req
+                    .limit(10)
+                    .action(Actions.WorkspaceOrOrg.pref_who_can_manage_ext_shared_channels));
+
+            assertThat(response.getEntries().size(), is(not(0)));
+
+            for (LogsResponse.Entry entry : response.getEntries()) {
+                assertThat(entry.getDetails().getNewValue(), is(notNullValue()));
+                assertThat(entry.getDetails().getNewValue().getStringValues(), is(nullValue()));
+                assertThat(entry.getDetails().getNewValue().getNamedStringValues(), is(notNullValue()));
+            }
         }
     }
 


### PR DESCRIPTION
###  Summary

This pull request fixes #525 (a bug on the Audit Logs API client) by correcting the structure of `entry.details`. Also, this pull request applies the following fixes and improvements.

* Add a few other missing fields in entries
* Add `rawBody` field (disabled by default) for workarounds (in the case some fields are still missing)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
