### PR TITLE
Enable path filtering for bolt-http4k apps

### DIFF
--- a/bolt-http4k/src/main/java/com/slack/api/bolt/http4k/Http4kSlackApp.java
+++ b/bolt-http4k/src/main/java/com/slack/api/bolt/http4k/Http4kSlackApp.java
@@ -91,19 +91,19 @@ public class Http4kSlackApp implements Function1<Request, Response> {
 
     protected Response buildEventErrorResponse(Request request, Exception e) {
         return Response.Companion.create(INTERNAL_SERVER_ERROR)
-                .header("Content-type", "application/json; charset=utf-8")
+                .header("Content-Type", "application/json; charset=utf-8")
                 .body("{\"error\":\"An error occurred during processing of the request\"}");
     }
 
     protected Response buildOAuthPageErrorResponse(Request request, Exception e) {
         return Response.Companion.create(INTERNAL_SERVER_ERROR)
-                .header("Content-type", "text/plain; charset=utf-8")
+                .header("Content-Type", "text/plain; charset=utf-8")
                 .body("Internal Server Error");
     }
 
     protected Response notFound(Request request) {
         return Response.Companion.create(NOT_FOUND)
-                .header("Content-type", "text/plain; charset=utf-8")
+                .header("Content-Type", "text/plain; charset=utf-8")
                 .body("Not Found");
     }
 

--- a/bolt-http4k/src/test/java/example/app/ExampleHttp4kBoltServer.java
+++ b/bolt-http4k/src/test/java/example/app/ExampleHttp4kBoltServer.java
@@ -7,6 +7,30 @@ import org.http4k.server.SunHttp;
 
 public class ExampleHttp4kBoltServer {
 
+    /*
+    import com.slack.api.bolt.AppConfig;
+
+    Simple Example:
+        App app = new App(AppConfig.builder()
+            .signingSecret("xxx")
+            .singleTeamBotToken("xoxb-111-111-xxx")
+            .build()
+        );
+
+    OAuth Example:
+        App app = new App(AppConfig.builder()
+            .signingSecret("xxx")
+            .clientId("111.111")
+            .clientSecret("xxx")
+            .scope("app_mentions:read,chat:write")
+            .oauthInstallPath("/slack/install")
+            .oauthRedirectUriPath("/slack/oauth_redirect")
+            .oauthCompletionUrl("https://www.example.com/success")
+            .oauthCancellationUrl("https://www.example.com/failure")
+            .build()
+        ).asOAuthApp(true);
+     */
+
     public static void main(String[] args) {
         App app = new App();
         app.command("/hi", (req, ctx) -> ctx.ack());

--- a/bolt-http4k/src/test/java/util/AuthTestMockServer.java
+++ b/bolt-http4k/src/test/java/util/AuthTestMockServer.java
@@ -28,6 +28,29 @@ public class AuthTestMockServer {
             "  \"error\": \"invalid\"\n" +
             "}";
 
+    static String oauthV2Access = "{\n" +
+            "    \"ok\": true,\n" +
+            "    \"access_token\": \"" + ValidToken + "\",\n" +
+            "    \"token_type\": \"bot\",\n" +
+            "    \"scope\": \"commands,incoming-webhook\",\n" +
+            "    \"bot_user_id\": \"U0KRQLJ9H\",\n" +
+            "    \"app_id\": \"A0KRD7HC3\",\n" +
+            "    \"team\": {\n" +
+            "        \"name\": \"Slack Softball Team\",\n" +
+            "        \"id\": \"T9TK3CUKW\"\n" +
+            "    },\n" +
+            "    \"enterprise\": {\n" +
+            "        \"name\": \"slack-sports\",\n" +
+            "        \"id\": \"E12345678\"\n" +
+            "    },\n" +
+            "    \"authed_user\": {\n" +
+            "        \"id\": \"U1234\",\n" +
+            "        \"scope\": \"chat:write\",\n" +
+            "        \"access_token\": \"xoxp-1234\",\n" +
+            "        \"token_type\": \"user\"\n" +
+            "    }\n" +
+            "}";
+
     @WebServlet
     public static class AuthTestMockEndpoint extends HttpServlet {
 
@@ -35,6 +58,10 @@ public class AuthTestMockServer {
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             resp.setStatus(200);
             resp.setContentType("application/json");
+            if (req.getRequestURI().equals("/api/oauth.v2.access")) {
+                resp.getWriter().write(oauthV2Access);
+                return;
+            }
             if (req.getHeader("Authorization") == null || !req.getHeader("Authorization").equals("Bearer " + ValidToken)) {
                 resp.getWriter().write(ng);
             } else {

--- a/bolt-http4k/src/test/resources/logback.xml
+++ b/bolt-http4k/src/test/resources/logback.xml
@@ -6,7 +6,8 @@
         </encoder>
     </appender>
     <logger name="com.slack.api" level="debug"/>
-    <root level="debug">
+    <logger name="org.eclipse.jetty" level="warn"/>
+    <root level="info">
         <appender-ref ref="default"/>
     </root>
 </configuration>


### PR DESCRIPTION
I overlooked the bolt-http4k module does not reflect the URLs set by `App`. This pull request adds the logic to check the HTTP request method & path to dispatch requests only to the registered URLs.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
