### PR TITLE
Fix #566 by stopping propagation of okhttp's exception message including header values

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
@@ -65,7 +65,16 @@ public class SlackHttpClient implements AutoCloseable {
         final Request request;
         if (token != null) {
             String bearerHeaderValue = "Bearer " + token;
-            request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).get().build();
+            Request.Builder rb = new Request.Builder().url(url).get();
+            try {
+                // may throw an IllegalArgumentException saying
+                // "Unexpected char 0x0a at 23 in Authorization value: Bearer ..."
+                rb = rb.header("Authorization", bearerHeaderValue);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid value detected for Authorization header");
+            }
+            request = rb.build();
+            return okHttpClient.newCall(request).execute();
         } else {
             request = new Request.Builder().url(url).get().build();
         }
@@ -74,7 +83,15 @@ public class SlackHttpClient implements AutoCloseable {
 
     public Response postMultipart(String url, String token, MultipartBody multipartBody) throws IOException {
         String bearerHeaderValue = "Bearer " + token;
-        Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).post(multipartBody).build();
+        Request.Builder rb = new Request.Builder().url(url).post(multipartBody);
+        try {
+            // may throw an IllegalArgumentException saying
+            // "Unexpected char 0x0a at 23 in Authorization value: Bearer ..."
+            rb = rb.header("Authorization", bearerHeaderValue);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid value detected for Authorization header");
+        }
+        Request request = rb.build();
         return okHttpClient.newCall(request).execute();
     }
 
@@ -89,7 +106,15 @@ public class SlackHttpClient implements AutoCloseable {
     }
 
     public Response postFormWithAuthorizationHeader(String url, String authorizationHeader, FormBody formBody) throws IOException {
-        Request request = new Request.Builder().url(url).header("Authorization", authorizationHeader).post(formBody).build();
+        Request.Builder rb = new Request.Builder().url(url).post(formBody);
+        try {
+            // may throw an IllegalArgumentException saying
+            // "Unexpected char 0x0a at 23 in Authorization value: Bearer ..."
+            rb = rb.header("Authorization", authorizationHeader);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid value detected for Authorization header");
+        }
+        Request request = rb.build();
         return okHttpClient.newCall(request).execute();
     }
 
@@ -102,21 +127,45 @@ public class SlackHttpClient implements AutoCloseable {
     public Response postCamelCaseJsonBodyWithBearerHeader(String url, String token, Object obj) throws IOException {
         String bearerHeaderValue = "Bearer " + token;
         RequestBody body = RequestBody.create(toCamelCaseJsonString(obj), MEDIA_TYPE_APPLICATION_JSON);
-        Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).post(body).build();
+        Request.Builder rb = new Request.Builder().url(url).post(body);
+        try {
+            // may throw an IllegalArgumentException saying
+            // "Unexpected char 0x0a at 23 in Authorization value: Bearer ..."
+            rb = rb.header("Authorization", bearerHeaderValue);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid value detected for Authorization header");
+        }
+        Request request = rb.build();
         return okHttpClient.newCall(request).execute();
     }
 
     public Response patchCamelCaseJsonBodyWithBearerHeader(String url, String token, Object obj) throws IOException {
         String bearerHeaderValue = "Bearer " + token;
         RequestBody body = RequestBody.create(toCamelCaseJsonString(obj), MEDIA_TYPE_APPLICATION_JSON);
-        Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).patch(body).build();
+        Request.Builder rb = new Request.Builder().url(url).patch(body);
+        try {
+            // may throw an IllegalArgumentException saying
+            // "Unexpected char 0x0a at 23 in Authorization value: Bearer ..."
+            rb = rb.header("Authorization", bearerHeaderValue);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid value detected for Authorization header");
+        }
+        Request request = rb.build();
         return okHttpClient.newCall(request).execute();
     }
 
     public Response putCamelCaseJsonBodyWithBearerHeader(String url, String token, Object obj) throws IOException {
         String bearerHeaderValue = "Bearer " + token;
         RequestBody body = RequestBody.create(toCamelCaseJsonString(obj), MEDIA_TYPE_APPLICATION_JSON);
-        Request request = new Request.Builder().url(url).header("Authorization", bearerHeaderValue).put(body).build();
+        Request.Builder rb = new Request.Builder().url(url).put(body);
+        try {
+            // may throw an IllegalArgumentException saying
+            // "Unexpected char 0x0a at 23 in Authorization value: Bearer ..."
+            rb = rb.header("Authorization", bearerHeaderValue);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid value detected for Authorization header");
+        }
+        Request request = rb.build();
         return okHttpClient.newCall(request).execute();
     }
 

--- a/slack-api-client/src/test/java/test_locally/api/methods/impl/TeamIdCacheTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/impl/TeamIdCacheTest.java
@@ -1,0 +1,25 @@
+package test_locally.api.methods.impl;
+
+import com.slack.api.methods.impl.MethodsClientImpl;
+import com.slack.api.methods.impl.TeamIdCache;
+import com.slack.api.util.http.SlackHttpClient;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TeamIdCacheTest {
+
+    // https://github.com/slackapi/java-slack-sdk/issues/566
+    @Test
+    public void shouldNotRevealAuthorizationHeaderEvenIfItIsInvalid() {
+        String token = "xoxb-111-222-zzz";
+        try {
+            TeamIdCache teamIdCache = new TeamIdCache(new MethodsClientImpl(new SlackHttpClient()));
+            teamIdCache.lookupOrResolve("xoxb-111-222-zzz\nsomething wrong");
+            fail();
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertFalse(e.getMessage(), e.getMessage().contains(token));
+        }
+    }
+}


### PR DESCRIPTION
This pull request fixes #566 by improving the error handling in the HTTP client.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.
