### PR TITLE
Fix #660 Add thread_ts to MessageBotEvent

### DIFF
--- a/json-logs/samples/events/MessageBotPayload.json
+++ b/json-logs/samples/events/MessageBotPayload.json
@@ -673,6 +673,7 @@
         }
       }
     ],
+    "thread_ts": "",
     "ts": "",
     "event_ts": "",
     "channel_type": ""

--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageBotEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageBotEvent.java
@@ -29,6 +29,7 @@ public class MessageBotEvent implements Event {
     private List<LayoutBlock> blocks;
     private List<Attachment> attachments;
 
+    private String threadTs;
     private String ts;
 
     private String eventTs;

--- a/slack-api-model/src/test/java/test_locally/api/model/event/MessageEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/MessageEventTest.java
@@ -198,6 +198,33 @@ public class MessageEventTest {
     }
 
     @Test
+    public void deserialize_botMessage_thread_ts() {
+        String json = "{\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"subtype\": \"bot_message\",\n" +
+                "  \"text\": \"Let's make a pact.\",\n" +
+                "  \"ts\": \"1610402265.000300\",\n" +
+                "  \"username\": \"classic-app-test\",\n" +
+                "  \"bot_id\": \"B111\",\n" +
+                "  \"thread_ts\": \"1610402224.000200\",\n" +
+                "  \"channel\": \"C111\",\n" +
+                "  \"event_ts\": \"1610402265.000300\",\n" +
+                "  \"channel_type\": \"channel\"\n" +
+                "}\n";
+        MessageBotEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageBotEvent.class);
+        assertThat(event.getType(), is("message"));
+        assertThat(event.getSubtype(), is("bot_message"));
+        assertThat(event.getChannel(), is("C111"));
+        assertThat(event.getText(), is("Let's make a pact."));
+        assertThat(event.getTs(), is("1610402265.000300"));
+        assertThat(event.getEventTs(), is("1610402265.000300"));
+        assertThat(event.getChannelType(), is("channel"));
+        assertThat(event.getUsername(), is("classic-app-test"));
+        assertThat(event.getBotId(), is("B111"));
+        assertThat(event.getThreadTs(), is("1610402224.000200"));
+    }
+
+    @Test
     public void serialize_simple() {
         Gson gson = GsonFactory.createSnakeCase();
         MessageEvent event = new MessageEvent();


### PR DESCRIPTION
This pull request fixes #660 by adding `thread_ts` to the `MessageBotEvent` class. The example payload in the test is the one based on a real payload.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
