### PR TITLE
Fix some gaps from other Bolt frameworks

### DIFF
--- a/bolt-aws-lambda/src/test/java/test_locally/SlackApiLambdaHandlerTest.java
+++ b/bolt-aws-lambda/src/test/java/test_locally/SlackApiLambdaHandlerTest.java
@@ -31,26 +31,36 @@ public class SlackApiLambdaHandlerTest {
     String signingSecret = "secret";
 
     @Test
-    public void invalidRequest() {
-        App app = new App(AppConfig.builder()
-                .singleTeamBotToken(AuthTestMockServer.ValidToken)
-                .signingSecret(signingSecret)
-                .build()
-        );
-        SlackApiLambdaHandler handler = new SlackApiLambdaHandler(app) {
-            @Override
-            protected boolean isWarmupRequest(ApiGatewayRequest awsReq) {
-                return false;
-            }
-        };
-        ApiGatewayRequest req = new ApiGatewayRequest();
-        initProperties(req);
-        req.setRequestContext(initProperties(new RequestContext()));
-        req.setBody("payload={}");
+    public void invalidRequest() throws Exception {
+        AuthTestMockServer slackApiServer = new AuthTestMockServer();
+        slackApiServer.start();
+        try {
+            SlackConfig slackConfig = new SlackConfig();
+            slackConfig.setMethodsEndpointUrlPrefix(slackApiServer.getMethodsEndpointPrefix());
+            Slack slack = Slack.getInstance(slackConfig);
+            App app = new App(AppConfig.builder().slack(slack)
+                    .singleTeamBotToken(AuthTestMockServer.ValidToken)
+                    .signingSecret(signingSecret)
+                    .build()
+            );
+            SlackApiLambdaHandler handler = new SlackApiLambdaHandler(app) {
+                @Override
+                protected boolean isWarmupRequest(ApiGatewayRequest awsReq) {
+                    return false;
+                }
+            };
+            ApiGatewayRequest req = new ApiGatewayRequest();
+            initProperties(req);
+            req.setRequestContext(initProperties(new RequestContext()));
+            req.setBody("payload={}");
 
-        Context context = mock(Context.class);
-        ApiGatewayResponse response = handler.handleRequest(req, context);
-        assertEquals(400, response.getStatusCode());
+            Context context = mock(Context.class);
+            ApiGatewayResponse response = handler.handleRequest(req, context);
+            assertEquals(400, response.getStatusCode());
+
+        } finally {
+            slackApiServer.stop();
+        }
     }
 
     String blockActionsPayload = "{\n" +
@@ -93,47 +103,67 @@ public class SlackApiLambdaHandlerTest {
             "}";
 
     @Test
-    public void warmup() {
-        App app = new App(AppConfig.builder()
-                .singleTeamBotToken(AuthTestMockServer.ValidToken)
-                .signingSecret(signingSecret)
-                .build()
-        );
-        SlackApiLambdaHandler handler = new SlackApiLambdaHandler(app) {
-            @Override
-            protected boolean isWarmupRequest(ApiGatewayRequest awsReq) {
-                return awsReq.getBody().equals("warmup");
-            }
-        };
-        ApiGatewayRequest req = new ApiGatewayRequest();
-        initProperties(req);
-        req.setRequestContext(initProperties(new RequestContext()));
-        req.setBody("warmup");
-        Context context = mock(Context.class);
-        ApiGatewayResponse response = handler.handleRequest(req, context);
-        assertNull(response);
+    public void warmup() throws Exception {
+        AuthTestMockServer slackApiServer = new AuthTestMockServer();
+        slackApiServer.start();
+        try {
+            SlackConfig slackConfig = new SlackConfig();
+            slackConfig.setMethodsEndpointUrlPrefix(slackApiServer.getMethodsEndpointPrefix());
+            Slack slack = Slack.getInstance(slackConfig);
+            App app = new App(AppConfig.builder().slack(slack)
+                    .singleTeamBotToken(AuthTestMockServer.ValidToken)
+                    .signingSecret(signingSecret)
+                    .build()
+            );
+            SlackApiLambdaHandler handler = new SlackApiLambdaHandler(app) {
+                @Override
+                protected boolean isWarmupRequest(ApiGatewayRequest awsReq) {
+                    return awsReq.getBody().equals("warmup");
+                }
+            };
+            ApiGatewayRequest req = new ApiGatewayRequest();
+            initProperties(req);
+            req.setRequestContext(initProperties(new RequestContext()));
+            req.setBody("warmup");
+            Context context = mock(Context.class);
+            ApiGatewayResponse response = handler.handleRequest(req, context);
+            assertNull(response);
+
+        } finally {
+            slackApiServer.stop();
+        }
     }
 
     @Test
-    public void signature_error() throws UnsupportedEncodingException {
-        App app = new App(AppConfig.builder()
-                .singleTeamBotToken(AuthTestMockServer.ValidToken)
-                .signingSecret(signingSecret)
-                .build()
-        );
-        SlackApiLambdaHandler handler = new SlackApiLambdaHandler(app) {
-            @Override
-            protected boolean isWarmupRequest(ApiGatewayRequest awsReq) {
-                return false;
-            }
-        };
-        ApiGatewayRequest req = new ApiGatewayRequest();
-        initProperties(req);
-        req.setRequestContext(initProperties(new RequestContext()));
-        req.setBody("payload=" + URLEncoder.encode(blockActionsPayload, "UTF-8"));
-        Context context = mock(Context.class);
-        ApiGatewayResponse response = handler.handleRequest(req, context);
-        assertEquals(401, response.getStatusCode());
+    public void signature_error() throws Exception {
+        AuthTestMockServer slackApiServer = new AuthTestMockServer();
+        slackApiServer.start();
+        try {
+            SlackConfig slackConfig = new SlackConfig();
+            slackConfig.setMethodsEndpointUrlPrefix(slackApiServer.getMethodsEndpointPrefix());
+            Slack slack = Slack.getInstance(slackConfig);
+            App app = new App(AppConfig.builder().slack(slack)
+                    .singleTeamBotToken(AuthTestMockServer.ValidToken)
+                    .signingSecret(signingSecret)
+                    .build()
+            );
+            SlackApiLambdaHandler handler = new SlackApiLambdaHandler(app) {
+                @Override
+                protected boolean isWarmupRequest(ApiGatewayRequest awsReq) {
+                    return false;
+                }
+            };
+            ApiGatewayRequest req = new ApiGatewayRequest();
+            initProperties(req);
+            req.setRequestContext(initProperties(new RequestContext()));
+            req.setBody("payload=" + URLEncoder.encode(blockActionsPayload, "UTF-8"));
+            Context context = mock(Context.class);
+            ApiGatewayResponse response = handler.handleRequest(req, context);
+            assertEquals(401, response.getStatusCode());
+
+        } finally {
+            slackApiServer.stop();
+        }
     }
 
     @Test

--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -77,6 +77,25 @@
             <version>${helidon.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty-for-tests.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty-for-tests.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <version>${jetty-for-tests.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/bolt-helidon/src/test/java/util/AuthTestMockServer.java
+++ b/bolt-helidon/src/test/java/util/AuthTestMockServer.java
@@ -1,0 +1,72 @@
+package util;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class AuthTestMockServer {
+
+    public static final String ValidToken = "xoxb-this-is-valid";
+
+    static String ok = "{\n" +
+            "  \"ok\": true,\n" +
+            "  \"url\": \"https://java-slack-sdk-test.slack.com/\",\n" +
+            "  \"team\": \"java-slack-sdk-test\",\n" +
+            "  \"user\": \"test_user\",\n" +
+            "  \"team_id\": \"T1234567\",\n" +
+            "  \"user_id\": \"U1234567\",\n" +
+            "  \"bot_id\": \"B12345678\",\n" +
+            "  \"enterprise_id\": \"E12345678\"\n" +
+            "}";
+    static String ng = "{\n" +
+            "  \"ok\": false,\n" +
+            "  \"error\": \"invalid\"\n" +
+            "}";
+
+    @WebServlet
+    public static class AuthTestMockEndpoint extends HttpServlet {
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            resp.setStatus(200);
+            resp.setContentType("application/json");
+            if (req.getHeader("Authorization") == null || !req.getHeader("Authorization").equals("Bearer " + ValidToken)) {
+                resp.getWriter().write(ng);
+            } else {
+                resp.getWriter().write(ok);
+            }
+        }
+    }
+
+    private final int port;
+    private final Server server;
+
+    public AuthTestMockServer() {
+        this(PortProvider.getPort(AuthTestMockServer.class.getName()));
+    }
+
+    public AuthTestMockServer(int port) {
+        this.port = port;
+        server = new Server(this.port);
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(AuthTestMockEndpoint.class, "/*");
+    }
+
+    public String getMethodsEndpointPrefix() {
+        return "http://localhost:" + port + "/api/";
+    }
+
+    public void start() throws Exception {
+        server.start();
+    }
+
+    public void stop() throws Exception {
+        server.stop();
+    }
+}

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -78,6 +78,25 @@
             <version>${mockito-all.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty-for-tests.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty-for-tests.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <version>${jetty-for-tests.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bolt-micronaut/src/test/java/util/AuthTestMockServer.java
+++ b/bolt-micronaut/src/test/java/util/AuthTestMockServer.java
@@ -1,0 +1,72 @@
+package util;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class AuthTestMockServer {
+
+    public static final String ValidToken = "xoxb-this-is-valid";
+
+    static String ok = "{\n" +
+            "  \"ok\": true,\n" +
+            "  \"url\": \"https://java-slack-sdk-test.slack.com/\",\n" +
+            "  \"team\": \"java-slack-sdk-test\",\n" +
+            "  \"user\": \"test_user\",\n" +
+            "  \"team_id\": \"T1234567\",\n" +
+            "  \"user_id\": \"U1234567\",\n" +
+            "  \"bot_id\": \"B12345678\",\n" +
+            "  \"enterprise_id\": \"E12345678\"\n" +
+            "}";
+    static String ng = "{\n" +
+            "  \"ok\": false,\n" +
+            "  \"error\": \"invalid\"\n" +
+            "}";
+
+    @WebServlet
+    public static class AuthTestMockEndpoint extends HttpServlet {
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            resp.setStatus(200);
+            resp.setContentType("application/json");
+            if (req.getHeader("Authorization") == null || !req.getHeader("Authorization").equals("Bearer " + ValidToken)) {
+                resp.getWriter().write(ng);
+            } else {
+                resp.getWriter().write(ok);
+            }
+        }
+    }
+
+    private final int port;
+    private final Server server;
+
+    public AuthTestMockServer() {
+        this(PortProvider.getPort(AuthTestMockServer.class.getName()));
+    }
+
+    public AuthTestMockServer(int port) {
+        this.port = port;
+        server = new Server(this.port);
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(AuthTestMockEndpoint.class, "/*");
+    }
+
+    public String getMethodsEndpointPrefix() {
+        return "http://localhost:" + port + "/api/";
+    }
+
+    public void start() throws Exception {
+        server.start();
+    }
+
+    public void stop() throws Exception {
+        server.stop();
+    }
+}

--- a/bolt-micronaut/src/test/java/util/PortProvider.java
+++ b/bolt-micronaut/src/test/java/util/PortProvider.java
@@ -1,0 +1,40 @@
+package util;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.security.SecureRandom;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class PortProvider {
+
+    private PortProvider() {
+    }
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
+
+    public static int getPort(String name) {
+        return PORTS.computeIfAbsent(name, (key) -> randomPort());
+    }
+
+    private static int randomPort() {
+        while (true) {
+            int randomPort = RANDOM.nextInt(9999);
+            if (randomPort < 1000) {
+                randomPort += 1000;
+            }
+            if (isAvailable(randomPort)) {
+                return randomPort;
+            }
+        }
+    }
+
+    private static boolean isAvailable(int port) {
+        try (Socket ignored = new Socket("localhost", port)) {
+            return false;
+        } catch (IOException ignored) {
+            return true;
+        }
+    }
+}

--- a/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/EventDataRecorder.java
+++ b/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/EventDataRecorder.java
@@ -130,15 +130,12 @@ public class EventDataRecorder {
                     array.add(attachment);
                 }
             } else if (name != null && name.equals("blocks")) {
-                System.out.println(array.size());
                 for (int idx = 0; idx < array.size(); idx++) {
                     array.remove(idx);
                 }
-                System.out.println(array.size());
                 for (JsonElement block : SampleObjects.Json.Blocks) {
                     array.add(block);
                 }
-                System.out.println(array.size());
             } else if (name != null && name.equals("replies")) {
                 for (int idx = 0; idx < array.size(); idx++) {
                     array.remove(idx);

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -29,14 +29,34 @@ public class AppConfig {
         public static final String SLACK_BOT_TOKEN = "SLACK_BOT_TOKEN";
         public static final String SLACK_SIGNING_SECRET = "SLACK_SIGNING_SECRET";
         public static final String SLACK_VERIFICATION_TOKEN = "SLACK_VERIFICATION_TOKEN";
+
+        public static final String SLACK_CLIENT_ID = "SLACK_CLIENT_ID";
+        public static final String SLACK_CLIENT_SECRET = "SLACK_CLIENT_SECRET";
+        public static final String SLACK_REDIRECT_URI = "SLACK_REDIRECT_URI";
+        public static final String SLACK_SCOPES = "SLACK_SCOPES";
+        public static final String SLACK_USER_SCOPES = "SLACK_USER_SCOPES";
+        public static final String SLACK_INSTALL_PATH = "SLACK_INSTALL_PATH";
+        public static final String SLACK_REDIRECT_URI_PATH = "SLACK_REDIRECT_URI_PATH";
+        public static final String SLACK_OAUTH_CANCELLATION_URL = "SLACK_OAUTH_CANCELLATION_URL";
+        public static final String SLACK_OAUTH_COMPLETION_URL = "SLACK_OAUTH_COMPLETION_URL";
+
+        @Deprecated // will be removed in v2.0
         public static final String SLACK_APP_CLIENT_ID = "SLACK_APP_CLIENT_ID";
+        @Deprecated // will be removed in v2.0
         public static final String SLACK_APP_CLIENT_SECRET = "SLACK_APP_CLIENT_SECRET";
+        @Deprecated // will be removed in v2.0
         public static final String SLACK_APP_REDIRECT_URI = "SLACK_APP_REDIRECT_URI";
+        @Deprecated // will be removed in v2.0
         public static final String SLACK_APP_SCOPE = "SLACK_APP_SCOPE";
+        @Deprecated // will be removed in v2.0
         public static final String SLACK_APP_USER_SCOPE = "SLACK_APP_USER_SCOPE";
+        @Deprecated // will be removed in v2.0
         public static final String SLACK_APP_OAUTH_START_PATH = "SLACK_APP_OAUTH_START_PATH";
+        @Deprecated // will be removed in v2.0
         public static final String SLACK_APP_OAUTH_CALLBACK_PATH = "SLACK_APP_OAUTH_CALLBACK_PATH";
+        @Deprecated // will be removed in v2.0
         public static final String SLACK_APP_OAUTH_CANCELLATION_URL = "SLACK_APP_OAUTH_CANCELLATION_URL";
+        @Deprecated // will be removed in v2.0
         public static final String SLACK_APP_OAUTH_COMPLETION_URL = "SLACK_APP_OAUTH_COMPLETION_URL";
     }
 
@@ -69,9 +89,8 @@ public class AppConfig {
     @Builder.Default
     private boolean oAuthCallbackEnabled = false;
 
-
     /**
-     * Returns true if auth.test call result cache in SingleTeamAuthorization or MultiTeamsAuthorization middleware
+     * Returns true if auth.test call result cache in MultiTeamsAuthorization middleware
      * is enabled. The default is false.
      */
     @Builder.Default
@@ -79,14 +98,20 @@ public class AppConfig {
 
     /**
      * Returns the millisecond value to keep cached auth.test response in cache.
-     * Negative value indicates the cache is permanent. The default is 3000 milliseconds.
+     * Negative value indicates the cache is permanent. The default is 10 minutes.
      */
     @Builder.Default
-    private long authTestCacheExpirationMillis = 3000L;
+    private long authTestCacheExpirationMillis = 600_000L;
 
     @Builder.Default
     // https://api.slack.com/authentication/migration
     private boolean classicAppPermissionsEnabled = false;
+
+    /**
+     * The thread pool size for the built-in handy executor service.
+     */
+    @Builder.Default
+    private int threadPoolSize = 10;
 
     public void setOauthStartPath(String oauthStartPath) {
         this.oauthStartPath = oauthStartPath;
@@ -99,15 +124,20 @@ public class AppConfig {
     }
 
     @Builder.Default
-    private String clientId = System.getenv(EnvVariableName.SLACK_APP_CLIENT_ID);
+    private String clientId = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_CLIENT_ID))
+            .orElse(System.getenv(EnvVariableName.SLACK_APP_CLIENT_ID));
     @Builder.Default
-    private String clientSecret = System.getenv(EnvVariableName.SLACK_APP_CLIENT_SECRET);
+    private String clientSecret = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_CLIENT_SECRET))
+            .orElse(System.getenv(EnvVariableName.SLACK_APP_CLIENT_SECRET));
     @Builder.Default
-    private String redirectUri = System.getenv(EnvVariableName.SLACK_APP_REDIRECT_URI);
+    private String redirectUri = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_REDIRECT_URI))
+            .orElse(System.getenv(EnvVariableName.SLACK_APP_REDIRECT_URI));
     @Builder.Default
-    private String scope = System.getenv(EnvVariableName.SLACK_APP_SCOPE);
+    private String scope = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_SCOPES))
+            .orElse(System.getenv(EnvVariableName.SLACK_APP_SCOPE));
     @Builder.Default
-    private String userScope = System.getenv(EnvVariableName.SLACK_APP_USER_SCOPE);
+    private String userScope = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_USER_SCOPES))
+            .orElse(System.getenv(EnvVariableName.SLACK_APP_USER_SCOPE));
 
     private String appPath;
 
@@ -128,14 +158,20 @@ public class AppConfig {
     }
 
     @Builder.Default
-    private String oauthStartPath = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_APP_OAUTH_START_PATH)).orElse("start");
+    private String oauthStartPath = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_INSTALL_PATH))
+            .orElse(Optional.ofNullable(System.getenv(EnvVariableName.SLACK_APP_OAUTH_START_PATH))
+                    .orElse("start"));
     @Builder.Default
-    private String oauthCallbackPath = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_APP_OAUTH_CALLBACK_PATH)).orElse("callback");
+    private String oauthCallbackPath = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_REDIRECT_URI_PATH))
+            .orElse(Optional.ofNullable(System.getenv(EnvVariableName.SLACK_APP_OAUTH_CALLBACK_PATH))
+                    .orElse("callback"));
 
     @Builder.Default
-    private String oauthCancellationUrl = System.getenv(EnvVariableName.SLACK_APP_OAUTH_CANCELLATION_URL);
+    private String oauthCancellationUrl = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_OAUTH_CANCELLATION_URL))
+            .orElse(System.getenv(EnvVariableName.SLACK_APP_OAUTH_CANCELLATION_URL));
     @Builder.Default
-    private String oauthCompletionUrl = System.getenv(EnvVariableName.SLACK_APP_OAUTH_COMPLETION_URL);
+    private String oauthCompletionUrl = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_OAUTH_COMPLETION_URL))
+            .orElse(System.getenv(EnvVariableName.SLACK_APP_OAUTH_COMPLETION_URL));
 
     @Builder.Default
     private boolean alwaysRequestUserTokenNeeded = false;

--- a/bolt/src/main/java/com/slack/api/bolt/model/Bot.java
+++ b/bolt/src/main/java/com/slack/api/bolt/model/Bot.java
@@ -5,6 +5,10 @@ package com.slack.api.bolt.model;
  */
 public interface Bot {
 
+    String getAppId();
+
+    void setAppId(String appId);
+
     String getEnterpriseId();
 
     void setEnterpriseId(String enterpriseId);

--- a/bolt/src/main/java/com/slack/api/bolt/model/Installer.java
+++ b/bolt/src/main/java/com/slack/api/bolt/model/Installer.java
@@ -6,6 +6,14 @@ package com.slack.api.bolt.model;
 public interface Installer {
 
     // ---------------------------------
+    // App
+    // ---------------------------------
+
+    String getAppId();
+
+    void setAppId(String appId);
+
+    // ---------------------------------
     // Organization / Workspace
     // ---------------------------------
 

--- a/bolt/src/main/java/com/slack/api/bolt/model/builtin/DefaultBot.java
+++ b/bolt/src/main/java/com/slack/api/bolt/model/builtin/DefaultBot.java
@@ -9,6 +9,8 @@ import lombok.Data;
 @Data
 public class DefaultBot implements Bot {
 
+    private String appId;
+
     private String enterpriseId;
     private String teamId;
     private String teamName;

--- a/bolt/src/main/java/com/slack/api/bolt/model/builtin/DefaultInstaller.java
+++ b/bolt/src/main/java/com/slack/api/bolt/model/builtin/DefaultInstaller.java
@@ -16,6 +16,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class DefaultInstaller implements Installer {
 
+    private String appId;
+
     private String enterpriseId;
     private String teamId;
     private String teamName;
@@ -42,6 +44,7 @@ public class DefaultInstaller implements Installer {
     @Override
     public Bot toBot() {
         DefaultBot bot = new DefaultBot();
+        bot.setAppId(appId);
         bot.setEnterpriseId(enterpriseId);
         bot.setTeamId(teamId);
         bot.setTeamName(teamName);

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultSuccessHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultSuccessHandler.java
@@ -37,6 +37,7 @@ public class OAuthDefaultSuccessHandler implements OAuthSuccessHandler {
         context.setRequestUserToken(o.getAccessToken());
 
         DefaultInstaller.DefaultInstallerBuilder i = DefaultInstaller.builder()
+                .appId(null)
                 .enterpriseId(o.getEnterpriseId())
                 .teamId(o.getTeamId())
                 .teamName(o.getTeamName())

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultSuccessHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultSuccessHandler.java
@@ -40,6 +40,7 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
         context.setRequestUserToken(o.getAccessToken());
 
         DefaultInstaller.DefaultInstallerBuilder i = DefaultInstaller.builder()
+                .appId(o.getAppId())
                 .botUserId(o.getBotUserId())
                 .botAccessToken(o.getAccessToken())
                 .enterpriseId(o.getEnterprise() != null ? o.getEnterprise().getId() : null)

--- a/bolt/src/test/java/test_locally/AppTest.java
+++ b/bolt/src/test/java/test_locally/AppTest.java
@@ -88,19 +88,8 @@ public class AppTest {
 
     @Test
     public void status() {
-        App app = new App(AppConfig.builder().signingSecret("secret").build());
+        App app = new App(AppConfig.builder().signingSecret("secret").singleTeamBotToken("xoxb-valid").build());
         assertThat(app.status(), is(App.Status.Stopped));
-        app.start();
-        assertThat(app.status(), is(App.Status.Running));
-        app.stop();
-        assertThat(app.status(), is(App.Status.Stopped));
-        app.start();
-        assertThat(app.status(), is(App.Status.Running));
-        app.stop();
-        assertThat(app.status(), is(App.Status.Stopped));
-        app.start();
-        app.start();
-        assertThat(app.status(), is(App.Status.Running));
     }
 
     @Test
@@ -156,8 +145,13 @@ public class AppTest {
         app.initializer("foo", (theApp) -> {
             called.set(true);
         });
-        app.start();
-        assertThat(called.get(), is(true));
+        try {
+            app.start();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("The token is invalid (auth.test error: account_inactive)"));
+        }
+        // TODO: valid pattern test
     }
 
     @Test

--- a/bolt/src/test/java/test_locally/app/MultiTeamsAuthTestCacheTest.java
+++ b/bolt/src/test/java/test_locally/app/MultiTeamsAuthTestCacheTest.java
@@ -98,7 +98,8 @@ public class MultiTeamsAuthTestCacheTest {
         Thread.sleep(3000L);
 
         response = app.run(req);
-        assertEquals(503L, response.getStatusCode().longValue());
+//        assertEquals(503L, response.getStatusCode().longValue());
+        assertEquals(200L, response.getStatusCode().longValue());
     }
 
     @Test

--- a/slack-api-client/src/test/java/test_locally/api/methods/impl/TeamIdCacheTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/impl/TeamIdCacheTest.java
@@ -18,7 +18,6 @@ public class TeamIdCacheTest {
             teamIdCache.lookupOrResolve("xoxb-111-222-zzz\nsomething wrong");
             fail();
         } catch (Exception e) {
-            e.printStackTrace();
             assertFalse(e.getMessage(), e.getMessage().contains(token));
         }
     }


### PR DESCRIPTION
This pull request fixes a few gaps from other Bolt frameworks. We're not aiming to completely remove such differences but the changes in this PR are all backward compatible. So, v1.2 is good timing to introduce these.

Also, this PR fixes #572 

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
