### PR TITLE
Add complete support for new Events API payload format

### DIFF
--- a/bolt-servlet/src/test/java/config/SlackTestConfig.java
+++ b/bolt-servlet/src/test/java/config/SlackTestConfig.java
@@ -5,11 +5,17 @@ import com.slack.api.methods.metrics.MetricsDatastore;
 import com.slack.api.util.http.listener.HttpResponseListener;
 import com.slack.api.util.json.GsonFactory;
 import lombok.extern.slf4j.Slf4j;
+import test_with_remote_apis.sample_json_generation.JsonDataRecordingListener;
 
 @Slf4j
 public class SlackTestConfig {
 
+    private static final JsonDataRecordingListener JSON_DATA_RECORDING_LISTENER = new JsonDataRecordingListener();
     private static final SlackConfig CONFIG = new SlackConfig();
+
+    public boolean areAllAsyncOperationsDone() {
+        return JSON_DATA_RECORDING_LISTENER.isAllDone();
+    }
 
     private final SlackConfig config;
 
@@ -31,6 +37,8 @@ public class SlackTestConfig {
     static {
         CONFIG.setLibraryMaintainerMode(true);
         CONFIG.setPrettyResponseLoggingEnabled(true);
+        CONFIG.setFailOnUnknownProperties(true);
+        CONFIG.getHttpClientResponseHandlers().add(JSON_DATA_RECORDING_LISTENER);
     }
 
     public static SlackTestConfig getInstance() {
@@ -39,6 +47,12 @@ public class SlackTestConfig {
 
     public SlackConfig getConfig() {
         return config;
+    }
+
+    public static void awaitCompletion(SlackTestConfig testConfig) throws InterruptedException {
+        while (!testConfig.areAllAsyncOperationsDone()) {
+            Thread.sleep(1000);
+        }
     }
 
 }

--- a/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/EventDataRecorder.java
+++ b/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/EventDataRecorder.java
@@ -193,6 +193,8 @@ public class EventDataRecorder {
                                     MergeJsonBuilder.mergeJsonObjects(first.getAsJsonObject(), CONFLICT_STRATEGY, elem.getAsJsonObject());
                                 } catch (MergeJsonBuilder.JsonConflictException e) {
                                     log.error("Failed to merge {} into {}", elem, first);
+                                } catch (IllegalStateException e) {
+                                    log.error("Failed to merge {} into {}", elem, first);
                                 }
                             }
                         }

--- a/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/JsonDataRecorder.java
+++ b/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/JsonDataRecorder.java
@@ -1,0 +1,436 @@
+package test_with_remote_apis.sample_json_generation;
+
+import com.google.gson.*;
+import com.slack.api.SlackConfig;
+import com.slack.api.methods.response.chat.scheduled_messages.ChatScheduledMessagesListResponse;
+import com.slack.api.model.Conversation;
+import com.slack.api.model.FileComment;
+import com.slack.api.model.Group;
+import com.slack.api.model.Message;
+import com.slack.api.model.admin.AppRequest;
+import com.slack.api.scim.model.User;
+import com.slack.api.status.v2.model.SlackIssue;
+import com.slack.api.util.json.GsonFactory;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Response;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class JsonDataRecorder {
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    private SlackConfig config;
+    private String outputDirectory;
+
+    public JsonDataRecorder(SlackConfig config, String outputDirectory) {
+        this.config = config;
+        this.outputDirectory = outputDirectory;
+    }
+
+    public void writeMergedResponse(Response response, String body) throws IOException {
+        String path = response.request().url().url().getPath();
+        String httpMethod = response.request().method();
+        if (path.startsWith("/scim")) {
+            if (httpMethod.toUpperCase(Locale.ENGLISH).equals("GET")) {
+                writeMergedJsonData(path, body);
+            }
+        } else {
+            writeMergedJsonData(path, body);
+        }
+    }
+
+    public void writeMergedJsonData(String path, String body) throws IOException {
+        if (body == null || (!body.trim().startsWith("{") && !body.trim().startsWith("["))) {
+            // given body is not in JSON format
+            return;
+        }
+        JsonElement newJson = JsonParser.parseString(body);
+
+        String existingJson = null;
+        if (path.startsWith("/scim")) {
+            path = path.replaceFirst("/\\w{9,11}$", "/00000000000");
+        }
+        // status api
+        if (path.startsWith("/api/v1.0.0") || path.startsWith("/api/v2.0.0")) {
+            path = "/status" + path;
+        }
+        try {
+            Path jsonFilePath = new File(toRawFilePath(path)).toPath();
+            existingJson = Files.readAllLines(jsonFilePath, UTF_8).stream().collect(Collectors.joining());
+        } catch (NoSuchFileException e) {
+        }
+        if (existingJson == null || existingJson.trim().isEmpty()) {
+            if (body.trim().startsWith("[")) {
+                existingJson = body;
+            } else {
+                existingJson = "{}";
+            }
+        }
+        JsonElement jsonElem = JsonParser.parseString(existingJson);
+        JsonObject jsonObj = jsonElem.isJsonObject() ? jsonElem.getAsJsonObject() : null;
+
+        if (newJson.isJsonObject()) {
+            try {
+                JsonObject newJsonObj = newJson.getAsJsonObject();
+                MergeJsonBuilder.mergeJsonObjects(jsonObj, MergeJsonBuilder.ConflictStrategy.PREFER_FIRST_OBJ, newJsonObj);
+            } catch (MergeJsonBuilder.JsonConflictException e) {
+                log.warn("Failed to merge JSON objects because {}", e.getMessage(), e);
+            }
+        }
+        Path rawFilePath = new File(toRawFilePath(path)).toPath();
+        Files.createDirectories(rawFilePath.getParent());
+        existingJson = gson().toJson(jsonElem);
+        Files.write(rawFilePath, existingJson.getBytes(UTF_8));
+
+        if (jsonElem.isJsonObject() && jsonObj != null) {
+            for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+                scanToNormalizeValues(path, jsonObj, entry.getKey(), entry.getValue());
+            }
+
+            if (path.startsWith("/scim")) {
+                if (jsonObj.get("Resources") != null) {
+                    for (JsonElement resource : jsonObj.get("Resources").getAsJsonArray()) {
+                        JsonObject resourceObj = resource.getAsJsonObject();
+                        if (resourceObj.get("userName") != null) {
+                            initializeSCIMUser(resourceObj);
+                        }
+                        if (resourceObj.get("members") != null) {
+                            initializeSCIMGroup(resourceObj);
+                        }
+                    }
+                } else {
+                    if (jsonObj.get("userName") != null) {
+                        initializeSCIMUser(jsonObj);
+                    }
+                    if (jsonObj.get("members") != null) {
+                        initializeSCIMGroup(jsonObj);
+                    }
+                }
+                existingJson = gson().toJson(jsonObj);
+                Path filePath = new File(toMaskedFilePath(path).replaceFirst("/\\w{9}.json$", "/000000000.json")).toPath();
+                Files.createDirectories(filePath.getParent());
+                Files.write(filePath, existingJson.getBytes(UTF_8));
+
+            } else {
+                if (!path.startsWith("/status")) {
+                    addCommonPropertiesAtTopLevel(jsonObj);
+                }
+
+                existingJson = gson().toJson(jsonObj);
+                Path filePath = new File(toMaskedFilePath(path)).toPath();
+                Files.createDirectories(filePath.getParent());
+                Files.write(filePath, existingJson.getBytes(UTF_8));
+            }
+        } else if (jsonElem.isJsonArray()) {
+            JsonArray jsonArray = jsonElem.getAsJsonArray();
+            scanToNormalizeValues(path, null, null, jsonArray);
+            existingJson = gson().toJson(jsonArray);
+            Path filePath = new File(toMaskedFilePath(path)).toPath();
+            Files.createDirectories(filePath.getParent());
+            Files.write(filePath, existingJson.getBytes(UTF_8));
+        }
+    }
+
+    private void initializeSCIMGroup(JsonObject resourceObj) {
+        if (resourceObj.get("members") == null) {
+            resourceObj.add("members", new JsonArray());
+        }
+        {
+            JsonArray objects = resourceObj.get("members").getAsJsonArray();
+            clearAllElements(objects);
+            com.slack.api.scim.model.Group.Member sampleObject =
+                    ObjectInitializer.initProperties(new com.slack.api.scim.model.Group.Member());
+            objects.add(GsonFactory.createCamelCase(config).toJsonTree(sampleObject));
+        }
+    }
+
+    private void initializeSCIMUser(JsonObject resourceObj) {
+        if (resourceObj.get("addresses") == null) {
+            resourceObj.add("addresses", new JsonArray());
+        }
+        {
+            JsonArray objects = resourceObj.get("addresses").getAsJsonArray();
+            clearAllElements(objects);
+            User.Address sampleObject = ObjectInitializer.initProperties(new User.Address());
+            objects.add(GsonFactory.createCamelCase(config).toJsonTree(sampleObject));
+        }
+        if (resourceObj.get("emails") == null) {
+            resourceObj.add("emails", new JsonArray());
+        }
+        {
+            JsonArray objects = resourceObj.get("emails").getAsJsonArray();
+            clearAllElements(objects);
+            User.Email sampleObject = ObjectInitializer.initProperties(new User.Email());
+            objects.add(GsonFactory.createCamelCase(config).toJsonTree(sampleObject));
+        }
+        if (resourceObj.get("phoneNumbers") == null) {
+            resourceObj.add("phoneNumbers", new JsonArray());
+        }
+        {
+            JsonArray objects = resourceObj.get("phoneNumbers").getAsJsonArray();
+            clearAllElements(objects);
+            User.PhoneNumber sampleObject = ObjectInitializer.initProperties(new User.PhoneNumber());
+            objects.add(GsonFactory.createCamelCase(config).toJsonTree(sampleObject));
+        }
+        if (resourceObj.get("photos") == null) {
+            resourceObj.add("photos", new JsonArray());
+        }
+        {
+            JsonArray objects = resourceObj.get("photos").getAsJsonArray();
+            clearAllElements(objects);
+            User.Photo sampleObject = ObjectInitializer.initProperties(new User.Photo());
+            objects.add(GsonFactory.createCamelCase(config).toJsonTree(sampleObject));
+        }
+        if (resourceObj.get("roles") == null) {
+            resourceObj.add("roles", new JsonArray());
+        }
+        {
+            JsonArray objects = resourceObj.get("roles").getAsJsonArray();
+            clearAllElements(objects);
+            User.Role sampleObject = ObjectInitializer.initProperties(new User.Role());
+            objects.add(GsonFactory.createCamelCase(config).toJsonTree(sampleObject));
+        }
+        if (resourceObj.get("groups") == null) {
+            resourceObj.add("groups", new JsonArray());
+        }
+        {
+            JsonArray objects = resourceObj.get("groups").getAsJsonArray();
+            clearAllElements(objects);
+            User.Group sampleObject = ObjectInitializer.initProperties(new User.Group());
+            objects.add(GsonFactory.createCamelCase(config).toJsonTree(sampleObject));
+        }
+    }
+
+    private static void clearAllElements(JsonArray objects) {
+        for (int i = 0; i < objects.size(); i++) {
+            objects.remove(i);
+        }
+    }
+
+    private static final List<String> COMMON_TOP_LEVEL_PROPERTY_NAMES = Arrays.asList(
+            "ok",
+            "error",
+            "needed",
+            "provided"
+    );
+
+    private static void addCommonPropertiesAtTopLevel(JsonObject root) {
+        List<String> missingPropNames = new ArrayList<>(COMMON_TOP_LEVEL_PROPERTY_NAMES);
+        for (Map.Entry<String, JsonElement> entry : root.entrySet()) {
+            missingPropNames.remove(entry.getKey());
+        }
+        for (String missingPropName : missingPropNames) {
+            if (missingPropName.equals("ok")) {
+                root.add(missingPropName, new JsonPrimitive(false));
+            } else {
+                root.add(missingPropName, new JsonPrimitive(""));
+            }
+        }
+    }
+
+
+    private MergeJsonBuilder.ConflictStrategy CONFLICT_STRATEGY = MergeJsonBuilder.ConflictStrategy.PREFER_FIRST_OBJ;
+
+    private void scanToNormalizeValues(String path, JsonElement parent, String name, JsonElement element) {
+        Gson gson = GsonFactory.createSnakeCase();
+        if (element.isJsonArray()) {
+            JsonArray array = element.getAsJsonArray();
+            if (name != null && name.equals("attachments")) {
+                for (int idx = 0; idx < array.size(); idx++) {
+                    array.remove(idx);
+                }
+                for (JsonElement attachment : SampleObjects.Json.Attachments) {
+                    array.add(attachment);
+                }
+            } else if (name != null && name.equals("blocks")) {
+                for (int idx = 0; idx < array.size(); idx++) {
+                    array.remove(idx);
+                }
+                for (JsonElement block : SampleObjects.Json.Blocks) {
+                    array.add(block);
+                }
+            } else if (name != null && name.equals("replies")) {
+                for (int idx = 0; idx < array.size(); idx++) {
+                    array.remove(idx);
+                }
+                array.add(gson.toJsonTree(ObjectInitializer.initProperties(new Message.MessageRootReply())));
+            } else if (name != null && name.equals("comments")) {
+                for (int idx = 0; idx < array.size(); idx++) {
+                    array.remove(idx);
+                }
+                array.add(gson.toJsonTree(ObjectInitializer.initProperties(new FileComment())));
+            }
+            if (array.size() == 0) {
+                List<String> addressNames = Arrays.asList("from", "to", "cc");
+                if (path.startsWith("/scim")) {
+                    // noop
+                } else if (addressNames.contains(name)) {
+                    Address address = new Address();
+                    address.setAddress("");
+                    address.setName("");
+                    address.setOriginal("");
+                    JsonElement elem = gson.toJsonTree(address);
+                    array.add(elem);
+                } else if (path.equals("/api/conversations.list") && name.equals("channels")) {
+                    array.add(gson.toJsonTree(ObjectInitializer.initProperties(new Conversation())));
+                } else if (path.equals("/api/users.conversations") && name.equals("channels")) {
+                    array.add(gson.toJsonTree(ObjectInitializer.initProperties(new Conversation())));
+                } else if (path.equals("/api/rtm.start") && name.equals("groups")) {
+                    array.add(gson.toJsonTree(ObjectInitializer.initProperties(new Group())));
+                } else if (name.equals("app_requests")) {
+                    array.add(gson.toJsonTree(ObjectInitializer.initProperties(new AppRequest())));
+                } else if (path.equals("/api/chat.scheduledMessages.list") && name.equals("scheduled_messages")) {
+                    array.add(gson.toJsonTree(ObjectInitializer.initProperties(new ChatScheduledMessagesListResponse.ScheduledMessage())));
+                } else if (name.equals("replies")) {
+                    array.add(gson.toJsonTree(ObjectInitializer.initProperties(new Message.MessageRootReply())));
+                } else if (name.equals("comments")) {
+                    array.add(gson.toJsonTree(ObjectInitializer.initProperties(new FileComment())));
+                } else if (name.equals("active_incidents")) {
+                    SlackIssue slackIssue = new SlackIssue();
+                    slackIssue.setNotes(Arrays.asList(ObjectInitializer.initProperties(new SlackIssue.Note())));
+                    slackIssue.setServices(Arrays.asList(""));
+                    slackIssue = ObjectInitializer.initProperties(slackIssue);
+                    array.add(gson.toJsonTree(slackIssue));
+                } else {
+                    array.add(""); // in most cases, empty array can have string values
+                }
+            } else {
+                JsonElement first = array.get(0);
+                if (first.isJsonPrimitive()) {
+                    array.set(0, normalize(first.getAsJsonPrimitive()));
+                    int size = array.size();
+                    if (size > 1) {
+                        for (int idx = size - 1; idx > 0; idx--) {
+                            array.remove(idx);
+                        }
+                    }
+                } else {
+                    for (JsonElement child : array) {
+                        scanToNormalizeValues(path, array, null, child);
+                    }
+                    if (array.size() >= 2) {
+                        for (int idx = 1; idx < array.size(); idx++) {
+                            JsonElement elem = array.get(idx);
+                            if (elem.isJsonArray()) {
+                                for (JsonElement child : elem.getAsJsonArray()) {
+                                    scanToNormalizeValues(path, elem, null, child);
+                                }
+                            } else {
+                                try {
+                                    MergeJsonBuilder.mergeJsonObjects(first.getAsJsonObject(), CONFLICT_STRATEGY, elem.getAsJsonObject());
+                                } catch (MergeJsonBuilder.JsonConflictException e) {
+                                    log.error("Failed to merge {} into {}", elem, first);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            int size = array.size();
+            if (size > 1) {
+                for (int idx = size - 1; idx > 0; idx--) {
+                    array.remove(idx);
+                }
+            }
+        } else if (element.isJsonObject()) {
+            List<Map.Entry<String, JsonElement>> entries = new ArrayList<>(element.getAsJsonObject().entrySet());
+            if (entries.size() > 0) {
+                if (entries.get(0).getKey().matches("^[A-Z].{8,10}$")) {
+                    Map.Entry<String, JsonElement> first = entries.get(0);
+                    for (Map.Entry<String, JsonElement> entry : entries) {
+                        element.getAsJsonObject().remove(entry.getKey());
+                    }
+                    // if the child element seems to be a Map object using identifiers (e.g., channel id, user id) as keys
+                    // the Map object should have 2+ elements to allow quicktype generate preferable code.
+                    element.getAsJsonObject().add(first.getKey().substring(0, 1) + "00000000", first.getValue());
+                    element.getAsJsonObject().add(first.getKey().substring(0, 1) + "00000001", first.getValue());
+                }
+                if (name != null && name.equals("emoji")) {
+                    Map.Entry<String, JsonElement> first = entries.get(0);
+                    for (Map.Entry<String, JsonElement> entry : entries) {
+                        element.getAsJsonObject().remove(entry.getKey());
+                    }
+                    element.getAsJsonObject().add("emoji", first.getValue());
+                    element.getAsJsonObject().add("emoji_", first.getValue());
+                }
+            }
+            for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+                scanToNormalizeValues(path, element, entry.getKey(), entry.getValue());
+            }
+        } else if (element.isJsonNull()) {
+            return;
+        } else if (!parent.isJsonArray() && element.isJsonPrimitive()) {
+            JsonPrimitive prim = element.getAsJsonPrimitive();
+            parent.getAsJsonObject().add(name, normalize(prim));
+        }
+    }
+
+    private JsonElement normalize(JsonPrimitive original) {
+        if (original.isString()) {
+            return new JsonPrimitive(normalizeString(original.getAsString()));
+        } else if (original.isBoolean()) {
+            return new JsonPrimitive(false);
+        } else if (original.isNumber()) {
+            return new JsonPrimitive(12345);
+        } else {
+            return JsonNull.INSTANCE;
+        }
+    }
+
+    private String normalizeString(String value) {
+        if (value == null) {
+            return null;
+        }
+        if (value.matches("^[\\d]+\\.[\\d]+$")) {
+            return "0000000000.000000"; // ts
+        }
+        if (value.matches("^[\\d]{10}$")) {
+            return "1234567890"; // epoch
+        }
+        // bmV4dF90czoxNTU2MDYwMTAzMDAwNDAw
+        if (value.startsWith("http://") || value.startsWith("https://")) {
+            return "https://www.example.com/";
+        }
+        if (value.matches("^[A-Z][A-Z0-9]{8,10}$")) {
+            return value.substring(0, 1) + "00000000"; // identifier
+        }
+        if (value.matches("^\\d$")) {
+            return "0"; // other numbers
+        } else if (value.matches("^[\\d]+$")) {
+            return "12345"; // other numbers
+        }
+        return "";
+    }
+
+    private Gson gson() {
+        return new GsonBuilder()
+                .setPrettyPrinting()
+                .create();
+    }
+
+    private String toRawFilePath(String path) {
+        return outputDirectory + "/raw/" + path + ".json";
+    }
+
+    private String toMaskedFilePath(String path) {
+        return outputDirectory + "/samples/" + path + ".json";
+    }
+
+    @Data
+    public static class Address {
+        private String address;
+        private String name;
+        private String original;
+    }
+
+}

--- a/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/JsonDataRecordingListener.java
+++ b/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/JsonDataRecordingListener.java
@@ -1,0 +1,53 @@
+package test_with_remote_apis.sample_json_generation;
+
+import com.slack.api.util.http.listener.HttpResponseListener;
+import com.slack.api.util.thread.ExecutorServiceFactory;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+
+import static java.util.stream.Collectors.joining;
+
+@Slf4j
+public class JsonDataRecordingListener extends HttpResponseListener {
+
+    private final CopyOnWriteArrayList<String> remaining = new CopyOnWriteArrayList<>();
+    private final String threadGroupName = "slack-unit-test-JsonDataRecordingListener";
+    private final ExecutorService executorService = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, 5);
+
+    public boolean isAllDone() {
+        if (remaining.size() > 0) {
+            log.debug("remaining: {} ({})",
+                    remaining.size(),
+                    remaining.stream().map(r -> "`" + (r.length() > 30 ? r.substring(0, 30) : r) + "...`").collect(joining(",", "[", "]")));
+        }
+        return remaining.size() == 0;
+    }
+
+    @Override
+    public void accept(State state) {
+        executorService.submit(() -> {
+            String bodyPrefix = state.getParsedResponseBody();
+            if (bodyPrefix != null && bodyPrefix.length() > 100) {
+                bodyPrefix = state.getParsedResponseBody().substring(0, 100) + "...";
+            }
+            try {
+                if (remaining.contains(bodyPrefix)) {
+                    // skip the same content
+                    return;
+                }
+                remaining.add(bodyPrefix);
+                log.debug("Started for `{}` - remaining: {}", bodyPrefix, remaining.size());
+                JsonDataRecorder recorder = new JsonDataRecorder(state.getConfig(), "../json-logs");
+                recorder.writeMergedResponse(state.getResponse(), state.getParsedResponseBody());
+            } catch (IOException e) {
+                log.error("Failed to write JSON files because {}", e.getMessage(), e);
+            } finally {
+                remaining.remove(bodyPrefix);
+                log.debug("Finished for `{}` - remaining: {}", bodyPrefix, remaining.size());
+            }
+        });
+    }
+}

--- a/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/ObjectToJsonDumper.java
+++ b/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/ObjectToJsonDumper.java
@@ -1,0 +1,37 @@
+package test_with_remote_apis.sample_json_generation;
+
+import com.slack.api.SlackConfig;
+import com.slack.api.util.json.GsonFactory;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Slf4j
+public class ObjectToJsonDumper {
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    private String outputDirectory;
+
+    public ObjectToJsonDumper(String outputDirectory) {
+        this.outputDirectory = outputDirectory;
+    }
+
+    public void dump(String path, Object obj) throws IOException {
+        SlackConfig config = new SlackConfig();
+        config.setPrettyResponseLoggingEnabled(true);
+        String json = GsonFactory.createSnakeCase(config).toJson(obj);
+        Path filePath = new File(toFilePath(path)).toPath();
+        Files.createDirectories(filePath.getParent());
+        Files.write(filePath, json.getBytes(UTF_8));
+    }
+
+    private String toFilePath(String path) {
+        return outputDirectory + "/" + path + ".json";
+    }
+
+}

--- a/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/SampleObjects.java
+++ b/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/SampleObjects.java
@@ -2,10 +2,9 @@ package test_with_remote_apis.sample_json_generation;
 
 import com.google.gson.JsonElement;
 import com.slack.api.model.*;
-import com.slack.api.model.block.ActionsBlock;
-import com.slack.api.model.block.LayoutBlock;
-import com.slack.api.model.block.SectionBlock;
+import com.slack.api.model.block.*;
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
+import com.slack.api.model.block.composition.OptionObject;
 import com.slack.api.model.block.composition.PlainTextObject;
 import com.slack.api.model.block.composition.TextObject;
 import com.slack.api.model.block.element.BlockElement;
@@ -17,15 +16,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.slack.api.model.block.Blocks.asBlocks;
-import static com.slack.api.model.block.Blocks.section;
+import static com.slack.api.model.block.Blocks.*;
 import static com.slack.api.model.block.composition.BlockCompositions.*;
 import static com.slack.api.model.block.element.BlockElements.*;
 import static test_with_remote_apis.sample_json_generation.ObjectInitializer.initProperties;
 
 public class SampleObjects {
-
-    private static final String imageUrl = "https://is5-ssl.mzstatic.com/image/thumb/Purple3/v4/d3/72/5c/d3725c8f-c642-5d69-1904-aa36e4297885/source/256x256bb.jpg";
 
     private SampleObjects() {
     }
@@ -42,8 +38,14 @@ public class SampleObjects {
                 GsonFactory.createSnakeCase().toJsonTree(initProperties(
                         ActionsBlock.builder().elements(BlockElements).build())),
                 GsonFactory.createSnakeCase().toJsonTree(initProperties(
+                        ContextBlock.builder().elements(ContextBlockElements).build())),
+                GsonFactory.createSnakeCase().toJsonTree(initProperties(
+                        DividerBlock.builder().build())),
+                GsonFactory.createSnakeCase().toJsonTree(initProperties(
+                        ImageBlock.builder().build())),
+                GsonFactory.createSnakeCase().toJsonTree(initProperties(
                         SectionBlock.builder()
-                                .accessory(initProperties(ImageElement.builder().imageUrl(imageUrl).build()))
+                                .accessory(initProperties(ImageElement.builder().build()))
                                 .text(TextObject)
                                 .fields(SectionBlockFieldElements)
                                 .build()))
@@ -64,27 +66,38 @@ public class SampleObjects {
 
     public static TextObject TextObject = initProperties(PlainTextObject.builder().build());
 
+    public static OptionObject Option = initProperties(OptionObject.builder()
+            .text(TextObject)
+            .description(PlainTextObject.builder().build())
+            .build());
+
     public static ConfirmationDialogObject Confirm = ConfirmationDialogObject.builder().text(TextObject).build();
 
     public static List<BlockElement> BlockElements = asElements(
-            initProperties(button(b -> b.actionId("button-action").confirm(Confirm))),
+            initProperties(button(b -> b.confirm(Confirm))),
             initProperties(channelsSelect(c -> c.confirm(Confirm))),
             initProperties(conversationsSelect(c -> c.confirm(Confirm))),
             initProperties(datePicker(d -> d.confirm(Confirm))),
-            initProperties(overflowMenu(o -> o
-                    .confirm(Confirm)
-                    .actionId("overflow-action")
-                    .options(asOptions(option(op -> op.text(plainText("l")).value("v"))))
-            )),
+            initProperties(externalSelect(e -> e.initialOption(Option).confirm(Confirm))),
+            initProperties(com.slack.api.model.block.element.BlockElements.image(i -> i)),
+            initProperties(overflowMenu(o -> o.confirm(Confirm))),
+            initProperties(staticSelect(s -> s.initialOption(Option).confirm(Confirm))),
             initProperties(usersSelect(u -> u.confirm(Confirm)))
+    );
+    public static List<ContextBlockElement> ContextBlockElements = asContextElements(
+            initProperties(ImageElement.builder().build())
     );
     public static List<TextObject> SectionBlockFieldElements = asSectionFields(
             initProperties(plainText(pt -> pt)),
             initProperties(markdownText(m -> m))
     );
     public static List<LayoutBlock> Blocks = asBlocks(
+            initProperties(actions(a -> a.elements(BlockElements))),
+            initProperties(context(c -> c.elements(ContextBlockElements))),
+            initProperties(divider()),
+            initProperties(com.slack.api.model.block.Blocks.image(i -> i)),
             initProperties(section(s -> s
-                    .accessory(initProperties(ImageElement.builder().imageUrl(imageUrl).build()))
+                    .accessory(initProperties(ImageElement.builder().build()))
                     .text(TextObject)
                     .fields(SectionBlockFieldElements)))
     );

--- a/bolt-servlet/src/test/resources/appConfig.example.json
+++ b/bolt-servlet/src/test/resources/appConfig.example.json
@@ -1,4 +1,5 @@
 {
   "publicUrl": "https://xxx.ngrok.io/slack/events",
-  "signingSecret": "abcabcabcabcabcabcabcabcabc"
+  "signingSecret": "abcabcabcabcabcabcabcabcabc",
+  "singleTeamBotToken": "xoxb-"
 }

--- a/bolt/src/main/java/com/slack/api/bolt/util/EventsApiPayloadParser.java
+++ b/bolt/src/main/java/com/slack/api/bolt/util/EventsApiPayloadParser.java
@@ -2,6 +2,7 @@ package com.slack.api.bolt.util;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.slack.api.app_backend.events.payload.Authorization;
 import com.slack.api.app_backend.events.payload.EventsApiPayload;
 import com.slack.api.bolt.request.builtin.EventRequest;
 import com.slack.api.model.event.Event;
@@ -78,6 +79,8 @@ public class EventsApiPayloadParser {
         private String type;
         private List<String> authedUsers;
         private List<String> authedTeams;
+        private List<Authorization> authorizations;
+        private boolean isExtSharedChannel;
         private String eventId;
         private Integer eventTime;
         private String eventContext;

--- a/json-logs/samples/api/apps.event.authorizations.list.json
+++ b/json-logs/samples/api/apps.event.authorizations.list.json
@@ -1,6 +1,15 @@
 {
   "ok": false,
   "error": "",
+  "authorizations": [
+    {
+      "enterprise_id": "E00000000",
+      "team_id": "T00000000",
+      "user_id": "W00000000",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
   "needed": "",
   "provided": ""
 }

--- a/json-logs/samples/api/chat.update.json
+++ b/json-logs/samples/api/chat.update.json
@@ -157,7 +157,43 @@
     "edited": {
       "user": "B00000000",
       "ts": "0000000000.000000"
-    }
+    },
+    "files": [
+      {
+        "id": "F00000000",
+        "created": 12345,
+        "timestamp": 12345,
+        "name": "",
+        "title": "",
+        "mimetype": "",
+        "filetype": "",
+        "pretty_type": "",
+        "user": "W00000000",
+        "editable": false,
+        "size": 12345,
+        "mode": "",
+        "is_external": false,
+        "external_type": "",
+        "is_public": false,
+        "public_url_shared": false,
+        "display_as_bot": false,
+        "username": "",
+        "url_private": "https://www.example.com/",
+        "url_private_download": "https://www.example.com/",
+        "permalink": "https://www.example.com/",
+        "permalink_public": "https://www.example.com/",
+        "edit_link": "https://www.example.com/",
+        "preview": "",
+        "preview_highlight": "",
+        "lines": 12345,
+        "lines_more": 12345,
+        "preview_is_truncated": false,
+        "is_starred": false,
+        "has_rich_preview": false
+      }
+    ],
+    "upload": false,
+    "display_as_bot": false
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/conversations.invite.json
+++ b/json-logs/samples/api/conversations.invite.json
@@ -41,7 +41,12 @@
     },
     "previous_names": [
       ""
-    ]
+    ],
+    "is_moved": 12345,
+    "internal_team_ids": [
+      "T00000000"
+    ],
+    "is_open": false
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/conversations.join.json
+++ b/json-logs/samples/api/conversations.join.json
@@ -42,7 +42,11 @@
       ""
     ],
     "last_read": "0000000000.000000",
-    "priority": 12345
+    "priority": 12345,
+    "is_moved": 12345,
+    "internal_team_ids": [
+      "T00000000"
+    ]
   },
   "warning": "",
   "response_metadata": {

--- a/json-logs/samples/api/conversations.rename.json
+++ b/json-logs/samples/api/conversations.rename.json
@@ -40,7 +40,12 @@
     },
     "previous_names": [
       ""
-    ]
+    ],
+    "is_moved": 12345,
+    "internal_team_ids": [
+      "T00000000"
+    ],
+    "is_open": false
   },
   "ok": false,
   "error": "",

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -622,7 +622,8 @@
       },
       "admin_customized_quick_reactions": [
         ""
-      ]
+      ],
+      "enable_connect_dm_early_access": false
     },
     "icon": {
       "image_34": "https://www.example.com/",

--- a/json-logs/samples/api/usergroups.disable.json
+++ b/json-logs/samples/api/usergroups.disable.json
@@ -25,7 +25,10 @@
         ""
       ]
     },
-    "channel_count": 12345
+    "channel_count": 12345,
+    "users": [
+      "W00000000"
+    ]
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/events/AppHomeOpenedPayload.json
+++ b/json-logs/samples/events/AppHomeOpenedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/AppMentionPayload.json
+++ b/json-logs/samples/events/AppMentionPayload.json
@@ -29,7 +29,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/AppRateLimitedPayload.json
+++ b/json-logs/samples/events/AppRateLimitedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/AppRequestedPayload.json
+++ b/json-logs/samples/events/AppRequestedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/AppUninstalledPayload.json
+++ b/json-logs/samples/events/AppUninstalledPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/CallRejectedPayload.json
+++ b/json-logs/samples/events/CallRejectedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/ChannelArchivePayload.json
+++ b/json-logs/samples/events/ChannelArchivePayload.json
@@ -13,7 +13,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/ChannelCreatedPayload.json
+++ b/json-logs/samples/events/ChannelCreatedPayload.json
@@ -20,8 +20,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
   ],
+  "is_ext_shared_channel": false,
   "event_context": ""
 }

--- a/json-logs/samples/events/ChannelDeletedPayload.json
+++ b/json-logs/samples/events/ChannelDeletedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/ChannelHistoryChangedPayload.json
+++ b/json-logs/samples/events/ChannelHistoryChangedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/ChannelLeftPayload.json
+++ b/json-logs/samples/events/ChannelLeftPayload.json
@@ -12,7 +12,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/ChannelRenamePayload.json
+++ b/json-logs/samples/events/ChannelRenamePayload.json
@@ -18,7 +18,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/ChannelSharedPayload.json
+++ b/json-logs/samples/events/ChannelSharedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/ChannelUnarchivePayload.json
+++ b/json-logs/samples/events/ChannelUnarchivePayload.json
@@ -12,7 +12,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/ChannelUnsharedPayload.json
+++ b/json-logs/samples/events/ChannelUnsharedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/DndUpdatedPayload.json
+++ b/json-logs/samples/events/DndUpdatedPayload.json
@@ -19,7 +19,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/DndUpdatedUserPayload.json
+++ b/json-logs/samples/events/DndUpdatedUserPayload.json
@@ -1,22 +1,27 @@
 {
   "token": "",
-  "team_id": "",
   "enterprise_id": "",
+  "team_id": "",
   "api_app_id": "",
+  "type": "",
+  "authed_users": [
+    ""
+  ],
+  "authed_teams": [
+    ""
+  ],
+  "is_ext_shared_channel": false,
+  "event_id": "",
+  "event_time": 123,
+  "event_context": "",
   "event": {
     "type": "dnd_updated_user",
     "user": "",
     "dnd_status": {
       "dnd_enabled": false,
-      "next_dnd_start_ts": 12345,
-      "next_dnd_end_ts": 12345
+      "next_dnd_start_ts": 123,
+      "next_dnd_end_ts": 123
     },
-    "event_ts": "0000000000.000000"
-  },
-  "type": "event_callback",
-  "event_id": "",
-  "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+    "event_ts": ""
+  }
 }

--- a/json-logs/samples/events/EmailDomainChangedPayload.json
+++ b/json-logs/samples/events/EmailDomainChangedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/EmojiChangedPayload.json
+++ b/json-logs/samples/events/EmojiChangedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/FileChangePayload.json
+++ b/json-logs/samples/events/FileChangePayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/FileCreatedPayload.json
+++ b/json-logs/samples/events/FileCreatedPayload.json
@@ -15,7 +15,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/FileDeletedPayload.json
+++ b/json-logs/samples/events/FileDeletedPayload.json
@@ -14,7 +14,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/FilePublicPayload.json
+++ b/json-logs/samples/events/FilePublicPayload.json
@@ -15,7 +15,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/FileSharedPayload.json
+++ b/json-logs/samples/events/FileSharedPayload.json
@@ -16,7 +16,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/FileUnsharedPayload.json
+++ b/json-logs/samples/events/FileUnsharedPayload.json
@@ -16,7 +16,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/GoodbyePayload.json
+++ b/json-logs/samples/events/GoodbyePayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/GridMigrationFinishedPayload.json
+++ b/json-logs/samples/events/GridMigrationFinishedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/GridMigrationStartedPayload.json
+++ b/json-logs/samples/events/GridMigrationStartedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/GroupArchivePayload.json
+++ b/json-logs/samples/events/GroupArchivePayload.json
@@ -13,7 +13,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/GroupClosePayload.json
+++ b/json-logs/samples/events/GroupClosePayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/GroupDeletedPayload.json
+++ b/json-logs/samples/events/GroupDeletedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/GroupHistoryChangedPayload.json
+++ b/json-logs/samples/events/GroupHistoryChangedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/GroupLeftPayload.json
+++ b/json-logs/samples/events/GroupLeftPayload.json
@@ -12,7 +12,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/GroupOpenPayload.json
+++ b/json-logs/samples/events/GroupOpenPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/GroupRenamePayload.json
+++ b/json-logs/samples/events/GroupRenamePayload.json
@@ -18,7 +18,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/GroupUnarchivePayload.json
+++ b/json-logs/samples/events/GroupUnarchivePayload.json
@@ -12,7 +12,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/ImClosePayload.json
+++ b/json-logs/samples/events/ImClosePayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/ImCreatedPayload.json
+++ b/json-logs/samples/events/ImCreatedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/ImHistoryChangedPayload.json
+++ b/json-logs/samples/events/ImHistoryChangedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/ImOpenPayload.json
+++ b/json-logs/samples/events/ImOpenPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/InviteRequestedPayload.json
+++ b/json-logs/samples/events/InviteRequestedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/LinkSharedPayload.json
+++ b/json-logs/samples/events/LinkSharedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/MemberJoinedChannelPayload.json
+++ b/json-logs/samples/events/MemberJoinedChannelPayload.json
@@ -15,8 +15,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
   ],
+  "is_ext_shared_channel": false,
   "event_context": ""
 }

--- a/json-logs/samples/events/MemberLeftChannelPayload.json
+++ b/json-logs/samples/events/MemberLeftChannelPayload.json
@@ -14,7 +14,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/MessageBotPayload.json
+++ b/json-logs/samples/events/MessageBotPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/MessageChangedPayload.json
+++ b/json-logs/samples/events/MessageChangedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/MessageDeletedPayload.json
+++ b/json-logs/samples/events/MessageDeletedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/MessageEkmAccessDeniedPayload.json
+++ b/json-logs/samples/events/MessageEkmAccessDeniedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/MessageFileSharePayload.json
+++ b/json-logs/samples/events/MessageFileSharePayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/MessageMePayload.json
+++ b/json-logs/samples/events/MessageMePayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/MessagePayload.json
+++ b/json-logs/samples/events/MessagePayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/MessageRepliedPayload.json
+++ b/json-logs/samples/events/MessageRepliedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/MessageThreadBroadcastPayload.json
+++ b/json-logs/samples/events/MessageThreadBroadcastPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/PinAddedPayload.json
+++ b/json-logs/samples/events/PinAddedPayload.json
@@ -50,7 +50,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/PinRemovedPayload.json
+++ b/json-logs/samples/events/PinRemovedPayload.json
@@ -48,7 +48,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/ReactionAddedPayload.json
+++ b/json-logs/samples/events/ReactionAddedPayload.json
@@ -18,7 +18,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/ReactionRemovedPayload.json
+++ b/json-logs/samples/events/ReactionRemovedPayload.json
@@ -18,7 +18,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/ResourcesAddedPayload.json
+++ b/json-logs/samples/events/ResourcesAddedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/ResourcesRemovedPayload.json
+++ b/json-logs/samples/events/ResourcesRemovedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/ScopeDeniedPayload.json
+++ b/json-logs/samples/events/ScopeDeniedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/ScopeGrantedPayload.json
+++ b/json-logs/samples/events/ScopeGrantedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/StarAddedPayload.json
+++ b/json-logs/samples/events/StarAddedPayload.json
@@ -35,32 +35,23 @@
         },
         "attachments": [
           {
-            "service_name": "",
-            "service_url": "https://www.example.com/",
-            "title": "",
-            "title_link": "https://www.example.com/",
-            "author_name": "",
-            "author_link": "https://www.example.com/",
-            "thumb_url": "https://www.example.com/",
-            "thumb_width": 12345,
-            "thumb_height": 12345,
-            "fallback": "",
-            "video_html": "",
-            "video_html_width": 12345,
-            "video_html_height": 12345,
-            "from_url": "https://www.example.com/",
-            "service_icon": "https://www.example.com/",
-            "id": 12345,
-            "original_url": "https://www.example.com/",
             "msg_subtype": "",
             "callback_id": "",
             "color": "",
             "pretext": "",
+            "service_url": "",
+            "service_name": "",
+            "service_icon": "",
             "author_id": "",
+            "author_name": "",
+            "author_link": "",
             "author_icon": "",
+            "from_url": "",
+            "original_url": "",
             "author_subname": "",
             "channel_id": "",
             "channel_name": "",
+            "id": 12345,
             "bot_id": "",
             "indent": false,
             "is_msg_unfurl": false,
@@ -68,6 +59,8 @@
             "is_thread_root_unfurl": false,
             "is_app_unfurl": false,
             "app_unfurl_url": "",
+            "title": "",
+            "title_link": "",
             "text": "",
             "fields": [
               {
@@ -76,6 +69,12 @@
                 "short": false
               }
             ],
+            "thumb_url": "",
+            "thumb_width": 12345,
+            "thumb_height": 12345,
+            "video_html": "",
+            "video_html_width": 12345,
+            "video_html_height": 12345,
             "footer": "",
             "footer_icon": "",
             "ts": "",
@@ -147,7 +146,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/StarRemovedPayload.json
+++ b/json-logs/samples/events/StarRemovedPayload.json
@@ -35,32 +35,23 @@
         },
         "attachments": [
           {
-            "service_name": "",
-            "service_url": "https://www.example.com/",
-            "title": "",
-            "title_link": "https://www.example.com/",
-            "author_name": "",
-            "author_link": "https://www.example.com/",
-            "thumb_url": "https://www.example.com/",
-            "thumb_width": 12345,
-            "thumb_height": 12345,
-            "fallback": "",
-            "video_html": "",
-            "video_html_width": 12345,
-            "video_html_height": 12345,
-            "from_url": "https://www.example.com/",
-            "service_icon": "https://www.example.com/",
-            "id": 12345,
-            "original_url": "https://www.example.com/",
             "msg_subtype": "",
             "callback_id": "",
             "color": "",
             "pretext": "",
+            "service_url": "",
+            "service_name": "",
+            "service_icon": "",
             "author_id": "",
+            "author_name": "",
+            "author_link": "",
             "author_icon": "",
+            "from_url": "",
+            "original_url": "",
             "author_subname": "",
             "channel_id": "",
             "channel_name": "",
+            "id": 12345,
             "bot_id": "",
             "indent": false,
             "is_msg_unfurl": false,
@@ -68,6 +59,8 @@
             "is_thread_root_unfurl": false,
             "is_app_unfurl": false,
             "app_unfurl_url": "",
+            "title": "",
+            "title_link": "",
             "text": "",
             "fields": [
               {
@@ -76,6 +69,12 @@
                 "short": false
               }
             ],
+            "thumb_url": "",
+            "thumb_width": 12345,
+            "thumb_height": 12345,
+            "video_html": "",
+            "video_html_width": 12345,
+            "video_html_height": 12345,
             "footer": "",
             "footer_icon": "",
             "ts": "",
@@ -146,7 +145,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/SubteamCreatedPayload.json
+++ b/json-logs/samples/events/SubteamCreatedPayload.json
@@ -36,7 +36,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/SubteamMembersChangedPayload.json
+++ b/json-logs/samples/events/SubteamMembersChangedPayload.json
@@ -22,7 +22,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/SubteamSelfAddedPayload.json
+++ b/json-logs/samples/events/SubteamSelfAddedPayload.json
@@ -11,7 +11,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/SubteamSelfRemovedPayload.json
+++ b/json-logs/samples/events/SubteamSelfRemovedPayload.json
@@ -11,7 +11,15 @@
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/SubteamUpdatedPayload.json
+++ b/json-logs/samples/events/SubteamUpdatedPayload.json
@@ -33,15 +33,22 @@
         ""
       ],
       "channel_count": 12345,
-      "user_count": 12345,
-      "deleted_by": ""
+      "user_count": 12345
     },
     "event_ts": "0000000000.000000"
   },
   "type": "event_callback",
   "event_id": "",
   "event_time": 12345,
-  "authed_users": [
-    ""
-  ]
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "",
+      "user_id": "",
+      "is_bot": false,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": ""
 }

--- a/json-logs/samples/events/TeamDomainChangePayload.json
+++ b/json-logs/samples/events/TeamDomainChangePayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/TeamJoinPayload.json
+++ b/json-logs/samples/events/TeamJoinPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/TeamRenamePayload.json
+++ b/json-logs/samples/events/TeamRenamePayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/TokensRevokedPayload.json
+++ b/json-logs/samples/events/TokensRevokedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/UserChangePayload.json
+++ b/json-logs/samples/events/UserChangePayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/UserResourceDeniedPayload.json
+++ b/json-logs/samples/events/UserResourceDeniedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/UserResourceGrantedPayload.json
+++ b/json-logs/samples/events/UserResourceGrantedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/json-logs/samples/events/UserResourceRemovedPayload.json
+++ b/json-logs/samples/events/UserResourceRemovedPayload.json
@@ -10,6 +10,7 @@
   "authed_teams": [
     ""
   ],
+  "is_ext_shared_channel": false,
   "event_id": "",
   "event_time": 123,
   "event_context": "",

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppHomeOpenedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppHomeOpenedPayload.java
@@ -15,6 +15,8 @@ public class AppHomeOpenedPayload implements EventsApiPayload<AppHomeOpenedEvent
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppMentionPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppMentionPayload.java
@@ -15,6 +15,8 @@ public class AppMentionPayload implements EventsApiPayload<AppMentionEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppRateLimitedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppRateLimitedPayload.java
@@ -15,6 +15,8 @@ public class AppRateLimitedPayload implements EventsApiPayload<AppRateLimitedEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppRequestedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppRequestedPayload.java
@@ -15,6 +15,8 @@ public class AppRequestedPayload implements EventsApiPayload<AppRequestedEvent> 
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppUninstalledPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppUninstalledPayload.java
@@ -15,6 +15,8 @@ public class AppUninstalledPayload implements EventsApiPayload<AppUninstalledEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/Authorization.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/Authorization.java
@@ -1,0 +1,12 @@
+package com.slack.api.app_backend.events.payload;
+
+import lombok.Data;
+
+@Data
+public class Authorization {
+    private String enterpriseId;
+    private String teamId;
+    private String userId;
+    private Boolean isBot;
+    private Boolean isEnterpriseInstall;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/CallRejectedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/CallRejectedPayload.java
@@ -15,6 +15,8 @@ public class CallRejectedPayload implements EventsApiPayload<CallRejectedEvent> 
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelArchivePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelArchivePayload.java
@@ -15,6 +15,8 @@ public class ChannelArchivePayload implements EventsApiPayload<ChannelArchiveEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelCreatedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelCreatedPayload.java
@@ -15,6 +15,8 @@ public class ChannelCreatedPayload implements EventsApiPayload<ChannelCreatedEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelDeletedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelDeletedPayload.java
@@ -15,6 +15,8 @@ public class ChannelDeletedPayload implements EventsApiPayload<ChannelDeletedEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelHistoryChangedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelHistoryChangedPayload.java
@@ -15,6 +15,8 @@ public class ChannelHistoryChangedPayload implements EventsApiPayload<ChannelHis
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelLeftPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelLeftPayload.java
@@ -15,6 +15,8 @@ public class ChannelLeftPayload implements EventsApiPayload<ChannelLeftEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelRenamePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelRenamePayload.java
@@ -15,6 +15,8 @@ public class ChannelRenamePayload implements EventsApiPayload<ChannelRenameEvent
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelSharedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelSharedPayload.java
@@ -15,6 +15,8 @@ public class ChannelSharedPayload implements EventsApiPayload<ChannelSharedEvent
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelUnarchivePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelUnarchivePayload.java
@@ -15,6 +15,8 @@ public class ChannelUnarchivePayload implements EventsApiPayload<ChannelUnarchiv
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelUnsharedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ChannelUnsharedPayload.java
@@ -15,6 +15,8 @@ public class ChannelUnsharedPayload implements EventsApiPayload<ChannelUnsharedE
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/DndUpdatedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/DndUpdatedPayload.java
@@ -15,6 +15,8 @@ public class DndUpdatedPayload implements EventsApiPayload<DndUpdatedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/DndUpdatedUserPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/DndUpdatedUserPayload.java
@@ -15,6 +15,8 @@ public class DndUpdatedUserPayload implements EventsApiPayload<DndUpdatedUserEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/EmailDomainChangedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/EmailDomainChangedPayload.java
@@ -15,6 +15,8 @@ public class EmailDomainChangedPayload implements EventsApiPayload<EmailDomainCh
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/EmojiChangedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/EmojiChangedPayload.java
@@ -15,6 +15,8 @@ public class EmojiChangedPayload implements EventsApiPayload<EmojiChangedEvent> 
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/EventsApiPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/EventsApiPayload.java
@@ -1,6 +1,5 @@
 package com.slack.api.app_backend.events.payload;
 
-import com.slack.api.methods.response.apps.event.authorizations.AppsEventAuthorizationsListResponse;
 import com.slack.api.model.event.Event;
 
 import java.util.List;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/EventsApiPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/EventsApiPayload.java
@@ -1,5 +1,6 @@
 package com.slack.api.app_backend.events.payload;
 
+import com.slack.api.methods.response.apps.event.authorizations.AppsEventAuthorizationsListResponse;
 import com.slack.api.model.event.Event;
 
 import java.util.List;
@@ -59,17 +60,33 @@ public interface EventsApiPayload<E extends Event> {
 
     void setEventContext(String eventContext);
 
+    // isExtSharedChannel
+
+    boolean isExtSharedChannel();
+
+    void setExtSharedChannel(boolean isExtSharedChannel);
+
     // authedUsers
 
+    @Deprecated
     List<String> getAuthedUsers();
 
+    @Deprecated
     void setAuthedUsers(List<String> authedUsers);
 
     // authedTeams
 
+    @Deprecated
     List<String> getAuthedTeams();
 
+    @Deprecated
     void setAuthedTeams(List<String> authedTeams);
+
+    // authorizations
+
+    List<Authorization> getAuthorizations();
+
+    void setAuthorizations(List<Authorization> authorizations);
 
     // enterpriseId
 

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileChangePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileChangePayload.java
@@ -15,6 +15,8 @@ public class FileChangePayload implements EventsApiPayload<FileChangeEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileCreatedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileCreatedPayload.java
@@ -15,6 +15,8 @@ public class FileCreatedPayload implements EventsApiPayload<FileCreatedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileDeletedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileDeletedPayload.java
@@ -15,6 +15,8 @@ public class FileDeletedPayload implements EventsApiPayload<FileDeletedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FilePublicPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FilePublicPayload.java
@@ -15,6 +15,8 @@ public class FilePublicPayload implements EventsApiPayload<FilePublicEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileSharedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileSharedPayload.java
@@ -15,6 +15,8 @@ public class FileSharedPayload implements EventsApiPayload<FileSharedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileUnsharedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileUnsharedPayload.java
@@ -15,6 +15,8 @@ public class FileUnsharedPayload implements EventsApiPayload<FileUnsharedEvent> 
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GoodbyePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GoodbyePayload.java
@@ -15,6 +15,8 @@ public class GoodbyePayload implements EventsApiPayload<GoodbyeEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GridMigrationFinishedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GridMigrationFinishedPayload.java
@@ -15,6 +15,8 @@ public class GridMigrationFinishedPayload implements EventsApiPayload<GridMigrat
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GridMigrationStartedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GridMigrationStartedPayload.java
@@ -15,6 +15,8 @@ public class GridMigrationStartedPayload implements EventsApiPayload<GridMigrati
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupArchivePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupArchivePayload.java
@@ -15,6 +15,8 @@ public class GroupArchivePayload implements EventsApiPayload<GroupArchiveEvent> 
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupClosePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupClosePayload.java
@@ -15,6 +15,8 @@ public class GroupClosePayload implements EventsApiPayload<GroupCloseEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupDeletedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupDeletedPayload.java
@@ -15,6 +15,8 @@ public class GroupDeletedPayload implements EventsApiPayload<GroupDeletedEvent> 
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupHistoryChangedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupHistoryChangedPayload.java
@@ -15,6 +15,8 @@ public class GroupHistoryChangedPayload implements EventsApiPayload<GroupHistory
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupLeftPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupLeftPayload.java
@@ -15,6 +15,8 @@ public class GroupLeftPayload implements EventsApiPayload<GroupLeftEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupOpenPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupOpenPayload.java
@@ -15,6 +15,8 @@ public class GroupOpenPayload implements EventsApiPayload<GroupOpenEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupRenamePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupRenamePayload.java
@@ -15,6 +15,8 @@ public class GroupRenamePayload implements EventsApiPayload<GroupRenameEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupUnarchivePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupUnarchivePayload.java
@@ -15,6 +15,8 @@ public class GroupUnarchivePayload implements EventsApiPayload<GroupUnarchiveEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ImClosePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ImClosePayload.java
@@ -15,6 +15,8 @@ public class ImClosePayload implements EventsApiPayload<ImCloseEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ImCreatedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ImCreatedPayload.java
@@ -15,6 +15,8 @@ public class ImCreatedPayload implements EventsApiPayload<ImCreatedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ImHistoryChangedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ImHistoryChangedPayload.java
@@ -15,6 +15,8 @@ public class ImHistoryChangedPayload implements EventsApiPayload<ImHistoryChange
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ImOpenPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ImOpenPayload.java
@@ -15,6 +15,8 @@ public class ImOpenPayload implements EventsApiPayload<ImOpenEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/InviteRequestedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/InviteRequestedPayload.java
@@ -15,6 +15,8 @@ public class InviteRequestedPayload implements EventsApiPayload<InviteRequestedE
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/LinkSharedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/LinkSharedPayload.java
@@ -15,6 +15,8 @@ public class LinkSharedPayload implements EventsApiPayload<LinkSharedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MemberJoinedChannelPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MemberJoinedChannelPayload.java
@@ -15,6 +15,8 @@ public class MemberJoinedChannelPayload implements EventsApiPayload<MemberJoined
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MemberLeftChannelPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MemberLeftChannelPayload.java
@@ -15,6 +15,8 @@ public class MemberLeftChannelPayload implements EventsApiPayload<MemberLeftChan
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageBotPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageBotPayload.java
@@ -15,6 +15,8 @@ public class MessageBotPayload implements EventsApiPayload<MessageBotEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageChangedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageChangedPayload.java
@@ -15,6 +15,8 @@ public class MessageChangedPayload implements EventsApiPayload<MessageChangedEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageDeletedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageDeletedPayload.java
@@ -15,6 +15,8 @@ public class MessageDeletedPayload implements EventsApiPayload<MessageDeletedEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageEkmAccessDeniedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageEkmAccessDeniedPayload.java
@@ -15,6 +15,8 @@ public class MessageEkmAccessDeniedPayload implements EventsApiPayload<MessageEk
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageFileSharePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageFileSharePayload.java
@@ -15,6 +15,8 @@ public class MessageFileSharePayload implements EventsApiPayload<MessageFileShar
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageMePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageMePayload.java
@@ -15,6 +15,8 @@ public class MessageMePayload implements EventsApiPayload<MessageMeEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessagePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessagePayload.java
@@ -15,6 +15,8 @@ public class MessagePayload implements EventsApiPayload<MessageEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageRepliedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageRepliedPayload.java
@@ -15,6 +15,8 @@ public class MessageRepliedPayload implements EventsApiPayload<MessageRepliedEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageThreadBroadcastPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageThreadBroadcastPayload.java
@@ -15,6 +15,8 @@ public class MessageThreadBroadcastPayload implements EventsApiPayload<MessageTh
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/PinAddedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/PinAddedPayload.java
@@ -15,6 +15,8 @@ public class PinAddedPayload implements EventsApiPayload<PinAddedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/PinRemovedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/PinRemovedPayload.java
@@ -15,6 +15,8 @@ public class PinRemovedPayload implements EventsApiPayload<PinRemovedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ReactionAddedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ReactionAddedPayload.java
@@ -15,6 +15,8 @@ public class ReactionAddedPayload implements EventsApiPayload<ReactionAddedEvent
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ReactionRemovedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ReactionRemovedPayload.java
@@ -15,6 +15,8 @@ public class ReactionRemovedPayload implements EventsApiPayload<ReactionRemovedE
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ResourcesAddedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ResourcesAddedPayload.java
@@ -15,6 +15,8 @@ public class ResourcesAddedPayload implements EventsApiPayload<ResourcesAddedEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ResourcesRemovedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ResourcesRemovedPayload.java
@@ -15,6 +15,8 @@ public class ResourcesRemovedPayload implements EventsApiPayload<ResourcesRemove
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ScopeDeniedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ScopeDeniedPayload.java
@@ -15,6 +15,8 @@ public class ScopeDeniedPayload implements EventsApiPayload<ScopeDeniedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ScopeGrantedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ScopeGrantedPayload.java
@@ -15,6 +15,8 @@ public class ScopeGrantedPayload implements EventsApiPayload<ScopeGrantedEvent> 
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/StarAddedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/StarAddedPayload.java
@@ -15,6 +15,8 @@ public class StarAddedPayload implements EventsApiPayload<StarAddedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/StarRemovedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/StarRemovedPayload.java
@@ -15,6 +15,8 @@ public class StarRemovedPayload implements EventsApiPayload<StarRemovedEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SubteamCreatedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SubteamCreatedPayload.java
@@ -15,6 +15,8 @@ public class SubteamCreatedPayload implements EventsApiPayload<SubteamCreatedEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SubteamMembersChangedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SubteamMembersChangedPayload.java
@@ -15,6 +15,8 @@ public class SubteamMembersChangedPayload implements EventsApiPayload<SubteamMem
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SubteamSelfAddedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SubteamSelfAddedPayload.java
@@ -15,6 +15,8 @@ public class SubteamSelfAddedPayload implements EventsApiPayload<SubteamSelfAdde
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SubteamSelfRemovedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SubteamSelfRemovedPayload.java
@@ -15,6 +15,8 @@ public class SubteamSelfRemovedPayload implements EventsApiPayload<SubteamSelfRe
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SubteamUpdatedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SubteamUpdatedPayload.java
@@ -15,6 +15,8 @@ public class SubteamUpdatedPayload implements EventsApiPayload<SubteamUpdatedEve
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TeamDomainChangePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TeamDomainChangePayload.java
@@ -15,6 +15,8 @@ public class TeamDomainChangePayload implements EventsApiPayload<TeamDomainChang
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TeamJoinPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TeamJoinPayload.java
@@ -15,6 +15,8 @@ public class TeamJoinPayload implements EventsApiPayload<TeamJoinEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TeamRenamePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TeamRenamePayload.java
@@ -15,6 +15,8 @@ public class TeamRenamePayload implements EventsApiPayload<TeamRenameEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TokensRevokedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TokensRevokedPayload.java
@@ -15,6 +15,8 @@ public class TokensRevokedPayload implements EventsApiPayload<TokensRevokedEvent
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/UserChangePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/UserChangePayload.java
@@ -15,6 +15,8 @@ public class UserChangePayload implements EventsApiPayload<UserChangeEvent> {
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/UserResourceDeniedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/UserResourceDeniedPayload.java
@@ -15,6 +15,8 @@ public class UserResourceDeniedPayload implements EventsApiPayload<UserResourceD
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/UserResourceGrantedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/UserResourceGrantedPayload.java
@@ -15,6 +15,8 @@ public class UserResourceGrantedPayload implements EventsApiPayload<UserResource
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/UserResourceRemovedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/UserResourceRemovedPayload.java
@@ -15,6 +15,8 @@ public class UserResourceRemovedPayload implements EventsApiPayload<UserResource
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/WorkflowStepExecutePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/WorkflowStepExecutePayload.java
@@ -15,6 +15,8 @@ public class WorkflowStepExecutePayload implements EventsApiPayload<WorkflowStep
     private String type;
     private List<String> authedUsers;
     private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
     private String eventId;
     private Integer eventTime;
     private String eventContext;


### PR DESCRIPTION
As an addition to #570 , this pull request updates the Events API payload classes to have the following fields.

* authorizations
* is_ext_shared_channel

Also, I've tweaked the test utilities a bit.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
