### PR TITLE
Update BoltLibraryVersion.java : Runtime of method is greater than accessing variable

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/meta/BoltLibraryVersion.java
+++ b/bolt/src/main/java/com/slack/api/bolt/meta/BoltLibraryVersion.java
@@ -1,11 +1,9 @@
 package com.slack.api.bolt.meta;
 
 public final class BoltLibraryVersion {
+    public static final String VERSION = "1.3.0-SNAPSHOT";
+    
     private BoltLibraryVersion() {
-    }
-
-    public static final String get() {
-        return "1.3.0-SNAPSHOT";
     }
 }
 


### PR DESCRIPTION
(Describe the goal of this PR. Mention any related Issue numbers)
The process involved with a method (time for one) is greater overall than accessing a variable, thus the change.
### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
