### PR TITLE
Upgrade okhttp from 4.8 to 4.9 (and some other minor ones too)

### DIFF
--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <micronaut.bom.version>2.0.2</micronaut.bom.version>
-        <micronaut.version>2.0.2</micronaut.version>
+        <micronaut.version>2.0.3</micronaut.version>
         <micronaut-test-junit5.version>1.2.0</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <quarkus.version>1.8.0.Final</quarkus.version>
+        <quarkus.version>1.8.1.Final</quarkus.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <!-- Quarkus 1.7+ requires Java 11+ -->

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,9 +7,9 @@ baseurl: /java-slack-sdk
 url: https://slack.dev
 
 sdkLatestVersion: 1.1.5
-okhttpVersion: 4.8.1
+okhttpVersion: 4.9.0
 kotlinVersion: 1.4.10
 springBootVersion: 2.3.3.RELEASE
 compatibleMicronautVersion: 2.x
-quarkusVersion: 1.8.0.Final
+quarkusVersion: 1.8.1.Final
 helidonVersion: 2.0.2

--- a/pom.xml
+++ b/pom.xml
@@ -41,18 +41,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <okhttp.version>4.8.1</okhttp.version>
+        <okhttp.version>4.9.0</okhttp.version>
         <gson.version>2.8.6</gson.version>
         <lombok.version>1.18.12</lombok.version>
         <lombok-maven-plugin.version>1.18.10.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
         <kotlin.version>1.4.10</kotlin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.861</aws.s3.version>
+        <aws.s3.version>1.11.868</aws.s3.version>
         <junit.version>4.13</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.5.10</mockito-core.version>
+        <mockito-core.version>3.5.11</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>


### PR DESCRIPTION
This pull request fixes #558 by upgrading okhttp's minor version. 

diff: https://github.com/square/okhttp/compare/parent-4.8.1...parent-4.9.0

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.
