### PR TITLE
Async AuditLogsClient & SCIMClient (Rate limits support) #414 #675

### DIFF
--- a/bolt-servlet/src/test/java/config/SlackTestConfig.java
+++ b/bolt-servlet/src/test/java/config/SlackTestConfig.java
@@ -1,9 +1,9 @@
 package config;
 
 import com.slack.api.SlackConfig;
-import com.slack.api.methods.metrics.MetricsDatastore;
 import com.slack.api.util.http.listener.HttpResponseListener;
 import com.slack.api.util.json.GsonFactory;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
 import lombok.extern.slf4j.Slf4j;
 import test_with_remote_apis.sample_json_generation.JsonDataRecordingListener;
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        threshold: 1.0%
+        threshold: 1.5%
     patch:
       default:
         target: 50%

--- a/json-logs/samples/api/channels.history.json
+++ b/json-logs/samples/api/channels.history.json
@@ -776,6 +776,112 @@
             "rotation": 12345,
             "thumb_tiny": ""
           }
+        },
+        {
+          "service_name": "",
+          "service_url": "https://www.example.com/",
+          "title": "",
+          "title_link": "https://www.example.com/",
+          "author_name": "",
+          "author_link": "https://www.example.com/",
+          "thumb_url": "https://www.example.com/",
+          "thumb_width": 12345,
+          "thumb_height": 12345,
+          "fallback": "",
+          "video_html": "",
+          "video_html_width": 12345,
+          "video_html_height": 12345,
+          "from_url": "https://www.example.com/",
+          "service_icon": "https://www.example.com/",
+          "id": 12345,
+          "original_url": "https://www.example.com/",
+          "msg_subtype": "",
+          "callback_id": "",
+          "color": "",
+          "pretext": "",
+          "author_id": "",
+          "author_icon": "",
+          "author_subname": "",
+          "channel_id": "",
+          "channel_name": "",
+          "bot_id": "",
+          "indent": false,
+          "is_msg_unfurl": false,
+          "is_reply_unfurl": false,
+          "is_thread_root_unfurl": false,
+          "is_app_unfurl": false,
+          "app_unfurl_url": "",
+          "text": "",
+          "fields": [
+            {
+              "title": "",
+              "value": "",
+              "short": false
+            }
+          ],
+          "image_url": "",
+          "image_width": 12345,
+          "image_height": 12345,
+          "image_bytes": 12345,
+          "footer": "",
+          "footer_icon": "",
+          "ts": "",
+          "mrkdwn_in": [
+            ""
+          ],
+          "actions": [
+            {
+              "id": "",
+              "name": "",
+              "text": "",
+              "style": "",
+              "type": "",
+              "value": "",
+              "confirm": {
+                "title": "",
+                "text": "",
+                "ok_text": "",
+                "dismiss_text": ""
+              },
+              "options": [
+                {
+                  "text": "",
+                  "value": ""
+                }
+              ],
+              "selected_options": [
+                {
+                  "text": "",
+                  "value": ""
+                }
+              ],
+              "data_source": "",
+              "min_query_length": 12345,
+              "option_groups": [
+                {
+                  "text": ""
+                }
+              ],
+              "url": ""
+            }
+          ],
+          "filename": "",
+          "size": 12345,
+          "mimetype": "",
+          "url": "",
+          "metadata": {
+            "thumb_64": false,
+            "thumb_80": false,
+            "thumb_160": false,
+            "original_w": 12345,
+            "original_h": 12345,
+            "thumb_360_w": 12345,
+            "thumb_360_h": 12345,
+            "format": "",
+            "extension": "",
+            "rotation": 12345,
+            "thumb_tiny": ""
+          }
         }
       ],
       "subtype": "",

--- a/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
@@ -1,9 +1,11 @@
 package com.slack.api;
 
 import com.slack.api.audit.AuditClient;
+import com.slack.api.audit.AuditConfig;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.MethodsConfig;
 import com.slack.api.scim.SCIMClient;
+import com.slack.api.scim.SCIMConfig;
 import com.slack.api.status.v1.LegacyStatusClient;
 import com.slack.api.status.v2.StatusClient;
 import com.slack.api.util.http.listener.DetailedLoggingListener;
@@ -81,6 +83,16 @@ public class SlackConfig {
 
         @Override
         public void setMethodsConfig(MethodsConfig methodsConfig) {
+            throwException();
+        }
+
+        @Override
+        public void setAuditConfig(AuditConfig auditConfig) {
+            throwException();
+        }
+
+        @Override
+        public void setSCIMConfig(SCIMConfig sCIMConfig) {
             throwException();
         }
 
@@ -182,4 +194,7 @@ public class SlackConfig {
 
     private MethodsConfig methodsConfig = MethodsConfig.DEFAULT_SINGLETON;
 
+    private AuditConfig auditConfig = AuditConfig.DEFAULT_SINGLETON;
+
+    private SCIMConfig sCIMConfig = SCIMConfig.DEFAULT_SINGLETON;
 }

--- a/slack-api-client/src/main/java/com/slack/api/audit/AsyncAuditClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AsyncAuditClient.java
@@ -1,0 +1,44 @@
+package com.slack.api.audit;
+
+import com.slack.api.RequestConfigurator;
+import com.slack.api.audit.request.ActionsRequest;
+import com.slack.api.audit.request.LogsRequest;
+import com.slack.api.audit.request.SchemasRequest;
+import com.slack.api.audit.response.ActionsResponse;
+import com.slack.api.audit.response.LogsResponse;
+import com.slack.api.audit.response.SchemasResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Audit Logs API client.
+ * <p>
+ * Monitor what's happening in your Enterprise Grid organization using Slack's Audit Logs API.
+ * The Audit Logs API can be used by security information and event management (SIEM) tools
+ * to provide analysis of how your Slack organization is being accessed.
+ * <p>
+ * You can also use this API to write your own applications to see how members of your organization are using Slack.
+ *
+ * @see <a href="https://api.slack.com/admins/audit-logs">Slack Audit Logs API</a>
+ */
+public interface AsyncAuditClient {
+
+    AsyncAuditClient attachRawBody(boolean attachRawBody);
+
+    CompletableFuture<SchemasResponse> getSchemas();
+
+    CompletableFuture<SchemasResponse> getSchemas(SchemasRequest req);
+
+    CompletableFuture<SchemasResponse> getSchemas(RequestConfigurator<SchemasRequest.SchemasRequestBuilder> req);
+
+    CompletableFuture<ActionsResponse> getActions();
+
+    CompletableFuture<ActionsResponse> getActions(ActionsRequest req);
+
+    CompletableFuture<ActionsResponse> getActions(RequestConfigurator<ActionsRequest.ActionsRequestBuilder> req);
+
+    CompletableFuture<LogsResponse> getLogs(LogsRequest req);
+
+    CompletableFuture<LogsResponse> getLogs(RequestConfigurator<LogsRequest.LogsRequestBuilder> req);
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditApiCompletionException.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditApiCompletionException.java
@@ -1,0 +1,24 @@
+package com.slack.api.audit;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Data
+@Slf4j
+@EqualsAndHashCode(callSuper = false)
+public class AuditApiCompletionException extends RuntimeException {
+
+    private final IOException ioException;
+    private final AuditApiException auditApiException;
+    private final Exception otherException;
+
+    public AuditApiCompletionException(IOException ioException, AuditApiException auditApiException, Exception otherException) {
+        this.ioException = ioException;
+        this.auditApiException = auditApiException;
+        this.otherException = otherException;
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditClient.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * <p>
  * You can also use this API to write your own applications to see how members of your organization are using Slack.
  *
- * @see <a href="https://api.slack.com/docs/audit-logs-api>Slack Audit Logs API</a>
+ * @see <a href="https://api.slack.com/admins/audit-logs">Slack Audit Logs API</a>
  */
 public interface AuditClient {
 

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditConfig.java
@@ -1,0 +1,101 @@
+package com.slack.api.audit;
+
+import com.slack.api.audit.metrics.MemoryMetricsDatastore;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration for {@link AuditClient}.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditConfig {
+
+    /**
+     * If you don't have a special reason, we recommend going with the singleton executor to track all the traffic
+     * your app generated towards the Slack Platform in one place (= in one metrics datastore).
+     */
+    public static final String DEFAULT_SINGLETON_EXECUTOR_NAME = MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME;
+
+    /**
+     * The default configuration. It's not allowed to modify this runtime for any reasons.
+     */
+    public static final AuditConfig DEFAULT_SINGLETON = new AuditConfig() {
+
+        void throwException() {
+            throw new UnsupportedOperationException("This config is immutable");
+        }
+
+        @Override
+        public void setStatsEnabled(boolean statsEnabled) {
+            throwException();
+        }
+
+        @Override
+        public void setExecutorName(String executorName) {
+            throwException();
+        }
+
+        @Override
+        public void setMaxIdleMills(int maxIdleMills) {
+            throwException();
+        }
+
+        @Override
+        public void setDefaultThreadPoolSize(int defaultThreadPoolSize) {
+            throwException();
+        }
+
+        @Override
+        public void setMetricsDatastore(MetricsDatastore metricsDatastore) {
+            throwException();
+        }
+
+        @Override
+        public void setCustomThreadPoolSizes(Map<String, Integer> customThreadPoolSizes) {
+            throwException();
+        }
+    };
+
+    @Builder.Default
+    private boolean statsEnabled = true;
+
+    /**
+     * If you need to have multiple executors in the same Slack app, name this accordingly.
+     */
+    @Builder.Default
+    private String executorName = DEFAULT_SINGLETON_EXECUTOR_NAME;
+
+    /**
+     * The max period to keep asynchronous API method calls idle.
+     */
+    @Builder.Default
+    private int maxIdleMills = 60 * 60 * 1000;
+
+    /**
+     * The default thread pool size used for asynchronous API method calls.
+     */
+    @Builder.Default
+    private int defaultThreadPoolSize = 5;
+
+    /**
+     * Enterprise ID -> thread pool size
+     */
+    @Builder.Default
+    private Map<String, Integer> customThreadPoolSizes = new HashMap<>();
+
+    /**
+     * The metrics datastore to track the traffic associated to this executor name.
+     */
+    @Builder.Default
+    private MetricsDatastore metricsDatastore = new MemoryMetricsDatastore(1);
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncAuditClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncAuditClientImpl.java
@@ -1,0 +1,103 @@
+package com.slack.api.audit.impl;
+
+import com.slack.api.RequestConfigurator;
+import com.slack.api.SlackConfig;
+import com.slack.api.audit.AsyncAuditClient;
+import com.slack.api.audit.AuditApiRequest;
+import com.slack.api.audit.request.ActionsRequest;
+import com.slack.api.audit.request.LogsRequest;
+import com.slack.api.audit.request.SchemasRequest;
+import com.slack.api.audit.response.ActionsResponse;
+import com.slack.api.audit.response.LogsResponse;
+import com.slack.api.audit.response.SchemasResponse;
+import com.slack.api.methods.impl.MethodsClientImpl;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+public class AsyncAuditClientImpl implements AsyncAuditClient {
+
+    private final String token;
+    private final AuditClientImpl underlying;
+    private final AsyncRateLimitExecutor executor;
+
+    public AsyncAuditClientImpl(
+            String token,
+            AuditClientImpl audit,
+            MethodsClientImpl methods,
+            SlackConfig config
+    ) {
+        this.token = token;
+        this.underlying = audit;
+        this.executor = AsyncRateLimitExecutor.getOrCreate(methods, config);
+    }
+
+    private String token(AuditApiRequest req) {
+        if (req.getToken() != null) {
+            return req.getToken();
+        } else {
+            return this.token;
+        }
+    }
+
+    private Map<String, String> toMap(AuditApiRequest req) {
+        Map<String, String> params = new HashMap<>();
+        params.put("token", token(req));
+        return params;
+    }
+
+    @Override
+    public AsyncAuditClient attachRawBody(boolean attachRawBody) {
+        this.underlying.attachRawBody(attachRawBody);
+        return this;
+    }
+
+    // ----------------------------------------------------------------------------------
+    // public methods
+    // ----------------------------------------------------------------------------------
+
+    @Override
+    public CompletableFuture<SchemasResponse> getSchemas() {
+        return executor.execute("schemas", Collections.emptyMap(), () -> this.underlying.getSchemas());
+    }
+
+    @Override
+    public CompletableFuture<SchemasResponse> getSchemas(SchemasRequest req) {
+        return executor.execute("schemas", toMap(req), () -> this.underlying.getSchemas(req));
+    }
+
+    @Override
+    public CompletableFuture<SchemasResponse> getSchemas(RequestConfigurator<SchemasRequest.SchemasRequestBuilder> req) {
+        return getSchemas(req.configure(SchemasRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<ActionsResponse> getActions() {
+        return executor.execute("actions", Collections.emptyMap(), () -> this.underlying.getActions());
+    }
+
+    @Override
+    public CompletableFuture<ActionsResponse> getActions(ActionsRequest req) {
+        return executor.execute("actions", toMap(req), () -> this.underlying.getActions(req));
+    }
+
+    @Override
+    public CompletableFuture<ActionsResponse> getActions(RequestConfigurator<ActionsRequest.ActionsRequestBuilder> req) {
+        return getActions(req.configure(ActionsRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<LogsResponse> getLogs(LogsRequest req) {
+        return executor.execute("logs", toMap(req), () -> this.underlying.getLogs(req));
+    }
+
+    @Override
+    public CompletableFuture<LogsResponse> getLogs(RequestConfigurator<LogsRequest.LogsRequestBuilder> req) {
+        return getLogs(req.configure(LogsRequest.builder()).build());
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncAuditRateLimiter.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncAuditRateLimiter.java
@@ -1,0 +1,80 @@
+package com.slack.api.audit.impl;
+
+import com.slack.api.audit.AuditConfig;
+import com.slack.api.methods.MethodsRateLimitTier;
+import com.slack.api.rate_limits.RateLimiter;
+import com.slack.api.rate_limits.WaitTime;
+import com.slack.api.rate_limits.WaitTimeCalculator;
+import com.slack.api.rate_limits.metrics.LastMinuteRequests;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+import static com.slack.api.methods.MethodsRateLimitTier.getAllowedRequestsPerMinute;
+
+@Slf4j
+public class AsyncAuditRateLimiter implements RateLimiter {
+
+    private static final MethodsRateLimitTier AUDIT_LOGS_RATE_LIMIT_TIER =
+            MethodsRateLimitTier.Tier3;
+
+    private final MetricsDatastore metricsDatastore;
+    private final AuditWaitTimeCalculator waitTimeCalculator;
+
+    public MetricsDatastore getMetricsDatastore() {
+        return metricsDatastore;
+    }
+
+    public AsyncAuditRateLimiter(AuditConfig config) {
+        this.metricsDatastore = config.getMetricsDatastore();
+        this.waitTimeCalculator = new AuditWaitTimeCalculator(config);
+    }
+
+    public static class AuditWaitTimeCalculator extends WaitTimeCalculator {
+        private final AuditConfig config;
+
+        public AuditWaitTimeCalculator(AuditConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public Optional<Long> getRateLimitedMethodRetryEpochMillis(
+                String executorName, String teamId, String key) {
+            return Optional.ofNullable(config.getMetricsDatastore().getRateLimitedMethodRetryEpochMillis(
+                    executorName, teamId, key
+            ));
+        }
+
+        @Override
+        public Integer getNumberOfNodes() {
+            return config.getMetricsDatastore().getNumberOfNodes();
+        }
+
+        @Override
+        public String getExecutorName() {
+            return config.getExecutorName();
+        }
+
+        @Override
+        public LastMinuteRequests getLastMinuteRequests(
+                String executorName, String teamId, String key) {
+            return config.getMetricsDatastore().getLastMinuteRequests(executorName, teamId, key);
+        }
+    }
+
+    @Override
+    public WaitTime acquireWaitTime(String teamId, String methodName) {
+        return waitTimeCalculator.calculateWaitTime(
+                teamId,
+                methodName,
+                getAllowedRequestsPerMinute(AUDIT_LOGS_RATE_LIMIT_TIER)
+        );
+    }
+
+    @Override
+    public WaitTime acquireWaitTimeForChatPostMessage(String teamId, String channel) {
+        return waitTimeCalculator.calculateWaitTimeForChatPostMessage(teamId, channel);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncExecutionSupplier.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncExecutionSupplier.java
@@ -1,0 +1,16 @@
+package com.slack.api.audit.impl;
+
+import com.slack.api.audit.AuditApiException;
+import com.slack.api.audit.AuditApiResponse;
+
+import java.io.IOException;
+
+/**
+ * A Supplier that holds an API Method execution.
+ */
+@FunctionalInterface
+public interface AsyncExecutionSupplier<T extends AuditApiResponse> {
+
+    T execute() throws IOException, AuditApiException;
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncRateLimitExecutor.java
@@ -1,0 +1,196 @@
+package com.slack.api.audit.impl;
+
+import com.slack.api.SlackConfig;
+import com.slack.api.audit.AuditApiCompletionException;
+import com.slack.api.audit.AuditApiException;
+import com.slack.api.audit.AuditApiResponse;
+import com.slack.api.audit.AuditConfig;
+import com.slack.api.methods.impl.MethodsClientImpl;
+import com.slack.api.methods.impl.TeamIdCache;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.rate_limits.queue.MessageIdGenerator;
+import com.slack.api.rate_limits.queue.MessageIdGeneratorUUIDImpl;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+
+@Slf4j
+public class AsyncRateLimitExecutor {
+
+    private static final ConcurrentMap<String, AsyncRateLimitExecutor> ALL_EXECUTORS = new ConcurrentHashMap<>();
+
+    private AuditConfig config;
+    private MetricsDatastore metricsDatastore; // intentionally mutable
+    private final TeamIdCache teamIdCache;
+    private final MessageIdGenerator messageIdGenerator;
+
+    private AsyncRateLimitExecutor(MethodsClientImpl methods, SlackConfig config) {
+        this.config = config.getAuditConfig();
+        this.metricsDatastore = config.getAuditConfig().getMetricsDatastore();
+        this.teamIdCache = new TeamIdCache(methods);
+        this.messageIdGenerator = new MessageIdGeneratorUUIDImpl();
+    }
+
+    public static AsyncRateLimitExecutor get(String executorName) {
+        return ALL_EXECUTORS.get(executorName);
+    }
+
+    public static AsyncRateLimitExecutor getOrCreate(MethodsClientImpl methods, SlackConfig config) {
+        AsyncRateLimitExecutor executor = ALL_EXECUTORS.get(config.getMethodsConfig().getExecutorName());
+        if (executor != null && executor.metricsDatastore != config.getMethodsConfig().getMetricsDatastore()) {
+            // As the metrics datastore has been changed, we should replace the executor
+            executor.config = config.getAuditConfig();
+            executor.metricsDatastore = config.getAuditConfig().getMetricsDatastore();
+        }
+        if (executor == null) {
+            executor = new AsyncRateLimitExecutor(methods, config);
+            ALL_EXECUTORS.putIfAbsent(config.getMethodsConfig().getExecutorName(), executor);
+        }
+        return executor;
+    }
+
+    private static final List<String> NO_TOKEN_METHOD_NAMES = Arrays.asList("schemas", "actions");
+
+    public <T extends AuditApiResponse> CompletableFuture<T> execute(
+            String methodName,
+            Map<String, String> params,
+            AsyncExecutionSupplier<T> methodsSupplier) {
+        String token = params.get("token");
+        final String teamId = token != null ? teamIdCache.lookupOrResolve(token) : null;
+        final ExecutorService executorService = teamId != null ? ThreadPools.getOrCreate(config, teamId) : ThreadPools.getDefault(config);
+        return CompletableFuture.supplyAsync(() -> {
+            String messageId = messageIdGenerator.generate();
+            addMessageId(teamId, methodName, messageId);
+            initCurrentQueueSizeStatsIfAbsent(teamId, methodName);
+            if (NO_TOKEN_METHOD_NAMES.contains(methodName) || teamId == null) {
+                return runWithoutQueue(teamId, methodName, methodsSupplier);
+            } else {
+                return enqueueThenRun(
+                        messageId,
+                        teamId,
+                        methodName,
+                        params,
+                        methodsSupplier
+                );
+            }
+        }, executorService);
+    }
+
+    private void initCurrentQueueSizeStatsIfAbsent(String teamId, String methodNameWithSuffix) {
+        if (teamId != null) {
+            metricsDatastore.setCurrentQueueSize(config.getExecutorName(), teamId, methodNameWithSuffix, 0);
+        }
+    }
+
+    private void addMessageId(
+            String teamId,
+            String methodNameWithSuffix,
+            String messageId) {
+        metricsDatastore.addToWaitingMessageIds(
+                config.getExecutorName(), teamId, methodNameWithSuffix, messageId);
+    }
+
+    private void removeMessageId(
+            String teamId,
+            String methodNameWithSuffix,
+            String messageId) {
+        metricsDatastore.deleteFromWaitingMessageIds(
+                config.getExecutorName(), teamId, methodNameWithSuffix, messageId);
+    }
+
+    private <T extends AuditApiResponse> T runWithoutQueue(
+            String teamId,
+            String methodName,
+            AsyncExecutionSupplier<T> methodsSupplier) {
+        try {
+            return methodsSupplier.execute();
+        } catch (RuntimeException e) {
+            return handleRuntimeException(teamId, methodName, e);
+        } catch (IOException e) {
+            return handleIOException(teamId, methodName, e);
+        } catch (AuditApiException e) {
+            logAuditApiException(teamId, methodName, e);
+            throw new AuditApiCompletionException(null, e, null);
+        }
+    }
+
+    private <T extends AuditApiResponse> T enqueueThenRun(
+            String messageId,
+            String teamId,
+            String methodName,
+            Map<String, String> params,
+            AsyncExecutionSupplier<T> methodsSupplier) {
+        try {
+            AsyncRateLimitQueue activeQueue = AsyncRateLimitQueue.getOrCreate(config, teamId);
+            if (activeQueue == null) {
+                log.warn("Queue for teamId: {} was not found. Going to run the API call immediately.", teamId);
+            }
+            AsyncExecutionSupplier<T> supplier = null;
+            activeQueue.enqueue(messageId, teamId, methodName, params, methodsSupplier);
+            long consumedMillis = 0L;
+            while (supplier == null && consumedMillis < config.getMaxIdleMills()) {
+                Thread.sleep(10);
+                consumedMillis += 10;
+                supplier = (AsyncExecutionSupplier<T>) activeQueue.dequeueIfReady(
+                        messageId, teamId, methodName, params);
+                removeMessageId(teamId, methodName, messageId);
+            }
+            if (supplier == null) {
+                activeQueue.remove(methodName, messageId);
+                throw new RejectedExecutionException("Gave up executing the message after " + config.getMaxIdleMills() + " milliseconds.");
+            }
+            T response = supplier.execute();
+            return response;
+
+        } catch (RuntimeException e) {
+            return handleRuntimeException(teamId, methodName, e);
+        } catch (IOException e) {
+            return handleIOException(teamId, methodName, e);
+        } catch (AuditApiException e) {
+            logAuditApiException(teamId, methodName, e);
+            if (e.getResponse().code() == 429) {
+                return enqueueThenRun(messageId, teamId, methodName, params, methodsSupplier);
+            }
+            throw new AuditApiCompletionException(null, e, null);
+        } catch (InterruptedException e) {
+            log.error("Got an InterruptedException (error: {})", e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <T extends AuditApiResponse> T handleRuntimeException(String teamId, String methodName, RuntimeException e) {
+        log.error("Got an exception while calling {} API (team: {}, error: {})", methodName, teamId, e.getMessage(), e);
+        throw new AuditApiCompletionException(null, null, e);
+    }
+
+    private static <T extends AuditApiResponse> T handleIOException(String teamId, String methodName, IOException e) {
+        log.error("Failed to connect to {} API (team: {}, error: {})", methodName, teamId, e.getMessage(), e);
+        throw new AuditApiCompletionException(e, null, null);
+    }
+
+    private static void logAuditApiException(String teamId, String methodName, AuditApiException e) {
+        if (e.getResponse().code() == 429) {
+            String retryAfterSeconds = e.getResponse().header("Retry-After");
+            log.error("Got a rate-limited response from {} API (team: {}, error: {}, retry-after: {})",
+                    methodName,
+                    teamId,
+                    e.getMessage(),
+                    retryAfterSeconds,
+                    e
+            );
+        } else {
+            log.error("Got an unsuccessful response from {} API (team: {}, error: {}, status code: {})",
+                    methodName,
+                    teamId,
+                    e.getMessage(),
+                    e.getResponse().code(),
+                    e
+            );
+        }
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncRateLimitQueue.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncRateLimitQueue.java
@@ -1,0 +1,93 @@
+package com.slack.api.audit.impl;
+
+import com.slack.api.audit.AuditApiResponse;
+import com.slack.api.audit.AuditConfig;
+import com.slack.api.rate_limits.WaitTime;
+import com.slack.api.rate_limits.queue.QueueMessage;
+import com.slack.api.rate_limits.queue.RateLimitQueue;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
+@Slf4j
+public class AsyncRateLimitQueue extends RateLimitQueue<
+        AsyncExecutionSupplier<? extends AuditApiResponse>,
+        AsyncRateLimitQueue.AuditMessage> {
+
+    @Data
+    @AllArgsConstructor
+    public static class AuditMessage extends QueueMessage<AsyncExecutionSupplier> {
+        private String id;
+        private long millisToRun;
+        private WaitTime waitTime;
+        private AsyncExecutionSupplier<?> supplier;
+    }
+
+    // Executor name -> Team ID -> Queue
+    private static final ConcurrentMap<String, ConcurrentMap<String, AsyncRateLimitQueue>> ALL_QUEUES = new ConcurrentHashMap<>();
+
+    private static ConcurrentMap<String, AsyncRateLimitQueue> getInstance(String executorName) {
+        ConcurrentMap<String, AsyncRateLimitQueue> teamIdToQueue = ALL_QUEUES.get(executorName);
+        if (teamIdToQueue == null) {
+            teamIdToQueue = new ConcurrentHashMap<>();
+            ALL_QUEUES.put(executorName, teamIdToQueue);
+        }
+        return teamIdToQueue;
+    }
+
+    private AsyncAuditRateLimiter rateLimiter; // intentionally mutable
+
+    public AsyncAuditRateLimiter getRateLimiter() {
+        return rateLimiter;
+    }
+
+    public void setRateLimiter(AsyncAuditRateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    private final ConcurrentMap<String, LinkedBlockingQueue<AuditMessage>> methodNameToActiveQueue = new ConcurrentHashMap<>();
+
+    private AsyncRateLimitQueue(AuditConfig config) {
+        this.rateLimiter = new AsyncAuditRateLimiter(config);
+    }
+
+    public static AsyncRateLimitQueue get(String executorName, String teamId) {
+        if (executorName == null || teamId == null) {
+            throw new IllegalArgumentException("`executorName` and `teamId` are required");
+        }
+        ConcurrentMap<String, AsyncRateLimitQueue> teamIdToQueue = getInstance(executorName);
+        return teamIdToQueue.get(teamId);
+    }
+
+    public static AsyncRateLimitQueue getOrCreate(AuditConfig config, String teamId) {
+        if (teamId == null) {
+            throw new IllegalArgumentException("`teamId` is required");
+        }
+        ConcurrentMap<String, AsyncRateLimitQueue> teamIdToQueue = getInstance(config.getExecutorName());
+        AsyncRateLimitQueue queue = teamIdToQueue.get(teamId);
+        if (queue != null && queue.getRateLimiter().getMetricsDatastore() != config.getMetricsDatastore()) {
+            // As the metrics datastore has been changed, we should replace the executor
+            queue.setRateLimiter(new AsyncAuditRateLimiter(config));
+        }
+        if (queue == null) {
+            queue = new AsyncRateLimitQueue(config);
+            teamIdToQueue.put(teamId, queue);
+        }
+        return queue;
+    }
+
+    @Override
+    protected AuditMessage buildNewMessage(
+            String messageId,
+            long epochMillisToRun,
+            WaitTime waitTime,
+            AsyncExecutionSupplier<? extends AuditApiResponse> methodsSupplier
+    ) {
+        return new AuditMessage(messageId, epochMillisToRun, waitTime, methodsSupplier);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/ThreadPools.java
@@ -1,0 +1,54 @@
+package com.slack.api.audit.impl;
+
+import com.slack.api.audit.AuditConfig;
+import com.slack.api.util.thread.ExecutorServiceFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+
+public class ThreadPools {
+
+    // Executor Name -> Executor
+    private static final ConcurrentMap<String, ExecutorService> ALL_DEFAULT = new ConcurrentHashMap<>();
+    // Executor Name -> Enterprise ID -> Executor
+    private static final ConcurrentMap<String, ConcurrentMap<String, ExecutorService>> ENTERPRISE_CUSTOM =
+            new ConcurrentHashMap<>();
+
+    private ThreadPools() {
+    }
+
+    public static ExecutorService getDefault(AuditConfig config) {
+        return getOrCreate(config, null);
+    }
+
+    public static ExecutorService getOrCreate(AuditConfig config, String enterpriseId) {
+        String executorName = config.getExecutorName();
+        Integer customPoolSize = enterpriseId != null ? config.getCustomThreadPoolSizes().get(enterpriseId) : null;
+        if (customPoolSize != null) {
+            ConcurrentMap<String, ExecutorService> allOrgs = ENTERPRISE_CUSTOM.get(executorName);
+            if (allOrgs == null) {
+                allOrgs = new ConcurrentHashMap<>();
+                ENTERPRISE_CUSTOM.put(executorName, allOrgs);
+            }
+            ExecutorService orgExecutor = allOrgs.get(enterpriseId);
+            if (orgExecutor == null) {
+                String threadGroupName = "slack-audit-logs-" + config.getExecutorName() + "-" + enterpriseId;
+                orgExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, customPoolSize);
+                allOrgs.put(enterpriseId, orgExecutor);
+            }
+            return orgExecutor;
+
+        } else {
+            ExecutorService defaultExecutor = ALL_DEFAULT.get(executorName);
+            if (defaultExecutor == null) {
+                String threadGroupName = "slack-audit-logs-" + config.getExecutorName();
+                int poolSize = config.getDefaultThreadPoolSize();
+                defaultExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, poolSize);
+                ALL_DEFAULT.put(config.getExecutorName(), defaultExecutor);
+            }
+            return defaultExecutor;
+        }
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
@@ -1,0 +1,25 @@
+package com.slack.api.audit.metrics;
+
+import com.slack.api.audit.AuditApiResponse;
+import com.slack.api.audit.impl.AsyncExecutionSupplier;
+import com.slack.api.audit.impl.AsyncRateLimitQueue;
+import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
+
+public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
+        AsyncExecutionSupplier<? extends AuditApiResponse>, AsyncRateLimitQueue.AuditMessage> {
+
+    public MemoryMetricsDatastore(int numberOfNodes) {
+        super(numberOfNodes);
+    }
+
+    @Override
+    protected String getMetricsType() {
+        return "AUDIT_LOGS";
+    }
+
+    @Override
+    public AsyncRateLimitQueue getRateLimitQueue(String executorName, String teamId) {
+        return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/RedisMetricsDatastore.java
@@ -1,0 +1,21 @@
+package com.slack.api.audit.metrics;
+
+import com.slack.api.audit.AuditApiResponse;
+import com.slack.api.audit.impl.AsyncExecutionSupplier;
+import com.slack.api.audit.impl.AsyncRateLimitQueue;
+import com.slack.api.rate_limits.metrics.impl.BaseRedisMetricsDatastore;
+import redis.clients.jedis.JedisPool;
+
+public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
+        AsyncExecutionSupplier<? extends AuditApiResponse>, AsyncRateLimitQueue.AuditMessage> {
+
+    public RedisMetricsDatastore(String appName, JedisPool jedisPool) {
+        super(appName, jedisPool);
+    }
+
+    @Override
+    public AsyncRateLimitQueue getRateLimitQueue(String executorName, String teamId) {
+        return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
@@ -3,8 +3,6 @@ package com.slack.api.audit.response;
 import com.google.gson.annotations.SerializedName;
 import com.slack.api.audit.AuditApiResponse;
 import com.slack.api.model.ResponseMetadata;
-import com.slack.api.model.admin.IdpUserGroup;
-import com.slack.api.model.admin.InformationBarrier;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsConfig.java
@@ -1,7 +1,7 @@
 package com.slack.api.methods;
 
-import com.slack.api.methods.metrics.MetricsDatastore;
-import com.slack.api.methods.metrics.impl.MemoryMetricsDatastore;
+import com.slack.api.methods.metrics.MemoryMetricsDatastore;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -23,7 +23,7 @@ public class MethodsConfig {
      * If you don't have a special reason, we recommend going with the singleton executor to track all the traffic
      * your app generated towards the Slack Platform in one place (= in one metrics datastore).
      */
-    public static final String DEFAULT_SINGLETON_EXECUTOR_NAME = "DEFAULT_SINGLETON_EXECUTOR";
+    public static final String DEFAULT_SINGLETON_EXECUTOR_NAME = MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME;
 
     /**
      * The default configuration. It's not allowed to modify this runtime for any reasons.

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsRateLimiter.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsRateLimiter.java
@@ -1,143 +1,75 @@
 package com.slack.api.methods.impl;
 
-import com.slack.api.methods.Methods;
 import com.slack.api.methods.MethodsConfig;
-import com.slack.api.methods.MethodsRateLimitTier;
 import com.slack.api.methods.MethodsRateLimits;
-import com.slack.api.methods.metrics.LastMinuteRequests;
-import com.slack.api.methods.metrics.MetricsDatastore;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import com.slack.api.rate_limits.RateLimiter;
+import com.slack.api.rate_limits.WaitTime;
+import com.slack.api.rate_limits.WaitTimeCalculator;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
-public class AsyncMethodsRateLimiter {
+import java.util.Optional;
 
-    private final MethodsConfig config;
+@Slf4j
+public class AsyncMethodsRateLimiter implements RateLimiter {
+
     private final MetricsDatastore metricsDatastore;
+    private final WaitTimeCalculator waitTimeCalculator;
 
     public MetricsDatastore getMetricsDatastore() {
         return metricsDatastore;
     }
 
     public AsyncMethodsRateLimiter(MethodsConfig config) {
-        this.config = config;
         this.metricsDatastore = config.getMetricsDatastore();
+        this.waitTimeCalculator = new MethodsWaitTimeCalculator(config);
     }
 
-    @Data
-    @AllArgsConstructor
-    static class WaitTime {
-        private long millisToWait;
-        private Pace pace;
-    }
-
-    enum Pace {
-        RateLimited,
-        Safe,
-        Optimal,
-        TooFastPaced,
-        Burst
-    }
-
+    @Override
     public WaitTime acquireWaitTime(String teamId, String methodName) {
-        return calculateWaitTime(teamId, methodName);
-    }
-
-    public WaitTime acquireWaitTimeForChatPostMessage(String teamId, String channelId) {
-        return calculateWaitTime(teamId, Methods.CHAT_POST_MESSAGE, "_" + channelId);
-    }
-
-    private WaitTime calculateWaitTime(String teamId, String methodName) {
-        return calculateWaitTime(teamId, methodName, "");
-    }
-
-    private WaitTime calculateWaitTime(String teamId, String methodName, String suffix) {
-        String key = methodName + suffix;
-
-        MethodsRateLimitTier tier = MethodsRateLimits.lookupRateLimitTier(methodName);
-        if (tier == null) {
-            log.warn("Rate Limit Tier for method: {} is not found", methodName);
-        }
-        int allowedRequests = getAllowedRequestsPerMinute(tier);
-        if (log.isDebugEnabled()) {
-            int currentRequests = getNumberOfLastMinuteRequests(teamId, key);
-            log.debug("current requests: {}, allowed requests: {}", currentRequests, allowedRequests);
-        }
-
-        Long retryAfterEpochMillis = metricsDatastore.getRateLimitedMethodRetryEpochMillis(
-                config.getExecutorName(), teamId, methodName);
-        if (retryAfterEpochMillis != null) { // rate limited now
-            long waitMillis = retryAfterEpochMillis - System.currentTimeMillis();
-            WaitTime currentSituation = calculateWaitTime(teamId, key, allowedRequests);
-            long additionalMillis = currentSituation.getMillisToWait();
-            if (currentSituation.getPace() == Pace.Burst) {
-                additionalMillis = additionalMillis * 7;
-            } else if (currentSituation.getPace() == Pace.TooFastPaced) {
-                additionalMillis = additionalMillis * 5;
-            }
-            return new WaitTime(waitMillis + additionalMillis, Pace.RateLimited);
-        } else {
-            return calculateWaitTime(teamId, key, allowedRequests);
-        }
-    }
-
-    private WaitTime calculateWaitTime(String teamId, String key, int allowedRequests) {
-        LastMinuteRequests lastMinuteRequests = metricsDatastore.getLastMinuteRequests(config.getExecutorName(), teamId, key);
-        if (isBurst(lastMinuteRequests, allowedRequests)) {
-            if (log.isDebugEnabled()) {
-                log.debug("Burst requests detected (method: {}, last minute requests: {}, allowed: {})",
-                        key, lastMinuteRequests.size(), allowedRequests);
-            }
-            Double waitMillis = 180000D / allowedRequests; // change the pace (60 -> 180 seconds)
-            return new WaitTime(waitMillis.longValue(), Pace.Burst);
-        } else if (isTooFastPaced(lastMinuteRequests, allowedRequests)) {
-            Double waitMillis = 120000D / allowedRequests; // change the pace (60 -> 120 seconds)
-            return new WaitTime(waitMillis.longValue(), Pace.TooFastPaced);
-        } else if (isOptimalPace(lastMinuteRequests, allowedRequests)) {
-            Double waitMillis = 60000D / allowedRequests; // keep the pace
-            return new WaitTime(waitMillis.longValue(), Pace.Optimal);
-        } else if (isSomewhatBusy(lastMinuteRequests, allowedRequests)) {
-            Double waitMillis = 30000D / allowedRequests; // let it a bit slower
-            return new WaitTime(waitMillis.longValue(), Pace.Safe);
-        } else {
-            return new WaitTime(0, Pace.Safe);
-        }
-    }
-
-    private boolean isBurst(LastMinuteRequests lastMinuteRequests, int allowedRequests) {
-        if (lastMinuteRequests.size() > (allowedRequests / 10)) {
-            long threeSecondsAgo = System.currentTimeMillis() - 3000L;
-            long burstRequests = lastMinuteRequests.stream().filter(millis -> millis > threeSecondsAgo).count();
-            return burstRequests >= (allowedRequests / 10);
-        }
-        return false;
-    }
-
-    private static boolean isSomewhatBusy(LastMinuteRequests lastMinuteRequests, int allowedRequests) {
-        int currentSize = lastMinuteRequests.size();
-        return currentSize >= allowedRequests * 0.3 && currentSize < allowedRequests * 0.6;
-    }
-
-    private static boolean isOptimalPace(LastMinuteRequests lastMinuteRequests, int allowedRequests) {
-        int currentSize = lastMinuteRequests.size();
-        return currentSize >= allowedRequests * 0.6 && currentSize < allowedRequests * 0.9;
-    }
-
-    private static boolean isTooFastPaced(LastMinuteRequests lastMinuteRequests, int allowedRequests) {
-        return lastMinuteRequests.size() >= allowedRequests * 0.9;
-    }
-
-    private Integer getAllowedRequestsPerMinute(MethodsRateLimitTier tier) {
-        Integer allowedRequestsForOneNode = MethodsRateLimitTier.getAllowedRequestsPerMinute(tier);
-        return allowedRequestsForOneNode / metricsDatastore.getNumberOfNodes();
-    }
-
-    private Integer getNumberOfLastMinuteRequests(String teamId, String methodNameWithSuffix) {
-        return metricsDatastore.getNumberOfLastMinuteRequests(
-                config.getExecutorName(),
+        return waitTimeCalculator.calculateWaitTime(
                 teamId,
-                methodNameWithSuffix);
+                methodName,
+                waitTimeCalculator.getAllowedRequestsPerMinute(MethodsRateLimits.lookupRateLimitTier(methodName))
+        );
     }
 
+    @Override
+    public WaitTime acquireWaitTimeForChatPostMessage(String teamId, String channel) {
+        return waitTimeCalculator.calculateWaitTimeForChatPostMessage(
+                teamId,
+                channel
+        );
+    }
+
+    public static class MethodsWaitTimeCalculator extends WaitTimeCalculator {
+        private final MethodsConfig config;
+
+        public MethodsWaitTimeCalculator(MethodsConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public Optional<Long> getRateLimitedMethodRetryEpochMillis(String executorName, String teamId, String key) {
+            return Optional.ofNullable(config.getMetricsDatastore().getRateLimitedMethodRetryEpochMillis(
+                    executorName, teamId, key
+            ));
+        }
+
+        @Override
+        public Integer getNumberOfNodes() {
+            return config.getMetricsDatastore().getNumberOfNodes();
+        }
+
+        @Override
+        public String getExecutorName() {
+            return config.getExecutorName();
+        }
+
+        @Override
+        public com.slack.api.rate_limits.metrics.LastMinuteRequests getLastMinuteRequests(
+                String executorName, String teamId, String key) {
+            return config.getMetricsDatastore().getLastMinuteRequests(executorName, teamId, key);
+        }
+    }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -3,7 +3,6 @@ package com.slack.api.methods.impl;
 import com.google.gson.Gson;
 import com.slack.api.RequestConfigurator;
 import com.slack.api.methods.*;
-import com.slack.api.methods.metrics.MetricsDatastore;
 import com.slack.api.methods.request.admin.analytics.AdminAnalyticsGetFileRequest;
 import com.slack.api.methods.request.admin.apps.*;
 import com.slack.api.methods.request.admin.barriers.AdminBarriersCreateRequest;
@@ -205,6 +204,7 @@ import com.slack.api.methods.response.workflows.WorkflowsStepFailedResponse;
 import com.slack.api.methods.response.workflows.WorkflowsUpdateStepResponse;
 import com.slack.api.util.http.SlackHttpClient;
 import com.slack.api.util.json.GsonFactory;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/TeamIdCache.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/TeamIdCache.java
@@ -37,6 +37,7 @@ public class TeamIdCache {
                         log.debug("Created cache for an auth.test API call (token: {}, team_id: {})",
                                 token.substring(0, 16) + "...", authTest.getTeamId());
                     }
+                    // for org admin user's token, this value can be an enterprise_id
                     return authTest.getTeamId();
                 } else {
                     log.error("Got an unsuccessful response from auth.test API (error: {})", authTest.getError());

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
@@ -1,0 +1,24 @@
+package com.slack.api.methods.metrics;
+
+import com.slack.api.methods.SlackApiResponse;
+import com.slack.api.methods.impl.AsyncExecutionSupplier;
+import com.slack.api.methods.impl.AsyncRateLimitQueue;
+import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
+
+public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<AsyncExecutionSupplier<? extends SlackApiResponse>, AsyncRateLimitQueue.Message> {
+
+    public MemoryMetricsDatastore(int numberOfNodes) {
+        super(numberOfNodes);
+    }
+
+    @Override
+    protected String getMetricsType() {
+        return "METHODS";
+    }
+
+    @Override
+    public AsyncRateLimitQueue getRateLimitQueue(String executorName, String teamId) {
+        return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/RedisMetricsDatastore.java
@@ -1,0 +1,20 @@
+package com.slack.api.methods.metrics;
+
+import com.slack.api.methods.SlackApiResponse;
+import com.slack.api.methods.impl.AsyncExecutionSupplier;
+import com.slack.api.methods.impl.AsyncRateLimitQueue;
+import com.slack.api.rate_limits.metrics.impl.BaseRedisMetricsDatastore;
+import com.slack.api.rate_limits.queue.RateLimitQueue;
+import redis.clients.jedis.JedisPool;
+
+public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<AsyncExecutionSupplier<? extends SlackApiResponse>, AsyncRateLimitQueue.Message> {
+
+    public RedisMetricsDatastore(String appName, JedisPool jedisPool) {
+        super(appName, jedisPool);
+    }
+
+    @Override
+    public RateLimitQueue<AsyncExecutionSupplier<? extends SlackApiResponse>, AsyncRateLimitQueue.Message> getRateLimitQueue(String executorName, String teamId) {
+        return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+}

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/RateLimiter.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/RateLimiter.java
@@ -1,0 +1,9 @@
+package com.slack.api.rate_limits;
+
+public interface RateLimiter {
+
+    WaitTime acquireWaitTime(String teamId, String methodName);
+
+    WaitTime acquireWaitTimeForChatPostMessage(String teamId, String channel);
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/WaitTime.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/WaitTime.java
@@ -1,0 +1,12 @@
+package com.slack.api.rate_limits;
+
+import com.slack.api.rate_limits.metrics.RequestPace;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class WaitTime {
+    private long millisToWait;
+    private RequestPace pace;
+}

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/WaitTimeCalculator.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/WaitTimeCalculator.java
@@ -1,0 +1,83 @@
+package com.slack.api.rate_limits;
+
+import com.slack.api.methods.Methods;
+import com.slack.api.methods.MethodsRateLimitTier;
+import com.slack.api.rate_limits.metrics.LastMinuteRequests;
+import com.slack.api.rate_limits.metrics.RequestPace;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+import static com.slack.api.methods.MethodsRateLimitTier.SpecialTier_chat_postMessage;
+
+@Slf4j
+public abstract class WaitTimeCalculator {
+
+    public abstract Integer getNumberOfNodes();
+
+    public abstract String getExecutorName();
+
+    public abstract Optional<Long> getRateLimitedMethodRetryEpochMillis(String executorName, String teamId, String key);
+
+    public abstract LastMinuteRequests getLastMinuteRequests(String executorName, String teamId, String key);
+
+    public WaitTime calculateWaitTime(String teamId, String key, int allowedRequests) {
+        LastMinuteRequests lastMinuteRequests = getLastMinuteRequests(getExecutorName(), teamId, key);
+        if (isBurst(lastMinuteRequests, allowedRequests)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Burst requests detected (method: {}, last minute requests: {}, allowed: {})",
+                        key, lastMinuteRequests.size(), allowedRequests);
+            }
+            Double waitMillis = 180000D / allowedRequests; // change the pace (60 -> 180 seconds)
+            return new WaitTime(waitMillis.longValue(), RequestPace.Burst);
+        } else if (isTooFastPaced(lastMinuteRequests, allowedRequests)) {
+            Double waitMillis = 120000D / allowedRequests; // change the pace (60 -> 120 seconds)
+            return new WaitTime(waitMillis.longValue(), RequestPace.TooFastPaced);
+        } else if (isOptimalPace(lastMinuteRequests, allowedRequests)) {
+            Double waitMillis = 60000D / allowedRequests; // keep the pace
+            return new WaitTime(waitMillis.longValue(), RequestPace.Optimal);
+        } else if (isSomewhatBusy(lastMinuteRequests, allowedRequests)) {
+            Double waitMillis = 30000D / allowedRequests; // let it a bit slower
+            return new WaitTime(waitMillis.longValue(), RequestPace.Safe);
+        } else {
+            return new WaitTime(0, RequestPace.Safe);
+        }
+    }
+
+    public WaitTime calculateWaitTimeForChatPostMessage(String teamId, String channel) {
+        return calculateWaitTime(
+                teamId,
+                Methods.CHAT_POST_MESSAGE + "_" + channel,
+                getAllowedRequestsPerMinute(SpecialTier_chat_postMessage)
+        );
+    }
+
+    private boolean isBurst(LastMinuteRequests lastMinuteRequests, int allowedRequests) {
+        if (lastMinuteRequests.size() > (allowedRequests / 10)) {
+            long threeSecondsAgo = System.currentTimeMillis() - 3000L;
+            long burstRequests = lastMinuteRequests.stream().filter(millis -> millis > threeSecondsAgo).count();
+            return burstRequests >= (allowedRequests / 10);
+        }
+        return false;
+    }
+
+    private static boolean isSomewhatBusy(LastMinuteRequests lastMinuteRequests, int allowedRequests) {
+        int currentSize = lastMinuteRequests.size();
+        return currentSize >= allowedRequests * 0.3 && currentSize < allowedRequests * 0.6;
+    }
+
+    private static boolean isOptimalPace(LastMinuteRequests lastMinuteRequests, int allowedRequests) {
+        int currentSize = lastMinuteRequests.size();
+        return currentSize >= allowedRequests * 0.6 && currentSize < allowedRequests * 0.9;
+    }
+
+    private static boolean isTooFastPaced(LastMinuteRequests lastMinuteRequests, int allowedRequests) {
+        return lastMinuteRequests.size() >= allowedRequests * 0.9;
+    }
+
+    public Integer getAllowedRequestsPerMinute(MethodsRateLimitTier tier) {
+        Integer allowedRequestsForOneNode = MethodsRateLimitTier.getAllowedRequestsPerMinute(tier);
+        return allowedRequestsForOneNode / getNumberOfNodes();
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/LastMinuteRequests.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/LastMinuteRequests.java
@@ -1,4 +1,4 @@
-package com.slack.api.methods.metrics;
+package com.slack.api.rate_limits.metrics;
 
 import java.util.concurrent.CopyOnWriteArrayList;
 

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/LiveRequestStats.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/LiveRequestStats.java
@@ -1,0 +1,18 @@
+package com.slack.api.rate_limits.metrics;
+
+import lombok.Data;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Data
+public class LiveRequestStats {
+    private final ConcurrentMap<String, AtomicLong> allCompletedCalls = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, AtomicLong> successfulCalls = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, AtomicLong> unsuccessfulCalls = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, AtomicLong> failedCalls = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Integer> currentQueueSize = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Integer> lastMinuteRequests = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Long> rateLimitedMethods = new ConcurrentHashMap<>();
+}

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
@@ -1,23 +1,22 @@
-package com.slack.api.methods.metrics;
-
-import com.slack.api.methods.MethodsConfig;
-import com.slack.api.methods.MethodsStats;
+package com.slack.api.rate_limits.metrics;
 
 import java.util.Map;
 
 public interface MetricsDatastore {
 
+    String DEFAULT_SINGLETON_EXECUTOR_NAME = "DEFAULT_SINGLETON_EXECUTOR";
+
     default int getNumberOfNodes() {
         return 1;
     }
 
-    Map<String, Map<String, MethodsStats>> getAllStats();
+    Map<String, Map<String, RequestStats>> getAllStats();
 
-    default MethodsStats getStats(String teamId) {
-        return getStats(MethodsConfig.DEFAULT_SINGLETON_EXECUTOR_NAME, teamId);
+    default RequestStats getStats(String teamId) {
+        return getStats(DEFAULT_SINGLETON_EXECUTOR_NAME, teamId);
     }
 
-    MethodsStats getStats(String executorName, String teamId);
+    RequestStats getStats(String executorName, String teamId);
 
     void incrementAllCompletedCalls(String executorName, String teamId, String methodName);
 

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/RequestPace.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/RequestPace.java
@@ -1,0 +1,9 @@
+package com.slack.api.rate_limits.metrics;
+
+public enum RequestPace {
+    RateLimited,
+    Safe,
+    Optimal,
+    TooFastPaced,
+    Burst
+}

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/RequestStats.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/RequestStats.java
@@ -1,4 +1,4 @@
-package com.slack.api.methods;
+package com.slack.api.rate_limits.metrics;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,7 +12,7 @@ import java.util.Map;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class MethodsStats {
+public class RequestStats {
 
     /**
      * Method name -> # of calls

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/queue/MessageIdGenerator.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/queue/MessageIdGenerator.java
@@ -1,0 +1,7 @@
+package com.slack.api.rate_limits.queue;
+
+public interface MessageIdGenerator {
+
+    String generate();
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/queue/MessageIdGeneratorUUIDImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/queue/MessageIdGeneratorUUIDImpl.java
@@ -1,0 +1,12 @@
+package com.slack.api.rate_limits.queue;
+
+import java.util.UUID;
+
+public class MessageIdGeneratorUUIDImpl implements MessageIdGenerator {
+
+    @Override
+    public String generate() {
+        return UUID.randomUUID().toString();
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/queue/QueueMessage.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/queue/QueueMessage.java
@@ -1,0 +1,14 @@
+package com.slack.api.rate_limits.queue;
+
+import com.slack.api.rate_limits.WaitTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public abstract class QueueMessage<SUPPLIER> {
+    private String id;
+    private long millisToRun;
+    private WaitTime waitTime;
+    private SUPPLIER supplier;
+}

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/queue/RateLimitQueue.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/queue/RateLimitQueue.java
@@ -1,0 +1,117 @@
+package com.slack.api.rate_limits.queue;
+
+import com.slack.api.methods.Methods;
+import com.slack.api.rate_limits.RateLimiter;
+import com.slack.api.rate_limits.WaitTime;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
+@Slf4j
+public abstract class RateLimitQueue<SUPPLIER, MSG extends QueueMessage> {
+
+    protected abstract RateLimiter getRateLimiter();
+
+    protected final ConcurrentMap<String, LinkedBlockingQueue<MSG>> methodNameToActiveQueue = new ConcurrentHashMap<>();
+
+    protected LinkedBlockingQueue<MSG> getOrCreateActiveQueue(String methodName) {
+        LinkedBlockingQueue<MSG> queue = methodNameToActiveQueue.get(methodName);
+        if (queue != null) {
+            return queue;
+        } else {
+            LinkedBlockingQueue<MSG> newQueue = new LinkedBlockingQueue<>();
+            methodNameToActiveQueue.putIfAbsent(methodName, newQueue);
+            return newQueue;
+        }
+    }
+
+    public synchronized SUPPLIER dequeueIfReady(
+            String messageId,
+            String teamId,
+            String methodName,
+            Map<String, String> params) {
+        LinkedBlockingQueue<MSG> activeQueue = getOrCreateActiveQueue(methodName);
+        MSG message = activeQueue.peek();
+        if (message == null) {
+            throw new IllegalStateException("No message is found in the queue");
+        }
+        if (message.getId().equals(messageId)
+                && message.getMillisToRun() <= System.currentTimeMillis()) {
+            // Make sure if the situation is still the same with the timing we determined the wait time
+            WaitTime original = message.getWaitTime();
+            WaitTime latest;
+            if (methodName.equals(Methods.CHAT_POST_MESSAGE)) {
+                latest = getRateLimiter().acquireWaitTimeForChatPostMessage(teamId, params.get("channel"));
+            } else {
+                latest = getRateLimiter().acquireWaitTime(teamId, methodName);
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Latest: {} ({} millis), original: {} ({} millis)",
+                        latest.getPace(), latest.getMillisToWait(), original.getPace(), original.getMillisToWait());
+            }
+            if (latest.getPace() != original.getPace() && latest.getMillisToWait() > original.getMillisToWait()) {
+                // The latest situation is worse than that timing.
+                long newMillisToRun = System.currentTimeMillis() + latest.getMillisToWait();
+                message.setMillisToRun(newMillisToRun);
+                message.setWaitTime(latest);
+            } else {
+                SUPPLIER supplier = (SUPPLIER) activeQueue.poll().getSupplier();
+                return supplier;
+            }
+        }
+        return null;
+    }
+
+    protected abstract MSG buildNewMessage(
+            String messageId,
+            long epochMillisToRun,
+            WaitTime waitTime,
+            SUPPLIER methodsSupplier
+    );
+
+    public void enqueue(
+            String messageId,
+            String teamId,
+            String methodName,
+            Map<String, String> params,
+            SUPPLIER methodsSupplier) throws InterruptedException {
+
+        WaitTime waitTime = getRateLimiter().acquireWaitTime(teamId, methodName);
+        if (methodName.equals(Methods.CHAT_POST_MESSAGE)) {
+            waitTime = getRateLimiter().acquireWaitTimeForChatPostMessage(teamId, params.get("channel"));
+        }
+        LinkedBlockingQueue<MSG> activeQueue = getOrCreateActiveQueue(methodName);
+        long epochMillisToRun = System.currentTimeMillis() + waitTime.getMillisToWait();
+        MSG message = buildNewMessage(messageId, epochMillisToRun, waitTime, methodsSupplier);
+        activeQueue.put(message);
+
+        if (log.isDebugEnabled()) {
+            log.debug("A new message has been enqueued (id: {}, pace: {}, wait time: {})",
+                    message.getId(),
+                    message.getWaitTime().getPace(),
+                    message.getWaitTime().getMillisToWait()
+            );
+        }
+    }
+
+    public synchronized void remove(String methodName, String messageId) {
+        LinkedBlockingQueue<MSG> activeQueue = getOrCreateActiveQueue(methodName);
+        MSG toRemove = null;
+        for (MSG message : activeQueue) {
+            if (message.getId().equals(messageId)) {
+                toRemove = message;
+                break;
+            }
+        }
+        activeQueue.remove(toRemove);
+    }
+
+    public Integer getCurrentActiveQueueSize(String methodNameWithSuffix) {
+        LinkedBlockingQueue<MSG> activeQueue = methodNameToActiveQueue.get(methodNameWithSuffix);
+        return activeQueue != null ? activeQueue.size() : 0;
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/queue/WaitingMessageIds.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/queue/WaitingMessageIds.java
@@ -1,4 +1,4 @@
-package com.slack.api.methods.metrics;
+package com.slack.api.rate_limits.queue;
 
 import java.util.concurrent.CopyOnWriteArrayList;
 

--- a/slack-api-client/src/main/java/com/slack/api/scim/AsyncSCIMClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/AsyncSCIMClient.java
@@ -1,0 +1,113 @@
+package com.slack.api.scim;
+
+import com.slack.api.RequestConfigurator;
+import com.slack.api.scim.request.*;
+import com.slack.api.scim.response.*;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Slack SCIM API client.
+ * <p>
+ * Provision and manage user accounts and groups with the Slack SCIM API.
+ * SCIM is used by Single Sign-On (SSO) services and identity providers to manage people
+ * across a variety of tools, including Slack.
+ * <p>
+ * It's also possible to write your own apps
+ * and scripts using the SCIM API to programmatically manage the members of your workspace.
+ *
+ * @see <a href="https://api.slack.com/scim">Slack SCIM API</a>
+ */
+public interface AsyncSCIMClient {
+
+    String ENDPOINT_URL_PREFIX = "https://api.slack.com/scim/v1/";
+
+    String getEndpointUrlPrefix();
+
+    void setEndpointUrlPrefix(String endpointUrlPrefix);
+
+    // --------------------
+    // ServiceProviderConfigs
+    // --------------------
+
+    CompletableFuture<ServiceProviderConfigsGetResponse> getServiceProviderConfigs(ServiceProviderConfigsGetRequest req);
+
+    CompletableFuture<ServiceProviderConfigsGetResponse> getServiceProviderConfigs(RequestConfigurator<ServiceProviderConfigsGetRequest.ServiceProviderConfigsGetRequestBuilder> req);
+
+    // --------------------
+    // Users
+    // --------------------
+
+    CompletableFuture<UsersSearchResponse> searchUsers(UsersSearchRequest req);
+
+    CompletableFuture<UsersSearchResponse> searchUsers(RequestConfigurator<UsersSearchRequest.UsersSearchRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<UsersReadResponse> readUser(UsersReadRequest req);
+
+    CompletableFuture<UsersReadResponse> readUser(RequestConfigurator<UsersReadRequest.UsersReadRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<UsersCreateResponse> createUser(UsersCreateRequest req);
+
+    CompletableFuture<UsersCreateResponse> createUser(RequestConfigurator<UsersCreateRequest.UsersCreateRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<UsersPatchResponse> patchUser(UsersPatchRequest req);
+
+    CompletableFuture<UsersPatchResponse> patchUser(RequestConfigurator<UsersPatchRequest.UsersPatchRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<UsersUpdateResponse> updateUser(UsersUpdateRequest req);
+
+    CompletableFuture<UsersUpdateResponse> updateUser(RequestConfigurator<UsersUpdateRequest.UsersUpdateRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<UsersDeleteResponse> deleteUser(UsersDeleteRequest req);
+
+    CompletableFuture<UsersDeleteResponse> deleteUser(RequestConfigurator<UsersDeleteRequest.UsersDeleteRequestBuilder> req);
+
+    // --------------------
+    // Groups
+    // --------------------
+
+    CompletableFuture<GroupsSearchResponse> searchGroups(GroupsSearchRequest req);
+
+    CompletableFuture<GroupsSearchResponse> searchGroups(RequestConfigurator<GroupsSearchRequest.GroupsSearchRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<GroupsReadResponse> readGroup(GroupsReadRequest req);
+
+    CompletableFuture<GroupsReadResponse> readGroup(RequestConfigurator<GroupsReadRequest.GroupsReadRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<GroupsCreateResponse> createGroup(GroupsCreateRequest req);
+
+    CompletableFuture<GroupsCreateResponse> createGroup(RequestConfigurator<GroupsCreateRequest.GroupsCreateRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<GroupsPatchResponse> patchGroup(GroupsPatchRequest req);
+
+    CompletableFuture<GroupsPatchResponse> patchGroup(RequestConfigurator<GroupsPatchRequest.GroupsPatchRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<GroupsUpdateResponse> updateGroup(GroupsUpdateRequest req);
+
+    CompletableFuture<GroupsUpdateResponse> updateGroup(RequestConfigurator<GroupsUpdateRequest.GroupsUpdateRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<GroupsDeleteResponse> deleteGroup(GroupsDeleteRequest req);
+
+    CompletableFuture<GroupsDeleteResponse> deleteGroup(RequestConfigurator<GroupsDeleteRequest.GroupsDeleteRequestBuilder> req);
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiCompletionException.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMApiCompletionException.java
@@ -1,0 +1,24 @@
+package com.slack.api.scim;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Data
+@Slf4j
+@EqualsAndHashCode(callSuper = false)
+public class SCIMApiCompletionException extends RuntimeException {
+
+    private final IOException ioException;
+    private final SCIMApiException scimApiException;
+    private final Exception otherException;
+
+    public SCIMApiCompletionException(IOException ioException, SCIMApiException scimApiException, Exception otherException) {
+        this.ioException = ioException;
+        this.scimApiException = scimApiException;
+        this.otherException = otherException;
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMConfig.java
@@ -1,0 +1,101 @@
+package com.slack.api.scim;
+
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.scim.metrics.MemoryMetricsDatastore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration for {@link SCIMClient}.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SCIMConfig {
+
+    /**
+     * If you don't have a special reason, we recommend going with the singleton executor to track all the traffic
+     * your app generated towards the Slack Platform in one place (= in one metrics datastore).
+     */
+    public static final String DEFAULT_SINGLETON_EXECUTOR_NAME = MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME;
+
+    /**
+     * The default configuration. It's not allowed to modify this runtime for any reasons.
+     */
+    public static final SCIMConfig DEFAULT_SINGLETON = new SCIMConfig() {
+
+        void throwException() {
+            throw new UnsupportedOperationException("This config is immutable");
+        }
+
+        @Override
+        public void setStatsEnabled(boolean statsEnabled) {
+            throwException();
+        }
+
+        @Override
+        public void setExecutorName(String executorName) {
+            throwException();
+        }
+
+        @Override
+        public void setMaxIdleMills(int maxIdleMills) {
+            throwException();
+        }
+
+        @Override
+        public void setDefaultThreadPoolSize(int defaultThreadPoolSize) {
+            throwException();
+        }
+
+        @Override
+        public void setMetricsDatastore(MetricsDatastore metricsDatastore) {
+            throwException();
+        }
+
+        @Override
+        public void setCustomThreadPoolSizes(Map<String, Integer> customThreadPoolSizes) {
+            throwException();
+        }
+    };
+
+    @Builder.Default
+    private boolean statsEnabled = true;
+
+    /**
+     * If you need to have multiple executors in the same Slack app, name this accordingly.
+     */
+    @Builder.Default
+    private String executorName = DEFAULT_SINGLETON_EXECUTOR_NAME;
+
+    /**
+     * The max period to keep asynchronous API method calls idle.
+     */
+    @Builder.Default
+    private int maxIdleMills = 60 * 60 * 1000;
+
+    /**
+     * The default thread pool size used for asynchronous API method calls.
+     */
+    @Builder.Default
+    private int defaultThreadPoolSize = 5;
+
+    /**
+     * Enterprise ID -> thread pool size
+     */
+    @Builder.Default
+    private Map<String, Integer> customThreadPoolSizes = new HashMap<>();
+
+    /**
+     * The metrics datastore to track the traffic associated to this executor name.
+     */
+    @Builder.Default
+    private MetricsDatastore metricsDatastore = new MemoryMetricsDatastore(1);
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMEndpointName.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMEndpointName.java
@@ -1,0 +1,17 @@
+package com.slack.api.scim;
+
+public enum SCIMEndpointName {
+    getServiceProviderConfigs,
+    searchUsers,
+    readUser,
+    createUser,
+    patchUser,
+    updateUser,
+    deleteUser,
+    searchGroups,
+    readGroup,
+    createGroup,
+    patchGroup,
+    updateGroup,
+    deleteGroup,
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncExecutionSupplier.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncExecutionSupplier.java
@@ -1,0 +1,16 @@
+package com.slack.api.scim.impl;
+
+import com.slack.api.scim.SCIMApiException;
+import com.slack.api.scim.SCIMApiResponse;
+
+import java.io.IOException;
+
+/**
+ * A Supplier that holds an API Method execution.
+ */
+@FunctionalInterface
+public interface AsyncExecutionSupplier<T extends SCIMApiResponse> {
+
+    T execute() throws IOException, SCIMApiException;
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncRateLimitExecutor.java
@@ -1,0 +1,200 @@
+package com.slack.api.scim.impl;
+
+import com.slack.api.SlackConfig;
+import com.slack.api.methods.impl.MethodsClientImpl;
+import com.slack.api.methods.impl.TeamIdCache;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.rate_limits.queue.MessageIdGenerator;
+import com.slack.api.rate_limits.queue.MessageIdGeneratorUUIDImpl;
+import com.slack.api.scim.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+
+@Slf4j
+public class AsyncRateLimitExecutor {
+
+    private static final ConcurrentMap<String, AsyncRateLimitExecutor> ALL_EXECUTORS = new ConcurrentHashMap<>();
+
+    private SCIMConfig config;
+    private MetricsDatastore metricsDatastore; // intentionally mutable
+    private final TeamIdCache teamIdCache;
+    private final MessageIdGenerator messageIdGenerator;
+
+    private AsyncRateLimitExecutor(MethodsClientImpl methods, SlackConfig config) {
+        this.config = config.getSCIMConfig();
+        this.metricsDatastore = config.getSCIMConfig().getMetricsDatastore();
+        this.teamIdCache = new TeamIdCache(methods);
+        this.messageIdGenerator = new MessageIdGeneratorUUIDImpl();
+    }
+
+    public static AsyncRateLimitExecutor get(String executorName) {
+        return ALL_EXECUTORS.get(executorName);
+    }
+
+    public static AsyncRateLimitExecutor getOrCreate(MethodsClientImpl methods, SlackConfig config) {
+        AsyncRateLimitExecutor executor = ALL_EXECUTORS.get(config.getMethodsConfig().getExecutorName());
+        if (executor != null && executor.metricsDatastore != config.getMethodsConfig().getMetricsDatastore()) {
+            // As the metrics datastore has been changed, we should replace the executor
+            executor.config = config.getSCIMConfig();
+            executor.metricsDatastore = config.getSCIMConfig().getMetricsDatastore();
+        }
+        if (executor == null) {
+            executor = new AsyncRateLimitExecutor(methods, config);
+            ALL_EXECUTORS.putIfAbsent(config.getMethodsConfig().getExecutorName(), executor);
+        }
+        return executor;
+    }
+
+    private static final List<String> NO_TOKEN_METHOD_NAMES = Collections.emptyList();
+
+    public <T extends SCIMApiResponse> CompletableFuture<T> execute(
+            SCIMEndpointName endpointName,
+            Map<String, String> params,
+            AsyncExecutionSupplier<T> methodsSupplier) {
+        String token = params.get("token");
+        final String teamId = token != null ? teamIdCache.lookupOrResolve(token) : null;
+        final ExecutorService executorService = teamId != null ? ThreadPools.getOrCreate(config, teamId) : ThreadPools.getDefault(config);
+        return CompletableFuture.supplyAsync(() -> {
+            String messageId = messageIdGenerator.generate();
+            addMessageId(teamId, endpointName, messageId);
+            initCurrentQueueSizeStatsIfAbsent(teamId, endpointName);
+            if (NO_TOKEN_METHOD_NAMES.contains(endpointName) || teamId == null) {
+                return runWithoutQueue(teamId, endpointName, methodsSupplier);
+            } else {
+                return enqueueThenRun(
+                        messageId,
+                        teamId,
+                        endpointName,
+                        params,
+                        methodsSupplier
+                );
+            }
+        }, executorService);
+    }
+
+    private void initCurrentQueueSizeStatsIfAbsent(String teamId, SCIMEndpointName endpointName) {
+        if (teamId != null) {
+            metricsDatastore.setCurrentQueueSize(
+                    config.getExecutorName(),
+                    teamId,
+                    endpointName.name(),
+                    0
+            );
+        }
+    }
+
+    private void addMessageId(
+            String teamId,
+            SCIMEndpointName endpointName,
+            String messageId) {
+        metricsDatastore.addToWaitingMessageIds(
+                config.getExecutorName(), teamId, endpointName.name(), messageId);
+    }
+
+    private void removeMessageId(
+            String teamId,
+            SCIMEndpointName endpointName,
+            String messageId) {
+        metricsDatastore.deleteFromWaitingMessageIds(
+                config.getExecutorName(), teamId, endpointName.name(), messageId);
+    }
+
+    private <T extends SCIMApiResponse> T runWithoutQueue(
+            String teamId,
+            SCIMEndpointName endpointName,
+            AsyncExecutionSupplier<T> methodsSupplier) {
+        try {
+            return methodsSupplier.execute();
+        } catch (RuntimeException e) {
+            return handleRuntimeException(teamId, endpointName, e);
+        } catch (IOException e) {
+            return handleIOException(teamId, endpointName, e);
+        } catch (SCIMApiException e) {
+            logSCIMApiException(teamId, endpointName, e);
+            throw new SCIMApiCompletionException(null, e, null);
+        }
+    }
+
+    private <T extends SCIMApiResponse> T enqueueThenRun(
+            String messageId,
+            String teamId,
+            SCIMEndpointName endpointName,
+            Map<String, String> params,
+            AsyncExecutionSupplier<T> methodsSupplier) {
+        try {
+            AsyncRateLimitQueue activeQueue = AsyncRateLimitQueue.getOrCreate(config, teamId);
+            if (activeQueue == null) {
+                log.warn("Queue for teamId: {} was not found. Going to run the API call immediately.", teamId);
+            }
+            AsyncExecutionSupplier<T> supplier = null;
+            activeQueue.enqueue(messageId, teamId, endpointName.name(), params, methodsSupplier);
+            long consumedMillis = 0L;
+            while (supplier == null && consumedMillis < config.getMaxIdleMills()) {
+                Thread.sleep(10);
+                consumedMillis += 10;
+                supplier = (AsyncExecutionSupplier<T>) activeQueue.dequeueIfReady(
+                        messageId, teamId, endpointName.name(), params);
+                removeMessageId(teamId, endpointName, messageId);
+            }
+            if (supplier == null) {
+                activeQueue.remove(endpointName.name(), messageId);
+                throw new RejectedExecutionException("Gave up executing the message after " + config.getMaxIdleMills() + " milliseconds.");
+            }
+            T response = supplier.execute();
+            return response;
+
+        } catch (RuntimeException e) {
+            return handleRuntimeException(teamId, endpointName, e);
+        } catch (IOException e) {
+            return handleIOException(teamId, endpointName, e);
+        } catch (SCIMApiException e) {
+            logSCIMApiException(teamId, endpointName, e);
+            if (e.getResponse().code() == 429) {
+                return enqueueThenRun(messageId, teamId, endpointName, params, methodsSupplier);
+            }
+            throw new SCIMApiCompletionException(null, e, null);
+        } catch (InterruptedException e) {
+            log.error("Got an InterruptedException (error: {})", e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <T extends SCIMApiResponse> T handleRuntimeException(
+            String teamId, SCIMEndpointName endpointName, RuntimeException e) {
+        log.error("Got an exception while calling {} API (team: {}, error: {})", endpointName, teamId, e.getMessage(), e);
+        throw new SCIMApiCompletionException(null, null, e);
+    }
+
+    private static <T extends SCIMApiResponse> T handleIOException(
+            String teamId, SCIMEndpointName endpointName, IOException e) {
+        log.error("Failed to connect to {} API (team: {}, error: {})", endpointName, teamId, e.getMessage(), e);
+        throw new SCIMApiCompletionException(e, null, null);
+    }
+
+    private static void logSCIMApiException(String teamId, SCIMEndpointName endpointName, SCIMApiException e) {
+        if (e.getResponse().code() == 429) {
+            String retryAfterSeconds = e.getResponse().header("Retry-After");
+            log.error("Got a rate-limited response from {} API (team: {}, error: {}, retry-after: {})",
+                    endpointName,
+                    teamId,
+                    e.getMessage(),
+                    retryAfterSeconds,
+                    e
+            );
+        } else {
+            log.error("Got an unsuccessful response from {} API (team: {}, error: {}, status code: {})",
+                    endpointName,
+                    teamId,
+                    e.getMessage(),
+                    e.getResponse().code(),
+                    e
+            );
+        }
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncRateLimitQueue.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncRateLimitQueue.java
@@ -1,0 +1,93 @@
+package com.slack.api.scim.impl;
+
+import com.slack.api.rate_limits.WaitTime;
+import com.slack.api.rate_limits.queue.QueueMessage;
+import com.slack.api.rate_limits.queue.RateLimitQueue;
+import com.slack.api.scim.SCIMApiResponse;
+import com.slack.api.scim.SCIMConfig;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
+@Slf4j
+public class AsyncRateLimitQueue extends RateLimitQueue<
+        AsyncExecutionSupplier<? extends SCIMApiResponse>,
+        AsyncRateLimitQueue.SCIMMessage> {
+
+    @Data
+    @AllArgsConstructor
+    public static class SCIMMessage extends QueueMessage<AsyncExecutionSupplier> {
+        private String id;
+        private long millisToRun;
+        private WaitTime waitTime;
+        private AsyncExecutionSupplier<?> supplier;
+    }
+
+    // Executor name -> Team ID -> Queue
+    private static final ConcurrentMap<String, ConcurrentMap<String, AsyncRateLimitQueue>> ALL_QUEUES = new ConcurrentHashMap<>();
+
+    private static ConcurrentMap<String, AsyncRateLimitQueue> getInstance(String executorName) {
+        ConcurrentMap<String, AsyncRateLimitQueue> teamIdToQueue = ALL_QUEUES.get(executorName);
+        if (teamIdToQueue == null) {
+            teamIdToQueue = new ConcurrentHashMap<>();
+            ALL_QUEUES.put(executorName, teamIdToQueue);
+        }
+        return teamIdToQueue;
+    }
+
+    private AsyncSCIMRateLimiter rateLimiter; // intentionally mutable
+
+    public AsyncSCIMRateLimiter getRateLimiter() {
+        return rateLimiter;
+    }
+
+    public void setRateLimiter(AsyncSCIMRateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    private final ConcurrentMap<String, LinkedBlockingQueue<SCIMMessage>> methodNameToActiveQueue = new ConcurrentHashMap<>();
+
+    private AsyncRateLimitQueue(SCIMConfig config) {
+        this.rateLimiter = new AsyncSCIMRateLimiter(config);
+    }
+
+    public static AsyncRateLimitQueue get(String executorName, String teamId) {
+        if (executorName == null || teamId == null) {
+            throw new IllegalArgumentException("`executorName` and `teamId` are required");
+        }
+        ConcurrentMap<String, AsyncRateLimitQueue> teamIdToQueue = getInstance(executorName);
+        return teamIdToQueue.get(teamId);
+    }
+
+    public static AsyncRateLimitQueue getOrCreate(SCIMConfig config, String teamId) {
+        if (teamId == null) {
+            throw new IllegalArgumentException("`teamId` is required");
+        }
+        ConcurrentMap<String, AsyncRateLimitQueue> teamIdToQueue = getInstance(config.getExecutorName());
+        AsyncRateLimitQueue queue = teamIdToQueue.get(teamId);
+        if (queue != null && queue.getRateLimiter().getMetricsDatastore() != config.getMetricsDatastore()) {
+            // As the metrics datastore has been changed, we should replace the executor
+            queue.setRateLimiter(new AsyncSCIMRateLimiter(config));
+        }
+        if (queue == null) {
+            queue = new AsyncRateLimitQueue(config);
+            teamIdToQueue.put(teamId, queue);
+        }
+        return queue;
+    }
+
+    @Override
+    protected SCIMMessage buildNewMessage(
+            String messageId,
+            long epochMillisToRun,
+            WaitTime waitTime,
+            AsyncExecutionSupplier<? extends SCIMApiResponse> methodsSupplier
+    ) {
+        return new SCIMMessage(messageId, epochMillisToRun, waitTime, methodsSupplier);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncSCIMClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncSCIMClientImpl.java
@@ -1,0 +1,246 @@
+package com.slack.api.scim.impl;
+
+import com.slack.api.RequestConfigurator;
+import com.slack.api.SlackConfig;
+import com.slack.api.methods.impl.MethodsClientImpl;
+import com.slack.api.scim.AsyncSCIMClient;
+import com.slack.api.scim.SCIMApiRequest;
+import com.slack.api.scim.request.*;
+import com.slack.api.scim.response.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static com.slack.api.scim.SCIMEndpointName.*;
+
+@Slf4j
+public class AsyncSCIMClientImpl implements AsyncSCIMClient {
+
+    private final String token;
+    private final SCIMClientImpl underlying;
+    private final AsyncRateLimitExecutor executor;
+
+    public AsyncSCIMClientImpl(
+            String token,
+            SCIMClientImpl scim,
+            MethodsClientImpl methods,
+            SlackConfig config
+    ) {
+        this.token = token;
+        this.underlying = scim;
+        this.executor = AsyncRateLimitExecutor.getOrCreate(methods, config);
+    }
+
+    private String token(SCIMApiRequest req) {
+        if (req.getToken() != null) {
+            return req.getToken();
+        } else {
+            return this.token;
+        }
+    }
+
+    private Map<String, String> toMap(SCIMApiRequest req) {
+        Map<String, String> params = new HashMap<>();
+        params.put("token", token(req));
+        return params;
+    }
+
+    // ----------------------------------------------------------------------------------
+    // public methods
+    // ----------------------------------------------------------------------------------
+
+    @Override
+    public String getEndpointUrlPrefix() {
+        return this.underlying.getEndpointUrlPrefix();
+    }
+
+    @Override
+    public void setEndpointUrlPrefix(String endpointUrlPrefix) {
+        this.underlying.setEndpointUrlPrefix(endpointUrlPrefix);
+    }
+
+    @Override
+    public CompletableFuture<ServiceProviderConfigsGetResponse> getServiceProviderConfigs(ServiceProviderConfigsGetRequest req) {
+        return executor.execute(
+                getServiceProviderConfigs,
+                toMap(req),
+                () -> this.underlying.getServiceProviderConfigs(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<ServiceProviderConfigsGetResponse> getServiceProviderConfigs(RequestConfigurator<ServiceProviderConfigsGetRequest.ServiceProviderConfigsGetRequestBuilder> req) {
+        return getServiceProviderConfigs(req.configure(ServiceProviderConfigsGetRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersSearchResponse> searchUsers(UsersSearchRequest req) {
+        return executor.execute(
+                searchUsers,
+                toMap(req),
+                () -> this.underlying.searchUsers(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersSearchResponse> searchUsers(RequestConfigurator<UsersSearchRequest.UsersSearchRequestBuilder> req) {
+        return searchUsers(req.configure(UsersSearchRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersReadResponse> readUser(UsersReadRequest req) {
+        return executor.execute(
+                readUser,
+                toMap(req),
+                () -> this.underlying.readUser(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersReadResponse> readUser(RequestConfigurator<UsersReadRequest.UsersReadRequestBuilder> req) {
+        return readUser(req.configure(UsersReadRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersCreateResponse> createUser(UsersCreateRequest req) {
+        return executor.execute(
+                createUser,
+                toMap(req),
+                () -> this.underlying.createUser(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersCreateResponse> createUser(RequestConfigurator<UsersCreateRequest.UsersCreateRequestBuilder> req) {
+        return createUser(req.configure(UsersCreateRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersPatchResponse> patchUser(UsersPatchRequest req) {
+        return executor.execute(
+                patchUser,
+                toMap(req),
+                () -> this.underlying.patchUser(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersPatchResponse> patchUser(RequestConfigurator<UsersPatchRequest.UsersPatchRequestBuilder> req) {
+        return patchUser(req.configure(UsersPatchRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersUpdateResponse> updateUser(UsersUpdateRequest req) {
+        return executor.execute(
+                updateUser,
+                toMap(req),
+                () -> this.underlying.updateUser(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersUpdateResponse> updateUser(RequestConfigurator<UsersUpdateRequest.UsersUpdateRequestBuilder> req) {
+        return updateUser(req.configure(UsersUpdateRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersDeleteResponse> deleteUser(UsersDeleteRequest req) {
+        return executor.execute(
+                deleteUser,
+                toMap(req),
+                () -> this.underlying.deleteUser(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersDeleteResponse> deleteUser(RequestConfigurator<UsersDeleteRequest.UsersDeleteRequestBuilder> req) {
+        return deleteUser(req.configure(UsersDeleteRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsSearchResponse> searchGroups(GroupsSearchRequest req) {
+        return executor.execute(
+                searchGroups,
+                toMap(req),
+                () -> this.underlying.searchGroups(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsSearchResponse> searchGroups(RequestConfigurator<GroupsSearchRequest.GroupsSearchRequestBuilder> req) {
+        return searchGroups(req.configure(GroupsSearchRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsReadResponse> readGroup(GroupsReadRequest req) {
+        return executor.execute(
+                readGroup,
+                toMap(req),
+                () -> this.underlying.readGroup(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsReadResponse> readGroup(RequestConfigurator<GroupsReadRequest.GroupsReadRequestBuilder> req) {
+        return readGroup(req.configure(GroupsReadRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsCreateResponse> createGroup(GroupsCreateRequest req) {
+        return executor.execute(
+                createGroup,
+                toMap(req),
+                () -> this.underlying.createGroup(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsCreateResponse> createGroup(RequestConfigurator<GroupsCreateRequest.GroupsCreateRequestBuilder> req) {
+        return createGroup(req.configure(GroupsCreateRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsPatchResponse> patchGroup(GroupsPatchRequest req) {
+        return executor.execute(
+                patchGroup,
+                toMap(req),
+                () -> this.underlying.patchGroup(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsPatchResponse> patchGroup(RequestConfigurator<GroupsPatchRequest.GroupsPatchRequestBuilder> req) {
+        return patchGroup(req.configure(GroupsPatchRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsUpdateResponse> updateGroup(GroupsUpdateRequest req) {
+        return executor.execute(
+                updateGroup,
+                toMap(req),
+                () -> this.underlying.updateGroup(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsUpdateResponse> updateGroup(RequestConfigurator<GroupsUpdateRequest.GroupsUpdateRequestBuilder> req) {
+        return updateGroup(req.configure(GroupsUpdateRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsDeleteResponse> deleteGroup(GroupsDeleteRequest req) {
+        return executor.execute(
+                deleteGroup,
+                toMap(req),
+                () -> this.underlying.deleteGroup(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsDeleteResponse> deleteGroup(RequestConfigurator<GroupsDeleteRequest.GroupsDeleteRequestBuilder> req) {
+        return deleteGroup(req.configure(GroupsDeleteRequest.builder()).build());
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncSCIMRateLimiter.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncSCIMRateLimiter.java
@@ -1,0 +1,149 @@
+package com.slack.api.scim.impl;
+
+import com.slack.api.rate_limits.RateLimiter;
+import com.slack.api.rate_limits.WaitTime;
+import com.slack.api.rate_limits.WaitTimeCalculator;
+import com.slack.api.rate_limits.metrics.LastMinuteRequests;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.rate_limits.metrics.RequestPace;
+import com.slack.api.rate_limits.metrics.RequestStats;
+import com.slack.api.scim.SCIMConfig;
+import com.slack.api.scim.SCIMEndpointName;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.slack.api.scim.SCIMEndpointName.*;
+
+@Slf4j
+public class AsyncSCIMRateLimiter implements RateLimiter {
+
+    private final MetricsDatastore metricsDatastore;
+    private final String executorName;
+    private final SCIMWaitTimeCalculator waitTimeCalculator;
+
+    public MetricsDatastore getMetricsDatastore() {
+        return metricsDatastore;
+    }
+
+    public AsyncSCIMRateLimiter(SCIMConfig config) {
+        this.metricsDatastore = config.getMetricsDatastore();
+        this.executorName = config.getExecutorName();
+        this.waitTimeCalculator = new SCIMWaitTimeCalculator(config);
+    }
+
+    public static class SCIMWaitTimeCalculator extends WaitTimeCalculator {
+        private final SCIMConfig config;
+
+        public SCIMWaitTimeCalculator(SCIMConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public Integer getNumberOfNodes() {
+            return config.getMetricsDatastore().getNumberOfNodes();
+        }
+
+        @Override
+        public String getExecutorName() {
+            return config.getExecutorName();
+        }
+
+        @Override
+        public Optional<Long> getRateLimitedMethodRetryEpochMillis(
+                String executorName, String teamId, String key) {
+            return Optional.ofNullable(config.getMetricsDatastore().getRateLimitedMethodRetryEpochMillis(
+                    executorName, teamId, key
+            ));
+        }
+
+        @Override
+        public LastMinuteRequests getLastMinuteRequests(
+                String executorName, String teamId, String key) {
+            return config.getMetricsDatastore().getLastMinuteRequests(executorName, teamId, key);
+        }
+    }
+
+    public int getAllowedRequestsPerMinutes(SCIMEndpointName endpoint) {
+        switch (endpoint) {
+            case getServiceProviderConfigs:
+            case searchUsers:
+            case searchGroups:
+                return 1000; // the maximum (the org-wide limits will be applied later)
+            case readUser:
+            case readGroup:
+                return 300;
+            case createUser:
+            case patchUser:
+            case updateUser:
+            case deleteUser:
+            case createGroup:
+            case patchGroup:
+            case updateGroup:
+            case deleteGroup:
+                return 180;
+            default:
+                break;
+        }
+        return 180; // the most conservative value
+    }
+
+    public int getRemainingAllowedRequestsPerMinutesForOrg(SCIMEndpointName endpoint, RequestStats stats) {
+        Map<String, Integer> r = stats.getLastMinuteRequests();
+        switch (endpoint) {
+            case getServiceProviderConfigs:
+            case searchUsers:
+            case searchGroups:
+            case readUser:
+            case readGroup:
+                return 1000 - (Optional.ofNullable(r.get(getServiceProviderConfigs.name())).orElse(0)
+                        + Optional.ofNullable(r.get(searchUsers.name())).orElse(0)
+                        + Optional.ofNullable(r.get(searchGroups.name())).orElse(0)
+                        + Optional.ofNullable(r.get(readUser.name())).orElse(0)
+                        + Optional.ofNullable(r.get(readGroup.name())).orElse(0)
+                );
+            case createUser:
+            case patchUser:
+            case updateUser:
+            case deleteUser:
+            case createGroup:
+            case patchGroup:
+            case updateGroup:
+            case deleteGroup:
+            default:
+                return 600 - (Optional.ofNullable(r.get(createUser.name())).orElse(0)
+                        + Optional.ofNullable(r.get(patchUser.name())).orElse(0)
+                        + Optional.ofNullable(r.get(updateUser.name())).orElse(0)
+                        + Optional.ofNullable(r.get(deleteUser.name())).orElse(0)
+                        + Optional.ofNullable(r.get(createGroup.name())).orElse(0)
+                        + Optional.ofNullable(r.get(patchGroup.name())).orElse(0)
+                        + Optional.ofNullable(r.get(updateGroup.name())).orElse(0)
+                        + Optional.ofNullable(r.get(deleteGroup.name())).orElse(0)
+                );
+        }
+    }
+
+    @Override
+    public WaitTime acquireWaitTime(String teamId, String methodName) {
+        Optional<Long> rateLimitedEpochMillis = waitTimeCalculator
+                .getRateLimitedMethodRetryEpochMillis(executorName, teamId, methodName);
+        if (rateLimitedEpochMillis.isPresent()) {
+            long millisToWait = rateLimitedEpochMillis.get() - System.currentTimeMillis();
+            return new WaitTime(millisToWait, RequestPace.RateLimited);
+        }
+        SCIMEndpointName endpoint = SCIMEndpointName.valueOf(methodName);
+        int orgRemainingRequests = getRemainingAllowedRequestsPerMinutesForOrg(
+                endpoint, metricsDatastore.getStats(this.executorName, teamId));
+        int endpointAllowedRequests = getAllowedRequestsPerMinutes(endpoint);
+        int allowedRequests = endpointAllowedRequests > orgRemainingRequests
+                ? endpointAllowedRequests : orgRemainingRequests;
+        return waitTimeCalculator.calculateWaitTime(teamId, methodName, allowedRequests);
+    }
+
+    @Override
+    public WaitTime acquireWaitTimeForChatPostMessage(String teamId, String channel) {
+        return waitTimeCalculator.calculateWaitTimeForChatPostMessage(teamId, channel);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/ThreadPools.java
@@ -1,0 +1,54 @@
+package com.slack.api.scim.impl;
+
+import com.slack.api.scim.SCIMConfig;
+import com.slack.api.util.thread.ExecutorServiceFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+
+public class ThreadPools {
+
+    // Executor Name -> Executor
+    private static final ConcurrentMap<String, ExecutorService> ALL_DEFAULT = new ConcurrentHashMap<>();
+    // Executor Name -> Enterprise ID -> Executor
+    private static final ConcurrentMap<String, ConcurrentMap<String, ExecutorService>> ENTERPRISE_CUSTOM =
+            new ConcurrentHashMap<>();
+
+    private ThreadPools() {
+    }
+
+    public static ExecutorService getDefault(SCIMConfig config) {
+        return getOrCreate(config, null);
+    }
+
+    public static ExecutorService getOrCreate(SCIMConfig config, String enterpriseId) {
+        String executorName = config.getExecutorName();
+        Integer customPoolSize = enterpriseId != null ? config.getCustomThreadPoolSizes().get(enterpriseId) : null;
+        if (customPoolSize != null) {
+            ConcurrentMap<String, ExecutorService> allOrgs = ENTERPRISE_CUSTOM.get(executorName);
+            if (allOrgs == null) {
+                allOrgs = new ConcurrentHashMap<>();
+                ENTERPRISE_CUSTOM.put(executorName, allOrgs);
+            }
+            ExecutorService orgExecutor = allOrgs.get(enterpriseId);
+            if (orgExecutor == null) {
+                String threadGroupName = "slack-scim-" + config.getExecutorName() + "-" + enterpriseId;
+                orgExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, customPoolSize);
+                allOrgs.put(enterpriseId, orgExecutor);
+            }
+            return orgExecutor;
+
+        } else {
+            ExecutorService defaultExecutor = ALL_DEFAULT.get(executorName);
+            if (defaultExecutor == null) {
+                String threadGroupName = "slack-scim-" + config.getExecutorName();
+                int poolSize = config.getDefaultThreadPoolSize();
+                defaultExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, poolSize);
+                ALL_DEFAULT.put(config.getExecutorName(), defaultExecutor);
+            }
+            return defaultExecutor;
+        }
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
@@ -1,0 +1,25 @@
+package com.slack.api.scim.metrics;
+
+import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
+import com.slack.api.scim.SCIMApiResponse;
+import com.slack.api.scim.impl.AsyncExecutionSupplier;
+import com.slack.api.scim.impl.AsyncRateLimitQueue;
+
+public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
+        AsyncExecutionSupplier<? extends SCIMApiResponse>, AsyncRateLimitQueue.SCIMMessage> {
+
+    public MemoryMetricsDatastore(int numberOfNodes) {
+        super(numberOfNodes);
+    }
+
+    @Override
+    protected String getMetricsType() {
+        return "SCIM";
+    }
+
+    @Override
+    public AsyncRateLimitQueue getRateLimitQueue(String executorName, String teamId) {
+        return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
@@ -1,0 +1,21 @@
+package com.slack.api.scim.metrics;
+
+import com.slack.api.rate_limits.metrics.impl.BaseRedisMetricsDatastore;
+import com.slack.api.scim.SCIMApiResponse;
+import com.slack.api.scim.impl.AsyncExecutionSupplier;
+import com.slack.api.scim.impl.AsyncRateLimitQueue;
+import redis.clients.jedis.JedisPool;
+
+public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
+        AsyncExecutionSupplier<? extends SCIMApiResponse>, AsyncRateLimitQueue.SCIMMessage> {
+
+    public RedisMetricsDatastore(String appName, JedisPool jedisPool) {
+        super(appName, jedisPool);
+    }
+
+    @Override
+    public AsyncRateLimitQueue getRateLimitQueue(String executorName, String teamId) {
+        return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+
+}

--- a/slack-api-client/src/test/java/config/SlackTestConfig.java
+++ b/slack-api-client/src/test/java/config/SlackTestConfig.java
@@ -1,10 +1,10 @@
 package config;
 
 import com.slack.api.SlackConfig;
-import com.slack.api.methods.metrics.MetricsDatastore;
-import com.slack.api.methods.metrics.impl.RedisMetricsDatastore;
+import com.slack.api.methods.metrics.RedisMetricsDatastore;
 import com.slack.api.util.http.listener.HttpResponseListener;
 import com.slack.api.util.json.GsonFactory;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
 import lombok.extern.slf4j.Slf4j;
 import redis.clients.jedis.JedisPool;
 import util.sample_json_generation.JsonDataRecordingListener;
@@ -21,8 +21,12 @@ public class SlackTestConfig {
 
     private final SlackConfig config;
 
-    public MetricsDatastore getMetricsDatastore() {
+    public MetricsDatastore getMethodsMetricsDatastore() {
         return getConfig().getMethodsConfig().getMetricsDatastore();
+    }
+
+    public MetricsDatastore getAuditMetricsDatastore() {
+        return getConfig().getAuditConfig().getMetricsDatastore();
     }
 
     private SlackTestConfig(SlackConfig config) {
@@ -30,8 +34,22 @@ public class SlackTestConfig {
         CONFIG.getHttpClientResponseHandlers().add(new HttpResponseListener() {
             @Override
             public void accept(State state) {
-                String json = GsonFactory.createSnakeCase(CONFIG).toJson(getMetricsDatastore().getAllStats());
-                log.debug("--- (MethodsStats) ---\n" + json);
+                String json = GsonFactory.createSnakeCase(CONFIG).toJson(getMethodsMetricsDatastore().getAllStats());
+                log.debug("--- (API Methods Stats) ---\n" + json);
+            }
+        });
+        CONFIG.getHttpClientResponseHandlers().add(new HttpResponseListener() {
+            @Override
+            public void accept(State state) {
+                String json = GsonFactory.createSnakeCase(CONFIG).toJson(getAuditMetricsDatastore().getAllStats());
+                log.debug("--- (Audit Logs Stats) ---\n" + json);
+            }
+        });
+        CONFIG.getHttpClientResponseHandlers().add(new HttpResponseListener() {
+            @Override
+            public void accept(State state) {
+                String json = GsonFactory.createSnakeCase(CONFIG).toJson(getAuditMetricsDatastore().getAllStats());
+                log.debug("--- (Audit Logs Stats) ---\n" + json);
             }
         });
 

--- a/slack-api-client/src/test/java/test_locally/SlackConfigTest.java
+++ b/slack-api-client/src/test/java/test_locally/SlackConfigTest.java
@@ -81,6 +81,16 @@ public class SlackConfigTest {
             fail();
         } catch (UnsupportedOperationException ignored) {
         }
+        try {
+            SlackConfig.DEFAULT.setAuditConfig(null);
+            fail();
+        } catch (UnsupportedOperationException ignored) {
+        }
+        try {
+            SlackConfig.DEFAULT.setSCIMConfig(null);
+            fail();
+        } catch (UnsupportedOperationException ignored) {
+        }
     }
 
 }

--- a/slack-api-client/src/test/java/test_locally/SlackTest.java
+++ b/slack-api-client/src/test/java/test_locally/SlackTest.java
@@ -3,12 +3,12 @@ package test_locally;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.audit.AuditClient;
-import com.slack.api.methods.MethodsStats;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.api.ApiTestResponse;
 import com.slack.api.rtm.RTMClient;
 import com.slack.api.scim.SCIMClient;
 import com.slack.api.util.http.SlackHttpClient;
+import com.slack.api.rate_limits.metrics.RequestStats;
 import com.slack.api.webhook.WebhookResponse;
 import org.junit.Test;
 import util.MockSlackApi;
@@ -127,11 +127,35 @@ public class SlackTest {
     @Test
     public void methodsStats() {
         {
-            MethodsStats stats = Slack.getInstance().methodsStats("T1234567");
+            RequestStats stats = Slack.getInstance().methodsStats("T1234567");
             assertNotNull(stats);
         }
         {
-            MethodsStats stats = Slack.getInstance().methodsStats("executor", "T1234567");
+            RequestStats stats = Slack.getInstance().methodsStats("executor", "T1234567");
+            assertNotNull(stats);
+        }
+    }
+
+    @Test
+    public void auditStats() {
+        {
+            RequestStats stats = Slack.getInstance().auditStats("E1234567");
+            assertNotNull(stats);
+        }
+        {
+            RequestStats stats = Slack.getInstance().auditStats("executor", "T1234567");
+            assertNotNull(stats);
+        }
+    }
+
+    @Test
+    public void scimStats() {
+        {
+            RequestStats stats = Slack.getInstance().scimStats("E1234567");
+            assertNotNull(stats);
+        }
+        {
+            RequestStats stats = Slack.getInstance().scimStats("executor", "E1234567");
             assertNotNull(stats);
         }
     }

--- a/slack-api-client/src/test/java/test_locally/api/audit/ApiTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/audit/ApiTest.java
@@ -3,7 +3,10 @@ package test_locally.api.audit;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.audit.AuditClient;
+import com.slack.api.audit.AuditConfig;
 import com.slack.api.audit.response.LogsResponse;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.rate_limits.metrics.RequestStats;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
@@ -13,6 +16,7 @@ import org.junit.Test;
 import util.FileReader;
 import util.PortProvider;
 
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -24,6 +28,7 @@ import java.io.InputStreamReader;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @Slf4j
@@ -36,6 +41,28 @@ public class ApiTest {
 
     @WebServlet
     public static class AuditLogsMockApi extends HttpServlet {
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            String endpoint = req.getRequestURI().replaceFirst("^/api/", "");
+            if (endpoint.equals("auth.test")) {
+                String body = "{\n" +
+                        "  \"ok\": true,\n" +
+                        "  \"url\": \"https://java-slack-sdk-test.slack.com/\",\n" +
+                        "  \"team\": \"java-slack-sdk-test\",\n" +
+                        "  \"user\": \"test_user\",\n" +
+                        "  \"team_id\": \"T1234567\",\n" +
+                        "  \"user_id\": \"U1234567\",\n" +
+                        "  \"bot_id\": \"B12345678\",\n" +
+                        "  \"enterprise_id\": \"E12345678\",\n" +
+                        "  \"error\": \"\"\n" +
+                        "}";
+                resp.setStatus(200);
+                resp.getWriter().write(body);
+                resp.setContentType("application/json");
+                return;
+            }
+        }
+
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             try (InputStream is = req.getInputStream();
@@ -79,29 +106,59 @@ public class ApiTest {
     @Test
     public void getLogs() throws Exception {
         SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix("http://localhost:" + port + "/api/");
         config.setAuditEndpointUrlPrefix("http://localhost:" + port + "/api/");
 
-        AuditClient audit = Slack.getInstance(config).audit("token");
+        config.setAuditConfig(new AuditConfig());
+        config.getAuditConfig().setExecutorName("getLogs" + System.currentTimeMillis());
+        MetricsDatastore datastore = config.getAuditConfig().getMetricsDatastore();
+        RequestStats stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("logs"), is(nullValue()));
+
+        AuditClient audit = Slack.getInstance(config).audit(ValidToken);
         LogsResponse response = audit.getLogs(r -> r.action("something"));
         assertThat(response.isOk(), is(true));
+
+        stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("logs"), is(1L));
     }
 
     @Test
     public void getSchemas() throws Exception {
         SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix("http://localhost:" + port + "/api/");
         config.setAuditEndpointUrlPrefix("http://localhost:" + port + "/api/");
 
-        AuditClient audit = Slack.getInstance(config).audit("token");
+        config.setAuditConfig(new AuditConfig());
+        config.getAuditConfig().setExecutorName("getSchemas" + System.currentTimeMillis());
+        MetricsDatastore datastore = config.getAuditConfig().getMetricsDatastore();
+        RequestStats stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("schemas"), is(nullValue()));
+
+        AuditClient audit = Slack.getInstance(config).audit(ValidToken);
         assertThat(audit.getSchemas().isOk(), is(true));
+
+        stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("schemas"), is(1L));
     }
 
     @Test
     public void getActions() throws Exception {
         SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix("http://localhost:" + port + "/api/");
         config.setAuditEndpointUrlPrefix("http://localhost:" + port + "/api/");
 
-        AuditClient audit = Slack.getInstance(config).audit("token");
+        config.setAuditConfig(new AuditConfig());
+        config.getAuditConfig().setExecutorName("getActions" + System.currentTimeMillis());
+        MetricsDatastore datastore = config.getAuditConfig().getMetricsDatastore();
+        RequestStats stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("actions"), is(nullValue()));
+
+        AuditClient audit = Slack.getInstance(config).audit(ValidToken);
         assertThat(audit.getActions().isOk(), is(true));
+
+        stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("actions"), is(1L));
     }
 
 }

--- a/slack-api-client/src/test/java/test_locally/api/audit/AsyncApiTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/audit/AsyncApiTest.java
@@ -1,0 +1,164 @@
+package test_locally.api.audit;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.audit.AsyncAuditClient;
+import com.slack.api.audit.AuditConfig;
+import com.slack.api.audit.response.LogsResponse;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.rate_limits.metrics.RequestStats;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import util.FileReader;
+import util.PortProvider;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Slf4j
+public class AsyncApiTest {
+
+    public static final String ValidToken = "xoxb-this-is-valid";
+    public static final String InvalidToken = "xoxb-this-is-INVALID";
+
+    private static final FileReader reader = new FileReader("../json-logs/samples/audit/v1/");
+
+    @WebServlet
+    public static class AuditLogsMockApi extends HttpServlet {
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            String endpoint = req.getRequestURI().replaceFirst("^/api/", "");
+            if (endpoint.equals("auth.test")) {
+                String body = "{\n" +
+                        "  \"ok\": true,\n" +
+                        "  \"url\": \"https://java-slack-sdk-test.slack.com/\",\n" +
+                        "  \"team\": \"java-slack-sdk-test\",\n" +
+                        "  \"user\": \"test_user\",\n" +
+                        "  \"team_id\": \"T1234567\",\n" +
+                        "  \"user_id\": \"U1234567\",\n" +
+                        "  \"bot_id\": \"B12345678\",\n" +
+                        "  \"enterprise_id\": \"E12345678\",\n" +
+                        "  \"error\": \"\"\n" +
+                        "}";
+                resp.setStatus(200);
+                resp.getWriter().write(body);
+                resp.setContentType("application/json");
+                return;
+            }
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            try (InputStream is = req.getInputStream();
+                 InputStreamReader isr = new InputStreamReader(is);
+                 BufferedReader br = new BufferedReader(isr)) {
+                String requestBody = br.lines().collect(Collectors.joining());
+                log.info("request body: {}", requestBody);
+            }
+            String endpoint = req.getRequestURI().replaceFirst("^/api/", "");
+            String body = reader.readWholeAsString(endpoint + ".json");
+            body = body.replaceFirst("\"ok\": false,", "\"ok\": true,");
+            if (body == null || body.trim().isEmpty()) {
+                resp.setStatus(400);
+                return;
+            }
+            resp.setStatus(200);
+            resp.getWriter().write(body);
+            resp.setContentType("application/json");
+        }
+    }
+
+    int port = PortProvider.getPort(AsyncApiTest.class.getName());
+    Server server = new Server(port);
+
+    {
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(AuditLogsMockApi.class, "/*");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void getLogs() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix("http://localhost:" + port + "/api/");
+        config.setAuditEndpointUrlPrefix("http://localhost:" + port + "/api/");
+
+        config.setAuditConfig(new AuditConfig());
+        config.getAuditConfig().setExecutorName("getActions" + System.currentTimeMillis());
+        MetricsDatastore datastore = config.getAuditConfig().getMetricsDatastore();
+        RequestStats stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("logs"), is(nullValue()));
+
+        AsyncAuditClient audit = Slack.getInstance(config).auditAsync(ValidToken);
+        LogsResponse response = audit.getLogs(r -> r.action("something")).get();
+        assertThat(response.isOk(), is(true));
+
+        stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("logs"), is(1L));
+    }
+
+    @Test
+    public void getSchemas() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix("http://localhost:" + port + "/api/");
+        config.setAuditEndpointUrlPrefix("http://localhost:" + port + "/api/");
+
+        config.setAuditConfig(new AuditConfig());
+        config.getAuditConfig().setExecutorName("getActions" + System.currentTimeMillis());
+        MetricsDatastore datastore = config.getAuditConfig().getMetricsDatastore();
+        RequestStats stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("schemas"), is(nullValue()));
+
+        AsyncAuditClient audit = Slack.getInstance(config).auditAsync(ValidToken);
+        assertThat(audit.getSchemas().get().isOk(), is(true));
+
+        stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("schemas"), is(1L));
+    }
+
+    @Test
+    public void getActions() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix("http://localhost:" + port + "/api/");
+        config.setAuditEndpointUrlPrefix("http://localhost:" + port + "/api/");
+
+        config.setAuditConfig(new AuditConfig());
+        config.getAuditConfig().setExecutorName("getActions" + System.currentTimeMillis());
+        MetricsDatastore datastore = config.getAuditConfig().getMetricsDatastore();
+        RequestStats stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("actions"), is(nullValue()));
+
+        AsyncAuditClient audit = Slack.getInstance(config).auditAsync(ValidToken);
+        assertThat(audit.getActions().get().isOk(), is(true));
+
+        stats = datastore.getStats(config.getAuditConfig().getExecutorName(), "T1234567");
+        assertThat(stats.getAllCompletedCalls().get("actions"), is(1L));
+    }
+
+}

--- a/slack-api-client/src/test/java/test_locally/api/audit/AsyncThreadPoolsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/audit/AsyncThreadPoolsTest.java
@@ -1,0 +1,34 @@
+package test_locally.api.audit;
+
+import com.slack.api.audit.AuditConfig;
+import com.slack.api.audit.impl.ThreadPools;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class AsyncThreadPoolsTest {
+
+    @Test
+    public void getDefault() {
+        ExecutorService service = ThreadPools.getDefault(AuditConfig.DEFAULT_SINGLETON);
+        assertThat(service, is(notNullValue()));
+    }
+
+    @Test
+    public void getOrCreate() {
+        AuditConfig config = new AuditConfig();
+        config.setExecutorName("getOrCreate" + System.currentTimeMillis());
+        Map<String, Integer> poolSizes = new HashMap<>();
+        poolSizes.put("E111", 1);
+        config.setCustomThreadPoolSizes(poolSizes);
+        ExecutorService service = ThreadPools.getOrCreate(config, "E111");
+        assertThat(service, is(notNullValue()));
+    }
+
+}

--- a/slack-api-client/src/test/java/test_locally/api/methods/metrics/MemoryMetricsDatastoreTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/metrics/MemoryMetricsDatastoreTest.java
@@ -1,7 +1,7 @@
 package test_locally.api.methods.metrics;
 
-import com.slack.api.methods.MethodsStats;
-import com.slack.api.methods.metrics.impl.MemoryMetricsDatastore;
+import com.slack.api.methods.metrics.MemoryMetricsDatastore;
+import com.slack.api.rate_limits.metrics.RequestStats;
 import org.junit.Test;
 
 import java.util.Map;
@@ -20,21 +20,21 @@ public class MemoryMetricsDatastoreTest {
     @Test
     public void getAllStats() {
         MemoryMetricsDatastore datastore = new MemoryMetricsDatastore(1);
-        Map<String, Map<String, MethodsStats>> allStats = datastore.getAllStats();
+        Map<String, Map<String, RequestStats>> allStats = datastore.getAllStats();
         assertNotNull(allStats);
     }
 
     @Test
     public void getStats_teamId() {
         MemoryMetricsDatastore datastore = new MemoryMetricsDatastore(1);
-        MethodsStats stats = datastore.getStats("T123");
+        RequestStats stats = datastore.getStats("T123");
         assertNotNull(stats);
     }
 
     @Test
     public void getStats() {
         MemoryMetricsDatastore datastore = new MemoryMetricsDatastore(1);
-        MethodsStats stats = datastore.getStats(DEFAULT_SINGLETON_EXECUTOR_NAME, "T123");
+        RequestStats stats = datastore.getStats(DEFAULT_SINGLETON_EXECUTOR_NAME, "T123");
         assertNotNull(stats);
     }
 

--- a/slack-api-client/src/test/java/test_locally/api/methods/metrics/RedisMetricsDatastoreTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/metrics/RedisMetricsDatastoreTest.java
@@ -5,8 +5,8 @@ import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.methods.AsyncMethodsClient;
 import com.slack.api.methods.MethodsConfig;
-import com.slack.api.methods.MethodsStats;
-import com.slack.api.methods.metrics.impl.RedisMetricsDatastore;
+import com.slack.api.methods.metrics.RedisMetricsDatastore;
+import com.slack.api.rate_limits.metrics.RequestStats;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,11 +66,11 @@ public class RedisMetricsDatastoreTest {
         for (int i = 0; i < 3; i++) {
             client.authTest(r -> r.token(ValidToken)).get();
         }
-        Map<String, Map<String, MethodsStats>> allStats = datastore.getAllStats();
+        Map<String, Map<String, RequestStats>> allStats = datastore.getAllStats();
         assertNotNull(allStats);
         assertEquals(1, allStats.get("DEFAULT_SINGLETON_EXECUTOR").size());
 
-        MethodsStats teamStats = allStats.get("DEFAULT_SINGLETON_EXECUTOR").values().iterator().next();
+        RequestStats teamStats = allStats.get("DEFAULT_SINGLETON_EXECUTOR").values().iterator().next();
         assertEquals(3L, teamStats.getAllCompletedCalls().get("auth.test").longValue());
         assertEquals(3L, teamStats.getSuccessfulCalls().get("auth.test").longValue());
         assertEquals(3L, teamStats.getLastMinuteRequests().get("auth.test").longValue());

--- a/slack-api-client/src/test/java/test_locally/api/scim/AsyncApiTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim/AsyncApiTest.java
@@ -1,0 +1,237 @@
+package test_locally.api.scim;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.scim.AsyncSCIMClient;
+import com.slack.api.scim.SCIMClient;
+import com.slack.api.scim.model.Group;
+import com.slack.api.scim.model.User;
+import com.slack.api.scim.request.GroupsPatchRequest;
+import com.slack.api.scim.response.*;
+import com.slack.api.util.http.listener.HttpResponseListener;
+import com.slack.api.util.json.GsonFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import util.FileReader;
+import util.PortProvider;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AsyncApiTest {
+
+    public static final String ValidToken = "xoxb-this-is-valid";
+    public static final String InvalidToken = "xoxb-this-is-INVALID";
+
+    private static final FileReader reader = new FileReader("../json-logs/samples/scim/v1/");
+
+    private static final Logger logger = LoggerFactory.getLogger(AsyncApiTest.class);
+
+    @Slf4j
+    @WebServlet
+    public static class SCIMMockApi extends HttpServlet {
+        @Override
+        protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            handle(req, resp);
+        }
+
+        private void handle(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            try (InputStream is = req.getInputStream();
+                 InputStreamReader isr = new InputStreamReader(is);
+                 BufferedReader br = new BufferedReader(isr)) {
+                String requestBody = br.lines().collect(Collectors.joining());
+                log.info("request body: {}", requestBody);
+            }
+            String endpoint = req.getRequestURI().replaceFirst("^/api/", "");
+            if (endpoint.equals("auth.test")) {
+                String body = "{\n" +
+                        "  \"ok\": true,\n" +
+                        "  \"url\": \"https://java-slack-sdk-test.slack.com/\",\n" +
+                        "  \"team\": \"java-slack-sdk-test\",\n" +
+                        "  \"user\": \"test_user\",\n" +
+                        "  \"team_id\": \"E12345678\",\n" +
+                        "  \"user_id\": \"U1234567\",\n" +
+                        "  \"bot_id\": \"B12345678\",\n" +
+                        "  \"enterprise_id\": \"E12345678\",\n" +
+                        "  \"error\": \"\"\n" +
+                        "}";
+                resp.setStatus(200);
+                resp.getWriter().write(body);
+                resp.setContentType("application/json");
+                return;
+            }
+
+            if (!req.getMethod().equals("GET") && !endpoint.endsWith("/00000000000")) {
+                endpoint += "/00000000000";
+            }
+            String body = reader.readWholeAsString(endpoint + ".json");
+            body = body.replaceFirst("\"ok\": false,", "\"ok\": true,");
+            if (body == null || body.trim().isEmpty()) {
+                resp.setStatus(400);
+                return;
+            }
+            resp.setStatus(200);
+            resp.getWriter().write(body);
+            resp.setContentType("application/json");
+        }
+    }
+
+    int port = PortProvider.getPort(AsyncApiTest.class.getName());
+    Server server = new Server(port);
+
+    {
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(SCIMMockApi.class, "/*");
+    }
+
+    SlackConfig config = new SlackConfig();
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+        config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix("http://localhost:" + port + "/api/");
+        config.setScimEndpointUrlPrefix("http://localhost:" + port + "/api/");
+        config.getHttpClientResponseHandlers().add(new HttpResponseListener() {
+            @Override
+            public void accept(State state) {
+                logger.debug("--- (SCIM Stats) ---\n" + GsonFactory.createSnakeCase(config).toJson(
+                        config.getSCIMConfig().getMetricsDatastore().getAllStats()));
+            }
+        });
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void searchUsers() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        UsersSearchResponse response = scim.searchUsers(r -> r
+                .filter("some filter").count(123).startIndex(1)).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void searchGroups() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        GroupsSearchResponse response = scim.searchGroups(r -> r
+                .filter("some filter").count(123).startIndex(1)).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void getServiceProviderConfigs() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        ServiceProviderConfigsGetResponse response = scim.getServiceProviderConfigs(r -> r).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void readUser() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        UsersReadResponse response = scim.readUser(r -> r.id("00000000000")).get();
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("W00000000"));
+    }
+
+    @Test
+    public void createUser() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        User user = new User();
+        user.setUserName("Kazuhiro Sera");
+        UsersCreateResponse response = scim.createUser(r -> r.user(user)).get();
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("W00000000"));
+    }
+
+    @Test
+    public void patchUser() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        User user = new User();
+        user.setUserName("Kazuhiro Sera");
+        UsersPatchResponse response = scim.patchUser(r -> r.id("00000000000").user(user)).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void updateUser() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        User user = new User();
+        user.setUserName("Kazuhiro Sera");
+        UsersUpdateResponse response = scim.updateUser(r -> r.id("00000000000").user(user)).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void deleteUser() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        UsersDeleteResponse response = scim.deleteUser(r -> r.id("00000000000")).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void readGroup() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        GroupsReadResponse response = scim.readGroup(r -> r.id("00000000000")).get();
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("S00000000"));
+    }
+
+    @Test
+    public void createGroup() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        Group group = new Group();
+        group.setDisplayName("Kazuhiro Sera");
+        GroupsCreateResponse response = scim.createGroup(r -> r.group(group)).get();
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("S00000000"));
+    }
+
+    @Test
+    public void patchGroup() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        GroupsPatchRequest.GroupOperation group = new GroupsPatchRequest.GroupOperation();
+        group.setMembers(Arrays.asList());
+        GroupsPatchResponse response = scim.patchGroup(r -> r.id("00000000000").group(group)).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void updateGroup() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        Group group = new Group();
+        group.setDisplayName("Kazuhiro Sera");
+        GroupsUpdateResponse response = scim.updateGroup(r -> r.id("00000000000").group(group)).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void deleteGroup() throws Exception {
+        AsyncSCIMClient scim = Slack.getInstance(config).scimAsync(ValidToken);
+        GroupsDeleteResponse response = scim.deleteGroup(r -> r.id("00000000000")).get();
+        assertThat(response, is(notNullValue()));
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/scim/AsyncThreadPoolsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim/AsyncThreadPoolsTest.java
@@ -1,0 +1,33 @@
+package test_locally.api.scim;
+
+import com.slack.api.scim.SCIMConfig;
+import com.slack.api.scim.impl.ThreadPools;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AsyncThreadPoolsTest {
+
+    @Test
+    public void getDefault() {
+        ExecutorService service = ThreadPools.getDefault(SCIMConfig.DEFAULT_SINGLETON);
+        assertThat(service, is(notNullValue()));
+    }
+
+    @Test
+    public void getOrCreate() {
+        SCIMConfig config = new SCIMConfig();
+        config.setExecutorName("getOrCreate" + System.currentTimeMillis());
+        Map<String, Integer> poolSizes = new HashMap<>();
+        poolSizes.put("E111", 1);
+        config.setCustomThreadPoolSizes(poolSizes);
+        ExecutorService service = ThreadPools.getOrCreate(config, "E111");
+        assertThat(service, is(notNullValue()));
+    }
+
+}

--- a/slack-api-client/src/test/java/test_with_remote_apis/ProxyTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/ProxyTest.java
@@ -171,7 +171,7 @@ public class ProxyTest {
             Slack slack = Slack.getInstance(config);
             ServiceProviderConfigsGetResponse response = slack.scim(scimToken).getServiceProviderConfigs(req -> req);
             assertThat(response.getAuthenticationSchemes(), is(notNullValue()));
-            assertThat(callCount.get(), is(1));
+            assertThat(callCount.get(), is(2)); // auth.test & scim
         }
     }
 

--- a/slack-api-client/src/test/java/test_with_remote_apis/scim/AsyncApiTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/scim/AsyncApiTest.java
@@ -1,0 +1,297 @@
+package test_with_remote_apis.scim;
+
+import com.slack.api.Slack;
+import com.slack.api.scim.SCIMApiCompletionException;
+import com.slack.api.scim.SCIMApiException;
+import com.slack.api.scim.model.Group;
+import com.slack.api.scim.model.User;
+import com.slack.api.scim.request.GroupsPatchRequest;
+import com.slack.api.scim.response.*;
+import com.slack.api.util.thread.ExecutorServiceFactory;
+import config.Constants;
+import config.SlackTestConfig;
+import org.junit.AfterClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+// required scope - admin
+public class AsyncApiTest {
+
+    static SlackTestConfig testConfig = SlackTestConfig.getInstance();
+    static Slack slack = Slack.getInstance(testConfig.getConfig());
+
+    @AfterClass
+    public static void tearDown() throws InterruptedException {
+        SlackTestConfig.awaitCompletion(testConfig);
+    }
+
+    String orgAdminToken = System.getenv(Constants.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN);
+
+    private UsersCreateResponse createNewUser() throws ExecutionException, InterruptedException {
+        String userName = "user" + System.currentTimeMillis();
+        User newUser = new User();
+        newUser.setName(new User.Name());
+        newUser.getName().setGivenName("Kazuhiro");
+        newUser.getName().setFamilyName("Sera");
+        newUser.setUserName(userName);
+        User.Email email = new User.Email();
+        email.setValue("seratch+" + System.currentTimeMillis() + "@gmail.com");
+        newUser.setEmails(Arrays.asList(email));
+        return slack.scimAsync(orgAdminToken).createUser(req -> req.user(newUser)).get();
+    }
+
+    @Test
+    public void getServiceProviderConfigs() throws ExecutionException, InterruptedException {
+        if (orgAdminToken != null) {
+            ServiceProviderConfigsGetResponse response = slack.scimAsync(orgAdminToken)
+                    .getServiceProviderConfigs(req -> req).get();
+            assertThat(response.getAuthenticationSchemes(), is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getServiceProviderConfigs_dummy() throws ExecutionException, InterruptedException {
+        ServiceProviderConfigsGetResponse response = slack.scimAsync("dummy")
+                .getServiceProviderConfigs(req -> req).get();
+        assertThat(response.getAuthenticationSchemes(), is(notNullValue()));
+    }
+
+    @Test
+    public void searchAndReadUser() throws ExecutionException, InterruptedException {
+        if (orgAdminToken != null) {
+            {
+                UsersSearchResponse users = slack.scimAsync(orgAdminToken).searchUsers(req -> req.count(1000)).get();
+                final String userId = users.getResources().get(0).getId();
+                UsersReadResponse read = slack.scimAsync(orgAdminToken).readUser(req -> req.id(userId)).get();
+                assertThat(read.getId(), is(userId));
+            }
+            {
+                // pagination
+                UsersSearchResponse users = slack.scimAsync(orgAdminToken)
+                        .searchUsers(req -> req.count(1).startIndex(2)).get();
+                assertThat(users.getItemsPerPage(), is(1));
+                assertThat(users.getResources().size(), is(1));
+                assertThat(users.getStartIndex(), is(2));
+            }
+        }
+    }
+
+    @Test
+    public void searchUser_dummy() throws IOException, ExecutionException, InterruptedException {
+        try {
+            slack.scimAsync("dummy").searchUsers(req -> req.count(1000)).get();
+        } catch (Exception _e) {
+            SCIMApiException e = ((SCIMApiCompletionException) _e.getCause()).getScimApiException();
+            assertThat(e.getMessage(), is("status: 401, description: invalid_authentication"));
+            assertThat(e.getError(), is(notNullValue()));
+            assertThat(e.getError().getErrors().getCode(), is(401));
+            assertThat(e.getError().getErrors().getDescription(), is("invalid_authentication"));
+        }
+    }
+
+    @Test
+    public void readUser_dummy() {
+        try {
+            slack.scimAsync("dummy").readUser(req -> req.id("U12345678")).get();
+        } catch (Exception _e) {
+            SCIMApiException e = ((SCIMApiCompletionException) _e.getCause()).getScimApiException();
+            assertThat(e.getMessage(), is("status: 401, description: invalid_authentication"));
+            assertThat(e.getError(), is(notNullValue()));
+            assertThat(e.getError().getErrors().getCode(), is(401));
+            assertThat(e.getError().getErrors().getDescription(), is("invalid_authentication"));
+        }
+    }
+
+    @Test
+    public void createAndDeleteUser() throws Exception {
+        if (orgAdminToken != null) {
+            UsersCreateResponse creation = createNewUser();
+            assertThat(creation.getId(), is(notNullValue()));
+
+            UsersReadResponse readResp = slack.scimAsync(orgAdminToken)
+                    .readUser(req -> req.id(creation.getId())).get();
+            assertThat(readResp.getId(), is(creation.getId()));
+            assertThat(readResp.getUserName(), is(creation.getUserName()));
+
+            try {
+                // https://api.slack.com/scim#filter
+                // filter query matching the created data
+                String userName = creation.getUserName();
+                UsersSearchResponse searchResp = slack.scimAsync(orgAdminToken)
+                        .searchUsers(req -> req.count(1).filter("userName eq \"" + userName + "\"")).get();
+                assertThat(searchResp.getItemsPerPage(), is(1));
+                assertThat(searchResp.getResources().size(), is(1));
+                assertThat(searchResp.getResources().get(0).getId(), is(creation.getId()));
+                assertThat(searchResp.getResources().get(0).getUserName(), is(creation.getUserName()));
+
+                String originalUserName = creation.getUserName();
+
+                User user = new User();
+                user.setUserName(originalUserName + "_ed");
+                slack.scimAsync(orgAdminToken).patchUser(req -> req.id(creation.getId()).user(user));
+
+                Thread.sleep(500L);
+                readResp = slack.scimAsync(orgAdminToken).readUser(req -> req.id(creation.getId())).get();
+                assertThat(readResp.getId(), is(creation.getId()));
+                assertThat(readResp.getUserName(), is(originalUserName + "_ed"));
+
+                User modifiedUser = readResp;
+                modifiedUser.setUserName(originalUserName + "_rv");
+                modifiedUser.setNickName(originalUserName + "_rv"); // required
+                slack.scimAsync(orgAdminToken).updateUser(req -> req.id(modifiedUser.getId()).user(modifiedUser));
+
+                Thread.sleep(500L);
+                readResp = slack.scimAsync(orgAdminToken).readUser(req -> req.id(modifiedUser.getId())).get();
+                assertThat(readResp.getId(), is(creation.getId()));
+                assertThat(readResp.getUserName(), is(originalUserName + "_rv"));
+
+            } finally {
+                UsersDeleteResponse deletion = slack.scimAsync(orgAdminToken)
+                        .deleteUser(req -> req.id(creation.getId())).get();
+                assertThat(deletion, is(nullValue()));
+                // can call twice
+                UsersDeleteResponse deletion2 = slack.scimAsync(orgAdminToken)
+                        .deleteUser(req -> req.id(creation.getId())).get();
+                assertThat(deletion2, is(nullValue()));
+
+                int counter = 0;
+                UsersReadResponse supposedToBeDeleted = null;
+                while (counter < 10) {
+                    Thread.sleep(1000);
+                    supposedToBeDeleted = slack.scimAsync(orgAdminToken)
+                            .readUser(req -> req.id(creation.getId())).get();
+                    if (!supposedToBeDeleted.getActive()) {
+                        break;
+                    }
+                }
+                assertThat(supposedToBeDeleted, is(notNullValue()));
+                assertThat(supposedToBeDeleted.getActive(), is(false));
+
+                // can call again
+                UsersDeleteResponse deletion3 = slack.scimAsync(orgAdminToken)
+                        .deleteUser(req -> req.id(creation.getId())).get();
+                assertThat(deletion3, is(nullValue()));
+            }
+        }
+    }
+
+    @Test
+    public void groups() throws ExecutionException, InterruptedException {
+        if (orgAdminToken != null) {
+            GroupsSearchResponse groups = slack.scimAsync(orgAdminToken)
+                    .searchGroups(req -> req.count(1000)).get();
+            if (groups.getResources().size() == 0) {
+                Group newGroup = new Group();
+                newGroup.setDisplayName("Test Group" + System.currentTimeMillis());
+
+                Group.Member member = new Group.Member();
+                UsersCreateResponse newUser = createNewUser();
+                assertThat(newUser.getId(), is(notNullValue()));
+                member.setValue(newUser.getId());
+                newGroup.setMembers(Arrays.asList(member));
+
+                GroupsCreateResponse createdGroup = slack.scimAsync(orgAdminToken)
+                        .createGroup(req -> req.group(newGroup)).get();
+                assertThat(createdGroup.getMembers().size(), is(1));
+            }
+
+            // pagination
+            GroupsSearchResponse pagination = slack.scimAsync(orgAdminToken)
+                    .searchGroups(req -> req.count(1)).get();
+            assertThat(pagination.getResources().size(), is(1));
+
+            Group group = groups.getResources().get(0);
+
+            GroupsPatchRequest.GroupOperation op = new GroupsPatchRequest.GroupOperation();
+            GroupsPatchRequest.MemberOperation memberOp = new GroupsPatchRequest.MemberOperation();
+            User user = slack.scimAsync(orgAdminToken).searchUsers(req -> req.count(1)).get().getResources().get(0);
+            memberOp.setValue(user.getId());
+            memberOp.setOperation("delete");
+            op.setMembers(Arrays.asList(memberOp));
+
+            slack.scimAsync(orgAdminToken).patchGroup(req -> req.id(group.getId()).group(op));
+
+            slack.scimAsync(orgAdminToken).updateGroup(req -> req.id(group.getId()).group(group));
+
+            GroupsReadResponse read = slack.scimAsync(orgAdminToken).readGroup(req -> req.id(group.getId())).get();
+            assertThat(read.getId(), is(group.getId()));
+        }
+    }
+
+    @Test
+    public void groupAndUsers() throws ExecutionException, InterruptedException {
+        if (orgAdminToken != null) {
+            Group newGroup = new Group();
+            newGroup.setDisplayName("Test Group" + System.currentTimeMillis());
+            UsersCreateResponse newUser = createNewUser();
+            assertThat(newUser.getId(), is(notNullValue()));
+            try {
+                Group.Member member = new Group.Member();
+                member.setValue(newUser.getId());
+                newGroup.setMembers(Arrays.asList(member));
+                GroupsCreateResponse createdGroup = slack.scimAsync(orgAdminToken)
+                        .createGroup(req -> req.group(newGroup)).get();
+                assertThat(createdGroup.getMembers().size(), is(1));
+                try {
+                    String userName = newUser.getUserName();
+                    UsersSearchResponse searchResp = slack.scimAsync(orgAdminToken)
+                            .searchUsers(req -> req.count(1).filter("userName eq \"" + userName + "\"")).get();
+                    assertThat(searchResp.getResources().size(), is(1));
+                    assertThat(searchResp.getResources().get(0).getGroups().size(), is(1));
+                } finally {
+                    GroupsDeleteResponse groupDeletion = slack.scimAsync(orgAdminToken)
+                            .deleteGroup(req -> req.id(createdGroup.getId())).get();
+                    assertThat(groupDeletion, is(nullValue()));
+                }
+            } finally {
+                UsersDeleteResponse deletion = slack.scimAsync(orgAdminToken)
+                        .deleteUser(req -> req.id(newUser.getId())).get();
+                assertThat(deletion, is(nullValue()));
+            }
+        }
+    }
+
+    @Test
+    public void groups_dummy() throws IOException, ExecutionException, InterruptedException {
+        try {
+            slack.scimAsync("dummy").searchGroups(req -> req.count(1000)).get();
+        } catch (Exception _e) {
+            SCIMApiException e = ((SCIMApiCompletionException) _e.getCause()).getScimApiException();
+            assertThat(e.getMessage(), is("status: 401, description: invalid_authentication"));
+            assertThat(e.getError(), is(notNullValue()));
+            assertThat(e.getError().getErrors().getCode(), is(401));
+            assertThat(e.getError().getErrors().getDescription(), is("invalid_authentication"));
+        }
+    }
+
+    @Ignore
+    @Test
+    public void demonstrateRateLimitedErrors() throws Exception {
+        Logger logger = LoggerFactory.getLogger(AsyncApiTest.class);
+        int concurrency = 10;
+        ExecutorService executorService = ExecutorServiceFactory.createDaemonThreadPoolExecutor("test", concurrency);
+        for (int i = 0; i < concurrency; i++) {
+            executorService.execute(() -> {
+                while (true) {
+                    try {
+                        slack.scimAsync(orgAdminToken).searchUsers(r -> r.count(1)).get();
+                    } catch (Exception e) {
+                        logger.info(e.getMessage(), e);
+                    }
+                }
+            });
+        }
+        Thread.sleep(300_000L);
+    }
+
+}


### PR DESCRIPTION
This pull request fixes #675 and also fixes #414 

* #675 Audit Logs
* #414 SCIM

As with `AsyncMethodsClient`, developers can use async clients for automatic request frequency adjustment with great consideration of Slack rate limits.

```java
Slack slack = Slack.getInstance();

String orgAdminUserToken = "xoxp-";

slack.scimAsync(orgAdminUserToken)
  .searchUsers(req -> req.filter("userName Eq \"Carly\"").count(10)); // returns Future

slack.auditAsync(orgAdminUserToken)
  .getLogs(req -> req.action(Actions.File.file_uploaded).limit(10)); // returns Future
```

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
