### PR TITLE
Bump dependencies in v1.2

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,8 +10,10 @@
     </parent>
 
     <properties>
-        <!--- TODO: upgrade to helidon 2.0 -->
-        <helidon.version>1.4.5</helidon.version>
+        <helidon.version>2.0.2</helidon.version>
+        <!-- Helidon 2.0 requires Java 11+ -->
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <groupId>com.slack.api</groupId>
@@ -71,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics2</artifactId>
+            <artifactId>helidon-metrics</artifactId>
             <version>${helidon.version}</version>
             <scope>test</scope>
         </dependency>

--- a/bolt-helidon/src/main/java/com/slack/api/bolt/helidon/SlackAppService.java
+++ b/bolt-helidon/src/main/java/com/slack/api/bolt/helidon/SlackAppService.java
@@ -99,6 +99,10 @@ public class SlackAppService implements Service {
             response.headers().add(header.getKey(), header.getValue());
         }
         response.headers().put("Content-Type", slackResponse.getContentType());
-        response.send(slackResponse.getBody());
+        String body = slackResponse.getBody();
+        if (body == null) {
+            body = "";
+        }
+        response.send(body);
     }
 }

--- a/bolt-helidon/src/test/java/util/HashRequestHeaders.java
+++ b/bolt-helidon/src/test/java/util/HashRequestHeaders.java
@@ -15,7 +15,6 @@
  */
 package util;
 
-import io.helidon.common.CollectionsHelper;
 import io.helidon.common.http.*;
 import io.helidon.webserver.RequestHeaders;
 
@@ -37,7 +36,7 @@ public class HashRequestHeaders extends ReadOnlyParameters implements RequestHea
     /**
      * Accepted types for {@link #HUC_ACCEPT_DEFAULT}.
      */
-    private static final List<MediaType> HUC_ACCEPT_DEFAULT_TYPES = CollectionsHelper.listOf(
+    private static final List<MediaType> HUC_ACCEPT_DEFAULT_TYPES = Arrays.asList(
             MediaType.TEXT_HTML,
             MediaType.parse("image/gif"),
             MediaType.parse("image/jpeg"),

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,9 +10,8 @@
     </parent>
 
     <properties>
-        <!-- TODO: upgrade once https://github.com/micronaut-projects/micronaut-core/issues/3933 is resolved -->
-        <micronaut.bom.version>2.0.0</micronaut.bom.version>
-        <micronaut.version>2.0.1</micronaut.version>
+        <micronaut.bom.version>2.0.2</micronaut.bom.version>
+        <micronaut.version>2.0.2</micronaut.version>
         <micronaut-test-junit5.version>1.2.0</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <quarkus.version>1.7.1.Final</quarkus.version>
+        <quarkus.version>1.8.0.Final</quarkus.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <!-- Quarkus 1.7+ requires Java 11+ -->

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,8 +8,8 @@ url: https://slack.dev
 
 sdkLatestVersion: 1.1.4
 okhttpVersion: 4.8.1
-kotlinVersion: 1.3.72
+kotlinVersion: 1.4.10
 springBootVersion: 2.3.3.RELEASE
 compatibleMicronautVersion: 2.x
-quarkusVersion: 1.7.1.Final
-helidonVersion: 1.4.5
+quarkusVersion: 1.8.0.Final
+helidonVersion: 2.0.2

--- a/pom.xml
+++ b/pom.xml
@@ -46,14 +46,13 @@
         <lombok.version>1.18.12</lombok.version>
         <lombok-maven-plugin.version>1.18.10.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
-        <!-- TODO: Kotlin 1.4 - https://github.com/slackapi/java-slack-sdk/issues/545 -->
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.4.10</kotlin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.852</aws.s3.version>
+        <aws.s3.version>1.11.861</aws.s3.version>
         <junit.version>4.13</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.5.7</mockito-core.version>
+        <mockito-core.version>3.5.10</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/scripts/run_no_prep_tests.sh
+++ b/scripts/run_no_prep_tests.sh
@@ -3,7 +3,7 @@ is_jdk_8=`echo $JAVA_HOME | grep 8.`
 is_travis_jdk_8=`echo $TRAVIS_JDK | grep openjdk8`
 if [[ "${is_jdk_8}" != "" && "${is_travis_jdk_8}" != "" ]];
 then
-  ./mvnw ${MAVEN_OPTS} -pl !bolt-google-cloud-functions \
+  ./mvnw ${MAVEN_OPTS} -pl !bolt-google-cloud-functions -pl !bolt-helidon \
     clean \
     test-compile \
     '-Dtest=test_locally.**.*Test' test \


### PR DESCRIPTION
This pull request fixes #557 #545 

* [major version] Helidon SE from 1.4 to 2.0 (reqiures JDK 11 builds)
* [minor version] Kotlin from 1.3 to 1.4
* [patch version] Micronaut, AWS S3 SDK

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
