### PR TITLE
Add org-level installation support #617

### DIFF
--- a/bolt-helidon/src/test/java/test_locally/MainTest.java
+++ b/bolt-helidon/src/test/java/test_locally/MainTest.java
@@ -29,6 +29,7 @@ public class MainTest {
             .redirectUri("https://www.example.com/slack/outh/callback")
             .oauthCompletionUrl("https://wwww.example.com/thank-you")
             .oauthCancellationUrl("https://www.example.com/something-wrong")
+            .oAuthInstallPageRenderingEnabled(false)
             .build();
 
     @Before

--- a/bolt-http4k/src/test/java/test_locally/Http4kSlackAppTest.java
+++ b/bolt-http4k/src/test/java/test_locally/Http4kSlackAppTest.java
@@ -66,6 +66,7 @@ public class Http4kSlackAppTest {
                 .oauthRedirectUriPath("/slack/oauth_redirect")
                 .oauthCompletionUrl("https://www.example.com/success")
                 .oauthCancellationUrl("https://www.example.com/failure")
+                .oAuthInstallPageRenderingEnabled(false)
                 .build()
         ).asOAuthApp(true);
         this.oauthSlackApp = new Http4kSlackApp(oauthApp);

--- a/bolt-servlet/src/test/java/samples/EnterpriseGridOrgAppSample.java
+++ b/bolt-servlet/src/test/java/samples/EnterpriseGridOrgAppSample.java
@@ -10,10 +10,10 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.stream.Collectors;
 
-public class GridOrgAdminAppSample {
+public class EnterpriseGridOrgAppSample {
 
     public static void main(String[] args) throws Exception {
-        String jsonString = Files.readAllLines(Paths.get("bolt-servlet/src/test/resources/appConfig_org_admin_app.json"))
+        String jsonString = Files.readAllLines(Paths.get("bolt-servlet/src/test/resources/appConfig_org_app.json"))
                 .stream().collect(Collectors.joining("\n"));
         AppConfig appConfig = GsonFactory.createCamelCase(SlackConfig.DEFAULT).fromJson(jsonString, AppConfig.class);
         App app = new App(appConfig).asOAuthApp(true);

--- a/bolt-servlet/src/test/java/samples/EnterpriseGridOrgAppSample.java
+++ b/bolt-servlet/src/test/java/samples/EnterpriseGridOrgAppSample.java
@@ -3,6 +3,7 @@ package samples;
 import com.slack.api.SlackConfig;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
+import com.slack.api.model.event.AppMentionEvent;
 import com.slack.api.util.json.GsonFactory;
 import util.TestSlackAppServer;
 
@@ -17,7 +18,11 @@ public class EnterpriseGridOrgAppSample {
                 .stream().collect(Collectors.joining("\n"));
         AppConfig appConfig = GsonFactory.createCamelCase(SlackConfig.DEFAULT).fromJson(jsonString, AppConfig.class);
         App app = new App(appConfig).asOAuthApp(true);
-        TestSlackAppServer server = new TestSlackAppServer(app, "/slack/oauth/");
+        app.event(AppMentionEvent.class, (req, ctx) -> {
+            ctx.say("Hi");
+            return ctx.ack();
+        });
+        TestSlackAppServer server = new TestSlackAppServer(app);
         server.start();
     }
 }

--- a/bolt-servlet/src/test/java/samples/OrgAppSample.java
+++ b/bolt-servlet/src/test/java/samples/OrgAppSample.java
@@ -1,0 +1,68 @@
+package samples;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.methods.response.bots.BotsInfoResponse;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.methods.response.views.ViewsOpenResponse;
+import com.slack.api.model.event.AppMentionEvent;
+import util.ResourceLoader;
+import util.TestSlackAppServer;
+
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static com.slack.api.model.block.element.BlockElements.plainTextInput;
+import static com.slack.api.model.view.Views.*;
+import static org.junit.Assert.assertNotNull;
+
+public class OrgAppSample {
+
+    public static void main(String[] args) throws Exception {
+        AppConfig config = ResourceLoader.loadAppConfig("appConfig_org_app.json");
+        App apiApp = new App(config).asOAuthApp(false);
+        apiApp.use((req, resp, chain) -> {
+            String body = req.getRequestBodyAsString();
+            String payload = body.startsWith("payload=") ? URLDecoder.decode(body.split("payload=")[1], "UTF-8") : body;
+            req.getContext().logger.info(payload);
+            return chain.next(req);
+        });
+
+        apiApp.event(AppMentionEvent.class, (req, ctx) -> {
+            ctx.say("Hi!");
+            BotsInfoResponse response = ctx.client().botsInfo(r -> r.bot(ctx.getBotId()));
+            ctx.logger.info("response: {}", response);
+            response = ctx.client().botsInfo(r -> r.teamId(req.getTeamId()).bot(ctx.getBotId()));
+            ctx.logger.info("response: {}", response);
+            return ctx.ack();
+        });
+
+        apiApp.command("/org-level-command", (req, ctx) -> {
+            return ctx.ack("It works!");
+        });
+
+        apiApp.globalShortcut("org-level-shortcut", (req, ctx) -> {
+            ViewsOpenResponse viewsOpen = ctx.client().viewsOpen(r -> r
+                    .triggerId(req.getContext().getTriggerId())
+                    .view(view(v -> v
+                            .type("modal")
+                            .callbackId("org-app-view")
+                            .title(viewTitle(vt -> vt.type("plain_text").text("Org App")))
+                            .close(viewClose(vc -> vc.type("plain_text").text("Close")))
+                            .blocks(asBlocks(section(s -> s.text(plainText("It works!")))))
+                    )));
+            return ctx.ack();
+        });
+
+        App oauthApp = new App(config).asOAuthApp(true);
+
+        Map<String, App> apps = new HashMap<>();
+        apps.put("/slack/events", apiApp);
+        apps.put("/slack/oauth/", oauthApp);
+        TestSlackAppServer server = new TestSlackAppServer(apps);
+        server.start();
+    }
+}

--- a/bolt-servlet/src/test/java/test_locally/servlet/SlackOAuthAppServletTest.java
+++ b/bolt-servlet/src/test/java/test_locally/servlet/SlackOAuthAppServletTest.java
@@ -91,7 +91,8 @@ public class SlackOAuthAppServletTest {
 
         servlet.service(req, resp);
 
-        verify(resp, times(1)).setStatus(302);
+        verify(resp, times(1)).setStatus(200);
+        verify(resp, times(1)).setHeader("Content-Type","text/html; charset=utf-8");
     }
 
     @Test

--- a/bolt-servlet/src/test/java/util/ResourceLoader.java
+++ b/bolt-servlet/src/test/java/util/ResourceLoader.java
@@ -35,6 +35,21 @@ public class ResourceLoader {
                     if (j.get("singleTeamBotToken") != null) {
                         config.setSingleTeamBotToken(j.get("singleTeamBotToken").getAsString());
                     }
+                    if (j.get("clientId") != null) {
+                        config.setClientId(j.get("clientId").getAsString());
+                    }
+                    if (j.get("clientSecret") != null) {
+                        config.setClientSecret(j.get("clientSecret").getAsString());
+                    }
+                    if (j.get("scope") != null) {
+                        config.setScope(j.get("scope").getAsString());
+                    }
+                    if (j.get("userScope") != null) {
+                        config.setUserScope(j.get("userScope").getAsString());
+                    }
+                    if (j.get("oauthCompletionUrl") != null) {
+                        config.setOauthCompletionUrl(j.get("oauthCompletionUrl").getAsString());
+                    }
                 } catch (IOException e) {
                     log.error(e.getMessage(), e);
                 }

--- a/bolt-servlet/src/test/resources/appConfig.example_org_app.json
+++ b/bolt-servlet/src/test/resources/appConfig.example_org_app.json
@@ -1,0 +1,10 @@
+{
+  "clientId": "111.222",
+  "clientSecret": "xxx",
+  "signingSecret": "xxx",
+  "oauthStartPath": "start",
+  "oauthCallbackPath": "callback",
+  "redirectUri": "https://your-subdomain.ngrok.io/slack/oauth/callback",
+  "scope": "app_mentions:read,channels:history,channels:read,chat:write,groups:history,im:history,mpim:history,groups:read,team:read",
+  "installation_url_memo": "https://your-subdomain.ngrok.io/slack/oauth/start"
+}

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -3,6 +3,10 @@ package com.slack.api.bolt;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.bolt.meta.BoltLibraryVersion;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthInstallPageRenderer;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
+import com.slack.api.bolt.service.builtin.oauth.view.default_impl.OAuthDefaultInstallPageRenderer;
+import com.slack.api.bolt.service.builtin.oauth.view.default_impl.OAuthDefaultRedirectUriPageRenderer;
 import com.slack.api.util.http.SlackHttpClient;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -61,7 +65,7 @@ public class AppConfig {
     }
 
     @Builder.Default
-    private Slack slack = Slack.getInstance(SlackConfig.DEFAULT, buildSlackHttpClient());
+    private transient Slack slack = Slack.getInstance(SlackConfig.DEFAULT, buildSlackHttpClient());
 
     private static SlackHttpClient buildSlackHttpClient() {
         Map<String, String> userAgentCustomInfo = new HashMap<>();
@@ -129,6 +133,29 @@ public class AppConfig {
     public void setOAuthCallbackEnabled(boolean enabled) {
         setOAuthRedirectUriPathEnabled(enabled);
     }
+
+    // --------------------------
+    // OAuth flow page renderer
+
+    /**
+     * If you prefer the behavior in v1.0 - 1.3, set this flag as false
+     */
+    @Builder.Default
+    private boolean oAuthInstallPageRenderingEnabled = true;
+
+    /**
+     * Renders the web page content to display to installers.
+     */
+    @Builder.Default
+    private transient OAuthInstallPageRenderer oAuthInstallPageRenderer =
+            new OAuthDefaultInstallPageRenderer();
+
+    /**
+     * Renders the web page content to display to installers.
+     */
+    @Builder.Default
+    private transient OAuthRedirectUriPageRenderer oAuthRedirectUriPageRenderer =
+            new OAuthDefaultRedirectUriPageRenderer();
 
     // --------------------------
 

--- a/bolt/src/main/java/com/slack/api/bolt/context/Context.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/Context.java
@@ -44,6 +44,11 @@ public abstract class Context {
     protected String teamId;
 
     /**
+     * Returns true if the token is issued by an enterprise install (= org-level installation)
+     */
+    protected boolean enterpriseInstall;
+
+    /**
      * A bot token associated with this request. The format must be starting with `xoxb-`.
      */
     protected String botToken;
@@ -68,11 +73,19 @@ public abstract class Context {
     protected final Map<String, String> additionalValues = new HashMap<>();
 
     public MethodsClient client() {
-        return getSlack().methods(botToken);
+        if (isEnterpriseInstall()) {
+            return getSlack().methods(botToken, teamId);
+        } else {
+            return getSlack().methods(botToken);
+        }
     }
 
     public AsyncMethodsClient asyncClient() {
-        return getSlack().methodsAsync(botToken);
+        if (isEnterpriseInstall()) {
+            return getSlack().methodsAsync(botToken, teamId);
+        } else {
+            return getSlack().methodsAsync(botToken);
+        }
     }
 
     public ChatPostMessageResponse say(BuilderConfigurator<ChatPostMessageRequest.ChatPostMessageRequestBuilder> request) throws IOException, SlackApiException {

--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/MultiTeamsAuthorization.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/MultiTeamsAuthorization.java
@@ -175,8 +175,13 @@ public class MultiTeamsAuthorization implements Middleware {
             if (authTestResponse.isOk()) {
                 context.setBotToken(botToken);
                 context.setRequestUserToken(userToken);
-                context.setTeamId(authTestResponse.getTeamId());
+                if (!authTestResponse.isEnterpriseInstall()) {
+                    context.setTeamId(authTestResponse.getTeamId());
+                    // As the team_id here is the org's ID,
+                    // Request#updateContext() does this for enterprise_install
+                }
                 context.setEnterpriseId(authTestResponse.getEnterpriseId());
+                context.setEnterpriseInstall(authTestResponse.isEnterpriseInstall());
                 if (bot != null) {
                     context.setBotId(bot.getBotId());
                     context.setBotUserId(authTestResponse.getUserId());

--- a/bolt/src/main/java/com/slack/api/bolt/model/Bot.java
+++ b/bolt/src/main/java/com/slack/api/bolt/model/Bot.java
@@ -9,6 +9,18 @@ public interface Bot {
 
     void setAppId(String appId);
 
+    Boolean getIsEnterpriseInstall();
+
+    void setIsEnterpriseInstall(Boolean isEnterpriseInstall);
+
+    String getEnterpriseUrl();
+
+    void setEnterpriseUrl(String enterpriseUrl);
+
+    String getTokenType();
+
+    void setTokenType(String tokenType);
+
     String getEnterpriseId();
 
     void setEnterpriseId(String enterpriseId);

--- a/bolt/src/main/java/com/slack/api/bolt/model/Installer.java
+++ b/bolt/src/main/java/com/slack/api/bolt/model/Installer.java
@@ -26,6 +26,22 @@ public interface Installer {
     void setTeamId(String teamId);
 
     // ---------------------------------
+    // Org-level installation
+    // ---------------------------------
+
+    Boolean getIsEnterpriseInstall();
+
+    void setIsEnterpriseInstall(Boolean isEnterpriseInstall);
+
+    String getEnterpriseUrl();
+
+    void setEnterpriseUrl(String enterpriseUrl);
+
+    String getTokenType();
+
+    void setTokenType(String tokenType);
+
+    // ---------------------------------
     // Installer
     // ---------------------------------
 

--- a/bolt/src/main/java/com/slack/api/bolt/model/builtin/DefaultBot.java
+++ b/bolt/src/main/java/com/slack/api/bolt/model/builtin/DefaultBot.java
@@ -10,10 +10,14 @@ import lombok.Data;
 public class DefaultBot implements Bot {
 
     private String appId;
-
     private String enterpriseId;
+    private String enterpriseName;
     private String teamId;
     private String teamName;
+
+    private Boolean isEnterpriseInstall;
+    private String enterpriseUrl;
+    private String tokenType;
 
     private String scope;
 

--- a/bolt/src/main/java/com/slack/api/bolt/model/builtin/DefaultInstaller.java
+++ b/bolt/src/main/java/com/slack/api/bolt/model/builtin/DefaultInstaller.java
@@ -17,10 +17,14 @@ import lombok.NoArgsConstructor;
 public class DefaultInstaller implements Installer {
 
     private String appId;
-
     private String enterpriseId;
+    private String enterpriseName;
     private String teamId;
     private String teamName;
+
+    private Boolean isEnterpriseInstall;
+    private String enterpriseUrl;
+    private String tokenType;
 
     private String installerUserId;
     private String installerUserScope;
@@ -45,9 +49,16 @@ public class DefaultInstaller implements Installer {
     public Bot toBot() {
         DefaultBot bot = new DefaultBot();
         bot.setAppId(appId);
+
         bot.setEnterpriseId(enterpriseId);
+        bot.setEnterpriseName(enterpriseName);
         bot.setTeamId(teamId);
         bot.setTeamName(teamName);
+
+        bot.setIsEnterpriseInstall(isEnterpriseInstall);
+        bot.setEnterpriseUrl(enterpriseUrl);
+        bot.setTokenType(tokenType);
+
         bot.setScope(botScope);
         bot.setBotId(botId);
         bot.setBotUserId(botUserId);

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
@@ -103,6 +103,22 @@ public class AmazonS3InstallationService implements InstallationService {
     @Override
     public Bot findBot(String enterpriseId, String teamId) {
         AmazonS3 s3 = this.createS3Client();
+        if (enterpriseId != null) {
+            // try finding org-level bot token first - teamId is intentionally null here
+            String fullKey = getBotKey(enterpriseId, null);
+            if (isHistoricalDataEnabled()) {
+                fullKey = fullKey + "-latest";
+            }
+            if (getObjectMetadata(s3, fullKey) != null) {
+                S3Object s3Object = getObject(s3, fullKey);
+                try {
+                    return toBot(s3Object);
+                } catch (IOException e) {
+                    log.error("Failed to load org-level Bot installation for enterprise_id: {}", enterpriseId);
+                }
+            }
+            // not found - going to find workspace level installation
+        }
         String fullKey = getBotKey(enterpriseId, teamId);
         if (isHistoricalDataEnabled()) {
             fullKey = fullKey + "-latest";
@@ -136,6 +152,22 @@ public class AmazonS3InstallationService implements InstallationService {
     @Override
     public Installer findInstaller(String enterpriseId, String teamId, String userId) {
         AmazonS3 s3 = this.createS3Client();
+        if (enterpriseId != null) {
+            // try finding org-level user token first - teamId is intentionally null here
+            String fullKey = getInstallerKey(enterpriseId, null, userId);
+            if (isHistoricalDataEnabled()) {
+                fullKey = fullKey + "-latest";
+            }
+            if (getObjectMetadata(s3, fullKey) != null) {
+                S3Object s3Object = getObject(s3, fullKey);
+                try {
+                    return toInstaller(s3Object);
+                } catch (IOException e) {
+                    log.error("Failed to load org-level installation for enterprise_id: {}, user_id: {}", enterpriseId, userId);
+                }
+            }
+            // not found - going to find workspace level installation
+        }
         String fullKey = getInstallerKey(enterpriseId, teamId, userId);
         if (isHistoricalDataEnabled()) {
             fullKey = fullKey + "-latest";
@@ -224,8 +256,10 @@ public class AmazonS3InstallationService implements InstallationService {
 
     private String getInstallerKey(String enterpriseId, String teamId, String userId) {
         return "installer/"
-                + Optional.ofNullable(enterpriseId).orElse("none") + "-"
-                + teamId + "-"
+                + Optional.ofNullable(enterpriseId).orElse("none")
+                + "-"
+                + Optional.ofNullable(teamId).orElse("none")
+                + "-"
                 + userId;
     }
 
@@ -235,7 +269,8 @@ public class AmazonS3InstallationService implements InstallationService {
 
     private String getBotKey(String enterpriseId, String teamId) {
         return "bot/"
-                + Optional.ofNullable(enterpriseId).orElse("none") + "-"
-                + teamId;
+                + Optional.ofNullable(enterpriseId).orElse("none")
+                + "-"
+                + Optional.ofNullable(teamId).orElse("none");
     }
 }

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/FileInstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/FileInstallationService.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 import static java.util.stream.Collectors.joining;
 
@@ -70,6 +71,17 @@ public class FileInstallationService implements InstallationService {
     public Bot findBot(String enterpriseId, String teamId) {
         try {
             String json = null;
+            if (enterpriseId != null) {
+                // try finding org-level bot token first
+                try {
+                    json = loadFileContent(getBotPath(enterpriseId, null));
+                } catch (IOException e) {
+                }
+                if (json != null) {
+                    return JsonOps.fromJson(json, DefaultBot.class);
+                }
+                // not found - going to find workspace level installation
+            }
             try {
                 json = loadFileContent(getBotPath(enterpriseId, teamId));
             } catch (IOException e) {
@@ -98,6 +110,17 @@ public class FileInstallationService implements InstallationService {
     public Installer findInstaller(String enterpriseId, String teamId, String userId) {
         try {
             String json = null;
+            if (enterpriseId != null) {
+                // try finding org-level user token first
+                try {
+                    json = loadFileContent(getInstallerPath(enterpriseId, null, userId));
+                } catch (IOException e) {
+                }
+                if (json != null) {
+                    return JsonOps.fromJson(json, DefaultInstaller.class);
+                }
+                // not found - going to find workspace level installation
+            }
             try {
                 json = loadFileContent(getInstallerPath(enterpriseId, teamId, userId));
             } catch (IOException e) {
@@ -132,7 +155,11 @@ public class FileInstallationService implements InstallationService {
         if (!Files.exists(dirPath)) {
             Files.createDirectories(dirPath);
         }
-        String key = ((enterpriseId == null) ? "none" : enterpriseId) + "-" + teamId + "-" + userId;
+        String key = Optional.ofNullable(enterpriseId).orElse("none")
+                + "-"
+                + Optional.ofNullable(teamId).orElse("none")
+                + "-"
+                + userId;
         if (isHistoricalDataEnabled()) {
             key = key + "-latest";
         }
@@ -145,7 +172,9 @@ public class FileInstallationService implements InstallationService {
         if (!Files.exists(dirPath)) {
             Files.createDirectories(dirPath);
         }
-        String key = ((enterpriseId == null) ? "none" : enterpriseId) + "-" + teamId;
+        String key = Optional.ofNullable(enterpriseId).orElse("none")
+                + "-"
+                + Optional.ofNullable(teamId).orElse("none");
         if (isHistoricalDataEnabled()) {
             key = key + "-latest";
         }

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultAccessErrorHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultAccessErrorHandler.java
@@ -1,8 +1,10 @@
 package com.slack.api.bolt.service.builtin.oauth.default_impl;
 
+import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.request.builtin.OAuthCallbackRequest;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.builtin.oauth.OAuthAccessErrorHandler;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
 import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 import lombok.extern.slf4j.Slf4j;
 
@@ -11,12 +13,28 @@ import java.util.Arrays;
 @Slf4j
 public class OAuthDefaultAccessErrorHandler implements OAuthAccessErrorHandler {
 
+    private final AppConfig appConfig;
+    private final OAuthRedirectUriPageRenderer pageRenderer;
+
+    public OAuthDefaultAccessErrorHandler(AppConfig appConfig) {
+        this.appConfig = appConfig;
+        this.pageRenderer = appConfig.getOAuthRedirectUriPageRenderer();
+    }
+
     @Override
     public Response handle(OAuthCallbackRequest request, Response response, OAuthAccessResponse apiResponse) {
         log.error("Failed to run an oauth.access API call: {} - {}", apiResponse.getError(), apiResponse);
 
-        response.setStatusCode(302);
-        response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        String url = request.getContext().getOauthCancellationUrl();
+        if (url != null && !url.isEmpty()) {
+            response.setStatusCode(302);
+            response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        } else {
+            String reason = apiResponse.getError();
+            response.setStatusCode(200);
+            response.setBody(pageRenderer.renderFailurePage(appConfig.getOauthInstallRequestURI(), reason));
+            response.setContentType("text/html; charset=utf-8");
+        }
         return response;
     }
 

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultErrorHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultErrorHandler.java
@@ -1,8 +1,10 @@
 package com.slack.api.bolt.service.builtin.oauth.default_impl;
 
+import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.request.builtin.OAuthCallbackRequest;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.builtin.oauth.OAuthErrorHandler;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
@@ -10,12 +12,28 @@ import java.util.Arrays;
 @Slf4j
 public class OAuthDefaultErrorHandler implements OAuthErrorHandler {
 
+    private final AppConfig appConfig;
+    private final OAuthRedirectUriPageRenderer pageRenderer;
+
+    public OAuthDefaultErrorHandler(AppConfig appConfig) {
+        this.appConfig = appConfig;
+        this.pageRenderer = appConfig.getOAuthRedirectUriPageRenderer();
+    }
+
     @Override
     public Response handle(OAuthCallbackRequest request, Response response) {
         log.error("Received error code in OAuth callback: {}", request.getPayload());
 
-        response.setStatusCode(302);
-        response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        String url = request.getContext().getOauthCancellationUrl();
+        if (url != null && !url.isEmpty()) {
+            response.setStatusCode(302);
+            response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        } else {
+            String reason = request.getPayload().getError();
+            response.setStatusCode(200);
+            response.setBody(pageRenderer.renderFailurePage(appConfig.getOauthInstallRequestURI(), reason));
+            response.setContentType("text/html; charset=utf-8");
+        }
         return response;
     }
 

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultExceptionHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.slack.api.bolt.service.builtin.oauth.default_impl;
 
+import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.request.builtin.OAuthCallbackRequest;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.builtin.oauth.OAuthExceptionHandler;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
@@ -10,12 +12,28 @@ import java.util.Arrays;
 @Slf4j
 public class OAuthDefaultExceptionHandler implements OAuthExceptionHandler {
 
+    private final AppConfig appConfig;
+    private final OAuthRedirectUriPageRenderer pageRenderer;
+
+    public OAuthDefaultExceptionHandler(AppConfig appConfig) {
+        this.appConfig = appConfig;
+        this.pageRenderer = appConfig.getOAuthRedirectUriPageRenderer();
+    }
+
     @Override
     public Response handle(OAuthCallbackRequest request, Response response, Exception e) {
         log.error("Failed to run an OAuth callback operation - {}", e.getMessage(), e);
 
-        response.setStatusCode(302);
-        response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        String url = request.getContext().getOauthCancellationUrl();
+        if (url != null && !url.isEmpty()) {
+            response.setStatusCode(302);
+            response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        } else {
+            String reason = e.getMessage();
+            response.setStatusCode(200);
+            response.setBody(pageRenderer.renderFailurePage(appConfig.getOauthInstallRequestURI(), reason));
+            response.setContentType("text/html; charset=utf-8");
+        }
         return response;
     }
 

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultStateErrorHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultStateErrorHandler.java
@@ -1,8 +1,10 @@
 package com.slack.api.bolt.service.builtin.oauth.default_impl;
 
+import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.request.builtin.OAuthCallbackRequest;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.builtin.oauth.OAuthStateErrorHandler;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
@@ -10,12 +12,28 @@ import java.util.Arrays;
 @Slf4j
 public class OAuthDefaultStateErrorHandler implements OAuthStateErrorHandler {
 
+    private final AppConfig appConfig;
+    private final OAuthRedirectUriPageRenderer pageRenderer;
+
+    public OAuthDefaultStateErrorHandler(AppConfig appConfig) {
+        this.appConfig = appConfig;
+        this.pageRenderer = appConfig.getOAuthRedirectUriPageRenderer();
+    }
+
     @Override
     public Response handle(OAuthCallbackRequest request, Response response) {
         log.warn("Invalid state parameter detected - payload: {}", request.getPayload());
 
-        response.setStatusCode(302);
-        response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        String url = request.getContext().getOauthCancellationUrl();
+        if (url != null && !url.isEmpty()) {
+            response.setStatusCode(302);
+            response.getHeaders().put("Location", Arrays.asList(request.getContext().getOauthCancellationUrl()));
+        } else {
+            String reason = "invalid_state";
+            response.setStatusCode(200);
+            response.setBody(pageRenderer.renderFailurePage(appConfig.getOauthInstallRequestURI(), reason));
+            response.setContentType("text/html; charset=utf-8");
+        }
         return response;
     }
 

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultSuccessHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthDefaultSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.slack.api.bolt.service.builtin.oauth.default_impl;
 
+import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.context.builtin.OAuthCallbackContext;
 import com.slack.api.bolt.model.Installer;
 import com.slack.api.bolt.model.builtin.DefaultInstaller;
@@ -7,6 +8,7 @@ import com.slack.api.bolt.request.builtin.OAuthCallbackRequest;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.InstallationService;
 import com.slack.api.bolt.service.builtin.oauth.OAuthSuccessHandler;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.auth.AuthTestResponse;
 import com.slack.api.methods.response.oauth.OAuthAccessResponse;
@@ -18,10 +20,14 @@ import java.util.Arrays;
 @Slf4j
 public class OAuthDefaultSuccessHandler implements OAuthSuccessHandler {
 
-    private InstallationService installationService;
+    private final AppConfig appConfig;
+    private final InstallationService installationService;
+    private final OAuthRedirectUriPageRenderer pageRenderer;
 
-    public OAuthDefaultSuccessHandler(InstallationService installationService) {
+    public OAuthDefaultSuccessHandler(AppConfig appConfig, InstallationService installationService) {
+        this.appConfig = appConfig;
         this.installationService = installationService;
+        this.pageRenderer = appConfig.getOAuthRedirectUriPageRenderer();
     }
 
     @Override
@@ -68,13 +74,29 @@ public class OAuthDefaultSuccessHandler implements OAuthSuccessHandler {
         }
         Installer installer = i.build();
 
-        response.setStatusCode(302);
         try {
             installationService.saveInstallerAndBot(installer);
-            response.getHeaders().put("Location", Arrays.asList(context.getOauthCompletionUrl()));
+            String url = context.getOauthCompletionUrl();
+            if (url != null) {
+                response.setStatusCode(302);
+                response.getHeaders().put("Location", Arrays.asList(url));
+            } else {
+                response.setStatusCode(200);
+                response.setBody(pageRenderer.renderSuccessPage(installer, appConfig.getOauthCompletionUrl()));
+                response.setContentType("text/html; charset=utf-8");
+            }
         } catch (Exception e) {
             log.warn("Failed to store the installation - {}", e.getMessage(), e);
-            response.getHeaders().put("Location", Arrays.asList(context.getOauthCancellationUrl()));
+            String url = context.getOauthCancellationUrl();
+            if (url != null) {
+                response.setStatusCode(302);
+                response.getHeaders().put("Location", Arrays.asList(url));
+            } else {
+                String reason = e.getMessage();
+                response.setStatusCode(200);
+                response.setBody(pageRenderer.renderFailurePage(appConfig.getOauthInstallRequestURI(), reason));
+                response.setContentType("text/html; charset=utf-8");
+            }
         }
         return response;
     }

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultAccessErrorHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultAccessErrorHandler.java
@@ -1,8 +1,10 @@
 package com.slack.api.bolt.service.builtin.oauth.default_impl;
 
+import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.request.builtin.OAuthCallbackRequest;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.builtin.oauth.OAuthV2AccessErrorHandler;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
 import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
 import lombok.extern.slf4j.Slf4j;
 
@@ -11,12 +13,28 @@ import java.util.Arrays;
 @Slf4j
 public class OAuthV2DefaultAccessErrorHandler implements OAuthV2AccessErrorHandler {
 
+    private final AppConfig appConfig;
+    private final OAuthRedirectUriPageRenderer pageRenderer;
+
+    public OAuthV2DefaultAccessErrorHandler(AppConfig appConfig) {
+        this.appConfig = appConfig;
+        this.pageRenderer = appConfig.getOAuthRedirectUriPageRenderer();
+    }
+
     @Override
     public Response handle(OAuthCallbackRequest req, Response response, OAuthV2AccessResponse apiResponse) {
         log.error("Failed to run an oauth.v2.access API call: {} - {}", apiResponse.getError(), apiResponse);
 
-        response.setStatusCode(302);
-        response.getHeaders().put("Location", Arrays.asList(req.getContext().getOauthCancellationUrl()));
+        String url = req.getContext().getOauthCancellationUrl();
+        if (url == null) {
+            String reason = apiResponse.getError();
+            response.setStatusCode(200);
+            response.setBody(pageRenderer.renderFailurePage(appConfig.getOauthInstallRequestURI(), reason));
+            response.setContentType("text/html; charset=utf-8");
+        } else {
+            response.setStatusCode(302);
+            response.getHeaders().put("Location", Arrays.asList(url));
+        }
         return response;
     }
 

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultSuccessHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultSuccessHandler.java
@@ -54,6 +54,7 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
                 .botUserId(o.getBotUserId())
                 .botAccessToken(o.getAccessToken())
                 .isEnterpriseInstall(o.isEnterpriseInstall())
+                .tokenType(o.getTokenType())
                 .enterpriseId(enterpriseId)
                 .enterpriseName(enterpriseName)
                 .teamId(teamId)

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/OAuthInstallPageRenderer.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/OAuthInstallPageRenderer.java
@@ -1,0 +1,16 @@
+package com.slack.api.bolt.service.builtin.oauth.view;
+
+/**
+ * Renders web pages for Slack app installers.
+ */
+public interface OAuthInstallPageRenderer {
+
+    /**
+     * Returns an HTML content for the page.
+     *
+     * @param authorizeUrl the Slack's authorize URL
+     * @return html content
+     */
+    String render(String authorizeUrl);
+
+}

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/OAuthRedirectUriPageRenderer.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/OAuthRedirectUriPageRenderer.java
@@ -1,0 +1,28 @@
+package com.slack.api.bolt.service.builtin.oauth.view;
+
+import com.slack.api.bolt.model.Installer;
+
+/**
+ * Renders web pages for Slack app installers.
+ */
+public interface OAuthRedirectUriPageRenderer {
+
+    /**
+     * Returns an HTML content for the success page.
+     *
+     * @param installer     installation information
+     * @param completionUrl the static URL to navigate installers
+     * @return html content
+     */
+    String renderSuccessPage(Installer installer, String completionUrl);
+
+    /**
+     * Returns an HTML content for the error page.
+     *
+     * @param installPath the defualt is /slack/install
+     * @param reason      error reason
+     * @return html content
+     */
+    String renderFailurePage(String installPath, String reason);
+
+}

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/default_impl/OAuthDefaultInstallPageRenderer.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/default_impl/OAuthDefaultInstallPageRenderer.java
@@ -1,0 +1,29 @@
+package com.slack.api.bolt.service.builtin.oauth.view.default_impl;
+
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthInstallPageRenderer;
+
+public class OAuthDefaultInstallPageRenderer implements OAuthInstallPageRenderer {
+
+    // variables: __URL__
+    public static final String PAGE_TEMPLATE = "<html>\n" +
+            "<head>\n" +
+            "<style>\n" +
+            "body {\n" +
+            "  padding: 10px 15px;\n" +
+            "  font-family: verdana;\n" +
+            "  text-align: center;\n" +
+            "}\n" +
+            "</style>\n" +
+            "</head>\n" +
+            "<body>\n" +
+            "<h2>Slack App Installation</h2>\n" +
+            "<p><a href=\"__URL__\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
+            "</body>\n" +
+            "</html>";
+
+    @Override
+    public String render(String authorizeUrl) {
+        return PAGE_TEMPLATE.replaceAll("__URL__", authorizeUrl == null ? "" : authorizeUrl);
+    }
+
+}

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/default_impl/OAuthDefaultRedirectUriPageRenderer.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/default_impl/OAuthDefaultRedirectUriPageRenderer.java
@@ -1,0 +1,70 @@
+package com.slack.api.bolt.service.builtin.oauth.view.default_impl;
+
+import com.slack.api.bolt.model.Installer;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
+
+public class OAuthDefaultRedirectUriPageRenderer implements OAuthRedirectUriPageRenderer {
+
+    // variables: __URL__
+    public static final String SUCCESS_PAGE_TEMPLATE = "<html>\n" +
+            "<head>\n" +
+            "<meta http-equiv=\"refresh\" content=\"0; URL=__URL__\">\n" +
+            "<style>\n" +
+            "body {\n" +
+            "  padding: 10px 15px;\n" +
+            "  font-family: verdana;\n" +
+            "  text-align: center;\n" +
+            "}\n" +
+            "</style>\n" +
+            "</head>\n" +
+            "<body>\n" +
+            "<h2>Thank you!</h2>\n" +
+            "<p>Redirecting to the Slack App... click <a href=\"__URL__\">here</a></p>\n" +
+            "</body>\n" +
+            "</html>";
+
+    // variables: __INSTALL_PATH__, __REASON__
+    public static final String FAILURE_PAGE_TEMPLATE = "<html>\n" +
+            "<head>\n" +
+            "<style>\n" +
+            "body {\n" +
+            "  padding: 10px 15px;\n" +
+            "  font-family: verdana;\n" +
+            "  text-align: center;\n" +
+            "}\n" +
+            "</style>\n" +
+            "</head>\n" +
+            "<body>\n" +
+            "<h2>Oops, Something Went Wrong!</h2>\n" +
+            "<p>Please try again from <a href=\"__INSTALL_PATH__\">here</a> or contact the app owner (reason: __REASON__)</p>\n" +
+            "</body>\n" +
+            "</html>";
+
+    @Override
+    public String renderSuccessPage(Installer installer, String completionUrl) {
+        String url = completionUrl;
+        if (url == null || url.isEmpty()) {
+            if (installer.getIsEnterpriseInstall() != null
+                    && installer.getIsEnterpriseInstall()
+                    && installer.getEnterpriseUrl() != null
+                    && installer.getAppId() != null
+            ) {
+                // org-level installation
+                String rootUrl = installer.getEnterpriseUrl(); // https://{org domain}.enterprise.slack.com/
+                url = rootUrl + "manage/organization/apps/profile/" + installer.getAppId() + "/workspaces/add";
+            } else if (installer.getTeamId() == null || installer.getAppId() == null) {
+                url = "slack://open";
+            } else {
+                url = "slack://app?team=" + installer.getTeamId() + "&id=" + installer.getAppId();
+            }
+        }
+        return SUCCESS_PAGE_TEMPLATE.replaceAll("__URL__", url == null ? "" : url);
+    }
+
+    @Override
+    public String renderFailurePage(String installPath, String reason) {
+        return FAILURE_PAGE_TEMPLATE
+                .replaceAll("__INSTALL_PATH__", installPath == null ? "" : installPath)
+                .replaceAll("__REASON__", reason == null ? "unknown_error" : reason);
+    }
+}

--- a/bolt/src/test/java/test_locally/AppTest.java
+++ b/bolt/src/test/java/test_locally/AppTest.java
@@ -46,7 +46,7 @@ public class AppTest {
     }
 
     @Test
-    public void getOauthInstallationUrl_v1() {
+    public void buildAuthorizeUrl_v1() {
         AppConfig config = AppConfig.builder()
                 .signingSecret("secret")
                 .clientId("123")
@@ -54,12 +54,12 @@ public class AppTest {
                 .classicAppPermissionsEnabled(true)
                 .build();
         App app = new App(config);
-        String url = app.getOauthInstallationUrl("state-value");
+        String url = app.buildAuthorizeUrl("state-value");
         assertEquals("https://slack.com/oauth/authorize?client_id=123&scope=commands,chat:write&state=state-value", url);
     }
 
     @Test
-    public void getOauthInstallationUrl_v1_with_redirect_uri() {
+    public void buildAuthorizeUrl_v1_with_redirect_uri() {
         AppConfig config = AppConfig.builder()
                 .signingSecret("secret")
                 .clientId("123")
@@ -68,12 +68,12 @@ public class AppTest {
                 .redirectUri("https://my.app/oauth/callback")
                 .build();
         App app = new App(config);
-        String url = app.getOauthInstallationUrl("state-value");
+        String url = app.buildAuthorizeUrl("state-value");
         assertEquals("https://slack.com/oauth/authorize?client_id=123&scope=commands,chat:write&state=state-value&redirect_uri=https%3A%2F%2Fmy.app%2Foauth%2Fcallback", url);
     }
 
     @Test
-    public void getOauthInstallationUrl_v2() {
+    public void buildAuthorizeUrl_v2() {
         AppConfig config = AppConfig.builder()
                 .signingSecret("secret")
                 .clientId("123")
@@ -81,12 +81,12 @@ public class AppTest {
                 .userScope("search:read")
                 .build();
         App app = new App(config);
-        String url = app.getOauthInstallationUrl("state-value");
+        String url = app.buildAuthorizeUrl("state-value");
         assertEquals("https://slack.com/oauth/v2/authorize?client_id=123&scope=commands,chat:write&user_scope=search:read&state=state-value", url);
     }
 
     @Test
-    public void getOauthInstallationUrl_v2_with_redirect_uri() {
+    public void buildAuthorizeUrl_v2_with_redirect_uri() {
         AppConfig config = AppConfig.builder()
                 .signingSecret("secret")
                 .clientId("123")
@@ -95,14 +95,14 @@ public class AppTest {
                 .redirectUri("https://my.app/oauth/callback")
                 .build();
         App app = new App(config);
-        String url = app.getOauthInstallationUrl("state-value");
+        String url = app.buildAuthorizeUrl("state-value");
         assertEquals("https://slack.com/oauth/v2/authorize?client_id=123&scope=commands,chat:write&user_scope=search:read&state=state-value&redirect_uri=https%3A%2F%2Fmy.app%2Foauth%2Fcallback", url);
     }
 
     @Test
-    public void getOauthInstallationUrl_null() {
+    public void buildAuthorizeUrl_null() {
         App app = new App();
-        String url = app.getOauthInstallationUrl("state-value");
+        String url = app.buildAuthorizeUrl("state-value");
         assertNull(url);
     }
 
@@ -226,9 +226,9 @@ public class AppTest {
         app.oauthCallbackAccessError((OAuthV2AccessErrorHandler) (request, response, apiResponse) -> response);
 
         app.oauthCallbackError((request, response) -> response);
-        app.oauthCallbackException(new OAuthDefaultExceptionHandler() {
+        app.oauthCallbackException(new OAuthDefaultExceptionHandler(config) {
         });
-        app.oauthCallbackStateError(new OAuthDefaultStateErrorHandler() {
+        app.oauthCallbackStateError(new OAuthDefaultStateErrorHandler(config) {
         });
     }
 

--- a/bolt/src/test/java/test_locally/app/OAuthStartTest.java
+++ b/bolt/src/test/java/test_locally/app/OAuthStartTest.java
@@ -20,6 +20,7 @@ public class OAuthStartTest {
     @Test
     public void start() throws Exception {
         App app = new App(AppConfig.builder()
+                .signingSecret("secret")
                 .clientId("111.222")
                 .clientSecret("secret")
                 .scope("commands,chat:write")

--- a/bolt/src/test/java/test_locally/app/OAuthStartTest.java
+++ b/bolt/src/test/java/test_locally/app/OAuthStartTest.java
@@ -1,0 +1,54 @@
+package test_locally.app;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.request.Request;
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.builtin.OAuthStartRequest;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.service.builtin.ClientOnlyOAuthStateService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+@Slf4j
+public class OAuthStartTest {
+
+    @Test
+    public void start() throws Exception {
+        App app = new App(AppConfig.builder()
+                .clientId("111.222")
+                .clientSecret("secret")
+                .scope("commands,chat:write")
+                .build());
+        app.service(new ClientOnlyOAuthStateService() {
+            @Override
+            public String issueNewState(Request request, Response response) {
+                return "generated-state-value";
+            }
+        });
+
+        OAuthStartRequest req = new OAuthStartRequest(null, new RequestHeaders(Collections.emptyMap()));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+        assertEquals("text/html; charset=utf-8", response.getContentType());
+        assertEquals("<html>\n" +
+                "<head>\n" +
+                "<style>\n" +
+                "body {\n" +
+                "  padding: 10px 15px;\n" +
+                "  font-family: verdana;\n" +
+                "  text-align: center;\n" +
+                "}\n" +
+                "</style>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<h2>Slack App Installation</h2>\n" +
+                "<p><a href=\"https://slack.com/oauth/v2/authorize?client_id=111.222&scope=commands,chat:write&user_scope=&state=generated-state-value\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
+                "</body>\n" +
+                "</html>", response.getBody());
+    }
+}

--- a/bolt/src/test/java/test_locally/service/oauth/OAuthV2DefaultSuccessHandlerTest.java
+++ b/bolt/src/test/java/test_locally/service/oauth/OAuthV2DefaultSuccessHandlerTest.java
@@ -21,7 +21,41 @@ public class OAuthV2DefaultSuccessHandlerTest {
     @Test
     public void completion() {
         InstallationService installationService = new FileInstallationService(new AppConfig(), "target/files");
-        OAuthV2DefaultSuccessHandler handler = new OAuthV2DefaultSuccessHandler(installationService);
+        OAuthV2DefaultSuccessHandler handler = new OAuthV2DefaultSuccessHandler(new AppConfig(), installationService);
+
+        RequestHeaders headers = new RequestHeaders(new HashMap<>());
+        OAuthCallbackRequest request = new OAuthCallbackRequest(new HashMap<>(), "", VerificationCodePayload.from(new HashMap<>()), headers);
+
+        Response response = new Response();
+        OAuthV2AccessResponse apiResponse = new OAuthV2AccessResponse();
+        apiResponse.setTeam(new OAuthV2AccessResponse.Team());
+        apiResponse.setAuthedUser(new OAuthV2AccessResponse.AuthedUser());
+
+        Response processedResponse = handler.handle(request, response, apiResponse);
+        assertEquals(200, processedResponse.getStatusCode().longValue());
+        assertEquals("text/html; charset=utf-8", processedResponse.getContentType());
+        assertEquals("<html>\n" +
+                "<head>\n" +
+                "<meta http-equiv=\"refresh\" content=\"0; URL=slack://open\">\n" +
+                "<style>\n" +
+                "body {\n" +
+                "  padding: 10px 15px;\n" +
+                "  font-family: verdana;\n" +
+                "  text-align: center;\n" +
+                "}\n" +
+                "</style>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<h2>Thank you!</h2>\n" +
+                "<p>Redirecting to the Slack App... click <a href=\"slack://open\">here</a></p>\n" +
+                "</body>\n" +
+                "</html>", processedResponse.getBody());
+    }
+
+    @Test
+    public void completion_with_urls() {
+        InstallationService installationService = new FileInstallationService(new AppConfig(), "target/files");
+        OAuthV2DefaultSuccessHandler handler = new OAuthV2DefaultSuccessHandler(new AppConfig(), installationService);
 
         RequestHeaders headers = new RequestHeaders(new HashMap<>());
         OAuthCallbackRequest request = new OAuthCallbackRequest(new HashMap<>(), "", VerificationCodePayload.from(new HashMap<>()), headers);
@@ -44,10 +78,49 @@ public class OAuthV2DefaultSuccessHandlerTest {
         InstallationService installationService = new FileInstallationService(new AppConfig(), "target/files") {
             @Override
             public void saveInstallerAndBot(Installer installer) {
+                throw new RuntimeException("something_wrong");
+            }
+        };
+        OAuthV2DefaultSuccessHandler handler = new OAuthV2DefaultSuccessHandler(new AppConfig(), installationService);
+
+        RequestHeaders headers = new RequestHeaders(new HashMap<>());
+        OAuthCallbackRequest request = new OAuthCallbackRequest(new HashMap<>(), "", VerificationCodePayload.from(new HashMap<>()), headers);
+
+        Response response = new Response();
+
+        OAuthV2AccessResponse apiResponse = new OAuthV2AccessResponse();
+        apiResponse.setTeam(new OAuthV2AccessResponse.Team());
+        apiResponse.setAuthedUser(new OAuthV2AccessResponse.AuthedUser());
+
+        Response processedResponse = handler.handle(request, response, apiResponse);
+        assertEquals(200, processedResponse.getStatusCode().longValue());
+        assertEquals("text/html; charset=utf-8", processedResponse.getContentType());
+        assertEquals("<html>\n" +
+                "<head>\n" +
+                "<style>\n" +
+                "body {\n" +
+                "  padding: 10px 15px;\n" +
+                "  font-family: verdana;\n" +
+                "  text-align: center;\n" +
+                "}\n" +
+                "</style>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<h2>Oops, Something Went Wrong!</h2>\n" +
+                "<p>Please try again from <a href=\"start\">here</a> or contact the app owner (reason: something_wrong)</p>\n" +
+                "</body>\n" +
+                "</html>", processedResponse.getBody());
+    }
+
+    @Test
+    public void failure_with_urls() {
+        InstallationService installationService = new FileInstallationService(new AppConfig(), "target/files") {
+            @Override
+            public void saveInstallerAndBot(Installer installer) {
                 throw new RuntimeException();
             }
         };
-        OAuthV2DefaultSuccessHandler handler = new OAuthV2DefaultSuccessHandler(installationService);
+        OAuthV2DefaultSuccessHandler handler = new OAuthV2DefaultSuccessHandler(new AppConfig(), installationService);
 
         RequestHeaders headers = new RequestHeaders(new HashMap<>());
         OAuthCallbackRequest request = new OAuthCallbackRequest(new HashMap<>(), "", VerificationCodePayload.from(new HashMap<>()), headers);

--- a/bolt/src/test/java/util/MockSlackApi.java
+++ b/bolt/src/test/java/util/MockSlackApi.java
@@ -56,6 +56,8 @@ public class MockSlackApi extends HttpServlet {
                 body = body.replaceFirst("\"ok\": false,", "\"ok\": true,");
                 body = body.replaceFirst("\"access_token\": \"\",", "\"access_token\": \"" + ValidToken + "\",");
                 body = body.replaceFirst("\"bot_access_token\": \"\",", "\"bot_access_token\": \"" + ValidToken + "\",");
+            } else {
+                body = body.replaceFirst("\"error\": \"\"", "\"error\": \"something-wrong\"");
             }
         } else {
             body = body.replaceFirst("\"ok\": false,", "\"ok\": true,");

--- a/json-logs/samples/api/auth.teams.list.json
+++ b/json-logs/samples/api/auth.teams.list.json
@@ -1,0 +1,15 @@
+{
+  "ok": false,
+  "teams": [
+    {
+      "id": "T00000000",
+      "name": ""
+    }
+  ],
+  "error": "",
+  "response_metadata": {
+    "next_cursor": ""
+  },
+  "needed": "",
+  "provided": ""
+}

--- a/json-logs/samples/api/auth.test.json
+++ b/json-logs/samples/api/auth.test.json
@@ -10,6 +10,7 @@
   "error": "",
   "app_name": "",
   "app_id": "A00000000",
+  "is_enterprise_install": false,
   "needed": "",
   "provided": ""
 }

--- a/json-logs/samples/api/oauth.v2.access.json
+++ b/json-logs/samples/api/oauth.v2.access.json
@@ -23,6 +23,7 @@
     "id": "",
     "name": ""
   },
+  "is_enterprise_install": false,
   "incoming_webhook": {
     "url": "",
     "channel": "",

--- a/slack-api-client/src/main/java/com/slack/api/Slack.java
+++ b/slack-api-client/src/main/java/com/slack/api/Slack.java
@@ -288,17 +288,25 @@ public class Slack implements AutoCloseable {
     }
 
     public MethodsClient methods(String token) {
-        MethodsClientImpl client = new MethodsClientImpl(httpClient, token);
+        return methods(token, null);
+    }
+
+    public MethodsClient methods(String token, String teamId) {
+        MethodsClientImpl client = new MethodsClientImpl(httpClient, token, teamId);
         client.setEndpointUrlPrefix(config.getMethodsEndpointUrlPrefix());
         return client;
     }
 
     public AsyncMethodsClient methodsAsync() {
-        return methodsAsync(null);
+        return methodsAsync(null, null);
     }
 
     public AsyncMethodsClient methodsAsync(String token) {
-        MethodsClientImpl client = new MethodsClientImpl(httpClient, token);
+        return methodsAsync(token, null);
+    }
+
+    public AsyncMethodsClient methodsAsync(String token, String teamId) {
+        MethodsClientImpl client = new MethodsClientImpl(httpClient, token, teamId);
         client.setEndpointUrlPrefix(config.getMethodsEndpointUrlPrefix());
         return new AsyncMethodsClientImpl(token, client, config);
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
@@ -28,6 +28,7 @@ import com.slack.api.methods.request.apps.AppsUninstallRequest;
 import com.slack.api.methods.request.apps.event.authorizations.AppsEventAuthorizationsListRequest;
 import com.slack.api.methods.request.auth.AuthRevokeRequest;
 import com.slack.api.methods.request.auth.AuthTestRequest;
+import com.slack.api.methods.request.auth.teams.AuthTeamsListRequest;
 import com.slack.api.methods.request.bots.BotsInfoRequest;
 import com.slack.api.methods.request.calls.CallsAddRequest;
 import com.slack.api.methods.request.calls.CallsEndRequest;
@@ -108,6 +109,7 @@ import com.slack.api.methods.response.apps.AppsUninstallResponse;
 import com.slack.api.methods.response.apps.event.authorizations.AppsEventAuthorizationsListResponse;
 import com.slack.api.methods.response.auth.AuthRevokeResponse;
 import com.slack.api.methods.response.auth.AuthTestResponse;
+import com.slack.api.methods.response.auth.teams.AuthTeamsListResponse;
 import com.slack.api.methods.response.bots.BotsInfoResponse;
 import com.slack.api.methods.response.calls.CallsAddResponse;
 import com.slack.api.methods.response.calls.CallsEndResponse;
@@ -537,6 +539,14 @@ public interface AsyncMethodsClient {
     CompletableFuture<AuthTestResponse> authTest(AuthTestRequest req);
 
     CompletableFuture<AuthTestResponse> authTest(RequestConfigurator<AuthTestRequest.AuthTestRequestBuilder> req);
+
+    // ------------------------------
+    // auth.teams
+    // ------------------------------
+
+    CompletableFuture<AuthTeamsListResponse> authTeamsList(AuthTeamsListRequest req);
+
+    CompletableFuture<AuthTeamsListResponse> authTeamsList(RequestConfigurator<AuthTeamsListRequest.AuthTeamsListRequestBuilder> req);
 
     // ------------------------------
     // bots

--- a/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
@@ -194,6 +194,12 @@ public class Methods {
     public static final String AUTH_TEST = "auth.test";
 
     // ------------------------------
+    // auth.teams
+    // ------------------------------
+
+    public static final String AUTH_TEAMS_LIST = "auth.teams.list";
+
+    // ------------------------------
     // bots
     // ------------------------------
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
@@ -34,6 +34,7 @@ import com.slack.api.methods.request.apps.permissions.users.AppsPermissionsUsers
 import com.slack.api.methods.request.apps.permissions.users.AppsPermissionsUsersRequestRequest;
 import com.slack.api.methods.request.auth.AuthRevokeRequest;
 import com.slack.api.methods.request.auth.AuthTestRequest;
+import com.slack.api.methods.request.auth.teams.AuthTeamsListRequest;
 import com.slack.api.methods.request.bots.BotsInfoRequest;
 import com.slack.api.methods.request.calls.CallsAddRequest;
 import com.slack.api.methods.request.calls.CallsEndRequest;
@@ -127,6 +128,7 @@ import com.slack.api.methods.response.apps.permissions.users.AppsPermissionsUser
 import com.slack.api.methods.response.apps.permissions.users.AppsPermissionsUsersRequestResponse;
 import com.slack.api.methods.response.auth.AuthRevokeResponse;
 import com.slack.api.methods.response.auth.AuthTestResponse;
+import com.slack.api.methods.response.auth.teams.AuthTeamsListResponse;
 import com.slack.api.methods.response.bots.BotsInfoResponse;
 import com.slack.api.methods.response.calls.CallsAddResponse;
 import com.slack.api.methods.response.calls.CallsEndResponse;
@@ -697,6 +699,14 @@ public interface MethodsClient {
     AuthTestResponse authTest(AuthTestRequest req) throws IOException, SlackApiException;
 
     AuthTestResponse authTest(RequestConfigurator<AuthTestRequest.AuthTestRequestBuilder> req) throws IOException, SlackApiException;
+
+    // ------------------------------
+    // auth.teams
+    // ------------------------------
+
+    AuthTeamsListResponse authTeamsList(AuthTeamsListRequest req) throws IOException, SlackApiException;
+
+    AuthTeamsListResponse authTeamsList(RequestConfigurator<AuthTeamsListRequest.AuthTeamsListRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // bots

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
@@ -155,6 +155,7 @@ public class MethodsRateLimits {
 
         setRateLimitTier(AUTH_REVOKE, Tier3);
         setRateLimitTier(AUTH_TEST, SpecialTier_auth_test);
+        setRateLimitTier(AUTH_TEAMS_LIST, Tier2);
 
         setRateLimitTier(BOTS_INFO, Tier3);
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -34,6 +34,7 @@ import com.slack.api.methods.request.apps.permissions.users.AppsPermissionsUsers
 import com.slack.api.methods.request.apps.permissions.users.AppsPermissionsUsersRequestRequest;
 import com.slack.api.methods.request.auth.AuthRevokeRequest;
 import com.slack.api.methods.request.auth.AuthTestRequest;
+import com.slack.api.methods.request.auth.teams.AuthTeamsListRequest;
 import com.slack.api.methods.request.bots.BotsInfoRequest;
 import com.slack.api.methods.request.calls.CallsAddRequest;
 import com.slack.api.methods.request.calls.CallsEndRequest;
@@ -683,9 +684,17 @@ public class RequestFormBuilder {
         return form;
     }
 
+    public static FormBody.Builder toForm(AuthTeamsListRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("cursor", req.getCursor(), form);
+        setIfNotNull("limit", req.getLimit(), form);
+        return form;
+    }
+
     public static FormBody.Builder toForm(BotsInfoRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("bot", req.getBot(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -757,6 +766,7 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("name", req.getName(), form);
         setIfNotNull("validate", req.isValidate(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -791,6 +801,7 @@ public class RequestFormBuilder {
         setIfNotNull("cursor", req.getCursor(), form);
         setIfNotNull("exclude_members", req.isExcludeMembers(), form);
         setIfNotNull("exclude_archived", req.isExcludeArchived(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -923,6 +934,7 @@ public class RequestFormBuilder {
         setIfNotNull("latest", req.getLatest(), form);
         setIfNotNull("limit", req.getLimit(), form);
         setIfNotNull("oldest", req.getOldest(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1054,6 +1066,7 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("name", req.getName(), form);
         setIfNotNull("is_private", req.isPrivate(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1117,6 +1130,7 @@ public class RequestFormBuilder {
             }
             setIfNotNull("types", typeValues.stream().collect(joining(",")), form);
         }
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1257,6 +1271,7 @@ public class RequestFormBuilder {
         setIfNotNull("count", req.getCount(), form);
         setIfNotNull("page", req.getPage(), form);
         setIfNotNull("show_files_hidden_by_limit", req.isShowFilesHiddenByLimit(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1424,6 +1439,7 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("name", req.getName(), form);
         setIfNotNull("validate", req.isValidate(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1476,6 +1492,7 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("exclude_archived", req.isExcludeArchived(), form);
         setIfNotNull("exclude_members", req.isExcludeMembers(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1571,6 +1588,7 @@ public class RequestFormBuilder {
         if (req.getUsers() != null) {
             setIfNotNull("users", req.getUsers().stream().collect(joining(",")), form);
         }
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1688,6 +1706,7 @@ public class RequestFormBuilder {
         setIfNotNull("full", req.isFull(), form);
         setIfNotNull("count", req.getCount(), form);
         setIfNotNull("page", req.getPage(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1759,6 +1778,7 @@ public class RequestFormBuilder {
         setIfNotNull("highlight", req.isHighlight(), form);
         setIfNotNull("count", req.getCount(), form);
         setIfNotNull("page", req.getPage(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1770,6 +1790,7 @@ public class RequestFormBuilder {
         setIfNotNull("highlight", req.isHighlight(), form);
         setIfNotNull("count", req.getCount(), form);
         setIfNotNull("page", req.getPage(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1781,6 +1802,7 @@ public class RequestFormBuilder {
         setIfNotNull("highlight", req.isHighlight(), form);
         setIfNotNull("count", req.getCount(), form);
         setIfNotNull("page", req.getPage(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1814,12 +1836,14 @@ public class RequestFormBuilder {
         setIfNotNull("before", req.getBefore(), form);
         setIfNotNull("count", req.getCount(), form);
         setIfNotNull("page", req.getPage(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
     public static FormBody.Builder toForm(TeamBillableInfoRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("user", req.getUser(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1835,12 +1859,14 @@ public class RequestFormBuilder {
         setIfNotNull("change_type", req.getChangeType(), form);
         setIfNotNull("count", req.getCount(), form);
         setIfNotNull("page", req.getPage(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
     public static FormBody.Builder toForm(TeamProfileGetRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("visibility", req.getVisibility(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1922,6 +1948,7 @@ public class RequestFormBuilder {
             }
             setIfNotNull("types", typeValues.stream().collect(joining(",")), form);
         }
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 
@@ -1954,6 +1981,7 @@ public class RequestFormBuilder {
         setIfNotNull("limit", req.getLimit(), form);
         setIfNotNull("include_locale", req.isIncludeLocale(), form);
         setIfNotNull("presence", req.isPresence(), form);
+        setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
@@ -32,6 +32,7 @@ import com.slack.api.methods.request.apps.AppsUninstallRequest;
 import com.slack.api.methods.request.apps.event.authorizations.AppsEventAuthorizationsListRequest;
 import com.slack.api.methods.request.auth.AuthRevokeRequest;
 import com.slack.api.methods.request.auth.AuthTestRequest;
+import com.slack.api.methods.request.auth.teams.AuthTeamsListRequest;
 import com.slack.api.methods.request.bots.BotsInfoRequest;
 import com.slack.api.methods.request.calls.CallsAddRequest;
 import com.slack.api.methods.request.calls.CallsEndRequest;
@@ -112,6 +113,7 @@ import com.slack.api.methods.response.apps.AppsUninstallResponse;
 import com.slack.api.methods.response.apps.event.authorizations.AppsEventAuthorizationsListResponse;
 import com.slack.api.methods.response.auth.AuthRevokeResponse;
 import com.slack.api.methods.response.auth.AuthTestResponse;
+import com.slack.api.methods.response.auth.teams.AuthTeamsListResponse;
 import com.slack.api.methods.response.bots.BotsInfoResponse;
 import com.slack.api.methods.response.calls.CallsAddResponse;
 import com.slack.api.methods.response.calls.CallsEndResponse;
@@ -877,6 +879,16 @@ public class AsyncMethodsClientImpl implements AsyncMethodsClient {
     @Override
     public CompletableFuture<AuthTestResponse> authTest(RequestConfigurator<AuthTestRequest.AuthTestRequestBuilder> req) {
         return authTest(req.configure(AuthTestRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<AuthTeamsListResponse> authTeamsList(AuthTeamsListRequest req) {
+        return executor.execute(AUTH_TEAMS_LIST, toMap(req), () -> methods.authTeamsList(req));
+    }
+
+    @Override
+    public CompletableFuture<AuthTeamsListResponse> authTeamsList(RequestConfigurator<AuthTeamsListRequest.AuthTeamsListRequestBuilder> req) {
+        return authTeamsList(req.configure(AuthTeamsListRequest.builder()).build());
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/auth/teams/AuthTeamsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/auth/teams/AuthTeamsListRequest.java
@@ -1,0 +1,15 @@
+package com.slack.api.methods.request.auth.teams;
+
+import com.slack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AuthTeamsListRequest implements SlackApiRequest {
+
+    private String token;
+    private String cursor;
+    private Integer limit;
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/bots/BotsInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/bots/BotsInfoRequest.java
@@ -18,4 +18,9 @@ public class BotsInfoRequest implements SlackApiRequest {
      */
     private String bot;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/channels/ChannelsCreateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/channels/ChannelsCreateRequest.java
@@ -24,4 +24,9 @@ public class ChannelsCreateRequest implements SlackApiRequest {
      */
     private boolean validate;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/channels/ChannelsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/channels/ChannelsListRequest.java
@@ -37,4 +37,9 @@ public class ChannelsListRequest implements SlackApiRequest {
      */
     private boolean excludeArchived;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/scheduled_messages/ChatScheduledMessagesListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/scheduled_messages/ChatScheduledMessagesListRequest.java
@@ -36,4 +36,9 @@ public class ChatScheduledMessagesListRequest implements SlackApiRequest {
      */
     private String oldest;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsCreateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsCreateRequest.java
@@ -23,4 +23,9 @@ public class ConversationsCreateRequest implements SlackApiRequest {
      */
     private boolean isPrivate;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsListRequest.java
@@ -40,4 +40,9 @@ public class ConversationsListRequest implements SlackApiRequest {
      */
     private List<ConversationType> types;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesListRequest.java
@@ -63,4 +63,9 @@ public class FilesListRequest implements SlackApiRequest {
      */
     private boolean showFilesHiddenByLimit;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/groups/GroupsCreateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/groups/GroupsCreateRequest.java
@@ -24,4 +24,9 @@ public class GroupsCreateRequest implements SlackApiRequest {
      */
     private boolean validate;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/groups/GroupsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/groups/GroupsListRequest.java
@@ -24,4 +24,9 @@ public class GroupsListRequest implements SlackApiRequest {
      */
     private boolean excludeArchived;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/migration/MigrationExchangeRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/migration/MigrationExchangeRequest.java
@@ -28,4 +28,9 @@ public class MigrationExchangeRequest implements SlackApiRequest {
      */
     private List<String> users;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsListRequest.java
@@ -27,4 +27,9 @@ public class ReactionsListRequest implements SlackApiRequest {
 
     private Integer page;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchAllRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchAllRequest.java
@@ -37,4 +37,9 @@ public class SearchAllRequest implements SlackApiRequest {
 
     private Integer page;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchFilesRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchFilesRequest.java
@@ -37,4 +37,9 @@ public class SearchFilesRequest implements SlackApiRequest {
 
     private Integer page;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchMessagesRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchMessagesRequest.java
@@ -37,4 +37,9 @@ public class SearchMessagesRequest implements SlackApiRequest {
 
     private Integer page;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamAccessLogsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamAccessLogsRequest.java
@@ -22,4 +22,9 @@ public class TeamAccessLogsRequest implements SlackApiRequest {
 
     private Integer page;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamBillableInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamBillableInfoRequest.java
@@ -18,4 +18,9 @@ public class TeamBillableInfoRequest implements SlackApiRequest {
      */
     private String user;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamIntegrationLogsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamIntegrationLogsRequest.java
@@ -37,4 +37,9 @@ public class TeamIntegrationLogsRequest implements SlackApiRequest {
 
     private Integer page;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/profile/TeamProfileGetRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/profile/TeamProfileGetRequest.java
@@ -18,4 +18,9 @@ public class TeamProfileGetRequest implements SlackApiRequest {
      */
     private String visibility;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersConversationsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersConversationsRequest.java
@@ -49,4 +49,9 @@ public class UsersConversationsRequest implements SlackApiRequest {
      */
     private List<ConversationType> types;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersListRequest.java
@@ -38,4 +38,9 @@ public class UsersListRequest implements SlackApiRequest {
     @Deprecated
     private boolean presence;
 
+    /**
+     * Required for org-wide apps.
+     */
+    private String teamId;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/auth/AuthTestResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/auth/AuthTestResponse.java
@@ -21,4 +21,5 @@ public class AuthTestResponse implements SlackApiTextResponse {
     private String enterpriseId;
     private String appId; // only for app-level tokens
     private String appName; // only for app-level tokens
+    private boolean isEnterpriseInstall;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/auth/teams/AuthTeamsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/auth/teams/AuthTeamsListResponse.java
@@ -1,0 +1,26 @@
+package com.slack.api.methods.response.auth.teams;
+
+import com.slack.api.methods.SlackApiTextResponse;
+import com.slack.api.model.ResponseMetadata;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AuthTeamsListResponse implements SlackApiTextResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private List<Team> teams;
+    private ResponseMetadata responseMetadata;
+
+    @Data
+    public static class Team {
+        private String id;
+        private String name;
+    }
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthV2AccessResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthV2AccessResponse.java
@@ -23,6 +23,7 @@ public class OAuthV2AccessResponse implements SlackApiTextResponse {
     private String botUserId;
     private Team team;
     private Enterprise enterprise;
+    private boolean isEnterpriseInstall;
     private IncomingWebhook incomingWebhook;
 
     @Data

--- a/slack-api-client/src/test/java/config/Constants.java
+++ b/slack-api-client/src/test/java/config/Constants.java
@@ -19,6 +19,8 @@ public class Constants {
     public static final String SLACK_SDK_TEST_GRID_IDP_USERGROUP_ID = "SLACK_SDK_TEST_GRID_IDP_USERGROUP_ID";
     // Shared channel ID for testing with Grid
     public static final String SLACK_SDK_TEST_GRID_SHARED_CHANNEL_ID = "SLACK_SDK_TEST_GRID_SHARED_CHANNEL_ID";
+    // Org level installed app
+    public static final String SLACK_SDK_TEST_GRID_ORG_LEVEL_APP_BOT_TOKEN = "SLACK_SDK_TEST_GRID_ORG_LEVEL_APP_BOT_TOKEN";
     // --------------------------------------------
 
     // normal user token / bot token

--- a/slack-api-client/src/test/java/test_locally/api/MethodsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/MethodsTest.java
@@ -43,6 +43,7 @@ public class MethodsTest {
             }
         }
 
+        methodNames.add("auth.teams.list");
         for (String method : methodNames) {
             if (!existingMethods.contains(method)) {
                 fail(method + " is not supported yet!");

--- a/slack-api-client/src/test/java/test_locally/api/methods/AuthTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/AuthTest.java
@@ -40,4 +40,9 @@ public class AuthTest {
         assertThat(slack.methodsAsync(ValidToken).authTest(r -> r).get().getTeamId(), is("T1234567"));
     }
 
+    @Test
+    public void authTeamsList() throws Exception {
+        assertThat(slack.methods(ValidToken).authTeamsList(r -> r.limit(10)).isOk(), is(true));
+    }
+
 }

--- a/slack-api-client/src/test/java/test_locally/api/methods/FieldValidation_a_to_c_Test.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/FieldValidation_a_to_c_Test.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.response.api.ApiTestResponse;
 import com.slack.api.methods.response.apps.AppsUninstallResponse;
 import com.slack.api.methods.response.auth.AuthRevokeResponse;
 import com.slack.api.methods.response.auth.AuthTestResponse;
+import com.slack.api.methods.response.auth.teams.AuthTeamsListResponse;
 import com.slack.api.methods.response.bots.BotsInfoResponse;
 import com.slack.api.methods.response.calls.CallsAddResponse;
 import com.slack.api.methods.response.calls.CallsEndResponse;
@@ -52,6 +53,12 @@ public class FieldValidation_a_to_c_Test {
     @Test
     public void auth_revoke() throws Exception {
         AuthRevokeResponse obj = parse("auth.revoke", AuthRevokeResponse.class);
+        verifyIfAllGettersReturnNonNull(obj);
+    }
+
+    @Test
+    public void auth_teams_list() throws Exception {
+        AuthTeamsListResponse obj = parse("auth.teams.list", AuthTeamsListResponse.class);
         verifyIfAllGettersReturnNonNull(obj);
     }
 

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/auth_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/auth_Test.java
@@ -8,6 +8,7 @@ import com.slack.api.methods.MethodsStats;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.auth.AuthRevokeResponse;
 import com.slack.api.methods.response.auth.AuthTestResponse;
+import com.slack.api.methods.response.auth.teams.AuthTeamsListResponse;
 import com.slack.api.util.json.GsonFactory;
 import config.Constants;
 import config.SlackTestConfig;
@@ -183,6 +184,36 @@ public class auth_Test {
         Integer oneMinuteLaterCount = oneMinuteLater.getLastMinuteRequests().get(Methods.AUTH_TEST);
         log.debug("Final stats: {}", gson.toJson(oneMinuteLater.getLastMinuteRequests()));
         assertThat(afterCount - oneMinuteLaterCount, is(greaterThanOrEqualTo(2)));
+    }
+
+    @Test
+    public void authTeamsList_non_org_level_app() throws Exception {
+        String token = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+        {
+            AuthTeamsListResponse response = slack.methods(token).authTeamsList(req -> req.limit(1));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+        }
+        {
+            AuthTeamsListResponse response = slack.methodsAsync(token).authTeamsList(req -> req.limit(1)).get();
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+        }
+    }
+
+    @Test
+    public void authTeamsList_org_level_app() throws Exception {
+        String token = System.getenv(Constants.SLACK_SDK_TEST_GRID_ORG_LEVEL_APP_BOT_TOKEN);
+        {
+            AuthTeamsListResponse response = slack.methods(token).authTeamsList(req -> req.limit(1));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+        }
+        {
+            AuthTeamsListResponse response = slack.methodsAsync(token).authTeamsList(req -> req.limit(1)).get();
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.getTeams().size(), is(greaterThanOrEqualTo(1)));
+        }
     }
 
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/event/TeamsAccessGrantedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/TeamsAccessGrantedEvent.java
@@ -1,0 +1,18 @@
+package com.slack.api.model.event;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/events/teams_access_granted
+ */
+@Data
+public class TeamsAccessGrantedEvent implements Event {
+
+    public static final String TYPE_NAME = "teams_access_granted";
+
+    private final String type = TYPE_NAME;
+    private List<String> teamIds; // teams added, up to 1000 teams
+
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/TeamsAccessRevokedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/TeamsAccessRevokedEvent.java
@@ -1,0 +1,18 @@
+package com.slack.api.model.event;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/events/teams_access_revoked
+ */
+@Data
+public class TeamsAccessRevokedEvent implements Event {
+
+    public static final String TYPE_NAME = "teams_access_revoked";
+
+    private final String type = TYPE_NAME;
+    private List<String> teamIds; // teams removed, up to 1000 teams
+
+}

--- a/slack-api-model/src/test/java/test_locally/api/model/event/TeamsAccessGrantedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/TeamsAccessGrantedEventTest.java
@@ -1,0 +1,40 @@
+package test_locally.api.model.event;
+
+import com.google.gson.Gson;
+import com.slack.api.model.event.TeamsAccessGrantedEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TeamsAccessGrantedEventTest {
+
+    @Test
+    public void typeName() {
+        assertThat(TeamsAccessGrantedEvent.TYPE_NAME, is("teams_access_granted"));
+    }
+
+    @Test
+    public void deserialize() {
+        String json = "{\n" +
+                "  \"type\": \"teams_access_granted\",\n" +
+                "  \"team_ids\": [\"T1XX3\", \"TXX34\"]\n" +
+                "}";
+        TeamsAccessGrantedEvent event = GsonFactory.createSnakeCase().fromJson(json, TeamsAccessGrantedEvent.class);
+        assertThat(event.getType(), is("teams_access_granted"));
+        assertThat(event.getTeamIds(), is(Arrays.asList("T1XX3", "TXX34")));
+    }
+
+    @Test
+    public void serialize() {
+        Gson gson = GsonFactory.createSnakeCase();
+        TeamsAccessGrantedEvent event = new TeamsAccessGrantedEvent();
+        String generatedJson = gson.toJson(event);
+        String expectedJson = "{\"type\":\"teams_access_granted\"}";
+        assertThat(generatedJson, is(expectedJson));
+    }
+
+}

--- a/slack-api-model/src/test/java/test_locally/api/model/event/TeamsAccessRevokedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/TeamsAccessRevokedEventTest.java
@@ -1,0 +1,40 @@
+package test_locally.api.model.event;
+
+import com.google.gson.Gson;
+import com.slack.api.model.event.TeamsAccessRevokedEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TeamsAccessRevokedEventTest {
+
+    @Test
+    public void typeName() {
+        assertThat(TeamsAccessRevokedEvent.TYPE_NAME, is("teams_access_revoked"));
+    }
+
+    @Test
+    public void deserialize() {
+        String json = "{\n" +
+                "  \"type\": \"teams_access_revoked\",\n" +
+                "  \"team_ids\": [\"TX123\", \"TX234\"]\n" +
+                "}";
+        TeamsAccessRevokedEvent event = GsonFactory.createSnakeCase().fromJson(json, TeamsAccessRevokedEvent.class);
+        assertThat(event.getType(), is("teams_access_revoked"));
+        assertThat(event.getTeamIds(), is(Arrays.asList("TX123", "TX234")));
+    }
+
+    @Test
+    public void serialize() {
+        Gson gson = GsonFactory.createSnakeCase();
+        TeamsAccessRevokedEvent event = new TeamsAccessRevokedEvent();
+        String generatedJson = gson.toJson(event);
+        String expectedJson = "{\"type\":\"teams_access_revoked\"}";
+        assertThat(generatedJson, is(expectedJson));
+    }
+
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/TeamsAccessGrantedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/TeamsAccessGrantedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.TeamsAccessGrantedPayload;
+import com.slack.api.model.event.TeamsAccessGrantedEvent;
+
+public abstract class TeamsAccessGrantedHandler extends EventHandler<TeamsAccessGrantedPayload> {
+
+    @Override
+    public String getEventType() {
+        return TeamsAccessGrantedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/TeamsAccessRevokedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/TeamsAccessRevokedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.TeamsAccessRevokedPayload;
+import com.slack.api.model.event.TeamsAccessRevokedEvent;
+
+public abstract class TeamsAccessRevokedHandler extends EventHandler<TeamsAccessRevokedPayload> {
+
+    @Override
+    public String getEventType() {
+        return TeamsAccessRevokedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TeamsAccessGrantedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TeamsAccessGrantedPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.TeamsAccessGrantedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TeamsAccessGrantedPayload implements EventsApiPayload<TeamsAccessGrantedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+    private boolean isExtSharedChannel;
+
+    private TeamsAccessGrantedEvent event;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TeamsAccessRevokedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/TeamsAccessRevokedPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.TeamsAccessRevokedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TeamsAccessRevokedPayload implements EventsApiPayload<TeamsAccessRevokedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+    private boolean isExtSharedChannel;
+
+    private TeamsAccessRevokedEvent event;
+}

--- a/slack-app-backend/src/test/java/test_locally/app_backend/events/EventHandlersTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/events/EventHandlersTest.java
@@ -335,6 +335,16 @@ public class EventHandlersTest {
                     @Override
                     public void handle(CallRejectedPayload payload) {
                     }
+                },
+                new TeamsAccessGrantedHandler() {
+                    @Override
+                    public void handle(TeamsAccessGrantedPayload payload) {
+                    }
+                },
+                new TeamsAccessRevokedHandler() {
+                    @Override
+                    public void handle(TeamsAccessRevokedPayload payload) {
+                    }
                 }
         );
         for (EventHandler<?> handler : handlers) {


### PR DESCRIPTION
This pull request adds a new feature called "Org Apps", which enables Slack apps to be installed into the Enterprise Grid organization, not into each workspace under an organization. This fixes #617 

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
