### PR TITLE
Bump patch versions of dependencies (okhttp, micronaut)

### DIFF
--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,8 @@
     </parent>
 
     <properties>
-        <micronaut.version>2.0.0</micronaut.version>
+        <micronaut.bom.version>2.0.0</micronaut.bom.version>
+        <micronaut.version>2.0.1</micronaut.version>
         <micronaut-test-junit5.version>1.2.0</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>
@@ -25,7 +26,7 @@
             <dependency>
                 <groupId>io.micronaut</groupId>
                 <artifactId>micronaut-bom</artifactId>
-                <version>${micronaut.version}</version>
+                <version>${micronaut.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.3.1.RELEASE</spring-boot.version>
+        <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,7 +8,7 @@ url: https://slack.dev
 
 sdkLatestVersion: 1.1.2
 kotlinVersion: 1.3.72
-springBootVersion: 2.3.1.RELEASE
+springBootVersion: 2.3.2.RELEASE
 compatibleMicronautVersion: 2.x
 quarkusVersion: 1.6.0.Final
 helidonVersion: 1.4.5

--- a/json-logs/raw/status/api/v1.0.0/current.json
+++ b/json-logs/raw/status/api/v1.0.0/current.json
@@ -249,6 +249,10 @@
     {
       "date_created": "2020-07-24T10:45:08-07:00",
       "body": "We\u0027re currently aware of some intermittent latency and timeouts with image attachments, certain API methods (including users.setPhoto, chat.postMessage and chat.update, views.*), and apps which use these features. We are currently investigating and will update when we believe these issues have been resolved. Sorry for the inconvenience."
+    },
+    {
+      "date_created": "2020-08-06T14:52:25-07:00",
+      "body": "Some users and app developers are currently seeing \"Request failed with status code 400\" errors when apps submit requests.  We are looking into this and will post when we have more information."
     }
   ]
 }

--- a/json-logs/raw/status/api/v2.0.0/current.json
+++ b/json-logs/raw/status/api/v2.0.0/current.json
@@ -365,6 +365,24 @@
           "body": "We\u0027re currently aware of some intermittent latency and timeouts with image attachments, certain API methods (including users.setPhoto, chat.postMessage and chat.update, views.*), and apps which use these features. We are currently investigating and will update when we believe these issues have been resolved. Sorry for the inconvenience."
         }
       ]
+    },
+    {
+      "id": 882,
+      "date_created": "2020-08-06T14:52:25-07:00",
+      "date_updated": "2020-08-06T14:52:25-07:00",
+      "title": "We\u0027re looking into an issue with API requests",
+      "type": "incident",
+      "status": "active",
+      "url": "https://status.slack.com/2020-08/025d277cbb15bb95",
+      "services": [
+        "Apps/Integrations/APIs"
+      ],
+      "notes": [
+        {
+          "date_created": "2020-08-06T14:52:25-07:00",
+          "body": "Some users and app developers are currently seeing \"Request failed with status code 400\" errors when apps submit requests.  We are looking into this and will post when we have more information."
+        }
+      ]
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,18 +38,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <okhttp.version>4.8.0</okhttp.version>
+        <okhttp.version>4.8.1</okhttp.version>
         <gson.version>2.8.6</gson.version>
         <lombok.version>1.18.12</lombok.version>
         <lombok-maven-plugin.version>1.18.10.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
         <kotlin.version>1.3.72</kotlin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.820</aws.s3.version>
+        <aws.s3.version>1.11.836</aws.s3.version>
         <junit.version>4.13</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.4.0</mockito-core.version>
+        <mockito-core.version>3.4.6</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>


### PR DESCRIPTION
###  Summary

* OKHTTP 4.8.0 -> 4.8.1 https://github.com/square/okhttp/compare/parent-4.8.0...parent-4.8.1
* Micronaut 2.0.0 -> 2.0.1
* AWS S3 SDK 1.11.820 -> 1.11.836

You can check the latest versions by `mvn versions:display-dependency-updates`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
