### PR TITLE
Fix #614 by overriding methods

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersLookupByEmailResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersLookupByEmailResponse.java
@@ -1,4 +1,89 @@
 package com.slack.api.methods.response.users;
 
+import com.slack.api.model.User;
+
 public class UsersLookupByEmailResponse extends com.slack.api.methods.response.channels.UsersLookupByEmailResponse {
+    public UsersLookupByEmailResponse() {
+        super();
+    }
+
+    @Override
+    public boolean isOk() {
+        return super.isOk();
+    }
+
+    @Override
+    public String getWarning() {
+        return super.getWarning();
+    }
+
+    @Override
+    public String getError() {
+        return super.getError();
+    }
+
+    @Override
+    public String getNeeded() {
+        return super.getNeeded();
+    }
+
+    @Override
+    public String getProvided() {
+        return super.getProvided();
+    }
+
+    @Override
+    public User getUser() {
+        return super.getUser();
+    }
+
+    @Override
+    public void setOk(boolean ok) {
+        super.setOk(ok);
+    }
+
+    @Override
+    public void setWarning(String warning) {
+        super.setWarning(warning);
+    }
+
+    @Override
+    public void setError(String error) {
+        super.setError(error);
+    }
+
+    @Override
+    public void setNeeded(String needed) {
+        super.setNeeded(needed);
+    }
+
+    @Override
+    public void setProvided(String provided) {
+        super.setProvided(provided);
+    }
+
+    @Override
+    public void setUser(User user) {
+        super.setUser(user);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    protected boolean canEqual(Object other) {
+        return super.canEqual(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
 }


### PR DESCRIPTION
This pull request fixes #614 by overriding all the public methods in `UsersLookupByEmailResponse` class. The reason why the class inherits a deprecated class is to ensure backward compatibility. The current implementation has been failing to completely hide the deprecation warnings on the parent class side.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
