### PR TITLE
Fix #588 Make OAuth related terms consistent (installPath, redirectUriPath)

### DIFF
--- a/bolt-helidon/src/main/java/com/slack/api/bolt/helidon/SlackAppServer.java
+++ b/bolt-helidon/src/main/java/com/slack/api/bolt/helidon/SlackAppServer.java
@@ -83,8 +83,8 @@ public class SlackAppServer {
         if (oauthApp != null) {
             SlackAppService oauthService = new SlackAppService(config, oauthApp);
             builder = builder
-                    .register(oauthApp.config().getOauthStartPath(), oauthService)
-                    .register(oauthApp.config().getOauthCallbackPath(), oauthService);
+                    .register(oauthApp.config().getOauthInstallPath(), oauthService)
+                    .register(oauthApp.config().getOauthRedirectUriPath(), oauthService);
         }
         return getAdditionalRoutingConfigurator().apply(builder).build();
     }

--- a/bolt-jetty/src/main/java/com/slack/api/bolt/jetty/SlackAppServer.java
+++ b/bolt-jetty/src/main/java/com/slack/api/bolt/jetty/SlackAppServer.java
@@ -86,22 +86,22 @@ public class SlackAppServer {
             if (theApp.config().isOAuthStartEnabled()) {
                 if (theApp.config().isDistributedApp()) {
                     // start
-                    String oAuthStartPath = appPath + theApp.config().getOauthStartPath();
-                    App oAuthStartApp = theApp.toOAuthStartApp();
-                    handler.addServlet(new ServletHolder(new SlackOAuthAppServlet(oAuthStartApp)), oAuthStartPath);
-                    addedOnes.put(oAuthStartPath, oAuthStartApp);
+                    String installPath = appPath + theApp.config().getOauthInstallPath();
+                    App installPathApp = theApp.toOAuthInstallPathEnabledApp();
+                    handler.addServlet(new ServletHolder(new SlackOAuthAppServlet(installPathApp)), installPath);
+                    addedOnes.put(installPath, installPathApp);
                 } else {
                     log.warn("The app is not ready for handling your Slack App installation URL. Make sure if you set all the necessary values in AppConfig.");
                 }
             }
 
-            if (theApp.config().isOAuthCallbackEnabled()) {
+            if (theApp.config().isOAuthRedirectUriPathEnabled()) {
                 if (theApp.config().isDistributedApp()) {
                     // callback
-                    String oAuthCallbackPath = appPath + theApp.config().getOauthCallbackPath();
-                    App oAuthCallbackApp = theApp.toOAuthCallbackApp();
-                    handler.addServlet(new ServletHolder(new SlackOAuthAppServlet(oAuthCallbackApp)), oAuthCallbackPath);
-                    addedOnes.put(oAuthCallbackPath, oAuthCallbackApp);
+                    String redirectUriPath = appPath + theApp.config().getOauthRedirectUriPath();
+                    App oAuthCallbackApp = theApp.toOAuthRedirectUriPathEnabledApp();
+                    handler.addServlet(new ServletHolder(new SlackOAuthAppServlet(oAuthCallbackApp)), redirectUriPath);
+                    addedOnes.put(redirectUriPath, oAuthCallbackApp);
                 } else {
                     log.warn("The app is not ready for handling OAuth callback requests. Make sure if you set all the necessary values in AppConfig.");
                 }

--- a/bolt-servlet/src/test/java/util/TestSlackAppServer.java
+++ b/bolt-servlet/src/test/java/util/TestSlackAppServer.java
@@ -47,25 +47,25 @@ public class TestSlackAppServer {
             theApp.config().setAppPath(appPath);
             handler.addServlet(new ServletHolder(new SlackAppServlet(theApp)), appPath);
 
-            if (theApp.config().isOAuthStartEnabled()) {
+            if (theApp.config().isOAuthInstallPathEnabled()) {
                 if (theApp.config().isDistributedApp()) {
                     // start
-                    String oAuthStartPath = appPath + theApp.config().getOauthStartPath();
-                    App oAuthStartApp = theApp.toOAuthStartApp();
-                    handler.addServlet(new ServletHolder(new SlackOAuthAppServlet(oAuthStartApp)), oAuthStartPath);
-                    addedOnes.put(oAuthStartPath, oAuthStartApp);
+                    String installPath = appPath + theApp.config().getOauthInstallPath();
+                    App installPathApp = theApp.toOAuthInstallPathEnabledApp();
+                    handler.addServlet(new ServletHolder(new SlackOAuthAppServlet(installPathApp)), installPath);
+                    addedOnes.put(installPath, installPathApp);
                 } else {
                     log.warn("The app is not ready for handling your Slack App installation URL. Make sure if you set all the necessary values in AppConfig.");
                 }
             }
 
-            if (theApp.config().isOAuthCallbackEnabled()) {
+            if (theApp.config().isOAuthRedirectUriPathEnabled()) {
                 if (theApp.config().isDistributedApp()) {
                     // callback
-                    String oAuthCallbackPath = appPath + theApp.config().getOauthCallbackPath();
-                    App oAuthCallbackApp = theApp.toOAuthCallbackApp();
-                    handler.addServlet(new ServletHolder(new SlackOAuthAppServlet(oAuthCallbackApp)), oAuthCallbackPath);
-                    addedOnes.put(oAuthCallbackPath, oAuthCallbackApp);
+                    String redirectUriPath = appPath + theApp.config().getOauthRedirectUriPath();
+                    App oAuthCallbackApp = theApp.toOAuthRedirectUriPathEnabledApp();
+                    handler.addServlet(new ServletHolder(new SlackOAuthAppServlet(oAuthCallbackApp)), redirectUriPath);
+                    addedOnes.put(redirectUriPath, oAuthCallbackApp);
                 } else {
                     log.warn("The app is not ready for handling OAuth callback requests. Make sure if you set all the necessary values in AppConfig.");
                 }

--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -272,7 +272,7 @@ public class App {
     private OAuthCallbackService oAuthCallbackService; // will be initialized by initOAuthServicesIfNecessary()
 
     private void initOAuthServicesIfNecessary() {
-        if (appConfig.isDistributedApp() && appConfig.isOAuthCallbackEnabled()) {
+        if (appConfig.isDistributedApp() && appConfig.isOAuthRedirectUriPathEnabled()) {
             if (this.oAuthCallbackService == null) {
                 this.oAuthCallbackService = new DefaultOAuthCallbackService(
                         config(),
@@ -758,8 +758,8 @@ public class App {
     // OAuth App configuration methods
 
     public App asOAuthApp(boolean enabled) {
-        config().setOAuthStartEnabled(enabled);
-        config().setOAuthCallbackEnabled(enabled);
+        config().setOAuthInstallPathEnabled(enabled);
+        config().setOAuthRedirectUriPathEnabled(enabled);
         return this;
     }
 
@@ -820,17 +820,27 @@ public class App {
         return this;
     }
 
+    @Deprecated
     public App toOAuthStartApp() {
+        return toOAuthInstallPathEnabledApp();
+    }
+
+    public App toOAuthInstallPathEnabledApp() {
         App newApp = toBuilder().appConfig(config().toBuilder().build()).build();
-        newApp.config().setOAuthStartEnabled(true);
-        newApp.config().setOAuthCallbackEnabled(false);
+        newApp.config().setOAuthInstallPathEnabled(true);
+        newApp.config().setOAuthRedirectUriPathEnabled(false);
         return newApp;
     }
 
+    @Deprecated
     public App toOAuthCallbackApp() {
+        return toOAuthRedirectUriPathEnabledApp();
+    }
+
+    public App toOAuthRedirectUriPathEnabledApp() {
         App newApp = toBuilder().appConfig(config().toBuilder().build()).build();
-        newApp.config().setOAuthStartEnabled(false);
-        newApp.config().setOAuthCallbackEnabled(true);
+        newApp.config().setOAuthInstallPathEnabled(false);
+        newApp.config().setOAuthRedirectUriPathEnabled(true);
         return newApp;
     }
 

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -206,6 +206,8 @@ public class AppConfig {
 
     // --------------------------
 
+    // NOTE: We should not change this default value in v1.x as it's a breaking change to existing users.
+    // We will be changing this in v2.0.
     private static final String DEFAULT_OAUTH_INSTALL_PATH = "start";
 
     @Deprecated // will be removed in v2.0 - use oauthInstallPath instead
@@ -248,6 +250,8 @@ public class AppConfig {
 
     // --------------------------
 
+    // NOTE: We should not change this default value in v1.x as it's a breaking change to existing users.
+    // We will be changing this in v2.0.
     private static final String DEFAULT_OAUTH_REDIRECT_URI_PATH = "callback";
 
     @Deprecated // will be removed in v2.0 - use oauthRedirectUriPath instead

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -89,6 +89,10 @@ public class AppConfig {
     @Builder.Default
     private boolean oAuthInstallPathEnabled = false;
 
+    public boolean isOAuthInstallPathEnabled() {
+        return oAuthInstallPathEnabled || oAuthStartEnabled;
+    }
+
     @Deprecated // will be removed in v2.0 - use oAuthInstallPathEnabled
     @Builder.Default
     private boolean oAuthStartEnabled = false;
@@ -98,10 +102,19 @@ public class AppConfig {
         return isOAuthInstallPathEnabled();
     }
 
+    @Deprecated
+    public void setOAuthStartEnabled(boolean enabled) {
+        setOAuthInstallPathEnabled(enabled);
+    }
+
     // --------------------------
 
     @Builder.Default
     private boolean oAuthRedirectUriPathEnabled = false;
+
+    public boolean isOAuthRedirectUriPathEnabled() {
+        return oAuthRedirectUriPathEnabled || oAuthCallbackEnabled;
+    }
 
     @Deprecated // will be removed in v2.0 - use oAuthRedirectUriPathEnabled
     @Builder.Default
@@ -110,6 +123,11 @@ public class AppConfig {
     @Deprecated
     public boolean isOAuthCallbackEnabled() {
         return isOAuthRedirectUriPathEnabled();
+    }
+
+    @Deprecated
+    public void setOAuthCallbackEnabled(boolean enabled) {
+        setOAuthRedirectUriPathEnabled(enabled);
     }
 
     // --------------------------

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -84,10 +84,35 @@ public class AppConfig {
         return clientId != null && clientSecret != null;
     }
 
+    // --------------------------
+
+    @Builder.Default
+    private boolean oAuthInstallPathEnabled = false;
+
+    @Deprecated // will be removed in v2.0 - use oAuthInstallPathEnabled
     @Builder.Default
     private boolean oAuthStartEnabled = false;
+
+    @Deprecated
+    public boolean isOAuthStartEnabled() {
+        return isOAuthInstallPathEnabled();
+    }
+
+    // --------------------------
+
+    @Builder.Default
+    private boolean oAuthRedirectUriPathEnabled = false;
+
+    @Deprecated // will be removed in v2.0 - use oAuthRedirectUriPathEnabled
     @Builder.Default
     private boolean oAuthCallbackEnabled = false;
+
+    @Deprecated
+    public boolean isOAuthCallbackEnabled() {
+        return isOAuthRedirectUriPathEnabled();
+    }
+
+    // --------------------------
 
     /**
      * Returns true if auth.test call result cache in MultiTeamsAuthorization middleware
@@ -113,16 +138,6 @@ public class AppConfig {
     @Builder.Default
     private int threadPoolSize = 10;
 
-    public void setOauthStartPath(String oauthStartPath) {
-        this.oauthStartPath = oauthStartPath;
-        this.oAuthStartEnabled = oauthStartPath != null;
-    }
-
-    public void setOauthCallbackPath(String oauthCallbackPath) {
-        this.oauthCallbackPath = oauthCallbackPath;
-        this.oAuthCallbackEnabled = oauthCallbackPath != null;
-    }
-
     @Builder.Default
     private String clientId = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_CLIENT_ID))
             .orElse(System.getenv(EnvVariableName.SLACK_APP_CLIENT_ID));
@@ -141,30 +156,121 @@ public class AppConfig {
 
     private String appPath;
 
+    // --------------------------
+
+    @Deprecated // will be removed in v2.0 - use getOauthInstallRequestURI instead
     public String getOauthStartRequestURI() {
+        return getOauthInstallRequestURI();
+    }
+
+    public String getOauthInstallRequestURI() {
         if (appPath == null) {
-            return oauthStartPath;
+            return getOauthInstallPath();
         } else {
-            return appPath + oauthStartPath;
+            return appPath + getOauthInstallPath();
         }
     }
 
+    // --------------------------
+
+    @Deprecated // will be removed in v2.0 - use getOauthRedirectUriRequestURI instead
     public String getOauthCallbackRequestURI() {
+        return getOauthRedirectUriRequestURI();
+    }
+
+    public String getOauthRedirectUriRequestURI() {
         if (appPath == null) {
-            return oauthCallbackPath;
+            return getOauthRedirectUriPath();
         } else {
-            return appPath + oauthCallbackPath;
+            return appPath + getOauthRedirectUriPath();
         }
     }
 
+    // --------------------------
+
+    private static final String DEFAULT_OAUTH_INSTALL_PATH = "start";
+
+    @Deprecated // will be removed in v2.0 - use oauthInstallPath instead
     @Builder.Default
     private String oauthStartPath = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_INSTALL_PATH))
             .orElse(Optional.ofNullable(System.getenv(EnvVariableName.SLACK_APP_OAUTH_START_PATH))
-                    .orElse("start"));
+                    .orElse(DEFAULT_OAUTH_INSTALL_PATH));
+
+    @Deprecated
+    public String getOauthStartPath() {
+        return getOauthInstallPath();
+    }
+
+    @Deprecated
+    public void setOauthStartPath(String oauthStartPath) {
+        setOauthInstallPath(oauthStartPath);
+    }
+
+    @Builder.Default
+    private String oauthInstallPath = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_INSTALL_PATH))
+            .orElse(Optional.ofNullable(System.getenv(EnvVariableName.SLACK_APP_OAUTH_START_PATH))
+                    .orElse(DEFAULT_OAUTH_INSTALL_PATH));
+
+    public String getOauthInstallPath() {
+        String path = this.oauthInstallPath;
+        String legacyPath = this.oauthStartPath;
+        if (path != null
+                && path.equals(DEFAULT_OAUTH_INSTALL_PATH) == false
+                && legacyPath.equals(DEFAULT_OAUTH_INSTALL_PATH)) {
+            return path;
+        } else {
+            return legacyPath;
+        }
+    }
+
+    public void setOauthInstallPath(String oauthInstallPath) {
+        this.oauthInstallPath = oauthInstallPath;
+        this.oAuthInstallPathEnabled = oauthInstallPath != null;
+    }
+
+    // --------------------------
+
+    private static final String DEFAULT_OAUTH_REDIRECT_URI_PATH = "callback";
+
+    @Deprecated // will be removed in v2.0 - use oauthRedirectUriPath instead
     @Builder.Default
     private String oauthCallbackPath = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_REDIRECT_URI_PATH))
             .orElse(Optional.ofNullable(System.getenv(EnvVariableName.SLACK_APP_OAUTH_CALLBACK_PATH))
-                    .orElse("callback"));
+                    .orElse(DEFAULT_OAUTH_REDIRECT_URI_PATH));
+
+    @Deprecated
+    public String getOauthCallbackPath() {
+        return getOauthRedirectUriPath();
+    }
+
+    @Deprecated
+    public void setOauthCallbackPath(String oauthCallbackPath) {
+        setOauthRedirectUriPath(oauthCallbackPath);
+    }
+
+    @Builder.Default
+    private String oauthRedirectUriPath = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_REDIRECT_URI_PATH))
+            .orElse(Optional.ofNullable(System.getenv(EnvVariableName.SLACK_APP_OAUTH_CALLBACK_PATH))
+                    .orElse(DEFAULT_OAUTH_REDIRECT_URI_PATH));
+
+    public String getOauthRedirectUriPath() {
+        String path = this.oauthRedirectUriPath;
+        String legacyPath = this.oauthCallbackPath;
+        if (path != null
+                && path.equals(DEFAULT_OAUTH_REDIRECT_URI_PATH) == false
+                && legacyPath.equals(DEFAULT_OAUTH_REDIRECT_URI_PATH)) {
+            return path;
+        } else {
+            return legacyPath;
+        }
+    }
+
+    public void setOauthRedirectUriPath(String oauthRedirectUriPath) {
+        this.oauthRedirectUriPath = oauthRedirectUriPath;
+        this.oAuthRedirectUriPathEnabled = oauthRedirectUriPath != null;
+    }
+
+    // --------------------------
 
     @Builder.Default
     private String oauthCancellationUrl = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_OAUTH_CANCELLATION_URL))

--- a/bolt/src/main/java/com/slack/api/bolt/util/SlackRequestParser.java
+++ b/bolt/src/main/java/com/slack/api/bolt/util/SlackRequestParser.java
@@ -132,10 +132,10 @@ public class SlackRequestParser {
                     slackRequest = new SlashCommandRequest(requestBody, headers);
                 } else if (sslCheckPayloadDetector.isSSLCheckRequest(requestBody)) {
                     slackRequest = new SSLCheckRequest(requestBody, headers);
-                } else if (appConfig.isOAuthStartEnabled() && appConfig.getOauthStartRequestURI().equals(requestUri)) {
+                } else if (appConfig.isOAuthInstallPathEnabled() && appConfig.getOauthInstallRequestURI().equals(requestUri)) {
                     slackRequest = new OAuthStartRequest(requestBody, headers);
-                } else if (appConfig.isOAuthCallbackEnabled()
-                        && appConfig.getOauthCallbackRequestURI().equals(requestUri)
+                } else if (appConfig.isOAuthRedirectUriPathEnabled()
+                        && appConfig.getOauthRedirectUriRequestURI().equals(requestUri)
                         && httpRequest.getQueryString() != null) {
                     Map<String, List<String>> queryString = new HashMap<>();
                     for (Map.Entry<String, List<String>> original : httpRequest.getQueryString().entrySet()) {

--- a/bolt/src/test/java/test_locally/AppConfigTest.java
+++ b/bolt/src/test/java/test_locally/AppConfigTest.java
@@ -11,32 +11,89 @@ public class AppConfigTest {
     @Test
     public void constructor() {
         AppConfig config = new AppConfig();
+        assertNotNull(config.getOauthInstallPath());
+        assertNotNull(config.getOauthRedirectUriPath());
+        assertNotNull(config.getOauthStartPath());
         assertNotNull(config.getOauthCallbackPath());
     }
 
     @Test
     public void builder() {
         AppConfig config = AppConfig.builder().build();
+        assertNotNull(config.getOauthInstallPath());
+        assertNotNull(config.getOauthRedirectUriPath());
+        assertNotNull(config.getOauthStartPath());
         assertNotNull(config.getOauthCallbackPath());
     }
 
     @Test
     public void accessors() {
         AppConfig config = new AppConfig();
-        config.setOauthStartPath("/start");
-        config.setOauthCallbackPath("/callback");
-        assertEquals("/start", config.getOauthStartRequestURI());
-        assertEquals("/callback", config.getOauthCallbackRequestURI());
+        config.setOauthInstallPath("/custom-start");
+        config.setOauthRedirectUriPath("/custom-callback");
+        assertEquals("/custom-start", config.getOauthInstallRequestURI());
+        assertEquals("/custom-callback", config.getOauthRedirectUriRequestURI());
+        assertEquals("/custom-start", config.getOauthStartRequestURI());
+        assertEquals("/custom-callback", config.getOauthCallbackRequestURI());
+    }
+
+    @Test
+    public void legacy_accessors() {
+        AppConfig config = new AppConfig();
+        config.setOauthStartPath("/custom-start");
+        config.setOauthCallbackPath("/custom-callback");
+        assertEquals("/custom-start", config.getOauthInstallRequestURI());
+        assertEquals("/custom-callback", config.getOauthRedirectUriRequestURI());
+        assertEquals("/custom-start", config.getOauthStartRequestURI());
+        assertEquals("/custom-callback", config.getOauthCallbackRequestURI());
     }
 
     @Test
     public void accessors_appPath() {
         AppConfig config = new AppConfig();
         config.setAppPath("/app");
+        config.setOauthInstallPath("/custom-start");
+        config.setOauthRedirectUriPath("/custom-callback");
+        assertEquals("/app/custom-start", config.getOauthInstallRequestURI());
+        assertEquals("/app/custom-callback", config.getOauthRedirectUriRequestURI());
+        assertEquals("/app/custom-start", config.getOauthStartRequestURI());
+        assertEquals("/app/custom-callback", config.getOauthCallbackRequestURI());
+    }
+
+    @Test
+    public void legacy_accessors_appPath() {
+        AppConfig config = new AppConfig();
+        config.setAppPath("/app");
         config.setOauthStartPath("/start");
         config.setOauthCallbackPath("/callback");
         assertEquals("/app/start", config.getOauthStartRequestURI());
         assertEquals("/app/callback", config.getOauthCallbackRequestURI());
+    }
+
+    @Test
+    public void builders() {
+        AppConfig config = AppConfig.builder()
+                .oauthInstallPath("/slack/install")
+                .oauthRedirectUriPath("/slack/oauth_redirect")
+                .build();
+        assertEquals("/slack/install", config.getOauthInstallPath());
+        assertEquals("/slack/oauth_redirect", config.getOauthRedirectUriPath());
+
+        assertEquals("/slack/install", config.getOauthStartPath());
+        assertEquals("/slack/oauth_redirect", config.getOauthCallbackPath());
+    }
+
+    @Test
+    public void legacy_builders() {
+        AppConfig config = AppConfig.builder()
+                .oauthStartPath("/slack/install")
+                .oauthCallbackPath("/slack/oauth_redirect")
+                .build();
+        assertEquals("/slack/install", config.getOauthInstallPath());
+        assertEquals("/slack/oauth_redirect", config.getOauthRedirectUriPath());
+
+        assertEquals("/slack/install", config.getOauthStartPath());
+        assertEquals("/slack/oauth_redirect", config.getOauthCallbackPath());
     }
 
 }


### PR DESCRIPTION
This pull request fixes #588. Refer to the issue for details.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
