### PR TITLE
Fix #676 Add an easier way to access Events API retry info

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,7 +10,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    # ubuntu-20.04 may be a bit unstable for this build
+    runs-on: ubuntu-18.04
     timeout-minutes: 10
     strategy:
       matrix:

--- a/bolt-socket-mode/src/test/java/test_locally/SocketModeAppTest.java
+++ b/bolt-socket-mode/src/test/java/test_locally/SocketModeAppTest.java
@@ -6,6 +6,7 @@ import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.socket_mode.SocketModeApp;
+import com.slack.api.model.event.AppMentionEvent;
 import com.slack.api.socket_mode.SocketModeClient;
 import org.junit.After;
 import org.junit.Before;
@@ -52,6 +53,7 @@ public class SocketModeAppTest {
                 .build());
         AtomicBoolean commandCalled = new AtomicBoolean(false);
         AtomicBoolean actionCalled = new AtomicBoolean(false);
+        AtomicBoolean eventCalled = new AtomicBoolean(false);
         app.command("/hi-socket-mode", (req, ctx) -> {
             commandCalled.set(true);
             return ctx.ack("Hello!");
@@ -60,12 +62,17 @@ public class SocketModeAppTest {
             actionCalled.set(true);
             return Response.builder().body("Thanks").build();
         });
+        app.event(AppMentionEvent.class, (req, ctx) -> {
+            eventCalled.set(ctx.getRetryNum() == 2 && ctx.getRetryReason().equals("timeout"));
+            return ctx.ack();
+        });
         SocketModeApp socketModeApp = new SocketModeApp(VALID_APP_TOKEN, app);
         socketModeApp.startAsync();
         try {
             Thread.sleep(1500L);
             assertTrue(commandCalled.get());
             assertTrue(actionCalled.get());
+            assertTrue(eventCalled.get());
         } finally {
             socketModeApp.stop();
         }

--- a/bolt-socket-mode/src/test/java/util/socket_mode/MockSocketMode.java
+++ b/bolt-socket-mode/src/test/java/util/socket_mode/MockSocketMode.java
@@ -217,8 +217,8 @@ public class MockSocketMode extends WebSocketAdapter {
             "  },\n" +
             "  \"type\": \"events_api\",\n" +
             "  \"accepts_response_payload\": false,\n" +
-            "  \"retry_attempt\": 0,\n" +
-            "  \"retry_reason\": \"\"\n" +
+            "  \"retry_attempt\": 2,\n" +
+            "  \"retry_reason\": \"timeout\"\n" +
             "}\n";
 
     String commandEnvelope = "{\n" +

--- a/bolt/src/main/java/com/slack/api/bolt/context/builtin/EventContext.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/builtin/EventContext.java
@@ -15,4 +15,11 @@ public class EventContext extends Context implements SayUtility {
 
     private String channelId;
 
+    // X-Slack-Retry-Num: 2 in HTTP Mode
+    // "retry_attempt": 0, in Socket Mode
+    private Integer retryNum;
+    // X-Slack-Retry-Reason: http_error in HTTP Mode
+    // "retry_reason": "timeout", in Socket Mode
+    private String retryReason;
+
 }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/EventRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/EventRequest.java
@@ -10,6 +10,8 @@ import com.slack.api.bolt.request.RequestType;
 import com.slack.api.util.json.GsonFactory;
 import lombok.ToString;
 
+import java.util.Locale;
+
 @ToString(callSuper = true)
 public class EventRequest extends Request<EventContext> {
 
@@ -79,6 +81,23 @@ public class EventRequest extends Request<EventContext> {
         }
         this.getContext().setEnterpriseId(enterpriseId);
         this.getContext().setTeamId(teamId);
+        // set retry related header values to the context
+        if (this.headers != null && this.headers.getNames().size() > 0) {
+            for (String name : this.headers.getNames()) {
+                String normalizedName = name.toLowerCase(Locale.ENGLISH);
+                String value = this.headers.getFirstValue(name);
+                if (normalizedName.equals("x-slack-retry-num")) {
+                    try {
+                        Integer num = Integer.parseInt(value);
+                        this.getContext().setRetryNum(num);
+                    } catch (NumberFormatException e) {
+                    }
+                }
+                if (normalizedName.equals("x-slack-retry-reason")) {
+                    this.getContext().setRetryReason(value);
+                }
+            }
+        }
 
         if (event.get("channel") != null && event.get("channel").isJsonPrimitive()) {
             this.getContext().setChannelId(event.get("channel").getAsString());


### PR DESCRIPTION
This pull request enables Events API listeners to access x-slack-retry-num / x-slack-retry-reason header values (retry_attempt / retry_reason in Socket Mode) in the following way.

```java
app.event(AppMentionEvent.class, (req, ctx) -> {
  Integer num = ctx.getRetryNum(); // 0-3
  String reason = ctx.getRetryReason(); // timeout, http_error etc
  return ctx.ack();
});
```

Fixes #676 

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-socket-mode** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
