### PR TITLE
Bump dependency versions for v1.4.0 release

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>3.271.0</http4k.version>
+        <http4k.version>3.278.0</http4k.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>1.4.1</ktor.version>
+        <ktor.version>1.4.2</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,9 +10,8 @@
     </parent>
 
     <properties>
-        <micronaut.bom.version>2.1.2</micronaut.bom.version>
-        <micronaut.version>2.1.2</micronaut.version>
-        <micronaut-test-junit5.version>2.1.1</micronaut-test-junit5.version>
+        <micronaut.version>2.2.0</micronaut.version>
+        <micronaut-test-junit5.version>2.2.1</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>
 

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <quarkus.version>1.9.1.Final</quarkus.version>
+        <quarkus.version>1.10.1.Final</quarkus.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <!-- Quarkus 1.7+ requires Java 11+ -->

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -10,7 +10,8 @@
     </parent>
 
     <properties>
-        <quarkus.version>1.10.1.Final</quarkus.version>
+        <!-- TODO: Upgrade to 1.10 -->
+        <quarkus.version>1.9.2.Final</quarkus.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <!-- Quarkus 1.7+ requires Java 11+ -->

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.3.5.RELEASE</spring-boot.version>
+        <spring-boot.version>2.4.0</spring-boot.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,5 +11,5 @@ okhttpVersion: 4.9.0
 kotlinVersion: 1.4.20
 springBootVersion: 2.4.0
 compatibleMicronautVersion: 2.x
-quarkusVersion: 1.10.1.Final
+quarkusVersion: 1.9.2.Final
 helidonVersion: 2.1.0

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,8 +8,8 @@ url: https://slack.dev
 
 sdkLatestVersion: 1.3.2
 okhttpVersion: 4.9.0
-kotlinVersion: 1.4.10
-springBootVersion: 2.3.5.RELEASE
+kotlinVersion: 1.4.20
+springBootVersion: 2.4.0
 compatibleMicronautVersion: 2.x
-quarkusVersion: 1.9.1.Final
+quarkusVersion: 1.10.1.Final
 helidonVersion: 2.1.0

--- a/pom.xml
+++ b/pom.xml
@@ -48,13 +48,13 @@
         <lombok.version>1.18.16</lombok.version>
         <lombok-maven-plugin.version>1.18.16.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
-        <kotlin.version>1.4.10</kotlin.version>
+        <kotlin.version>1.4.20</kotlin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.893</aws.s3.version>
+        <aws.s3.version>1.11.908</aws.s3.version>
         <junit.version>4.13.1</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.6.0</mockito-core.version>
+        <mockito-core.version>3.6.28</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>


### PR DESCRIPTION
This pull request upgrades the dependency versions before v1.4 release. The affected libraries are:

* All Kotlin extensions - Kotlin version from 1.4.10 to 1.4.20
* Ktor from 1.4.1 to 1.4.2
* http4k from 3.271.0 to 3.278.0

Others are only for documents, examples, and tests.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
