### PR TITLE
Add new user_auth_blocks property to chat.unfurl

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -1094,6 +1094,7 @@ public class RequestFormBuilder {
         }
         setIfNotNull("user_auth_required", req.isUserAuthRequired(), form);
         setIfNotNull("user_auth_message", req.getUserAuthMessage(), form);
+        setIfNotNull("user_auth_blocks", req.getUserAuthBlocks(), form);
         setIfNotNull("user_auth_url", req.getUserAuthUrl(), form);
         return form;
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
@@ -29,6 +29,12 @@ public class ChatUnfurlRequest implements SlackApiRequest {
     private String userAuthMessage;
 
     /**
+     * Provide an array of blocks to send as an ephemeral message to the user
+     * as invitation to authenticate further and enable full unfurling behavior
+     */
+    private List<LayoutBlock> userAuthBlocks;
+
+    /**
      * Set to `true` or `1` to indicate the user must install your Slack app to trigger unfurls for this domain
      */
     private boolean userAuthRequired;


### PR DESCRIPTION
Add support for new `user_auth_blocks` property to chat.unfurl.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
