### PR TITLE
Add more message events (channel_topic, group_topic sub types) #631

### DIFF
--- a/bolt-servlet/src/test/java/samples/EventsSample.java
+++ b/bolt-servlet/src/test/java/samples/EventsSample.java
@@ -4,9 +4,7 @@ import com.slack.api.app_backend.events.handler.MessageHandler;
 import com.slack.api.app_backend.events.payload.MessagePayload;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
-import com.slack.api.model.event.MessageBotEvent;
-import com.slack.api.model.event.MessageDeletedEvent;
-import com.slack.api.model.event.MessageEvent;
+import com.slack.api.model.event.*;
 import lombok.extern.slf4j.Slf4j;
 import util.ResourceLoader;
 import util.TestSlackAppServer;
@@ -29,6 +27,14 @@ public class EventsSample {
         });
         app.event(MessageDeletedEvent.class, (event, ctx) -> {
             ctx.logger.info("message deleted - {}", event);
+            return ctx.ack();
+        });
+        app.event(MessageChannelTopicEvent.class, (event, ctx) -> {
+            ctx.logger.info("channel topic - {}", event);
+            return ctx.ack();
+        });
+        app.event(MessageGroupTopicEvent.class, (event, ctx) -> {
+            ctx.logger.info("group topic - {}", event);
             return ctx.ack();
         });
 

--- a/json-logs/samples/events/MessageChannelTopicPayload.json
+++ b/json-logs/samples/events/MessageChannelTopicPayload.json
@@ -1,0 +1,28 @@
+{
+  "token": "",
+  "enterprise_id": "",
+  "team_id": "",
+  "api_app_id": "",
+  "type": "",
+  "authed_users": [
+    ""
+  ],
+  "authed_teams": [
+    ""
+  ],
+  "is_ext_shared_channel": false,
+  "event_id": "",
+  "event_time": 123,
+  "event_context": "",
+  "event": {
+    "type": "message",
+    "subtype": "channel_topic",
+    "user": "",
+    "team": "",
+    "channel": "",
+    "topic": "",
+    "text": "",
+    "ts": "",
+    "event_ts": ""
+  }
+}

--- a/json-logs/samples/events/MessageChannelTopicPayload.json
+++ b/json-logs/samples/events/MessageChannelTopicPayload.json
@@ -18,10 +18,10 @@
     "type": "message",
     "subtype": "channel_topic",
     "user": "",
-    "team": "",
     "channel": "",
-    "topic": "",
+    "channel_type": "",
     "text": "",
+    "topic": "",
     "ts": "",
     "event_ts": ""
   }

--- a/json-logs/samples/events/MessageGroupTopicPayload.json
+++ b/json-logs/samples/events/MessageGroupTopicPayload.json
@@ -1,0 +1,28 @@
+{
+  "token": "",
+  "enterprise_id": "",
+  "team_id": "",
+  "api_app_id": "",
+  "type": "",
+  "authed_users": [
+    ""
+  ],
+  "authed_teams": [
+    ""
+  ],
+  "is_ext_shared_channel": false,
+  "event_id": "",
+  "event_time": 123,
+  "event_context": "",
+  "event": {
+    "type": "message",
+    "subtype": "group_topic",
+    "user": "",
+    "team": "",
+    "channel": "",
+    "topic": "",
+    "text": "",
+    "ts": "",
+    "event_ts": ""
+  }
+}

--- a/json-logs/samples/events/MessageGroupTopicPayload.json
+++ b/json-logs/samples/events/MessageGroupTopicPayload.json
@@ -18,10 +18,10 @@
     "type": "message",
     "subtype": "group_topic",
     "user": "",
-    "team": "",
     "channel": "",
-    "topic": "",
+    "channel_type": "",
     "text": "",
+    "topic": "",
     "ts": "",
     "event_ts": ""
   }

--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageChannelTopicEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageChannelTopicEvent.java
@@ -15,11 +15,11 @@ public class MessageChannelTopicEvent implements Event {
 	private final String subtype = SUBTYPE_NAME;
 
 	private String user;
-	private String team;
 	private String channel;
+	private String channelType; // "channel"
 
-	private String topic;
 	private String text;
+	private String topic;
 
 	private String ts;
 	private String eventTs;

--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageChannelTopicEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageChannelTopicEvent.java
@@ -1,0 +1,26 @@
+package com.slack.api.model.event;
+
+import lombok.Data;
+
+/**
+ * https://api.slack.com/events/message/channel_topic
+ */
+@Data
+public class MessageChannelTopicEvent implements Event {
+
+	public static final String TYPE_NAME = "message";
+	public static final String SUBTYPE_NAME = "channel_topic";
+
+	private final String type = TYPE_NAME;
+	private final String subtype = SUBTYPE_NAME;
+
+	private String user;
+	private String team;
+	private String channel;
+
+	private String topic;
+	private String text;
+
+	private String ts;
+	private String eventTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageGroupTopicEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageGroupTopicEvent.java
@@ -1,0 +1,26 @@
+package com.slack.api.model.event;
+
+import lombok.Data;
+
+/**
+ * https://api.slack.com/events/message/group_topic
+ */
+@Data
+public class MessageGroupTopicEvent implements Event {
+
+	public static final String TYPE_NAME = "message";
+	public static final String SUBTYPE_NAME = "group_topic";
+
+	private final String type = TYPE_NAME;
+	private final String subtype = SUBTYPE_NAME;
+
+	private String user;
+	private String team;
+	private String channel;
+
+	private String topic;
+	private String text;
+
+	private String ts;
+	private String eventTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageGroupTopicEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageGroupTopicEvent.java
@@ -15,11 +15,11 @@ public class MessageGroupTopicEvent implements Event {
 	private final String subtype = SUBTYPE_NAME;
 
 	private String user;
-	private String team;
 	private String channel;
+	private String channelType; // "group"
 
-	private String topic;
 	private String text;
+	private String topic;
 
 	private String ts;
 	private String eventTs;

--- a/slack-api-model/src/test/java/test_locally/api/model/event/MessageChannelTopicEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/MessageChannelTopicEventTest.java
@@ -1,0 +1,36 @@
+package test_locally.api.model.event;
+
+import com.slack.api.model.event.MessageChannelTopicEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MessageChannelTopicEventTest {
+
+    @Test
+    public void typeName() {
+        assertThat(MessageChannelTopicEvent.TYPE_NAME, is("message"));
+        assertThat(MessageChannelTopicEvent.SUBTYPE_NAME, is("channel_topic"));
+    }
+
+    @Test
+    public void deserialize_simple() {
+        String json = "{\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"subtype\": \"channel_topic\",\n" +
+                "  \"ts\": \"1608102495.000300\",\n" +
+                "  \"user\": \"W111\",\n" +
+                "  \"text\": \"<@W111> set the topic: Non-work banter and water cooler conversation\",\n" +
+                "  \"topic\": \"Non-work banter and water cooler conversation\",\n" +
+                "  \"channel\": \"C111\",\n" +
+                "  \"event_ts\": \"1608102495.000300\",\n" +
+                "  \"channel_type\": \"channel\"\n" +
+                "}";
+        MessageChannelTopicEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageChannelTopicEvent.class);
+        assertThat(event.getType(), is("message"));
+        assertThat(event.getSubtype(), is("channel_topic"));
+    }
+
+}

--- a/slack-api-model/src/test/java/test_locally/api/model/event/MessageGroupTopicEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/MessageGroupTopicEventTest.java
@@ -1,0 +1,36 @@
+package test_locally.api.model.event;
+
+import com.slack.api.model.event.MessageGroupTopicEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MessageGroupTopicEventTest {
+
+    @Test
+    public void typeName() {
+        assertThat(MessageGroupTopicEvent.TYPE_NAME, is("message"));
+        assertThat(MessageGroupTopicEvent.SUBTYPE_NAME, is("group_topic"));
+    }
+
+    @Test
+    public void deserialize_simple() {
+        String json = "{\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"subtype\": \"group_topic\",\n" +
+                "  \"ts\": \"1608102528.000300\",\n" +
+                "  \"user\": \"W111\",\n" +
+                "  \"text\": \"<@W111> set the topic: topic!\",\n" +
+                "  \"topic\": \"topic!\",\n" +
+                "  \"channel\": \"G111\",\n" +
+                "  \"event_ts\": \"1608102528.000300\",\n" +
+                "  \"channel_type\": \"group\"\n" +
+                "}";
+        MessageGroupTopicEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageGroupTopicEvent.class);
+        assertThat(event.getType(), is("message"));
+        assertThat(event.getSubtype(), is("group_topic"));
+    }
+
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/MessageChannelTopicHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/MessageChannelTopicHandler.java
@@ -1,0 +1,18 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.MessageChannelTopicPayload;
+import com.slack.api.model.event.MessageChannelTopicEvent;
+
+public abstract class MessageChannelTopicHandler extends EventHandler<MessageChannelTopicPayload> {
+
+	@Override
+	public String getEventType() {
+		return MessageChannelTopicEvent.TYPE_NAME;
+	}
+
+	@Override
+	public String getEventSubtype() {
+		return MessageChannelTopicEvent.SUBTYPE_NAME;
+	}
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/MessageGroupTopicHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/MessageGroupTopicHandler.java
@@ -1,0 +1,18 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.MessageGroupTopicPayload;
+import com.slack.api.model.event.MessageGroupTopicEvent;
+
+public abstract class MessageGroupTopicHandler extends EventHandler<MessageGroupTopicPayload> {
+
+	@Override
+	public String getEventType() {
+		return MessageGroupTopicEvent.TYPE_NAME;
+	}
+
+	@Override
+	public String getEventSubtype() {
+		return MessageGroupTopicEvent.SUBTYPE_NAME;
+	}
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageChannelTopicPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageChannelTopicPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.MessageChannelTopicEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MessageChannelTopicPayload implements EventsApiPayload<MessageChannelTopicEvent> {
+
+	private String token;
+	private String enterpriseId;
+	private String teamId;
+	private String apiAppId;
+	private String type;
+	private List<String> authedUsers;
+	private List<String> authedTeams;
+	private List<Authorization> authorizations;
+	private boolean isExtSharedChannel;
+	private String eventId;
+	private Integer eventTime;
+	private String eventContext;
+
+	private MessageChannelTopicEvent event;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageGroupTopicPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageGroupTopicPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.MessageGroupTopicEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MessageGroupTopicPayload implements EventsApiPayload<MessageGroupTopicEvent> {
+
+	private String token;
+	private String enterpriseId;
+	private String teamId;
+	private String apiAppId;
+	private String type;
+	private List<String> authedUsers;
+	private List<String> authedTeams;
+	private List<Authorization> authorizations;
+	private boolean isExtSharedChannel;
+	private String eventId;
+	private Integer eventTime;
+	private String eventContext;
+
+	private MessageGroupTopicEvent event;
+}

--- a/slack-app-backend/src/test/java/test_locally/app_backend/events/EventHandlersTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/events/EventHandlersTest.java
@@ -15,7 +15,7 @@ public class EventHandlersTest {
 
     @Test
     public void handlers() {
-        List<EventHandler<?>> handlers = Arrays.asList(
+        List<EventHandler<?>> handlersWithoutSubtype = Arrays.asList(
                 new ImCloseHandler() {
                     @Override
                     public void handle(ImClosePayload payload) {
@@ -347,9 +347,28 @@ public class EventHandlersTest {
                     }
                 }
         );
-        for (EventHandler<?> handler : handlers) {
+
+        for (EventHandler<?> handler : handlersWithoutSubtype) {
             assertNotNull(handler.getEventType());
             assertNull(handler.getEventSubtype());
+        }
+
+        List<EventHandler<?>> handlersWithSubtype = Arrays.asList(
+                new MessageGroupTopicHandler() {
+                    @Override
+                    public void handle(MessageGroupTopicPayload payload) {
+                    }
+                },
+                new MessageChannelTopicHandler() {
+                    @Override
+                    public void handle(MessageChannelTopicPayload payload) {
+                    }
+                }
+        );
+
+        for (EventHandler<?> handler : handlersWithSubtype) {
+            assertNotNull(handler.getEventType());
+            assertNotNull(handler.getEventSubtype());
         }
     }
 

--- a/slack-app-backend/src/test/java/test_locally/sample_json_generation/EventsApiPayloadDumpTest.java
+++ b/slack-app-backend/src/test/java/test_locally/sample_json_generation/EventsApiPayloadDumpTest.java
@@ -101,7 +101,9 @@ public class EventsApiPayloadDumpTest {
                 new UserChangePayload(),
                 buildUserResourceDeniedPayload(),
                 buildUserResourceGrantedPayload(),
-                new UserResourceRemovedPayload()
+                new UserResourceRemovedPayload(),
+                new MessageGroupTopicPayload(),
+                new MessageChannelTopicPayload()
         );
         for (EventsApiPayload<?> payload : payloads) {
             try {


### PR DESCRIPTION
This pull request adds more message events to the payload data definition. thanks @gaspardpetit

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
