### PR TITLE
Add original_connected_channel_id to entry.channel in Audit Logs response

### DIFF
--- a/json-logs/raw/status/api/v1.0.0/current.json
+++ b/json-logs/raw/status/api/v1.0.0/current.json
@@ -265,6 +265,10 @@
     {
       "date_created": "2020-08-20T10:50:22-07:00",
       "body": "We\u0027ve received some reports of folks being suddenly signed out of Slack on desktop, and we\u0027re investigating this issue further. We apologize for any disruption this may have caused and will let you know once we have more details."
+    },
+    {
+      "date_created": "2020-09-09T14:23:48-07:00",
+      "body": "Some users are unable to sign in to Slack using Google SSO. This issue appears to be isolated to desktop at this time. We\u0027re working to get things back to normal as quickly as possible, and we apologize for the disruption."
     }
   ]
 }

--- a/json-logs/raw/status/api/v2.0.0/current.json
+++ b/json-logs/raw/status/api/v2.0.0/current.json
@@ -423,6 +423,24 @@
           "body": "We\u0027ve received some reports of folks being suddenly signed out of Slack on desktop, and we\u0027re investigating this issue further. We apologize for any disruption this may have caused and will let you know once we have more details."
         }
       ]
+    },
+    {
+      "id": 893,
+      "date_created": "2020-09-09T14:23:48-07:00",
+      "date_updated": "2020-09-09T14:23:48-07:00",
+      "title": "Trouble signing in to Slack using Google SSO",
+      "type": "incident",
+      "status": "active",
+      "url": "https://status.slack.com/2020-09/03fcf2c4b34371ef",
+      "services": [
+        "Login/SSO"
+      ],
+      "notes": [
+        {
+          "date_created": "2020-09-09T14:23:48-07:00",
+          "body": "Some users are unable to sign in to Slack using Google SSO. This issue appears to be isolated to desktop at this time. We\u0027re working to get things back to normal as quickly as possible, and we apologize for the disruption."
+        }
+      ]
     }
   ]
 }

--- a/json-logs/samples/api/search.all.json
+++ b/json-logs/samples/api/search.all.json
@@ -62,7 +62,115 @@
           "ts": "0000000000.000000",
           "text": "",
           "iid": "",
-          "permalink": "https://www.example.com/"
+          "permalink": "https://www.example.com/",
+          "attachments": [
+            {
+              "service_name": "",
+              "title": "",
+              "title_link": "https://www.example.com/",
+              "text": "",
+              "fallback": "",
+              "image_url": "https://www.example.com/",
+              "ts": 12345,
+              "from_url": "https://www.example.com/",
+              "image_width": 12345,
+              "image_height": 12345,
+              "image_bytes": 12345,
+              "service_icon": "https://www.example.com/",
+              "id": 12345,
+              "original_url": "https://www.example.com/",
+              "msg_subtype": "",
+              "callback_id": "",
+              "color": "",
+              "pretext": "",
+              "service_url": "",
+              "author_id": "",
+              "author_name": "",
+              "author_link": "",
+              "author_icon": "",
+              "author_subname": "",
+              "channel_id": "",
+              "channel_name": "",
+              "bot_id": "",
+              "indent": false,
+              "is_msg_unfurl": false,
+              "is_reply_unfurl": false,
+              "is_thread_root_unfurl": false,
+              "is_app_unfurl": false,
+              "app_unfurl_url": "",
+              "fields": [
+                {
+                  "title": "",
+                  "value": "",
+                  "short": false
+                }
+              ],
+              "thumb_url": "",
+              "thumb_width": 12345,
+              "thumb_height": 12345,
+              "video_html": "",
+              "video_html_width": 12345,
+              "video_html_height": 12345,
+              "footer": "",
+              "footer_icon": "",
+              "mrkdwn_in": [
+                ""
+              ],
+              "actions": [
+                {
+                  "id": "",
+                  "name": "",
+                  "text": "",
+                  "style": "",
+                  "type": "",
+                  "value": "",
+                  "confirm": {
+                    "title": "",
+                    "text": "",
+                    "ok_text": "",
+                    "dismiss_text": ""
+                  },
+                  "options": [
+                    {
+                      "text": "",
+                      "value": ""
+                    }
+                  ],
+                  "selected_options": [
+                    {
+                      "text": "",
+                      "value": ""
+                    }
+                  ],
+                  "data_source": "",
+                  "min_query_length": 12345,
+                  "option_groups": [
+                    {
+                      "text": ""
+                    }
+                  ],
+                  "url": ""
+                }
+              ],
+              "filename": "",
+              "size": 12345,
+              "mimetype": "",
+              "url": "",
+              "metadata": {
+                "thumb_64": false,
+                "thumb_80": false,
+                "thumb_160": false,
+                "original_w": 12345,
+                "original_h": 12345,
+                "thumb_360_w": 12345,
+                "thumb_360_h": 12345,
+                "format": "",
+                "extension": "",
+                "rotation": 12345,
+                "thumb_tiny": ""
+              }
+            }
+          ]
         },
         "blocks": [
           {

--- a/json-logs/samples/api/search.messages.json
+++ b/json-logs/samples/api/search.messages.json
@@ -61,7 +61,115 @@
           "ts": "0000000000.000000",
           "text": "",
           "iid": "",
-          "permalink": "https://www.example.com/"
+          "permalink": "https://www.example.com/",
+          "attachments": [
+            {
+              "service_name": "",
+              "title": "",
+              "title_link": "https://www.example.com/",
+              "text": "",
+              "fallback": "",
+              "image_url": "https://www.example.com/",
+              "ts": 12345,
+              "from_url": "https://www.example.com/",
+              "image_width": 12345,
+              "image_height": 12345,
+              "image_bytes": 12345,
+              "service_icon": "https://www.example.com/",
+              "id": 12345,
+              "original_url": "https://www.example.com/",
+              "msg_subtype": "",
+              "callback_id": "",
+              "color": "",
+              "pretext": "",
+              "service_url": "",
+              "author_id": "",
+              "author_name": "",
+              "author_link": "",
+              "author_icon": "",
+              "author_subname": "",
+              "channel_id": "",
+              "channel_name": "",
+              "bot_id": "",
+              "indent": false,
+              "is_msg_unfurl": false,
+              "is_reply_unfurl": false,
+              "is_thread_root_unfurl": false,
+              "is_app_unfurl": false,
+              "app_unfurl_url": "",
+              "fields": [
+                {
+                  "title": "",
+                  "value": "",
+                  "short": false
+                }
+              ],
+              "thumb_url": "",
+              "thumb_width": 12345,
+              "thumb_height": 12345,
+              "video_html": "",
+              "video_html_width": 12345,
+              "video_html_height": 12345,
+              "footer": "",
+              "footer_icon": "",
+              "mrkdwn_in": [
+                ""
+              ],
+              "actions": [
+                {
+                  "id": "",
+                  "name": "",
+                  "text": "",
+                  "style": "",
+                  "type": "",
+                  "value": "",
+                  "confirm": {
+                    "title": "",
+                    "text": "",
+                    "ok_text": "",
+                    "dismiss_text": ""
+                  },
+                  "options": [
+                    {
+                      "text": "",
+                      "value": ""
+                    }
+                  ],
+                  "selected_options": [
+                    {
+                      "text": "",
+                      "value": ""
+                    }
+                  ],
+                  "data_source": "",
+                  "min_query_length": 12345,
+                  "option_groups": [
+                    {
+                      "text": ""
+                    }
+                  ],
+                  "url": ""
+                }
+              ],
+              "filename": "",
+              "size": 12345,
+              "mimetype": "",
+              "url": "",
+              "metadata": {
+                "thumb_64": false,
+                "thumb_80": false,
+                "thumb_160": false,
+                "original_w": 12345,
+                "original_h": 12345,
+                "thumb_360_w": 12345,
+                "thumb_360_h": 12345,
+                "format": "",
+                "extension": "",
+                "rotation": 12345,
+                "thumb_tiny": ""
+              }
+            }
+          ]
         },
         "blocks": [
           {

--- a/json-logs/samples/audit/v1/logs.json
+++ b/json-logs/samples/audit/v1/logs.json
@@ -40,7 +40,8 @@
           "teams_shared_with": [
             "T00000000",
             ""
-          ]
+          ],
+          "original_connected_channel_id": "G00000000"
         },
         "file": {
           "id": "F00000000",

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
@@ -113,6 +113,7 @@ public class LogsResponse implements AuditApiResponse {
         @SerializedName("is_org_shared")
         private Boolean orgShared;
         private List<String> teamsSharedWith;
+        private String originalConnectedChannelId;
     }
 
     @Data


### PR DESCRIPTION
An integration test detected a new field in Audit Logs API response.
https://github.com/slackapi/java-slack-sdk/blob/v1.1.3/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java#L193

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.
