### PR TITLE
Update Audit Logs API to support barrier and some new fields

### DIFF
--- a/json-logs/raw/audit/v1/actions.json
+++ b/json-logs/raw/audit/v1/actions.json
@@ -103,7 +103,10 @@
       "pref.session_duration_type_changed",
       "org_verified",
       "org_unverified",
-      "org_public_url_updated"
+      "org_public_url_updated",
+      "organization_verified",
+      "organization_unverified",
+      "organization_public_url_updated"
     ],
     "user": [
       "custom_tos_accepted",
@@ -202,6 +205,11 @@
     "message": [
       "message_tombstoned",
       "message_restored"
+    ],
+    "barrier": [
+      "barrier_created",
+      "barrier_updated",
+      "barrier_deleted"
     ]
   }
 }

--- a/json-logs/raw/audit/v1/schemas.json
+++ b/json-logs/raw/audit/v1/schemas.json
@@ -70,6 +70,14 @@
         "channel": "string",
         "timestamp": "string"
       }
+    },
+    {
+      "type": "barrier",
+      "barrier": {
+        "id": "string",
+        "primary_usergroup": "string",
+        "barriered_from_usergroup": "string"
+      }
     }
   ]
 }

--- a/json-logs/samples/audit/v1/actions.json
+++ b/json-logs/samples/audit/v1/actions.json
@@ -20,6 +20,9 @@
     ],
     "message": [
       ""
+    ],
+    "barrier": [
+      ""
     ]
   },
   "ok": false,

--- a/json-logs/samples/audit/v1/schemas.json
+++ b/json-logs/samples/audit/v1/schemas.json
@@ -48,6 +48,11 @@
         "team": "",
         "channel": "",
         "timestamp": ""
+      },
+      "barrier": {
+        "id": "",
+        "primary_usergroup": "",
+        "barriered_from_usergroup": ""
       }
     }
   ],

--- a/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
@@ -115,6 +115,9 @@ public class Actions {
         public static final String org_verified = "org_verified";
         public static final String org_unverified = "org_unverified";
         public static final String org_public_url_updated = "org_public_url_updated";
+        public static final String organization_verified = "organization_verified";
+        public static final String organization_unverified = "organization_unverified";
+        public static final String organization_public_url_updated = "organization_public_url_updated";
     }
 
     public static class User {
@@ -238,5 +241,14 @@ public class Actions {
         public static final String workflow_unpublished = "workflow_unpublished";
         public static final String workflow_responses_csv_download = "workflow_responses_csv_download";
         public static final String workflow_unknown_action = "workflow_unknown_action";
+    }
+
+    public static class Barrier {
+        private Barrier() {
+        }
+
+        public static final String barrier_created = "barrier_created";
+        public static final String barrier_updated = "barrier_updated";
+        public static final String barrier_deleted = "barrier_deleted";
     }
 }

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
@@ -28,5 +28,6 @@ public class ActionsResponse implements AuditApiResponse {
         private List<String> app;
         private List<String> message;
         private List<String> workflowBuilder;
+        private List<String> barrier;
     }
 }

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
@@ -163,6 +163,8 @@ public class LogsResponse implements AuditApiResponse {
         private DetailsChangedValue previousValue; // pref.who_can_manage_shared_channels etc
         private Kicker kicker;
         private String installerUserId;
+        private String approverId;
+        private String approvalType;
         private Boolean appPreviouslyApproved;
         private List<String> oldScopes;
         private String name;

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
@@ -30,6 +30,7 @@ public class SchemasResponse implements AuditApiResponse {
         private App app;
         private Message message;
         private Workflow workflow;
+        private Barrier barrier;
     }
 
     @Data
@@ -93,6 +94,13 @@ public class SchemasResponse implements AuditApiResponse {
     public static class Workflow {
         private String id;
         private String name;
+    }
+
+    @Data
+    public static class Barrier {
+        private String id;
+        private String primaryUsergroup;
+        private String barrieredFromUsergroup;
     }
 
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
@@ -192,6 +192,7 @@ public class ApiTest {
             verifyAllActions(orgAdminUserToken, Actions.File.class);
             verifyAllActions(orgAdminUserToken, Actions.Channel.class);
             verifyAllActions(orgAdminUserToken, Actions.App.class);
+            verifyAllActions(orgAdminUserToken, Actions.Barrier.class);
         }
     }
 


### PR DESCRIPTION
This pull request adds a few new fields to Audit Logs API response that were just added today.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.