### PR TITLE
Fix #609 by adding timeout settings in SlackConfig

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -66,7 +66,7 @@ public class AppConfig {
     private static SlackHttpClient buildSlackHttpClient() {
         Map<String, String> userAgentCustomInfo = new HashMap<>();
         userAgentCustomInfo.put("bolt", BoltLibraryVersion.get());
-        SlackHttpClient client = new SlackHttpClient(userAgentCustomInfo);
+        SlackHttpClient client = new SlackHttpClient(SlackConfig.DEFAULT, userAgentCustomInfo);
         return client;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
@@ -88,12 +88,47 @@ public class SlackConfig {
         public void setProxyUrl(String proxyUrl) {
             throwException();
         }
+
+        @Override
+        public void setHttpClientCallTimeoutMillis(Integer httpClientCallTimeoutMillis) {
+            throwException();
+        }
+
+        @Override
+        public void setHttpClientWriteTimeoutMillis(Integer httpClientWriteTimeoutMillis) {
+            throwException();
+        }
+
+        @Override
+        public void setHttpClientReadTimeoutMillis(Integer httpClientReadTimeoutMillis) {
+            throwException();
+        }
     };
 
     public SlackConfig() {
         getHttpClientResponseHandlers().add(new DetailedLoggingListener());
         getHttpClientResponseHandlers().add(new ResponsePrettyPrintingListener());
     }
+
+    /**
+     * The underlying HTTP client's read timeout (in milliseconds). The default is 10 seconds.
+     * https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/read-timeout-millis/
+     */
+    private Integer httpClientReadTimeoutMillis;
+
+    /**
+     * The underlying HTTP client's write timeout (in milliseconds). The default is 10 seconds.
+     * https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/write-timeout-millis/
+     */
+    private Integer httpClientWriteTimeoutMillis;
+
+    /**
+     * The underlying HTTP client's call timeout (in milliseconds).
+     * By default there is no timeout for complete calls,
+     * but there is for the connect, write, and read actions within a call.
+     * https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/call-timeout-millis/
+     */
+    private Integer httpClientCallTimeoutMillis;
 
     /**
      * The proxy server URL supposed to be used for all api calls.

--- a/slack-api-client/src/test/java/test_locally/api/methods/ApiTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/ApiTest.java
@@ -8,6 +8,10 @@ import org.junit.Before;
 import org.junit.Test;
 import util.MockSlackApiServer;
 
+import java.io.IOException;
+
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -40,6 +44,40 @@ public class ApiTest {
         ApiTestResponse response = slack.methodsAsync().apiTest(r -> r.error("error").foo("bar")).get();
         assertThat(response.isOk(), is(true));
         assertThat(response.getArgs().getFoo(), is(""));
+    }
+
+    @Test
+    public void customTimeouts_read() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+        config.setHttpClientReadTimeoutMillis(1);
+        try {
+            Slack.getInstance(config).methods().apiTest(r -> r.foo("bar"));
+            fail();
+        } catch (IOException e) {
+            assertTrue(e.getMessage().equals("Read timed out") || e.getMessage().equals("timeout"));
+        }
+    }
+
+    @Test
+    public void customTimeouts_write() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+        config.setHttpClientWriteTimeoutMillis(1);
+        Slack.getInstance(config).methods().apiTest(r -> r.foo("bar"));
+    }
+
+    @Test
+    public void customTimeouts_call() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+        config.setHttpClientCallTimeoutMillis(1);
+        try {
+            Slack.getInstance(config).methods().apiTest(r -> r.foo("bar"));
+            fail();
+        } catch (IOException e) {
+            assertTrue(e.getMessage().equals("Read timed out") || e.getMessage().equals("timeout"));
+        }
     }
 
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/api_test_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/api_test_Test.java
@@ -1,6 +1,7 @@
 package test_with_remote_apis.methods;
 
 import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
 import com.slack.api.methods.Methods;
 import com.slack.api.methods.RequestFormBuilder;
 import com.slack.api.methods.SlackApiException;
@@ -20,6 +21,8 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.concurrent.ExecutionException;
 
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -89,6 +92,37 @@ public class api_test_Test {
         assertThat(response.code(), is(200));
         String body = response.body().string();
         assertThat(body, is("{\"ok\":true,\"args\":{\"foo\":\"fine\"}}"));
+    }
+
+    @Test
+    public void customTimeouts_read() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setHttpClientReadTimeoutMillis(1);
+        try {
+            Slack.getInstance(config).methods().apiTest(r -> r.foo("bar"));
+            fail();
+        } catch (IOException e) {
+            assertTrue(e.getMessage().equals("Read timed out") || e.getMessage().equals("timeout"));
+        }
+    }
+
+    @Test
+    public void customTimeouts_write() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setHttpClientWriteTimeoutMillis(1);
+        Slack.getInstance(config).methods().apiTest(r -> r.foo("bar"));
+    }
+
+    @Test
+    public void customTimeouts_call() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setHttpClientCallTimeoutMillis(1);
+        try {
+            Slack.getInstance(config).methods().apiTest(r -> r.foo("bar"));
+            fail();
+        } catch (IOException e) {
+            assertTrue(e.getMessage().equals("Read timed out") || e.getMessage().equals("timeout"));
+        }
     }
 
 }


### PR DESCRIPTION
This pull request fixes #609 by adding timeout settings to `SlackConfig` class for ease of configuration.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
