### PR TITLE
[1.3.x] Add state field to block_actions payload #635

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/model/view/ViewState.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/view/ViewState.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 import java.util.Map;
 
+// For historical reasons, this class is under view package but it can be used for payloads
+// representing block_actions events in messages too.
 @Data
 @Builder
 @NoArgsConstructor

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/payload/BlockActionPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/payload/BlockActionPayload.java
@@ -6,6 +6,7 @@ import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.OptionObject;
 import com.slack.api.model.block.composition.PlainTextObject;
 import com.slack.api.model.view.View;
+import com.slack.api.model.view.ViewState;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -35,6 +36,7 @@ public class BlockActionPayload {
     private Message message;
     private String responseUrl;
     private View view;
+    private ViewState state; // for actions in a message
     private List<Action> actions;
 
     // TODO: app_unfurl

--- a/slack-app-backend/src/test/java/test_locally/app_backend/interactive_components/payload/BlockActionPayloadTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/interactive_components/payload/BlockActionPayloadTest.java
@@ -160,4 +160,76 @@ public class BlockActionPayloadTest {
         assertThat(payload.getContainer(), is(notNullValue()));
     }
 
+    String jsonWithState = "{\n" +
+            "  \"type\": \"block_actions\",\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"U111\",\n" +
+            "    \"username\": \"seratch\",\n" +
+            "    \"name\": \"seratch\",\n" +
+            "    \"team_id\": \"T111\"\n" +
+            "  },\n" +
+            "  \"api_app_id\": \"A111\",\n" +
+            "  \"token\": \"xxx\",\n" +
+            "  \"container\": {\n" +
+            "    \"type\": \"message\",\n" +
+            "    \"message_ts\": \"1606455372.001200\",\n" +
+            "    \"channel_id\": \"C111\",\n" +
+            "    \"is_ephemeral\": true\n" +
+            "  },\n" +
+            "  \"trigger_id\": \"111.222.xxx\",\n" +
+            "  \"team\": {\n" +
+            "    \"id\": \"T111\",\n" +
+            "    \"domain\": \"xxx\"\n" +
+            "  },\n" +
+            "  \"channel\": {\n" +
+            "    \"id\": \"C111\",\n" +
+            "    \"name\": \"random\"\n" +
+            "  },\n" +
+            "  \"state\": {\n" +
+            "    \"values\": {\n" +
+            "      \"block_1\": {\n" +
+            "        \"action_1\": {\n" +
+            "          \"type\": \"external_select\",\n" +
+            "          \"selected_option\": {\n" +
+            "            \"text\": {\n" +
+            "              \"type\": \"plain_text\",\n" +
+            "              \"text\": \"Schedule\",\n" +
+            "              \"emoji\": true\n" +
+            "            },\n" +
+            "            \"value\": \"schedule\"\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"response_url\": \"https://hooks.slack.com/actions/T111/111/xxx\",\n" +
+            "  \"actions\": [\n" +
+            "    {\n" +
+            "      \"action_id\": \"save\",\n" +
+            "      \"block_id\": \"block_1\",\n" +
+            "      \"text\": {\n" +
+            "        \"type\": \"plain_text\",\n" +
+            "        \"text\": \"Save\",\n" +
+            "        \"emoji\": true\n" +
+            "      },\n" +
+            "      \"value\": \"1\",\n" +
+            "      \"type\": \"button\",\n" +
+            "      \"action_ts\": \"1606455407.603639\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    @Test
+    public void state_in_messages() {
+        BlockActionPayload payload = GsonFactory.createSnakeCase().fromJson(jsonWithState, BlockActionPayload.class);
+        assertThat(payload.getType(), is("block_actions"));
+        assertThat(payload.getActions().size(), is(1));
+
+        assertThat(payload.getState().getValues()
+                .get("block_1")
+                .get("action_1")
+                .getSelectedOption().getValue(),
+                is("schedule"));
+    }
+
 }


### PR DESCRIPTION
This pull request fixes #635 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
