### PR TITLE
Correct javadoc for GoodbyeEvent

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/model/event/GoodbyeEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/GoodbyeEvent.java
@@ -3,11 +3,16 @@ package com.slack.api.model.event;
 import lombok.Data;
 
 /**
- * The file_unshared event is sent when a file is unshared.
- * It is sent to all connected clients for all users that had permission to see the file.
- * The file property includes the file ID, as well as a top-level file_id.
- * To obtain additional information about the unshared file, use the files.info API method.
+ * The server intends to close the connection soon.
  * <p>
+ * The goodbye event may be sent by a server that expects it will close the connection after an unspecified amount of time.
+ * A well formed client should reconnect to avoid data loss.
+ * <p>
+ * Other scenarios where you might encounter the goodbye event are:
+ * <ul>
+ * <li>reaching the maximum duration of a RTM web socket connection (8 hours)
+ * <li>your workspace has been inactive for over two minutes
+ * </ul>
  * https://api.slack.com/events/goodbye
  */
 @Data


### PR DESCRIPTION
Correct javadoc for the GoodbyeEvent

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
