### PR TITLE
Fix an error in a Japanese document

### DIFF
--- a/docs/guides/ja/bolt-basics.md
+++ b/docs/guides/ja/bolt-basics.md
@@ -280,7 +280,7 @@ Bolt は、デフォルトで以下のミドルウェアを有効にします。
 * [IgnoringSelfEvents](https://github.com/slackapi/java-slack-sdk/blob/main/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/IgnoringSelfEvents.java) はそのアプリの bot user が発生させたイベントをスキップします（これは無限ループを起こすようなコーディングミスを防止するために有用です）
 * [SSLCheck](https://github.com/slackapi/java-slack-sdk/blob/main/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/SSLCheck.java) は Slack からの `ssl_check=1` リクエストをハンドリングします
 
-一般的にこれらのミドルウェアは共通で必要となるもなので無効化することを推奨しませんが、`AppConfig` オブジェクトの `ignoringSelfEventsEnabled` などのフラグを設定して無効化することができます。
+一般的にこれらのミドルウェアは共通で必要となるものなので無効化することを推奨しませんが、`AppConfig` オブジェクトの `ignoringSelfEventsEnabled` などのフラグを設定して無効化することができます。
 
 ```java
 AppConfig appConfig = new AppConfig();


### PR DESCRIPTION
This pull request fixes a minor misspelling in Japanese documents.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
