### PR TITLE
[1.5.x] Bump dependency versions

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <helidon.version>2.1.0</helidon.version>
+        <helidon.version>2.2.0</helidon.version>
         <!-- Helidon 2.x requires Java 11+ -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>3.283.0</http4k.version>
+        <http4k.version>3.285.1</http4k.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>1.4.3</ktor.version>
+        <ktor.version>1.5.0</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,8 +10,8 @@
     </parent>
 
     <properties>
-        <micronaut.version>2.2.1</micronaut.version>
-        <micronaut-test-junit5.version>2.3.0</micronaut-test-junit5.version>
+        <micronaut.version>2.2.2</micronaut.version>
+        <micronaut-test-junit5.version>2.3.1</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
         <lombok.version>1.18.16</lombok.version>
         <lombok-maven-plugin.version>1.18.16.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
-        <kotlin.version>1.4.21</kotlin.version>
+        <kotlin.version>1.4.21-2</kotlin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.919</aws.s3.version>
+        <aws.s3.version>1.11.930</aws.s3.version>
         <junit.version>4.13.1</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -18,7 +18,7 @@
         <javax.websocket-api.version>1.1</javax.websocket-api.version>
         <!-- TODO upgrade to 2.0 in the next minor version -->
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
-        <jedis.version>3.4.0</jedis.version>
+        <jedis.version>3.4.1</jedis.version>
         <jedis-mock.version>0.1.16</jedis-mock.version>
     </properties>
 


### PR DESCRIPTION
This pull request upgrades minor/patch versions of dependencies as below:

* [bolt-helidon] Helidon SE from 2.1 to 2.2
* [bolt-http4k] HTTP4K to the latest of 3.x
* [bolt-ktor] Ktor from 1.4 to 1.5
* [bolt-micronaut] Micronaut from 2.2.1 to 2.2.2
* [all Kotlin modules] Kotlin language from 1.4.21 to 1.4.21-2
* [slack-api-client] Jedis from 3.4.0 to 3.4.1 (optional dependency)

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
