### PR TITLE
Fix #610 by adding timepicker block element support

### DIFF
--- a/json-logs/samples/api/chat.postMessage.json
+++ b/json-logs/samples/api/chat.postMessage.json
@@ -68,7 +68,14 @@
           "image_height": 12345,
           "image_bytes": 12345,
           "type": "",
-          "alt_text": ""
+          "alt_text": "",
+          "action_id": "",
+          "initial_time": "",
+          "placeholder": {
+            "type": "",
+            "text": "",
+            "emoji": false
+          }
         },
         "elements": [
           {

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
@@ -30,6 +30,8 @@ import static com.slack.api.model.Attachments.attachment;
 import static com.slack.api.model.block.Blocks.asBlocks;
 import static com.slack.api.model.block.Blocks.section;
 import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static com.slack.api.model.block.element.BlockElements.timePicker;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
@@ -742,6 +744,24 @@ public class chat_Test {
                 .text(":wave: Hello! 哈囉"));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.getMessage().getText(), is(":wave: Hello! 哈囉"));
+    }
+
+    @Test
+    public void post_messages_timepicker() throws Exception {
+        loadRandomChannelId();
+
+        ChatPostMessageResponse response = slack.methods(botToken).chatPostMessage(r -> r.channel(randomChannelId)
+                .blocks(Arrays.asList(section(s -> s.text(plainText("test")).blockId("b").accessory(
+                        timePicker(t -> t
+                                .actionId("a")
+                                .initialTime("09:10")
+                                .placeholder(plainText("It's time to start!")))
+                        ))
+                ))
+        );
+        // invalid_blocks means you haven't turned the beta feature on
+        // Go to https://api.slack.com/apps/{api_app_id}/developer-beta
+        assertThat(response.getError(), is(nullValue()));
     }
 
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/BlockElements.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/BlockElements.java
@@ -53,6 +53,12 @@ public class BlockElements {
         return configurator.configure(DatePickerElement.builder()).build();
     }
 
+    // TimePickerElement
+
+    public static TimePickerElement timePicker(ModelConfigurator<TimePickerElement.TimePickerElementBuilder> configurator) {
+        return configurator.configure(TimePickerElement.builder()).build();
+    }
+
     // ImageElement
 
     public static ImageElement image(ModelConfigurator<ImageElement.ImageElementBuilder> configurator) {

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/TimePickerElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/TimePickerElement.java
@@ -1,0 +1,45 @@
+package com.slack.api.model.block.element;
+
+import com.slack.api.model.block.composition.ConfirmationDialogObject;
+import com.slack.api.model.block.composition.PlainTextObject;
+import lombok.*;
+
+/**
+ * https://api.slack.com/reference/block-kit/block-elements#timepicker
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class TimePickerElement extends BlockElement {
+    public static final String TYPE = "timepicker";
+    private final String type = TYPE;
+
+    /**
+     * An identifier for the action triggered when a time is selected.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other action_ids in the containing block.
+     * Maximum length for this field is 255 characters.
+     */
+    private String actionId;
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the timepicker.
+     * Maximum length for the text in this field is 150 characters.
+     */
+    private PlainTextObject placeholder;
+
+    /**
+     * The initial time that is selected when the element is loaded.
+     * This should be in the format HH:mm, where HH is the 24-hour format of an hour (00 to 23)
+     * and mm is minutes with leading zeros (00 to 59), for example 22:25 for 10:25pm.
+     */
+    private String initialTime;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears after a date is selected.
+     */
+    private ConfirmationDialogObject confirm;
+
+}

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonBlockElementFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonBlockElementFactory.java
@@ -70,6 +70,8 @@ public class GsonBlockElementFactory implements JsonDeserializer<BlockElement>, 
                 return OverflowMenuElement.class;
             case DatePickerElement.TYPE:
                 return DatePickerElement.class;
+            case TimePickerElement.TYPE:
+                return TimePickerElement.class;
             case PlainTextInputElement.TYPE:
                 return PlainTextInputElement.class;
             case RichTextSectionElement.TYPE:

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -1,11 +1,9 @@
 package test_locally.api.model.block;
 
+import com.google.gson.Gson;
 import com.slack.api.model.Message;
 import com.slack.api.model.block.*;
-import com.slack.api.model.block.element.BlockElement;
-import com.slack.api.model.block.element.ChannelsSelectElement;
-import com.slack.api.model.block.element.ConversationsSelectElement;
-import com.slack.api.model.block.element.MultiConversationsSelectElement;
+import com.slack.api.model.block.element.*;
 import com.slack.api.model.view.View;
 import org.junit.Test;
 import test_locally.unit.GsonFactory;
@@ -19,8 +17,7 @@ import static com.slack.api.model.block.composition.BlockCompositions.plainText;
 import static com.slack.api.model.block.element.BlockElements.*;
 import static com.slack.api.model.view.Views.view;
 import static com.slack.api.model.view.Views.viewSubmit;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
@@ -398,5 +395,37 @@ public class BlocksTest {
         assertNotNull(modalView);
     }
 
+    @Test
+    public void timePickerElement() {
+        // https://api.slack.com/reference/block-kit/block-elements#timepicker
+        String json = "{\n" +
+                "  \"type\": \"section\",\n" +
+                "  \"block_id\": \"section1234\",\n" +
+                "  \"text\": {\n" +
+                "    \"type\": \"mrkdwn\",\n" +
+                "    \"text\": \"Pick a date for the deadline.\"\n" +
+                "  },\n" +
+                "  \"accessory\": {\n" +
+                "    \"type\": \"timepicker\",\n" +
+                "    \"action_id\": \"timepicker123\",\n" +
+                "    \"initial_time\": \"11:40\",\n" +
+                "    \"placeholder\": {\n" +
+                "      \"type\": \"plain_text\",\n" +
+                "      \"text\": \"Select a time\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        Gson gson = GsonFactory.createSnakeCase();
+        SectionBlock section = gson.fromJson(json, SectionBlock.class);
+        assertThat(section.getBlockId(), is("section1234"));
+        TimePickerElement accessory = (TimePickerElement) section.getAccessory();
+        assertThat(accessory.getActionId(), is("timepicker123"));
+        assertThat(accessory.getInitialTime(), is("11:40"));
+        assertThat(accessory.getPlaceholder().getText(), is("Select a time"));
+        assertThat(accessory.getConfirm(), is(nullValue()));
+
+        String output = gson.toJson(section);
+        assertThat(output, is("{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Pick a date for the deadline.\"},\"block_id\":\"section1234\",\"accessory\":{\"type\":\"timepicker\",\"action_id\":\"timepicker123\",\"placeholder\":{\"type\":\"plain_text\",\"text\":\"Select a time\"},\"initial_time\":\"11:40\"}}"));
+    }
 
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/block/EqualityTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/EqualityTest.java
@@ -23,6 +23,7 @@ public class EqualityTest {
         assertEquals(new CheckboxesElement(), new CheckboxesElement());
         assertEquals(new ConversationsSelectElement(), new ConversationsSelectElement());
         assertEquals(new DatePickerElement(), new DatePickerElement());
+        assertEquals(new TimePickerElement(), new TimePickerElement());
         assertEquals(new ExternalSelectElement(), new ExternalSelectElement());
         assertEquals(new ImageElement(), new ImageElement());
         assertEquals(new MultiChannelsSelectElement(), new MultiChannelsSelectElement());


### PR DESCRIPTION
This pull request fixes #610 by adding `timepicker` block element support.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
