### PR TITLE
Add dispatch_action support in blocks

### DIFF
--- a/bolt-servlet/src/test/java/samples/ViewDispatchActionSample.java
+++ b/bolt-servlet/src/test/java/samples/ViewDispatchActionSample.java
@@ -1,0 +1,101 @@
+package samples;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.util.json.GsonFactory;
+import lombok.extern.slf4j.Slf4j;
+import util.ResourceLoader;
+import util.TestSlackAppServer;
+
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import static com.slack.api.model.block.Blocks.asBlocks;
+import static com.slack.api.model.block.Blocks.input;
+import static com.slack.api.model.block.composition.BlockCompositions.dispatchActionConfig;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static com.slack.api.model.block.element.BlockElements.plainTextInput;
+import static com.slack.api.model.view.Views.*;
+
+@Slf4j
+public class ViewDispatchActionSample {
+
+    public static void main(String[] args) throws Exception {
+        SlackConfig slackConfig = new SlackConfig();
+        slackConfig.setPrettyResponseLoggingEnabled(true);
+        Slack slack = Slack.getInstance(slackConfig);
+        AppConfig appConfig = ResourceLoader.loadAppConfig();
+        appConfig.setSlack(slack);
+        App app = new App(appConfig);
+
+        app.command("/open-modal", (req, ctx) -> {
+            ctx.client().viewsOpen(r -> r
+                    .triggerId(req.getPayload().getTriggerId())
+                    .view(view(v -> v
+                            .type("modal")
+                            .callbackId("test-view")
+                            .title(viewTitle(vt -> vt.type("plain_text").text("Modal by Global Shortcut")))
+                            .close(viewClose(vc -> vc.type("plain_text").text("Close")))
+                            .submit(viewSubmit(vs -> vs.type("plain_text").text("Submit")))
+                            .blocks(asBlocks(
+                                    input(i -> i
+                                            .blockId("b-1")
+                                            .dispatchAction(true)
+                                            .element(plainTextInput(e -> e
+                                                    .actionId("a-1")
+                                                    .dispatchActionConfig(dispatchActionConfig(d -> d
+                                                            .triggerActionsOn(Arrays.asList("on_character_entered"))))
+                                            ))
+                                            .label(plainText("Label"))
+                                    ),
+                                    input(i -> i
+                                            .blockId("b-2")
+                                            .dispatchAction(true)
+                                            .element(plainTextInput(e -> e
+                                                    .actionId("a-2")
+                                                    .dispatchActionConfig(dispatchActionConfig(d -> d
+                                                            .triggerActionsOn(Arrays.asList("on_enter_pressed"))))
+                                            ))
+                                            .label(plainText("Label"))
+                                    ),
+                                    input(i -> i
+                                            .blockId("b-3")
+                                            .dispatchAction(false)
+                                            .element(plainTextInput(e -> e
+                                                    .actionId("a-3")
+                                                    .dispatchActionConfig(dispatchActionConfig(d -> d
+                                                            .triggerActionsOn(Arrays.asList("on_enter_pressed"))))
+                                            ))
+                                            .label(plainText("Label"))
+                                    )
+                            )))
+                    ));
+            return ctx.ack();
+        });
+
+        app.blockAction(Pattern.compile("a-\\d+"), (req, ctx) -> ctx.ack());
+
+        app.viewSubmission("test-view", (req, ctx) -> ctx.ack());
+
+        app.use((req, resp, chain) -> {
+            Gson gson = GsonFactory.createSnakeCase(slackConfig);
+            String body = req.getRequestBodyAsString();
+            String payload = body.startsWith("payload=") ? URLDecoder.decode(body.split("payload=")[1], "UTF-8") : body;
+            try {
+                payload = gson.toJson(gson.fromJson(payload, JsonElement.class));
+            } catch (JsonSyntaxException ignore) {
+            }
+            req.getContext().logger.info("Payload:\n{}", payload);
+            return chain.next(req);
+        });
+
+        TestSlackAppServer server = new TestSlackAppServer(app);
+        server.start();
+    }
+}

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/InputBlockBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/InputBlockBuilder.kt
@@ -13,7 +13,7 @@ class InputBlockBuilder private constructor(
     private var label: PlainTextObject? = null
     private var hint: PlainTextObject? = null
     private var optional: Boolean = false
-    private var dispatchAction: Boolean = false
+    private var dispatchAction: Boolean? = null
 
     constructor() : this(SingleBlockElementContainer())
 

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/InputBlockBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/InputBlockBuilder.kt
@@ -13,6 +13,7 @@ class InputBlockBuilder private constructor(
     private var label: PlainTextObject? = null
     private var hint: PlainTextObject? = null
     private var optional: Boolean = false
+    private var dispatchAction: Boolean = false
 
     constructor() : this(SingleBlockElementContainer())
 
@@ -66,6 +67,15 @@ class InputBlockBuilder private constructor(
         this.optional = optional
     }
 
+    /**
+     * A boolean that indicates whether the input element may be empty when a user submits the modal. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/blocks#input">Input block documentation</a>
+     */
+    fun dispatchAction(dispatchAction: Boolean) {
+        this.dispatchAction = dispatchAction
+    }
+
     override fun build(): InputBlock {
         return InputBlock.builder()
                 .blockId(blockId)
@@ -73,6 +83,7 @@ class InputBlockBuilder private constructor(
                 .element(elementContainer.underlying)
                 .hint(hint)
                 .optional(optional)
+                .dispatchAction(dispatchAction)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/composition/DispatchActionConfigBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/composition/DispatchActionConfigBuilder.kt
@@ -1,0 +1,26 @@
+package com.slack.api.model.kotlin_extension.block.composition
+
+import com.slack.api.model.block.composition.DispatchActionConfig
+import com.slack.api.model.kotlin_extension.block.BlockLayoutBuilder
+import com.slack.api.model.kotlin_extension.block.Builder
+import com.slack.api.model.kotlin_extension.block.composition.dsl.DispatchActionConfigDsl
+
+// same name with the object + "Builder" suffix
+@BlockLayoutBuilder
+class DispatchActionConfigBuilder() : Builder<DispatchActionConfig>, DispatchActionConfigDsl {
+    private var triggerActionsOn: MutableList<String> = mutableListOf()
+
+    override fun triggerActionsOn(vararg triggerActions: String) {
+        this.triggerActionsOn = triggerActions.toMutableList()
+    }
+
+    override fun triggerActionsOn(vararg triggerActions: TriggerActionOn) {
+        this.triggerActionsOn = triggerActions.mapNotNull { it.value }.toMutableList()
+    }
+
+    override fun build(): DispatchActionConfig {
+        return DispatchActionConfig.builder()
+                .triggerActionsOn(triggerActionsOn)
+                .build()
+    }
+}

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/composition/TriggerActionOn.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/composition/TriggerActionOn.kt
@@ -1,0 +1,21 @@
+package com.slack.api.model.kotlin_extension.block.composition
+
+enum class TriggerActionOn {
+
+    /**
+     * payload is dispatched when user presses the enter key while the input is in focus.
+     * Hint text will appear underneath the input explaining to the user to press enter to submit.
+     */
+    ON_ENTER_PRESSED {
+        override val value: String? = "on_enter_pressed"
+    },
+
+    /**
+     * payload is dispatched when a character is entered (or removed) in the input.
+     */
+    ON_CHARACTER_ENTERED {
+        override val value: String? = "on_character_entered"
+    };
+
+    abstract val value: String?
+}

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/composition/dsl/DispatchActionConfigDsl.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/composition/dsl/DispatchActionConfigDsl.kt
@@ -1,0 +1,13 @@
+package com.slack.api.model.kotlin_extension.block.composition.dsl
+
+import com.slack.api.model.kotlin_extension.block.BlockLayoutBuilder
+import com.slack.api.model.kotlin_extension.block.composition.TriggerActionOn
+
+@BlockLayoutBuilder
+interface DispatchActionConfigDsl {
+
+    fun triggerActionsOn(vararg triggerActions: String)
+
+    fun triggerActionsOn(vararg triggerActions: TriggerActionOn)
+
+}

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/PlainTextInputElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/PlainTextInputElementBuilder.kt
@@ -75,6 +75,11 @@ class PlainTextInputElementBuilder : Builder<PlainTextInputElement> {
         maxLength = length
     }
 
+    /**
+     * Determines when a plain-text input element will return a block_actions interaction payload.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config">The document</a>
+     */
     fun dispatchActionConfig(builder: DispatchActionConfigBuilder.() -> Unit) {
         dispatchActionConfig = DispatchActionConfigBuilder().apply(builder).build()
     }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/PlainTextInputElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/PlainTextInputElementBuilder.kt
@@ -1,9 +1,11 @@
 package com.slack.api.model.kotlin_extension.block.element
 
 import com.slack.api.model.block.composition.PlainTextObject
+import com.slack.api.model.block.composition.DispatchActionConfig
 import com.slack.api.model.block.element.PlainTextInputElement
 import com.slack.api.model.kotlin_extension.block.BlockLayoutBuilder
 import com.slack.api.model.kotlin_extension.block.Builder
+import com.slack.api.model.kotlin_extension.block.composition.DispatchActionConfigBuilder
 
 @BlockLayoutBuilder
 class PlainTextInputElementBuilder : Builder<PlainTextInputElement> {
@@ -13,6 +15,7 @@ class PlainTextInputElementBuilder : Builder<PlainTextInputElement> {
     private var multiline: Boolean = false
     private var minLength: Int? = null
     private var maxLength: Int? = null
+    private var dispatchActionConfig: DispatchActionConfig? = null
 
     /**
      * An identifier for the input value when the parent modal is submitted. You can use this when you receive a
@@ -72,6 +75,10 @@ class PlainTextInputElementBuilder : Builder<PlainTextInputElement> {
         maxLength = length
     }
 
+    fun dispatchActionConfig(builder: DispatchActionConfigBuilder.() -> Unit) {
+        dispatchActionConfig = DispatchActionConfigBuilder().apply(builder).build()
+    }
+
     override fun build(): PlainTextInputElement {
         return PlainTextInputElement.builder()
                 .actionId(actionId)
@@ -80,6 +87,7 @@ class PlainTextInputElementBuilder : Builder<PlainTextInputElement> {
                 .multiline(multiline)
                 .minLength(minLength)
                 .maxLength(maxLength)
+                .dispatchActionConfig(dispatchActionConfig)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/InputBlockTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/InputBlockTest.kt
@@ -1,0 +1,46 @@
+package test_locally.block
+
+import com.slack.api.model.kotlin_extension.block.composition.TriggerActionOn
+import com.slack.api.model.kotlin_extension.block.withBlocks
+import com.slack.api.util.json.GsonFactory
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class InputBlockTest {
+
+    @Test
+    fun dispatchActions() {
+        val gson = GsonFactory.createSnakeCase()
+        val blocks = withBlocks {
+            input {
+                blockId("b-1")
+                dispatchAction(true)
+                element {
+                    plainTextInput {
+                        actionId("a-1")
+                        dispatchActionConfig {
+                            triggerActionsOn("on_enter_pressed", "on_character_entered")
+                        }
+                    }
+                }
+                label("Test")
+            }
+            input {
+                blockId("b-2")
+                dispatchAction(true)
+                element {
+                    plainTextInput {
+                        actionId("a-2")
+                        dispatchActionConfig {
+                            triggerActionsOn(TriggerActionOn.ON_ENTER_PRESSED, TriggerActionOn.ON_CHARACTER_ENTERED)
+                        }
+                    }
+                }
+                label("Test")
+            }
+        }
+        val result = gson.toJson(blocks)
+        val expected = """[{"type":"input","block_id":"b-1","label":{"type":"plain_text","text":"Test"},"element":{"type":"plain_text_input","action_id":"a-1","multiline":false,"dispatch_action_config":{"trigger_actions_on":["on_enter_pressed","on_character_entered"]}},"dispatch_action":true,"optional":false},{"type":"input","block_id":"b-2","label":{"type":"plain_text","text":"Test"},"element":{"type":"plain_text_input","action_id":"a-2","multiline":false,"dispatch_action_config":{"trigger_actions_on":["on_enter_pressed","on_character_entered"]}},"dispatch_action":true,"optional":false}]"""
+        assertEquals(expected, result)
+    }
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/block/InputBlock.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/InputBlock.java
@@ -32,6 +32,12 @@ public class InputBlock implements LayoutBlock {
     private BlockElement element;
 
     /**
+     * A boolean that indicates whether or not use of element in this block
+     * should dispatch a block_actions payload. Defaults to false.
+     */
+    private boolean dispatchAction;
+
+    /**
      * An optional hint that appears below an input element in a lighter grey.
      * It must be a a text object with a type of plain_text.
      * Maximum length for the text in this field is 2000 characters.

--- a/slack-api-model/src/main/java/com/slack/api/model/block/InputBlock.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/InputBlock.java
@@ -35,7 +35,7 @@ public class InputBlock implements LayoutBlock {
      * A boolean that indicates whether or not use of element in this block
      * should dispatch a block_actions payload. Defaults to false.
      */
-    private boolean dispatchAction;
+    private Boolean dispatchAction;
 
     /**
      * An optional hint that appears below an input element in a lighter grey.

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/BlockCompositions.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/BlockCompositions.java
@@ -70,5 +70,11 @@ public class BlockCompositions {
         return OptionObject.builder().text(text).value(value).build();
     }
 
+    // DispatchActionConfig
+
+    public static DispatchActionConfig dispatchActionConfig(ModelConfigurator<DispatchActionConfig.DispatchActionConfigBuilder> configurator) {
+        return configurator.configure(DispatchActionConfig.builder()).build();
+    }
+
 }
 

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/DispatchActionConfig.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/DispatchActionConfig.java
@@ -1,0 +1,28 @@
+package com.slack.api.model.block.composition;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DispatchActionConfig {
+
+    /**
+     * An array of interaction types that you would like to receive a block_actions payload for.
+     * <p>
+     * Should be one or both of:
+     * - on_enter_pressed — payload is dispatched when user presses the enter key while the input is in focus.
+     * Hint text will appear underneath the input explaining to the user to press enter to submit.
+     * - on_character_entered — payload is dispatched when a character is entered (or removed) in the input.
+     */
+    private List<String> triggerActionsOn;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/PlainTextInputElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/PlainTextInputElement.java
@@ -1,5 +1,6 @@
 package com.slack.api.model.block.element;
 
+import com.slack.api.model.block.composition.DispatchActionConfig;
 import com.slack.api.model.block.composition.PlainTextObject;
 import lombok.*;
 
@@ -50,4 +51,6 @@ public class PlainTextInputElement extends BlockElement {
      * The maximum length of input that the user can provide. If the user provides more, they will receive an error.
      */
     private Integer maxLength;
+
+    private DispatchActionConfig dispatchActionConfig;
 }


### PR DESCRIPTION
This pull request adds `dispatch_action` flag to `input` blocks and `dispatch_action_config` field to `plain_text_input` block elements.

* https://api.slack.com/reference/block-kit/blocks#input
* https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
