### PR TITLE
FIX: typo in ChatUnfurlRequest docs

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
@@ -34,7 +34,7 @@ public class ChatUnfurlRequest implements SlackApiRequest {
     private boolean userAuthRequired;
 
     /**
-     * URL-encoded JSON map with keys set to URLs featured in the the message, pointing to their unfurl message attachments.
+     * URL-encoded JSON map with keys set to URLs featured in the message, pointing to their unfurl message attachments.
      */
     private String rawUnfurls;
 


### PR DESCRIPTION
###  Summary

Fixes a super critical typo 🙂 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/java-slack-sdk/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
