### PR TITLE
Fix #538 by adding api_app_id to SlashCommandPayload

### DIFF
--- a/json-logs/samples/app-backend/slash-commands/SlashCommandPayload.json
+++ b/json-logs/samples/app-backend/slash-commands/SlashCommandPayload.json
@@ -1,5 +1,6 @@
 {
   "token": "",
+  "api_app_id": "",
   "team_id": "",
   "team_domain": "",
   "enterprise_id": "",

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/slash_commands/SlashCommandPayloadParser.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/slash_commands/SlashCommandPayloadParser.java
@@ -37,6 +37,9 @@ public class SlashCommandPayloadParser {
                         case "enterprise_name":
                             payload.setEnterpriseName(value);
                             break;
+                        case "api_app_id":
+                            payload.setApiAppId(value);
+                            break;
                         case "channel_id":
                             payload.setChannelId(value);
                             break;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/slash_commands/payload/SlashCommandPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/slash_commands/payload/SlashCommandPayload.java
@@ -5,6 +5,7 @@ import lombok.Data;
 @Data
 public class SlashCommandPayload {
     private String token;
+    private String apiAppId;
     private String teamId;
     private String teamDomain;
     private String enterpriseId;

--- a/slack-app-backend/src/test/java/test_locally/app_backend/slash_commands/SlashCommandPayloadTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/slash_commands/SlashCommandPayloadTest.java
@@ -6,6 +6,7 @@ import com.slack.api.app_backend.slash_commands.payload.SlashCommandPayload;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -13,7 +14,8 @@ public class SlashCommandPayloadTest {
 
     SlashCommandPayloadParser parser = new SlashCommandPayloadParser();
 
-    String body = "token=gIkuvaNzQIHg97ATvDxqgjtO" +
+    // https://api.slack.com/interactivity/slash-commands#app_command_handling
+    String body1 = "token=gIkuvaNzQIHg97ATvDxqgjtO" +
             "&team_id=T0001" +
             "&team_domain=example" +
             "&enterprise_id=E0001" +
@@ -25,17 +27,35 @@ public class SlashCommandPayloadTest {
             "&command=/weather" +
             "&text=94070" +
             "&response_url=https://hooks.slack.com/commands/1234/5678" +
-            "&trigger_id=13345224609.738474920.8088930838d88f008e0";
+            "&trigger_id=13345224609.738474920.8088930838d88f008e0" +
+            "&api_app_id=A123456";
+
+    // (modified) real payload
+    String body2 = "token=xxx&" +
+            "team_id=T111&" +
+            "team_domain=test-workspace&" +
+            "channel_id=C111&" +
+            "channel_name=general&" +
+            "user_id=W111&" +
+            "user_name=primary-owner&" +
+            "command=%2Fhello&" +
+            "text=&" +
+            "api_app_id=A111&" +
+            "enterprise_id=E111&" +
+            "enterprise_name=Sandbox+Org&" +
+            "response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxx&" +
+            "trigger_id=111.222.xxx";
 
     @Test
-    public void parse() {
-        SlashCommandPayload payload = parser.parse(body);
+    public void parse_1() {
+        SlashCommandPayload payload = parser.parse(body1);
 
         assertThat(payload.getToken(), is("gIkuvaNzQIHg97ATvDxqgjtO"));
         assertThat(payload.getTeamId(), is("T0001"));
         assertThat(payload.getTeamDomain(), is("example"));
         assertThat(payload.getEnterpriseId(), is("E0001"));
         assertThat(payload.getEnterpriseName(), is("Globular Construct Inc"));
+        assertThat(payload.getApiAppId(), is("A123456"));
         assertThat(payload.getChannelId(), is("C2147483705"));
         assertThat(payload.getChannelName(), is("test"));
         assertThat(payload.getUserId(), is("U2147483697"));
@@ -47,8 +67,28 @@ public class SlashCommandPayloadTest {
     }
 
     @Test
+    public void parse_2() {
+        SlashCommandPayload payload = parser.parse(body2);
+
+        assertThat(payload.getToken(), is("xxx"));
+        assertThat(payload.getTeamId(), is("T111"));
+        assertThat(payload.getTeamDomain(), is("test-workspace"));
+        assertThat(payload.getEnterpriseId(), is("E111"));
+        assertThat(payload.getEnterpriseName(), is("Sandbox Org"));
+        assertThat(payload.getApiAppId(), is("A111"));
+        assertThat(payload.getChannelId(), is("C111"));
+        assertThat(payload.getChannelName(), is("general"));
+        assertThat(payload.getUserId(), is("W111"));
+        assertThat(payload.getUserName(), is("primary-owner"));
+        assertThat(payload.getCommand(), is("/hello"));
+        assertThat(payload.getText(), is(nullValue()));
+        assertThat(payload.getResponseUrl(), is("https://hooks.slack.com/commands/T111/111/xxx"));
+        assertThat(payload.getTriggerId(), is("111.222.xxx"));
+    }
+
+    @Test
     public void detect() {
         SlashCommandPayloadDetector detector = new SlashCommandPayloadDetector();
-        assertTrue(detector.isCommand(body));
+        assertTrue(detector.isCommand(body1));
     }
 }


### PR DESCRIPTION
###  Summary

This pull request fixes #538 by adding `api_app_id` to the slash command payload data class. 

As the Bolt framework's request objects just hold the instance, we don't need to apply any changes to the Bolt library side.
https://github.com/slackapi/java-slack-sdk/blob/v1.1.3/bolt/src/main/java/com/slack/api/bolt/request/builtin/SlashCommandRequest.java#L20

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
