### PR TITLE
Fix bolt-http4k to work with empty response body

### DIFF
--- a/bolt-http4k/src/main/java/com/slack/api/bolt/http4k/Http4kSlackApp.java
+++ b/bolt-http4k/src/main/java/com/slack/api/bolt/http4k/Http4kSlackApp.java
@@ -58,12 +58,16 @@ public class Http4kSlackApp implements Function1<Request, Response> {
     }
 
     private Response toHttp4kResponse(com.slack.api.bolt.response.Response boltResponse) {
+        Status status = new Status(boltResponse.getStatusCode(), "");
         List<Pair<String, String>> headers = boltResponse.getHeaders()
                 .entrySet().stream()
                 .flatMap(it -> it.getValue().stream().map(it2 -> new Pair<String, String>(it.getKey(), it2)))
                 .collect(Collectors.toList());
-        return Response.Companion.create(new Status(boltResponse.getStatusCode(), ""))
+        String body = boltResponse.getBody();
+        return Response.Companion
+                .create(status)
                 .headers(headers)
-                .body(boltResponse.getBody());
+                // null here is not allowed by http4k
+                .body(body == null ? "" : body);
     }
 }

--- a/bolt-http4k/src/test/java/test_locally/Http4kSlackAppTest.java
+++ b/bolt-http4k/src/test/java/test_locally/Http4kSlackAppTest.java
@@ -48,6 +48,9 @@ public class Http4kSlackAppTest {
             String body = req.getRequestBodyAsString();
             return r.text("query: " + query + " headers: " + headers + " body: " + body);
         }));
+
+        app.command("do-nothing", (req, ctx) -> ctx.ack());
+
         this.http4kSlackApp = new Http4kSlackApp(app);
     }
 
@@ -79,6 +82,13 @@ public class Http4kSlackAppTest {
                         "\"}");
 
         Response response = http4kSlackApp.invoke(buildRequest("command=echo"));
+        assertThat(response, equalTo(expected));
+    }
+
+    @Test
+    public void emptyResponse() {
+        Response expected = Response.Companion.create(Status.OK).body("");
+        Response response = http4kSlackApp.invoke(buildRequest("command=do-nothing"));
         assertThat(response, equalTo(expected));
     }
 


### PR DESCRIPTION
(Describe the goal of this PR. Mention any related Issue numbers)

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
