### PR TITLE
Fix #595 Support app_uninstalled, tokens_revoked events in Bolt

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/middleware/MiddlewareOps.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/MiddlewareOps.java
@@ -1,6 +1,13 @@
 package com.slack.api.bolt.middleware;
 
+import com.slack.api.bolt.request.Request;
 import com.slack.api.bolt.request.RequestType;
+import com.slack.api.bolt.request.builtin.EventRequest;
+import com.slack.api.model.event.AppUninstalledEvent;
+import com.slack.api.model.event.TokensRevokedEvent;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Utilities for Middleware.
@@ -32,4 +39,22 @@ public class MiddlewareOps {
         return isNoSlackSignatureRequest(requestType)
                 || requestType == RequestType.UrlVerification;
     }
+
+    private static final List<String> EVENT_TYPES_TO_SKIP_AUTHORIZATION =
+            Arrays.asList(AppUninstalledEvent.TYPE_NAME, TokensRevokedEvent.TYPE_NAME);
+
+    /**
+     * Returns true if the request is an Event API payload and matches specific types.
+     * @param req request
+     * @return true if middleware can skip fetching tokens
+     */
+    public static boolean isNoTokenRequiredRequest(Request req) {
+        if (req.getRequestType() == RequestType.Event) {
+            EventRequest eventRequest = (EventRequest) req;
+            String eventType = eventRequest.getEventType();
+            return eventType != null && EVENT_TYPES_TO_SKIP_AUTHORIZATION.contains(eventType);
+        }
+        return false;
+    }
+
 }

--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/MultiTeamsAuthorization.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/MultiTeamsAuthorization.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static com.slack.api.bolt.middleware.MiddlewareOps.isNoAuthRequiredRequest;
+import static com.slack.api.bolt.middleware.MiddlewareOps.isNoTokenRequiredRequest;
 import static com.slack.api.bolt.response.ResponseTypes.ephemeral;
 
 /**
@@ -105,6 +106,11 @@ public class MultiTeamsAuthorization implements Middleware {
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
         if (isNoAuthRequiredRequest(req.getRequestType())) {
+            return chain.next(req);
+        }
+        if (isNoTokenRequiredRequest(req)) {
+            // Nothing to do here
+            // enterprise_id / team_id are already set by Request object constructor
             return chain.next(req);
         }
 

--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/SingleTeamAuthorization.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/SingleTeamAuthorization.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.slack.api.bolt.middleware.MiddlewareOps.isNoAuthRequiredRequest;
+import static com.slack.api.bolt.middleware.MiddlewareOps.isNoTokenRequiredRequest;
 
 /**
  * Verifies if the given access token when booting this app is valid for incoming requests.
@@ -47,6 +48,11 @@ public class SingleTeamAuthorization implements Middleware {
     @Override
     public Response apply(Request req, Response resp, MiddlewareChain chain) throws Exception {
         if (isNoAuthRequiredRequest(req.getRequestType())) {
+            return chain.next(req);
+        }
+        if (isNoTokenRequiredRequest(req)) {
+            // Nothing to do here
+            // enterprise_id / team_id are already set by Request object constructor
             return chain.next(req);
         }
 


### PR DESCRIPTION
This pull request fixes #595 by updating authorization middleware

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
