### PR TITLE
version 1.1.4 release

### DIFF
--- a/bolt-aws-lambda/pom.xml
+++ b/bolt-aws-lambda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-aws-lambda</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-docker-examples/echo-command-app/build.gradle
+++ b/bolt-docker-examples/echo-command-app/build.gradle
@@ -10,7 +10,7 @@ repositories {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("com.slack.api:bolt-jetty:1.1.3")
+    implementation("com.slack.api:bolt-jetty:1.1.4")
     implementation("ch.qos.logback:logback-classic:1.2.3")
     implementation('net.logstash.logback:logstash-logback-encoder:6.2')
 }

--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <properties>
@@ -16,7 +16,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-helidon</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-jetty/pom.xml
+++ b/bolt-jetty/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-jetty</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-kotlin-examples/pom.xml
+++ b/bolt-kotlin-examples/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-kotlin-examples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <properties>
@@ -19,7 +19,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-micronaut</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <dependencyManagement>

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <properties>
@@ -22,7 +22,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-quarkus-examples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-servlet/pom.xml
+++ b/bolt-servlet/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-servlet</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <properties>
@@ -15,7 +15,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt-spring-boot-examples</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt/pom.xml
+++ b/bolt/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>bolt</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt/src/main/java/com/slack/api/bolt/meta/BoltLibraryVersion.java
+++ b/bolt/src/main/java/com/slack/api/bolt/meta/BoltLibraryVersion.java
@@ -5,7 +5,7 @@ public final class BoltLibraryVersion {
     }
 
     public static final String get() {
-        return "1.1.4-SNAPSHOT";
+        return "1.1.4";
     }
 }
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,7 +6,7 @@ markdown: kramdown
 baseurl: /java-slack-sdk
 url: https://slack.dev
 
-sdkLatestVersion: 1.1.3
+sdkLatestVersion: 1.1.4
 okhttpVersion: 4.8.1
 kotlinVersion: 1.3.72
 springBootVersion: 2.3.3.RELEASE

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-sdk-parent</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>pom</packaging>
 
     <name>Java Slack SDK Project</name>

--- a/slack-api-client-kotlin-extension/pom.xml
+++ b/slack-api-client-kotlin-extension/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-api-client-kotlin-extension</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-api-client</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/slack-api-client/src/main/java/com/slack/api/meta/SlackApiClientLibraryVersion.java
+++ b/slack-api-client/src/main/java/com/slack/api/meta/SlackApiClientLibraryVersion.java
@@ -5,7 +5,7 @@ public final class SlackApiClientLibraryVersion {
     }
 
     public static final String get() {
-        return "1.1.4-SNAPSHOT";
+        return "1.1.4";
     }
 }
 

--- a/slack-api-model-kotlin-extension/pom.xml
+++ b/slack-api-model-kotlin-extension/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-api-model-kotlin-extension</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/slack-api-model/pom.xml
+++ b/slack-api-model/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-api-model</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
     
     <dependencies>

--- a/slack-api-model/src/main/java/com/slack/api/meta/SlackApiModelLibraryVersion.java
+++ b/slack-api-model/src/main/java/com/slack/api/meta/SlackApiModelLibraryVersion.java
@@ -5,7 +5,7 @@ public final class SlackApiModelLibraryVersion {
     }
 
     public static final String get() {
-        return "1.1.4-SNAPSHOT";
+        return "1.1.4";
     }
 }
 

--- a/slack-app-backend/pom.xml
+++ b/slack-app-backend/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.1.4-SNAPSHOT</version>
+        <version>1.1.4</version>
     </parent>
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-app-backend</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <dependencies>


### PR DESCRIPTION
We are going to release v1.1.4 within a few days. The operations I did for this are:

```bash
git checkout -b v1.1.4-release
./scripts/set_version.sh 1.1.4
git add . -v
git commit -m'version 1.1.4'
git push seratch v1.1.4-release
```

I will do a releases in these steps tomorrow: https://github.com/slackapi/java-slack-sdk/blob/main/.github/maintainers_guide.md#releasing

# Changelog

The following is the release note for this patch release.

## Changes

* [slack-api-client] #554 #553 Add new admin.conversations.* APIs - Thanks @seratch
* [slack-app-backend] #539 Fix #538 by adding api_app_id to SlashCommandPayload - Thanks @seratch
* [slack-api-client] #540 Fix a typo in ChatUnfurlRequest docs - Thanks @markrmullan
* [slack-api-client] Update data classes/constants for Web APIs and Audit Logs API - Thanks @seratch
* [slack-api-client] #556 Add original_connected_channel_id to entry.channel in Audit Logs response - Thanks @seratch

---
* All issues/pull requests: https://github.com/slackapi/java-slack-sdk/milestone/11?closed=1
* All changes: https://github.com/slackapi/java-slack-sdk/compare/v1.1.3...v1.1.4

(I'm going to cut off `v1.1.4` tag. The diff is https://github.com/slackapi/java-slack-sdk/compare/v1.1.3...main )

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.
