### PR TITLE
Added org-apps reference to docs

### DIFF
--- a/docs/guides/app-distribution.md
+++ b/docs/guides/app-distribution.md
@@ -17,6 +17,8 @@ To enable App Distribution, visit the [Slack App configuration page](http://api.
 
 For **Redirect URL**, Bolt apps respond to `https://{your app's public URL domain}/slack/oauth/callback` if you go with recommended settings. To know how to configure such settings, consult the list of the available env variables below in this page.
 
+Bolt for Java automatically includes support for [org wide installations](https://api.slack.com/enterprise/apps) since version `1.4.0`. Org wide installations can be enabled in your app configuration settings under **Org Level Apps**.
+
 ### What Your Bolt App Does
 
 All your app needs to do to properly handle OAuth Flow are:


### PR DESCRIPTION
Adding a blurb about upcoming org wide app installations

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
