### PR TITLE
Remove micronaut bom from bolt-micronaut project

### DIFF
--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,9 +10,9 @@
     </parent>
 
     <properties>
-        <micronaut.bom.version>2.0.2</micronaut.bom.version>
-        <micronaut.version>2.0.3</micronaut.version>
-        <micronaut-test-junit5.version>1.2.0</micronaut-test-junit5.version>
+        <micronaut.bom.version>2.1.2</micronaut.bom.version>
+        <micronaut.version>2.1.2</micronaut.version>
+        <micronaut-test-junit5.version>2.1.1</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>
 
@@ -20,18 +20,6 @@
     <artifactId>bolt-micronaut</artifactId>
     <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.micronaut</groupId>
-                <artifactId>micronaut-bom</artifactId>
-                <version>${micronaut.bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -54,6 +42,7 @@
             <artifactId>bolt</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-http-server-netty</artifactId>
@@ -70,6 +59,18 @@
             <groupId>io.micronaut.test</groupId>
             <artifactId>micronaut-test-junit5</artifactId>
             <version>${micronaut-test-junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-inject-java-test</artifactId>
+            <version>${micronaut.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-inject-java-test</artifactId>
+            <version>${micronaut.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
@@ -14,8 +14,8 @@ import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
-import io.micronaut.test.annotation.MicronautTest;
 import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
To run unit tests, the bolt-micronaut has been depending on micronaut-bom base settings. This pull request removes the bom from the build settings to reduce unnecessary dependencies from the project.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
