### PR TITLE
[1.3.x] Add missing timepicker related fields in payloads

### DIFF
--- a/bolt-servlet/src/test/java/samples/TimepickerSample.java
+++ b/bolt-servlet/src/test/java/samples/TimepickerSample.java
@@ -1,0 +1,49 @@
+package samples;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.model.view.View;
+import lombok.extern.slf4j.Slf4j;
+import util.ResourceLoader;
+import util.TestSlackAppServer;
+
+import java.util.Arrays;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static com.slack.api.model.block.element.BlockElements.timePicker;
+import static com.slack.api.model.view.Views.*;
+
+@Slf4j
+public class TimepickerSample {
+
+    public static void main(String[] args) throws Exception {
+        AppConfig appConfig = ResourceLoader.loadAppConfig();
+        App app = new App(appConfig);
+        app.command("/open-modal", (req, ctx) -> {
+            View view = view(v -> v
+                    .type("modal")
+                    .callbackId("view-id")
+                    .title(viewTitle(vt -> vt.type("plain_text").text("Org App")))
+                    .submit(viewSubmit(vs -> vs.type("plain_text").text("Submit")))
+                    .close(viewClose(vc -> vc.type("plain_text").text("Close")))
+                    .blocks(asBlocks(
+                            actions(a -> a.blockId("b1").elements(Arrays.asList(timePicker(t -> t.actionId("time1").initialTime("01:02"))))),
+                            input(i -> i.blockId("b2").label(plainText("Time")).element(timePicker(t -> t.actionId("time2").initialTime("02:03"))))
+                    )));
+            ctx.client().viewsOpen(r -> r.triggerId(req.getPayload().getTriggerId()).view(view));
+            return ctx.ack();
+        });
+        app.blockAction("time1", (req, ctx) -> {
+            ctx.logger.info("action: {}", req.getPayload().getActions().get(0));
+           return ctx.ack();
+        });
+        app.viewSubmission("view-id", (req, ctx) -> {
+            ctx.logger.info("values: {}", req.getPayload().getView().getState().getValues());
+            return ctx.ack();
+        });
+        TestSlackAppServer server = new TestSlackAppServer(app);
+        server.start();
+    }
+
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/view/ViewState.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/view/ViewState.java
@@ -22,6 +22,7 @@ public class ViewState {
         private String type;
         private String value;
         private String selectedDate;
+        private String selectedTime;
         private String selectedConversation;
         private String selectedChannel;
         private String selectedUser;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/payload/BlockActionPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/payload/BlockActionPayload.java
@@ -114,6 +114,10 @@ public class BlockActionPayload {
         private String selectedDate;
         private String initialDate;
 
+        // timepicker
+        private String selectedTime;
+        private String initialTime;
+
         // multi_static_select
         // multi_external_select
         private List<OptionObject> initialOptions;


### PR DESCRIPTION
`selected_time` field in block_actions / view_submission payloads was missing in the PR #613 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
