### PR TITLE
Add support for four workflow events

### DIFF
--- a/bolt-servlet/src/test/java/samples/WorkflowStepListenersSample.java
+++ b/bolt-servlet/src/test/java/samples/WorkflowStepListenersSample.java
@@ -4,6 +4,10 @@ import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.views.ViewsOpenResponse;
+import com.slack.api.model.event.WorkflowDeletedEvent;
+import com.slack.api.model.event.WorkflowPublishedEvent;
+import com.slack.api.model.event.WorkflowStepDeletedEvent;
+import com.slack.api.model.event.WorkflowUnpublishedEvent;
 import com.slack.api.model.view.ViewState;
 import com.slack.api.model.workflow.WorkflowStepExecution;
 import com.slack.api.model.workflow.WorkflowStepInput;
@@ -93,6 +97,26 @@ public class WorkflowStepListenersSample {
                     }
                 }
             });
+            return ctx.ack();
+        });
+
+        app.event(WorkflowDeletedEvent.class, (req, ctx) -> {
+            ctx.logger.info("workflow deleted - {}", req);
+            return ctx.ack();
+        });
+
+        app.event(WorkflowPublishedEvent.class, (req, ctx) -> {
+            ctx.logger.info("workflow published - {}", req);
+            return ctx.ack();
+        });
+
+        app.event(WorkflowUnpublishedEvent.class, (req, ctx) -> {
+            ctx.logger.info("workflow unpublished - {}", req);
+            return ctx.ack();
+        });
+
+        app.event(WorkflowStepDeletedEvent.class, (req, ctx) -> {
+            ctx.logger.info("workflow step deleted - {}", req);
             return ctx.ack();
         });
 

--- a/slack-api-model/src/main/java/com/slack/api/model/AppStep.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/AppStep.java
@@ -1,0 +1,11 @@
+package com.slack.api.model;
+
+import lombok.Data;
+
+@Data
+public class AppStep {
+
+    private String appId;
+    private String workflowStepId;
+    private String callbackId;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/WorkflowDeletedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/WorkflowDeletedEvent.java
@@ -1,0 +1,20 @@
+package com.slack.api.model.event;
+
+import com.slack.api.model.workflow.WorkflowDraftConfiguration;
+import lombok.Data;
+
+/**
+ * A workflow that contains a step supported by your app was deleted
+ *
+ * https://api.slack.com/events/workflow_deleted
+ */
+@Data
+public class WorkflowDeletedEvent implements Event {
+
+    public static final String TYPE_NAME = "workflow_deleted";
+
+    private final String type = TYPE_NAME;
+    private String workflowId;
+    private WorkflowDraftConfiguration workflowDraftConfiguration;
+    private String eventTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/WorkflowPublishedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/WorkflowPublishedEvent.java
@@ -1,0 +1,21 @@
+package com.slack.api.model.event;
+
+import com.slack.api.model.workflow.WorkflowDraftConfiguration;
+import com.slack.api.model.workflow.WorkflowPublishedConfiguration;
+import lombok.Data;
+
+/**
+ * A workflow that contains a step supported by your app was published
+ *
+ * https://api.slack.com/events/workflow_published
+ */
+@Data
+public class WorkflowPublishedEvent implements Event {
+
+    public static final String TYPE_NAME = "workflow_published";
+
+    private final String type = TYPE_NAME;
+    private String workflowId;
+    private WorkflowPublishedConfiguration workflowPublishedConfiguration;
+    private String eventTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/WorkflowStepDeletedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/WorkflowStepDeletedEvent.java
@@ -1,0 +1,22 @@
+package com.slack.api.model.event;
+
+import com.slack.api.model.workflow.WorkflowDraftConfiguration;
+import com.slack.api.model.workflow.WorkflowPublishedConfiguration;
+import lombok.Data;
+
+/**
+ * A workflow step supported by your app was removed from a workflow
+ *
+ * https://api.slack.com/events/workflow_step_deleted
+ */
+@Data
+public class WorkflowStepDeletedEvent implements Event {
+
+    public static final String TYPE_NAME = "workflow_step_deleted";
+
+    private final String type = TYPE_NAME;
+    private String workflowId;
+    private WorkflowDraftConfiguration workflowDraftConfiguration;
+    private WorkflowPublishedConfiguration workflowPublishedConfiguration;
+    private String eventTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/WorkflowUnpublishedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/WorkflowUnpublishedEvent.java
@@ -1,0 +1,20 @@
+package com.slack.api.model.event;
+
+import com.slack.api.model.workflow.WorkflowDraftConfiguration;
+import lombok.Data;
+
+/**
+ * A workflow that contains a step supported by your app was unpublished
+ *
+ * https://api.slack.com/events/workflow_unpublished
+ */
+@Data
+public class WorkflowUnpublishedEvent implements Event {
+
+    public static final String TYPE_NAME = "workflow_unpublished";
+
+    private final String type = TYPE_NAME;
+    private String workflowId;
+    private WorkflowDraftConfiguration workflowDraftConfiguration;
+    private String eventTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/workflow/AppStep.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/workflow/AppStep.java
@@ -1,4 +1,4 @@
-package com.slack.api.model;
+package com.slack.api.model.workflow;
 
 import lombok.Data;
 

--- a/slack-api-model/src/main/java/com/slack/api/model/workflow/WorkflowDraftConfiguration.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/workflow/WorkflowDraftConfiguration.java
@@ -1,6 +1,5 @@
 package com.slack.api.model.workflow;
 
-import com.slack.api.model.AppStep;
 import lombok.Data;
 
 import java.util.List;

--- a/slack-api-model/src/main/java/com/slack/api/model/workflow/WorkflowDraftConfiguration.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/workflow/WorkflowDraftConfiguration.java
@@ -1,0 +1,13 @@
+package com.slack.api.model.workflow;
+
+import com.slack.api.model.AppStep;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class WorkflowDraftConfiguration {
+
+    private String versionId;
+    private List<AppStep> appSteps;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/workflow/WorkflowPublishedConfiguration.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/workflow/WorkflowPublishedConfiguration.java
@@ -1,0 +1,13 @@
+package com.slack.api.model.workflow;
+
+import com.slack.api.model.AppStep;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class WorkflowPublishedConfiguration {
+
+    private String versionId;
+    private List<AppStep> appSteps;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/workflow/WorkflowPublishedConfiguration.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/workflow/WorkflowPublishedConfiguration.java
@@ -1,6 +1,5 @@
 package com.slack.api.model.workflow;
 
-import com.slack.api.model.AppStep;
 import lombok.Data;
 
 import java.util.List;

--- a/slack-api-model/src/test/java/test_locally/api/model/event/WorkflowDeletedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/WorkflowDeletedEventTest.java
@@ -1,0 +1,54 @@
+package test_locally.api.model.event;
+
+import com.google.gson.Gson;
+import com.slack.api.model.event.WorkflowDeletedEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class WorkflowDeletedEventTest {
+
+    @Test
+    public void typeName() {
+        assertThat(WorkflowDeletedEvent.TYPE_NAME, is("workflow_deleted"));
+    }
+
+    @Test
+    public void deserialize() {
+        String json = "{\n" +
+                "    \"type\": \"workflow_deleted\",\n" +
+                "    \"workflow_id\": \"338772933017143757\",\n" +
+                "    \"workflow_draft_configuration\": {\n" +
+                "        \"version_id\": \"338776445998336786\",\n" +
+                "        \"app_steps\": [\n" +
+                "            {\n" +
+                "                \"app_id\": \"A012VT792TC\",\n" +
+                "                \"workflow_step_id\": \"def5f7a2-365f-42e9-8ab8-26f9e9716696\",\n" +
+                "                \"callback_id\": \"take_two\"\n" +
+                "            },\n" +
+                "            {\n" +
+                "                \"app_id\": \"A012VT792TC\",\n" +
+                "                \"workflow_step_id\": \"19dab8c3-c062-43f7-a912-a69da0cf0bc0\",\n" +
+                "                \"callback_id\": \"take_three\"\n" +
+                "            }\n" +
+                "        ]\n" +
+                "    },\n" +
+                "    \"event_ts\": \"1611456217.716570\"\n" +
+                "}";
+        WorkflowDeletedEvent deletedEvent = GsonFactory.createSnakeCase().fromJson(json, WorkflowDeletedEvent.class);
+        assertThat(deletedEvent.getType(), is("workflow_deleted"));
+    }
+
+    @Test
+    public void serialize() {
+        Gson gson = GsonFactory.createSnakeCase();
+        WorkflowDeletedEvent deletedEvent = new WorkflowDeletedEvent();
+        deletedEvent.setWorkflowId("338772933017143757");
+        deletedEvent.setEventTs("1611456217.716570");
+        String generatedJson = gson.toJson(deletedEvent);
+        String expectedJson = "{\"type\":\"workflow_deleted\",\"workflow_id\":\"338772933017143757\",\"event_ts\":\"1611456217.716570\"}";
+        assertThat(generatedJson, is(expectedJson));
+    }
+}

--- a/slack-api-model/src/test/java/test_locally/api/model/event/WorkflowPublishedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/WorkflowPublishedEventTest.java
@@ -1,0 +1,56 @@
+package test_locally.api.model.event;
+
+import com.google.gson.Gson;
+import com.slack.api.model.event.WorkflowPublishedEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class WorkflowPublishedEventTest {
+
+    @Test
+    public void typeName() {
+        assertThat(WorkflowPublishedEvent.TYPE_NAME, is("workflow_published"));
+    }
+
+    @Test
+    public void deserialize() {
+        String json = "{\n" +
+                "   \"type\": \"workflow_published\",\n" +
+                "   \"workflow_id\": \"338772933017143757\",\n" +
+                "   \"workflow_published_configuration\": {\n" +
+                "      \"version_id\": \"338776445998336786\",\n" +
+                "      \"app_steps\": [\n" +
+                "         {\n" +
+                "            \"app_id\": \"A012VT792TC\",\n" +
+                "            \"workflow_step_id\": \"def5f7a2-365f-42e9-8ab8-26f9e9716696\",\n" +
+                "            \"callback_id\": \"take_two\"\n" +
+                "         },\n" +
+                "         {\n" +
+                "            \"app_id\": \"A012VT792TC\",\n" +
+                "            \"workflow_step_id\": \"19dab8c3-c062-43f7-a912-a69da0cf0bc0\",\n" +
+                "            \"callback_id\": \"take_three\"\n" +
+                "         }\n" +
+                "      ]\n" +
+                "   },\n" +
+                "   \"event_ts\": \"1611456104.5588\"\n" +
+                "}";
+
+        WorkflowPublishedEvent publishedEvent = GsonFactory.createSnakeCase().fromJson(json, WorkflowPublishedEvent.class);
+        assertThat(publishedEvent.getType(), is("workflow_published"));
+    }
+
+    @Test
+    public void serialize() {
+        Gson gson = GsonFactory.createSnakeCase();
+        WorkflowPublishedEvent publishedEvent = new WorkflowPublishedEvent();
+        publishedEvent.setWorkflowId("338772933017143757");
+        publishedEvent.setEventTs("1611456104.5588");
+        String generatedJson = gson.toJson(publishedEvent);
+        String expectedJson = "{\"type\":\"workflow_published\",\"workflow_id\":\"338772933017143757\",\"event_ts\":\"1611456104.5588\"}";
+
+        assertThat(generatedJson, is(expectedJson));
+    }
+}

--- a/slack-api-model/src/test/java/test_locally/api/model/event/WorkflowStepDeletedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/WorkflowStepDeletedEventTest.java
@@ -1,0 +1,72 @@
+package test_locally.api.model.event;
+
+import com.google.gson.Gson;
+import com.slack.api.model.event.WorkflowStepDeletedEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class WorkflowStepDeletedEventTest {
+
+    @Test
+    public void typeName() {assertThat(WorkflowStepDeletedEvent.TYPE_NAME, is("workflow_step_deleted"));}
+
+    @Test
+    public void deserialize() {
+        String json = "{\n" +
+                "   \"type\": \"workflow_step_deleted\",\n" +
+                "   \"workflow_id\": \"338772933017143757\",\n" +
+                "   \"workflow_draft_configuration\": {\n" +
+                "      \"version_id\": \"338776577011617206\",\n" +
+                "      \"app_steps\": [\n" +
+                "         {\n" +
+                "            \"app_id\": \"A012VT792TC\",\n" +
+                "            \"workflow_step_id\": \"def5f7a2-365f-42e9-8ab8-26f9e9716696\",\n" +
+                "            \"callback_id\": \"take_two\"\n" +
+                "         },\n" +
+                "         {\n" +
+                "            \"app_id\": \"A012VT792TC\",\n" +
+                "            \"workflow_step_id\": \"19dab8c3-c062-43f7-a912-a69da0cf0bc0\",\n" +
+                "            \"callback_id\": \"take_three\"\n" +
+                "         }\n" +
+                "      ]\n" +
+                "   },\n" +
+                "   \"workflow_published_configuration\": {\n" +
+                "      \"version_id\": \"338776445998336786\",\n" +
+                "      \"app_steps\": [\n" +
+                "         {\n" +
+                "            \"app_id\": \"A012VT792TC\",\n" +
+                "            \"workflow_step_id\": \"def5f7a2-365f-42e9-8ab8-26f9e9716696\",\n" +
+                "            \"callback_id\": \"take_two\"\n" +
+                "         },\n" +
+                "         {\n" +
+                "            \"app_id\": \"A012VT792TC\",\n" +
+                "            \"workflow_step_id\": \"19dab8c3-c062-43f7-a912-a69da0cf0bc0\",\n" +
+                "            \"callback_id\": \"take_three\"\n" +
+                "         },\n" +
+                "         {\n" +
+                "            \"app_id\": \"A012VT792TC\",\n" +
+                "            \"workflow_step_id\": \"e9f8c121-de29-4d37-9e00-5204663a1b4d\",\n" +
+                "            \"callback_id\": \"take_four\"\n" +
+                "         }\n" +
+                "      ]\n" +
+                "   },\n" +
+                "   \"event_ts\": \"1611456175.413379\"\n" +
+                "}";
+        WorkflowStepDeletedEvent stepDeletedEvent = GsonFactory.createSnakeCase().fromJson(json, WorkflowStepDeletedEvent.class);
+        assertThat(stepDeletedEvent.getType(), is("workflow_step_deleted"));
+    }
+
+    @Test
+    public void serialize() {
+        Gson gson = GsonFactory.createSnakeCase();
+        WorkflowStepDeletedEvent stepDeletedEvent = new WorkflowStepDeletedEvent();
+        stepDeletedEvent.setWorkflowId("338772933017143757");
+        stepDeletedEvent.setEventTs("1611456175.413379");
+        String generatedJson = gson.toJson(stepDeletedEvent);
+        String expectedJson = "{\"type\":\"workflow_step_deleted\",\"workflow_id\":\"338772933017143757\",\"event_ts\":\"1611456175.413379\"}";
+        assertThat(generatedJson, is(expectedJson));
+    }
+}

--- a/slack-api-model/src/test/java/test_locally/api/model/event/WorkflowUnpublishedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/WorkflowUnpublishedEventTest.java
@@ -1,0 +1,52 @@
+package test_locally.api.model.event;
+
+import com.google.gson.Gson;
+import com.slack.api.model.event.WorkflowUnpublishedEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class WorkflowUnpublishedEventTest {
+
+    @Test
+    public void typeName() {assertThat(WorkflowUnpublishedEvent.TYPE_NAME, is("workflow_unpublished"));}
+
+    @Test
+    public void deserialize() {
+        String json = "{\n" +
+                "   \"type\": \"workflow_unpublished\",\n" +
+                "   \"workflow_id\": \"338772933017143757\",\n" +
+                "   \"workflow_draft_configuration\":{\n" +
+                "      \"version_id\": \"338776445998336786\",\n" +
+                "      \"app_steps\":[\n" +
+                "         {\n" +
+                "            \"app_id\": \"A012VT792TC\",\n" +
+                "            \"workflow_step_id\": \"def5f7a2-365f-42e9-8ab8-26f9e9716696\",\n" +
+                "            \"callback_id\": \"take_two\"\n" +
+                "         },\n" +
+                "         {\n" +
+                "            \"app_id\": \"A012VT792TC\",\n" +
+                "            \"workflow_step_id\": \"19dab8c3-c062-43f7-a912-a69da0cf0bc0\",\n" +
+                "            \"callback_id\": \"take_three\"\n" +
+                "         }\n" +
+                "      ]\n" +
+                "   },\n" +
+                "   \"event_ts\": \"1611456137.967843\"\n" +
+                "}";
+        WorkflowUnpublishedEvent unpublishedEvent = GsonFactory.createSnakeCase().fromJson(json, WorkflowUnpublishedEvent.class);
+        assertThat(unpublishedEvent.getType(), is("workflow_unpublished"));
+    }
+
+    @Test
+    public void serialize() {
+        Gson gson = GsonFactory.createSnakeCase();
+        WorkflowUnpublishedEvent unpublishedEvent = new WorkflowUnpublishedEvent();
+        unpublishedEvent.setWorkflowId("338772933017143757");
+        unpublishedEvent.setEventTs("1611456137.967843");
+        String generateJson = gson.toJson(unpublishedEvent);
+        String expectedJson = "{\"type\":\"workflow_unpublished\",\"workflow_id\":\"338772933017143757\",\"event_ts\":\"1611456137.967843\"}";
+        assertThat(generateJson, is(expectedJson));
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/WorkflowDeletedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/WorkflowDeletedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.WorkflowDeletedPayload;
+import com.slack.api.model.event.WorkflowDeletedEvent;
+
+public abstract class WorkflowDeletedHandler extends EventHandler<WorkflowDeletedPayload> {
+
+    @Override
+    public String getEventType() {
+        return WorkflowDeletedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/WorkflowPublishedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/WorkflowPublishedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.WorkflowPublishedPayload;
+import com.slack.api.model.event.WorkflowPublishedEvent;
+
+public abstract class WorkflowPublishedHandler extends EventHandler<WorkflowPublishedPayload> {
+
+    @Override
+    public String getEventType() {
+        return WorkflowPublishedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/WorkflowStepDeletedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/WorkflowStepDeletedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.WorkflowStepDeletedPayload;
+import com.slack.api.model.event.WorkflowStepDeletedEvent;
+
+public abstract class WorkflowStepDeletedHandler extends EventHandler<WorkflowStepDeletedPayload> {
+
+    @Override
+    public String getEventType() {
+        return WorkflowStepDeletedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/WorkflowUnpublishedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/WorkflowUnpublishedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.WorkflowPublishedPayload;
+import com.slack.api.model.event.WorkflowUnpublishedEvent;
+
+public abstract class WorkflowUnpublishedHandler extends EventHandler<WorkflowPublishedPayload> {
+
+    @Override
+    public String getEventType() {
+        return WorkflowUnpublishedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/WorkflowDeletedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/WorkflowDeletedPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.WorkflowDeletedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class WorkflowDeletedPayload implements EventsApiPayload<WorkflowDeletedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private WorkflowDeletedEvent event;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/WorkflowPublishedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/WorkflowPublishedPayload.java
@@ -1,0 +1,26 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.WorkflowDeletedEvent;
+import com.slack.api.model.event.WorkflowPublishedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class WorkflowPublishedPayload implements EventsApiPayload<WorkflowPublishedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private WorkflowPublishedEvent event;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/WorkflowStepDeletedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/WorkflowStepDeletedPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.WorkflowStepDeletedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class WorkflowStepDeletedPayload implements EventsApiPayload<WorkflowStepDeletedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private WorkflowStepDeletedEvent event;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/WorkflowUnpublishedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/WorkflowUnpublishedPayload.java
@@ -1,0 +1,26 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.WorkflowStepDeletedEvent;
+import com.slack.api.model.event.WorkflowUnpublishedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class WorkflowUnpublishedPayload implements EventsApiPayload<WorkflowUnpublishedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private WorkflowUnpublishedEvent event;
+}


### PR DESCRIPTION
This pull request fixes #669 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
