### PR TITLE
Fix #527 by adding header block support

### DIFF
--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/BlockKit_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/BlockKit_Test.java
@@ -112,7 +112,7 @@ public class BlockKit_Test {
 
             assertThat(postResponse.getError(), is(nullValue()));
             assertThat(postResponse.isOk(), is(true));
-            assertThat(postResponse.getMessage().getBlocks().size(), is(7));
+            assertThat(postResponse.getMessage().getBlocks().size(), is(8));
         }
 
         // message modification

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/BlockKit_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/BlockKit_Test.java
@@ -204,6 +204,7 @@ public class BlockKit_Test {
 
     private List<LayoutBlock> exampleBlocks() {
         return asBlocks(
+                header(h -> h.blockId("header").text(plainText("This is a test!"))),
                 section(s -> s.text(markdownText("Hello, Assistant to the Regional Manager Dwight! *Michael Scott* wants to know where you'd like to take the Paper Company investors to dinner tonight.\n\n*Please select a restaurant:*"))),
                 divider(),
                 section(s -> s.text(markdownText("*Farmhouse Thai Cuisine*\n:star::star::star::star: 1528 reviews\n They do have some vegan options, like the roti and curry, plus they have a ton of salad stuff and noodles can be ordered without meat!! They have something for everyone here"))

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/HeaderBlockBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/HeaderBlockBuilder.kt
@@ -1,0 +1,25 @@
+package com.slack.api.model.kotlin_extension.block
+
+import com.slack.api.model.block.HeaderBlock
+import com.slack.api.model.block.composition.PlainTextObject
+
+@BlockLayoutBuilder
+class HeaderBlockBuilder : Builder<HeaderBlock> {
+    private var blockId: String? = null
+    private var _text: PlainTextObject? = null
+
+    fun blockId(id: String) {
+        blockId = id
+    }
+
+    fun text(text: String, emoji: Boolean? = null) {
+        _text = PlainTextObject(text, emoji)
+    }
+
+    override fun build(): HeaderBlock {
+        return HeaderBlock.builder()
+                .blockId(blockId)
+                .text(_text)
+                .build()
+    }
+}

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/container/MultiLayoutBlockContainer.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/container/MultiLayoutBlockContainer.kt
@@ -16,6 +16,10 @@ class MultiLayoutBlockContainer : LayoutBlockDsl {
         underlying += SectionBlockBuilder().apply(builder).build()
     }
 
+    override fun header(builder: HeaderBlockBuilder.() -> Unit) {
+        underlying += HeaderBlockBuilder().apply(builder).build()
+    }
+
     override fun divider(blockId: String?) {
         underlying += DividerBlock(blockId)
     }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/dsl/LayoutBlockDsl.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/dsl/LayoutBlockDsl.kt
@@ -14,6 +14,14 @@ interface LayoutBlockDsl {
     fun section(builder: SectionBlockBuilder.() -> Unit)
 
     /**
+     * A header is a plain-text block that displays in a larger, bold font.
+     * Use it to delineate between different groups of content in your app's surfaces.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/blocks#header">Header documentation</a>
+     */
+    fun header(builder: HeaderBlockBuilder.() -> Unit)
+
+    /**
      * A content divider, like an <hr>, to split up different blocks inside of a message. The divider block is nice
      * and neat, requiring only a type.
      *

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/BasicUsageTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/BasicUsageTest.kt
@@ -21,6 +21,10 @@ class BasicUsageTest {
                 .channel("general")
                 .text("User did a thing!")
                 .blocks(withBlocks {
+                    header {
+                        blockId("header")
+                        text("This is the headline!", emoji = true)
+                    }
                     section {
                         plainText("This is the text in this section")
                     }
@@ -57,6 +61,9 @@ class BasicUsageTest {
                 .channel("general")
                 .text("User did a thing!")
                 .blocks(asBlocks(
+                        header { h ->
+                            h.blockId("header").text(plainText("This is the headline!", true))
+                        },
                         section { thisSection ->
                             thisSection.text(plainText("This is the text in this section"))
                         },

--- a/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
@@ -57,6 +57,12 @@ public class Blocks {
         return DividerBlock.builder().build();
     }
 
+    // HeaderBlock
+
+    public static HeaderBlock header(ModelConfigurator<HeaderBlock.HeaderBlockBuilder> configurator) {
+        return configurator.configure(HeaderBlock.builder()).build();
+    }
+
     // CallBlock
 
     public static CallBlock call(ModelConfigurator<CallBlock.CallBlockBuilder> configurator) {

--- a/slack-api-model/src/main/java/com/slack/api/model/block/HeaderBlock.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/HeaderBlock.java
@@ -1,0 +1,34 @@
+package com.slack.api.model.block;
+
+import com.slack.api.model.block.composition.PlainTextObject;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://api.slack.com/reference/messaging/blocks#header
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HeaderBlock implements LayoutBlock {
+    public static final String TYPE = "header";
+    private final String type = TYPE;
+
+    /**
+     * A string acting as a unique identifier for a block. If not specified, one will be generated.
+     * Maximum length for this field is 255 characters.
+     * block_id should be unique for each message and each iteration of a message.
+     * If a message is updated, use a new block_id.
+     */
+    private String blockId;
+
+    /**
+     * The text for the block, in the form of a plain_text text object.
+     * Maximum length for the text in this field is 3000 characters.
+     */
+    private PlainTextObject text;
+
+}

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
@@ -49,6 +49,8 @@ public class GsonLayoutBlockFactory implements JsonDeserializer<LayoutBlock>, Js
                 return FileBlock.class;
             case InputBlock.TYPE:
                 return InputBlock.class;
+            case HeaderBlock.TYPE:
+                return HeaderBlock.class;
             case RichTextBlock.TYPE:
                 return RichTextBlock.class;
             default:

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -2,6 +2,7 @@ package test_locally.api.model.block;
 
 import com.google.gson.JsonParseException;
 import com.slack.api.model.Message;
+import com.slack.api.model.block.HeaderBlock;
 import com.slack.api.model.block.InputBlock;
 import com.slack.api.model.block.RichTextBlock;
 import com.slack.api.model.block.SectionBlock;
@@ -965,4 +966,24 @@ public class BlockKitTest {
         assertThat(obj.getStyle(), is("primary"));
     }
 
+    @Test
+    public void parseHeader() {
+        String json = "{\n" +
+                "  \"blocks\": [{\n" +
+                "    \"type\": \"header\",\n" +
+                "    \"block_id\": \"b\",\n" +
+                "    \"text\": {\n" +
+                "      \"type\": \"plain_text\",\n" +
+                "      \"text\": \"Budget Performance\"\n" +
+                "    }\n" +
+                "  }]\n" +
+                "}";
+        Message message = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+        assertThat(message, is(notNullValue()));
+
+        HeaderBlock header = (HeaderBlock) message.getBlocks().get(0);
+        assertThat(header.getBlockId(), is("b"));
+        assertThat(header.getText().getType(), is("plain_text"));
+        assertThat(header.getText().getText(), is("Budget Performance"));
+    }
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -79,6 +79,11 @@ public class BlocksTest {
     }
 
     @Test
+    public void testHeader() {
+        assertThat(header(h -> h.blockId("block-id").text(plainText("This is the headline!"))), is(notNullValue()));
+    }
+
+    @Test
     public void testRichText() {
         assertThat(richText(i -> i
                 .blockId("block-id")


### PR DESCRIPTION
###  Summary

This pull request fixes #527 by adding "header" block support to slack-api-model & slack-api-model-kotlin-extension.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
