### PR TITLE
Change the fallback behavior of Events API handlers to be compatible with Bolt JS/Python

### DIFF
--- a/bolt-aws-lambda/src/test/java/test_locally/Issue419UseCaseTest.java
+++ b/bolt-aws-lambda/src/test/java/test_locally/Issue419UseCaseTest.java
@@ -79,6 +79,7 @@ public class Issue419UseCaseTest {
                 headers.put("additional-header", Arrays.asList("foo"));
                 return Response.builder().statusCode(200).headers(headers).build();
             });
+            app.message("Hello", (req, ctx) -> ctx.ack());
 
             SampleHandler handler = new SampleHandler(app);
 

--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -930,16 +930,16 @@ public class App {
                 case Event: {
                     if (eventsDispatcher.isRunning()) {
                         eventsDispatcher.enqueue(slackRequest.getRequestBodyAsString());
+                        return Response.ok();
                     }
                     EventRequest request = (EventRequest) slackRequest;
                     BoltEventHandler<Event> handler = eventHandlers.get(request.getEventTypeAndSubtype());
                     if (handler != null) {
                         EventsApiPayload<Event> payload = buildEventPayload(request);
                         return handler.apply(payload, request.getContext());
-                    } else {
-                        log.warn("No BoltEventHandler registered for event: {}", request.getEventTypeAndSubtype());
-                        return Response.ok();
                     }
+                    log.warn("No BoltEventHandler registered for event: {}", request.getEventTypeAndSubtype());
+                    break;
                 }
                 case UrlVerification: {
                     // https://api.slack.com/events/url_verification
@@ -1144,16 +1144,16 @@ public class App {
                     // Fallback to Events API handlers
                     if (eventsDispatcher.isRunning()) {
                         eventsDispatcher.enqueue(slackRequest.getRequestBodyAsString());
+                        return Response.ok();
                     }
                     EventRequest request = new EventRequest(stepRequest.getRequestBodyAsString(), stepRequest.getHeaders());
                     BoltEventHandler<Event> handler = eventHandlers.get(request.getEventTypeAndSubtype());
                     if (handler != null) {
                         EventsApiPayload<Event> payload = buildEventPayload(request);
                         return handler.apply(payload, request.getContext());
-                    } else {
-                        log.warn("No BoltEventHandler registered for event: {}", request.getEventTypeAndSubtype());
-                        return Response.ok();
                     }
+                    log.warn("No BoltEventHandler registered for event: {}", request.getEventTypeAndSubtype());
+                    break;
                 }
                 default:
             }

--- a/bolt/src/test/java/test_locally/app/MessageTest.java
+++ b/bolt/src/test/java/test_locally/app/MessageTest.java
@@ -193,7 +193,7 @@ public class MessageTest {
     }
 
     @Test
-    public void bot() throws Exception {
+    public void bot_subtype() throws Exception {
         App app = buildApp();
         AtomicBoolean userMessageReceived = new AtomicBoolean(false);
         app.message("sent by a bot user", (req, ctx) -> {
@@ -201,11 +201,14 @@ public class MessageTest {
             return ctx.ack();
         });
 
+        // "This is a message sent by a bot user."
         EventsApiPayload<MessageBotEvent> payload = buildUserBotMessagePayload();
 
         EventRequest req = buildRequest(gson.toJson(payload));
         Response response = app.run(req);
-        assertEquals(200L, response.getStatusCode().longValue());
+        // NOTE: subtype: bot_message events are not handled by this
+        // while message events with bot_id / bot_profile are caught
+        assertEquals(404L, response.getStatusCode().longValue());
 
         assertFalse(userMessageReceived.get());
     }
@@ -219,11 +222,12 @@ public class MessageTest {
             return ctx.ack();
         });
 
+        // "This is a message sent by a bot user."
         EventsApiPayload<MessageBotEvent> payload = buildUserBotMessagePayload();
 
         EventRequest req = buildRequest(gson.toJson(payload));
         Response response = app.run(req);
-        assertEquals(200L, response.getStatusCode().longValue());
+        assertEquals(404L, response.getStatusCode().longValue());
 
         assertFalse(userMessageReceived.get());
     }


### PR DESCRIPTION
While doing tests with Workflow Steps, I found the current fallback logic of Events API handlers in Bolt for Java is to ignore unknown events by returning 200 OK. While it may be convenient for some apps, this is obviously incompatible with other Bolt frameworks. So, since v1.2, we will change this behavior.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.
