### PR TITLE
Fix #623 by repackaging Responder in Bolt

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/context/ActionRespondUtility.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/ActionRespondUtility.java
@@ -1,7 +1,7 @@
 package com.slack.api.bolt.context;
 
 import com.slack.api.app_backend.interactive_components.response.ActionResponse;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.bolt.util.BuilderConfigurator;
 import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.webhook.WebhookResponse;

--- a/bolt/src/main/java/com/slack/api/bolt/context/RespondUtility.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/RespondUtility.java
@@ -1,7 +1,7 @@
 package com.slack.api.bolt.context;
 
 import com.slack.api.Slack;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 
 public interface RespondUtility {
 

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/ActionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/ActionContext.java
@@ -2,7 +2,7 @@ package com.slack.api.bolt.context.builtin;
 
 import com.slack.api.bolt.context.ActionRespondUtility;
 import com.slack.api.bolt.context.Context;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import lombok.*;
 
 /**

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/AttachmentActionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/AttachmentActionContext.java
@@ -3,7 +3,7 @@ package com.slack.api.bolt.context.builtin;
 import com.slack.api.bolt.context.ActionRespondUtility;
 import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.context.SayUtility;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import lombok.*;
 
 /**

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogCancellationContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogCancellationContext.java
@@ -3,7 +3,7 @@ package com.slack.api.bolt.context.builtin;
 import com.slack.api.bolt.context.ActionRespondUtility;
 import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.context.SayUtility;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import lombok.*;
 
 @Getter

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSubmissionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/DialogSubmissionContext.java
@@ -5,7 +5,7 @@ import com.slack.api.app_backend.dialogs.response.Error;
 import com.slack.api.bolt.context.ActionRespondUtility;
 import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.context.SayUtility;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.util.BuilderConfigurator;
 import lombok.*;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/MessageShortcutContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/MessageShortcutContext.java
@@ -3,7 +3,7 @@ package com.slack.api.bolt.context.builtin;
 import com.slack.api.bolt.context.ActionRespondUtility;
 import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.context.SayUtility;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import lombok.*;
 
 /**

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/SlashCommandContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/SlashCommandContext.java
@@ -4,7 +4,7 @@ import com.slack.api.app_backend.slash_commands.response.SlashCommandResponse;
 import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.context.RespondUtility;
 import com.slack.api.bolt.context.SayUtility;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.util.BuilderConfigurator;
 import com.slack.api.model.block.LayoutBlock;

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/ViewSubmissionContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/ViewSubmissionContext.java
@@ -5,7 +5,7 @@ import com.slack.api.app_backend.views.payload.ViewSubmissionPayload;
 import com.slack.api.app_backend.views.response.ViewSubmissionResponse;
 import com.slack.api.bolt.context.Context;
 import com.slack.api.bolt.context.InputBlockRespondUtility;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.util.BuilderConfigurator;
 import com.slack.api.model.view.View;

--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/MultiTeamsAuthorization.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/MultiTeamsAuthorization.java
@@ -8,7 +8,7 @@ import com.slack.api.bolt.model.Bot;
 import com.slack.api.bolt.model.Installer;
 import com.slack.api.bolt.request.Request;
 import com.slack.api.bolt.request.RequestType;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.InstallationService;
 import com.slack.api.methods.MethodsClient;

--- a/bolt/src/main/java/com/slack/api/bolt/response/Responder.java
+++ b/bolt/src/main/java/com/slack/api/bolt/response/Responder.java
@@ -1,74 +1,15 @@
 package com.slack.api.bolt.response;
 
-import com.slack.api.RequestConfigurator;
 import com.slack.api.Slack;
-import com.slack.api.app_backend.interactive_components.ActionResponseSender;
-import com.slack.api.app_backend.interactive_components.response.ActionResponse;
-import com.slack.api.app_backend.slash_commands.SlashCommandResponseSender;
-import com.slack.api.app_backend.slash_commands.response.SlashCommandResponse;
-import com.slack.api.app_backend.views.InputBlockResponseSender;
-import com.slack.api.app_backend.views.response.InputBlockResponse;
-import com.slack.api.webhook.WebhookResponse;
-
-import java.io.IOException;
 
 /**
- * HTTP response sender using response_url.
+ * Use com.slack.api.bolt.util.Responder instead. This class will be removed in v2.0.
  */
-public class Responder {
+@Deprecated
+public class Responder extends com.slack.api.bolt.util.Responder {
 
-    private final Slack slack;
-    private final String responseUrl;
-
-    private final ActionResponseSender actionResponseSender;
-    private final SlashCommandResponseSender slashCommandResponseSender;
-    private final InputBlockResponseSender inputBlockResponseSender;
-
-    /**
-     * Initializes with a valid response_url
-     *
-     * @param slack       the underlying sender
-     * @param responseUrl the response_url in a payload
-     */
+    @Deprecated
     public Responder(Slack slack, String responseUrl) {
-        this.slack = slack;
-        this.responseUrl = responseUrl;
-        this.actionResponseSender = new ActionResponseSender(slack);
-        this.slashCommandResponseSender = new SlashCommandResponseSender(slack);
-        this.inputBlockResponseSender = new InputBlockResponseSender(slack);
+        super(slack, responseUrl);
     }
-
-    /**
-     * Sends an HTTP response for a slash command invocation.
-     */
-    public WebhookResponse send(SlashCommandResponse response) throws IOException {
-        return slashCommandResponseSender.send(responseUrl, response);
-    }
-
-    /**
-     * Sends an HTTP response for an action.
-     */
-    public WebhookResponse send(ActionResponse response) throws IOException {
-        return actionResponseSender.send(responseUrl, response);
-    }
-
-    /**
-     * Sends an HTTP response for an input block in a modal.
-     */
-    public WebhookResponse send(InputBlockResponse response) throws IOException {
-        return inputBlockResponseSender.send(responseUrl, response);
-    }
-
-    public WebhookResponse sendToAction(RequestConfigurator<ActionResponse.ActionResponseBuilder> body) throws IOException {
-        return send(body.configure(ActionResponse.builder()).build());
-    }
-
-    public WebhookResponse sendToCommand(RequestConfigurator<SlashCommandResponse.SlashCommandResponseBuilder> body) throws IOException {
-        return send(body.configure(SlashCommandResponse.builder()).build());
-    }
-
-    public WebhookResponse sendFromModal(RequestConfigurator<InputBlockResponse.InputBlockResponseBuilder> body) throws IOException {
-        return send(body.configure(InputBlockResponse.builder()).build());
-    }
-
 }

--- a/bolt/src/main/java/com/slack/api/bolt/util/Responder.java
+++ b/bolt/src/main/java/com/slack/api/bolt/util/Responder.java
@@ -1,0 +1,74 @@
+package com.slack.api.bolt.util;
+
+import com.slack.api.RequestConfigurator;
+import com.slack.api.Slack;
+import com.slack.api.app_backend.interactive_components.ActionResponseSender;
+import com.slack.api.app_backend.interactive_components.response.ActionResponse;
+import com.slack.api.app_backend.slash_commands.SlashCommandResponseSender;
+import com.slack.api.app_backend.slash_commands.response.SlashCommandResponse;
+import com.slack.api.app_backend.views.InputBlockResponseSender;
+import com.slack.api.app_backend.views.response.InputBlockResponse;
+import com.slack.api.webhook.WebhookResponse;
+
+import java.io.IOException;
+
+/**
+ * HTTP response sender using response_url.
+ */
+public class Responder {
+
+    private final Slack slack;
+    private final String responseUrl;
+
+    private final ActionResponseSender actionResponseSender;
+    private final SlashCommandResponseSender slashCommandResponseSender;
+    private final InputBlockResponseSender inputBlockResponseSender;
+
+    /**
+     * Initializes with a valid response_url
+     *
+     * @param slack       the underlying sender
+     * @param responseUrl the response_url in a payload
+     */
+    public Responder(Slack slack, String responseUrl) {
+        this.slack = slack;
+        this.responseUrl = responseUrl;
+        this.actionResponseSender = new ActionResponseSender(slack);
+        this.slashCommandResponseSender = new SlashCommandResponseSender(slack);
+        this.inputBlockResponseSender = new InputBlockResponseSender(slack);
+    }
+
+    /**
+     * Sends an HTTP response for a slash command invocation.
+     */
+    public WebhookResponse send(SlashCommandResponse response) throws IOException {
+        return slashCommandResponseSender.send(responseUrl, response);
+    }
+
+    /**
+     * Sends an HTTP response for an action.
+     */
+    public WebhookResponse send(ActionResponse response) throws IOException {
+        return actionResponseSender.send(responseUrl, response);
+    }
+
+    /**
+     * Sends an HTTP response for an input block in a modal.
+     */
+    public WebhookResponse send(InputBlockResponse response) throws IOException {
+        return inputBlockResponseSender.send(responseUrl, response);
+    }
+
+    public WebhookResponse sendToAction(RequestConfigurator<ActionResponse.ActionResponseBuilder> body) throws IOException {
+        return send(body.configure(ActionResponse.builder()).build());
+    }
+
+    public WebhookResponse sendToCommand(RequestConfigurator<SlashCommandResponse.SlashCommandResponseBuilder> body) throws IOException {
+        return send(body.configure(SlashCommandResponse.builder()).build());
+    }
+
+    public WebhookResponse sendFromModal(RequestConfigurator<InputBlockResponse.InputBlockResponseBuilder> body) throws IOException {
+        return send(body.configure(InputBlockResponse.builder()).build());
+    }
+
+}

--- a/bolt/src/test/java/test_locally/ActionRespondUtilityTest.java
+++ b/bolt/src/test/java/test_locally/ActionRespondUtilityTest.java
@@ -2,7 +2,7 @@ package test_locally;
 
 import com.slack.api.Slack;
 import com.slack.api.bolt.context.ActionRespondUtility;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.webhook.WebhookResponse;
 import org.junit.Test;
 import util.WebhookMockServer;

--- a/bolt/src/test/java/test_locally/context/ActionContextTest.java
+++ b/bolt/src/test/java/test_locally/context/ActionContextTest.java
@@ -3,7 +3,7 @@ package test_locally.context;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.bolt.context.builtin.ActionContext;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.webhook.WebhookResponse;
 import org.junit.After;
 import org.junit.Before;

--- a/bolt/src/test/java/test_locally/context/AttachmentActionContextTest.java
+++ b/bolt/src/test/java/test_locally/context/AttachmentActionContextTest.java
@@ -3,7 +3,7 @@ package test_locally.context;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.bolt.context.builtin.AttachmentActionContext;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.webhook.WebhookResponse;
 import org.junit.After;
 import org.junit.Before;

--- a/bolt/src/test/java/test_locally/context/DialogCancellationContextTest.java
+++ b/bolt/src/test/java/test_locally/context/DialogCancellationContextTest.java
@@ -3,7 +3,7 @@ package test_locally.context;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.bolt.context.builtin.DialogCancellationContext;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.webhook.WebhookResponse;
 import org.junit.After;
 import org.junit.Before;

--- a/bolt/src/test/java/test_locally/context/DialogSubmissionContextTest.java
+++ b/bolt/src/test/java/test_locally/context/DialogSubmissionContextTest.java
@@ -3,7 +3,7 @@ package test_locally.context;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.bolt.context.builtin.DialogSubmissionContext;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.webhook.WebhookResponse;
 import org.junit.After;
 import org.junit.Before;

--- a/bolt/src/test/java/test_locally/context/MessageShortcutContextTest.java
+++ b/bolt/src/test/java/test_locally/context/MessageShortcutContextTest.java
@@ -3,7 +3,7 @@ package test_locally.context;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.bolt.context.builtin.MessageShortcutContext;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.webhook.WebhookResponse;
 import org.junit.After;
 import org.junit.Before;

--- a/bolt/src/test/java/test_locally/context/SlashCommandContextTest.java
+++ b/bolt/src/test/java/test_locally/context/SlashCommandContextTest.java
@@ -3,7 +3,7 @@ package test_locally.context;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.bolt.context.builtin.SlashCommandContext;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.webhook.WebhookResponse;
 import org.junit.After;

--- a/bolt/src/test/java/test_locally/response/ResponderTest.java
+++ b/bolt/src/test/java/test_locally/response/ResponderTest.java
@@ -2,7 +2,7 @@ package test_locally.response;
 
 import com.slack.api.Slack;
 import com.slack.api.app_backend.interactive_components.response.ActionResponse;
-import com.slack.api.bolt.response.Responder;
+import com.slack.api.bolt.util.Responder;
 import com.slack.api.webhook.WebhookResponse;
 import org.junit.Test;
 import util.WebhookMockServer;


### PR DESCRIPTION
This pull request fixes #623 by moving the `Response` class from `response` package to `util`. At the same time, I added a deprecated sub-class for backward-compatibility. Some tests in bolt-servlet project verify existing code works as-is with deprecation warnings.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
