### PR TITLE
Fix #643 Warn when chat.postMessage is called without `text` argument

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -932,6 +932,7 @@ public class RequestFormBuilder {
     public static FormBody.Builder toForm(ChatMeMessageRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("channel", req.getChannel(), form);
+        // We don't use #setTextAndWarnIfMissing for this because text here is required
         setIfNotNull("text", req.getText(), form);
         return form;
     }
@@ -940,7 +941,7 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("channel", req.getChannel(), form);
         setIfNotNull("post_at", req.getPostAt(), form);
-        setIfNotNull("text", req.getText(), form);
+        setTextAndWarnIfMissing("chat.scheduleMessage",req.getText(), form);
         setIfNotNull("as_user", req.isAsUser(), form);
 
         if (req.getBlocksAsString() != null) {
@@ -982,7 +983,7 @@ public class RequestFormBuilder {
     public static FormBody.Builder toForm(ChatPostEphemeralRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("channel", req.getChannel(), form);
-        setIfNotNull("text", req.getText(), form);
+        setTextAndWarnIfMissing("chat.postEphemeral", req.getText(), form);
         setIfNotNull("user", req.getUser(), form);
         setIfNotNull("as_user", req.isAsUser(), form);
 
@@ -1015,7 +1016,7 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("channel", req.getChannel(), form);
         setIfNotNull("thread_ts", req.getThreadTs(), form);
-        setIfNotNull("text", req.getText(), form);
+        setTextAndWarnIfMissing("chat.postMessage", req.getText(), form);
         setIfNotNull("parse", req.getParse(), form);
         setIfNotNull("link_names", req.isLinkNames(), form);
         setIfNotNull("mrkdwn", req.isMrkdwn(), form);
@@ -1051,7 +1052,7 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("ts", req.getTs(), form);
         setIfNotNull("channel", req.getChannel(), form);
-        setIfNotNull("text", req.getText(), form);
+        setTextAndWarnIfMissing("chat.update", req.getText(), form);
         setIfNotNull("parse", req.getParse(), form);
         setIfNotNull("link_names", req.isLinkNames(), form);
 
@@ -2163,6 +2164,13 @@ public class RequestFormBuilder {
     // ----------------------------------------------------------------------------------
     // internal methods
     // ----------------------------------------------------------------------------------
+
+    private static void setTextAndWarnIfMissing(String endpointName, String value, FormBody.Builder form) {
+        if (value == null || value.trim().isEmpty()) {
+            log.warn("The `text` argument is missing in the request payload for a {} call - It's a best practice to always provide a text argument when posting a message. The `text` is used in places where `blocks` cannot be rendered such as: system push notifications, assistive technology such as screen readers, etc.", endpointName);
+        }
+        setIfNotNull("text", value, form);
+    }
 
     private static void setIfNotNull(String name, Object value, FormBody.Builder form) {
         if (value != null) {

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
@@ -791,4 +791,28 @@ public class chat_Test {
         assertThat(message.isOk(), is(true));
     }
 
+    // 2021-01-05 14:38:54,767 WARN [main] com.slack.api.methods.RequestFormBuilder The `text` argument is missing in the request payload for a chat.postMessage call - It's a best practice to always provide a text argument when posting a message. The `text` is used in places where `blocks` cannot be rendered such as: system push notifications, assistive technology such as screen readers, etc.
+    // 2021-01-05 14:38:55,055 WARN [main] com.slack.api.methods.RequestFormBuilder The `text` argument is missing in the request payload for a chat.update call - It's a best practice to always provide a text argument when posting a message. The `text` is used in places where `blocks` cannot be rendered such as: system push notifications, assistive technology such as screen readers, etc.
+    @Test
+    public void textWarnings() throws Exception {
+        loadRandomChannelId();
+
+        ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+                .token(botToken)
+                .channel(randomChannelId)
+                .text(null)
+                .blocksAsString(blocksAsString)
+                .build());
+        assertThat(postResponse.getError(), is(nullValue()));
+
+        ChatUpdateResponse updateMessage = slack.methods().chatUpdate(ChatUpdateRequest.builder()
+                .channel(randomChannelId)
+                .token(botToken)
+                .ts(postResponse.getTs())
+                .text(null)
+                .blocksAsString(blocksAsString)
+                .build());
+        assertThat(updateMessage.getError(), is(nullValue()));
+    }
+
 }


### PR DESCRIPTION
This pull request fixes #643 by adding warning logs in the case where `text` parameter is missing.

* chat.postMessage
* chat.postEphemeral
* chat.scheduleMessage
* chat.update

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
