### PR TITLE
Fix #662 by correcting data class for option_groups response

### DIFF
--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/response/OptionGroup.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/response/OptionGroup.java
@@ -1,5 +1,6 @@
 package com.slack.api.app_backend.interactive_components.response;
 
+import com.slack.api.model.block.composition.TextObject;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,6 +13,6 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class OptionGroup {
-    private String label;
+    private TextObject label;
     private List<Option> options;
 }

--- a/slack-app-backend/src/test/java/test_locally/app_backend/interactive_components/response/BlockSuggestionResponseTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/interactive_components/response/BlockSuggestionResponseTest.java
@@ -1,0 +1,94 @@
+package test_locally.app_backend.interactive_components.response;
+
+import com.slack.api.app_backend.interactive_components.response.BlockSuggestionResponse;
+import com.slack.api.app_backend.interactive_components.response.OptionGroup;
+import com.slack.api.model.block.composition.PlainTextObject;
+import com.slack.api.util.json.GsonFactory;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class BlockSuggestionResponseTest {
+
+    // https://api.slack.com/reference/block-kit/composition-objects#option_group
+    @Test
+    public void optionGroups() {
+        String json = "{\n" +
+                "  \"option_groups\": [\n" +
+                "    {\n" +
+                "      \"label\": {\n" +
+                "        \"type\": \"plain_text\",\n" +
+                "        \"text\": \"Group 1\"\n" +
+                "      },\n" +
+                "      \"options\": [\n" +
+                "        {\n" +
+                "          \"text\": {\n" +
+                "            \"type\": \"plain_text\",\n" +
+                "            \"text\": \"*this is plain_text text*\"\n" +
+                "          },\n" +
+                "          \"value\": \"value-0\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"text\": {\n" +
+                "            \"type\": \"plain_text\",\n" +
+                "            \"text\": \"*this is plain_text text*\"\n" +
+                "          },\n" +
+                "          \"value\": \"value-1\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"text\": {\n" +
+                "            \"type\": \"plain_text\",\n" +
+                "            \"text\": \"*this is plain_text text*\"\n" +
+                "          },\n" +
+                "          \"value\": \"value-2\"\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"label\": {\n" +
+                "        \"type\": \"plain_text\",\n" +
+                "        \"text\": \"Group 2\"\n" +
+                "      },\n" +
+                "      \"options\": [\n" +
+                "        {\n" +
+                "          \"text\": {\n" +
+                "            \"type\": \"plain_text\",\n" +
+                "            \"text\": \"*this is plain_text text*\"\n" +
+                "          },\n" +
+                "          \"value\": \"value-3\"\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n";
+        BlockSuggestionResponse response = GsonFactory.createSnakeCase().fromJson(json, BlockSuggestionResponse.class);
+        assertThat(response.getOptionGroups().size(), is(2));
+
+        OptionGroup optionGroup = response.getOptionGroups().get(0);
+        PlainTextObject label = (PlainTextObject) optionGroup.getLabel();
+        assertThat(label.getText(), is("Group 1"));
+    }
+
+    @Test
+    public void options() {
+        String json = "{\n" +
+                "  \"options\": [\n" +
+                "    {\n" +
+                "      \"text\": {\n" +
+                "        \"type\": \"plain_text\",\n" +
+                "        \"text\": \"*this is plain_text text*\"\n" +
+                "      },\n" +
+                "      \"value\": \"value-3\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n";
+
+        BlockSuggestionResponse response = GsonFactory.createSnakeCase().fromJson(json, BlockSuggestionResponse.class);
+        assertThat(response.getOptions().size(), is(1));
+
+        PlainTextObject text = (PlainTextObject) response.getOptions().get(0).getText();
+        assertThat(text.getText(), is("*this is plain_text text*"));
+    }
+
+}


### PR DESCRIPTION
This pull request fixes #662 by correcting the data class for options response. As this is a blocker issue for Bolt users, I will shortly release a hotfix version today.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
