### PR TITLE
Upgrade dependencies for 1.6 release

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>3.285.2</http4k.version>
+        <http4k.version>4.2.0.0</http4k.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>1.5.0</ktor.version>
+        <ktor.version>1.5.1</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,8 +10,8 @@
     </parent>
 
     <properties>
-        <micronaut.version>2.2.3</micronaut.version>
-        <micronaut-test-junit5.version>2.3.1</micronaut-test-junit5.version>
+        <micronaut.version>2.3.1</micronaut.version>
+        <micronaut-test-junit5.version>2.3.2</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>
 

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.4.1</spring-boot.version>
+        <spring-boot.version>2.4.2</spring-boot.version>
     </properties>
 
     <groupId>com.slack.api</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,18 +44,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <okhttp.version>4.9.0</okhttp.version>
+        <okhttp.version>4.9.1</okhttp.version>
         <gson.version>2.8.6</gson.version>
-        <lombok.version>1.18.16</lombok.version>
+        <lombok.version>1.18.18</lombok.version>
         <lombok-maven-plugin.version>1.18.16.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
         <kotlin.version>1.4.21-2</kotlin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.934</aws.s3.version>
+        <aws.s3.version>1.11.947</aws.s3.version>
         <junit.version>4.13.1</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.7.0</mockito-core.version>
+        <mockito-core.version>3.7.7</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -19,7 +19,7 @@
         <!-- TODO upgrade to 2.0 in the next major version -->
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
         <java-websocket.version>1.5.1</java-websocket.version>
-        <jedis.version>3.4.1</jedis.version>
+        <jedis.version>3.5.1</jedis.version>
         <jedis-mock.version>0.1.16</jedis-mock.version>
     </properties>
 


### PR DESCRIPTION
This pull request upgrades a few external dependency versions. The following ones are minor upgrades for required dependencies.

* bolt-http4k: http4k from 3 to 4.2
* bolt-micronaut: micronaut from 2.2 to 2.3

The rest are path version upgrade or only for tests/examples.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
