### PR TITLE
Add "channel_posting_permissions" message event support

### DIFF
--- a/json-logs/samples/events/MessageChannelPostingPermissionsPayload.json
+++ b/json-logs/samples/events/MessageChannelPostingPermissionsPayload.json
@@ -1,0 +1,27 @@
+{
+  "token": "",
+  "enterprise_id": "",
+  "team_id": "",
+  "api_app_id": "",
+  "type": "",
+  "authed_users": [
+    ""
+  ],
+  "authed_teams": [
+    ""
+  ],
+  "is_ext_shared_channel": false,
+  "event_id": "",
+  "event_time": 123,
+  "event_context": "",
+  "event": {
+    "type": "message",
+    "subtype": "channel_posting_permissions",
+    "user": "",
+    "channel": "",
+    "channel_type": "",
+    "text": "",
+    "ts": "",
+    "event_ts": ""
+  }
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageChannelPostingPermissionsEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageChannelPostingPermissionsEvent.java
@@ -1,0 +1,25 @@
+package com.slack.api.model.event;
+
+import lombok.Data;
+
+/**
+ * https://api.slack.com/events/message/channel_posting_permissions
+ */
+@Data
+public class MessageChannelPostingPermissionsEvent implements Event {
+
+	public static final String TYPE_NAME = "message";
+	public static final String SUBTYPE_NAME = "channel_posting_permissions";
+
+	private final String type = TYPE_NAME;
+	private final String subtype = SUBTYPE_NAME;
+
+	private String user;
+	private String channel;
+	private String channelType; // "channel"
+
+	private String text;
+
+	private String ts;
+	private String eventTs;
+}

--- a/slack-api-model/src/test/java/test_locally/api/model/event/MessageChannelPostingPermissionsEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/MessageChannelPostingPermissionsEventTest.java
@@ -1,0 +1,35 @@
+package test_locally.api.model.event;
+
+import com.slack.api.model.event.MessageChannelPostingPermissionsEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MessageChannelPostingPermissionsEventTest {
+
+    @Test
+    public void typeName() {
+        assertThat(MessageChannelPostingPermissionsEvent.TYPE_NAME, is("message"));
+        assertThat(MessageChannelPostingPermissionsEvent.SUBTYPE_NAME, is("channel_posting_permissions"));
+    }
+
+    @Test
+    public void deserialize_simple() {
+        String json = "{\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"subtype\": \"channel_posting_permissions\",\n" +
+                "  \"ts\": \"1614215651.001300\",\n" +
+                "  \"user\": \"W111\",\n" +
+                "  \"text\": \"changed channel posting permissions.\",\n" +
+                "  \"channel\": \"C111\",\n" +
+                "  \"event_ts\": \"1614215651.001300\",\n" +
+                "  \"channel_type\": \"channel\"\n" +
+                "}";
+        MessageChannelPostingPermissionsEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageChannelPostingPermissionsEvent.class);
+        assertThat(event.getType(), is("message"));
+        assertThat(event.getSubtype(), is("channel_posting_permissions"));
+    }
+
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/MessageChannelPostingPermissionsHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/MessageChannelPostingPermissionsHandler.java
@@ -1,0 +1,18 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.MessageChannelPostingPermissionsPayload;
+import com.slack.api.model.event.MessageChannelPostingPermissionsEvent;
+
+public abstract class MessageChannelPostingPermissionsHandler extends EventHandler<MessageChannelPostingPermissionsPayload> {
+
+    @Override
+    public String getEventType() {
+        return MessageChannelPostingPermissionsEvent.TYPE_NAME;
+    }
+
+    @Override
+    public String getEventSubtype() {
+        return MessageChannelPostingPermissionsEvent.SUBTYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageChannelPostingPermissionsPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageChannelPostingPermissionsPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.MessageChannelPostingPermissionsEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MessageChannelPostingPermissionsPayload implements EventsApiPayload<MessageChannelPostingPermissionsEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private MessageChannelPostingPermissionsEvent event;
+}

--- a/slack-app-backend/src/test/java/test_locally/app_backend/events/EventHandlersTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/events/EventHandlersTest.java
@@ -436,6 +436,11 @@ public class EventHandlersTest {
                     @Override
                     public void handle(MessageChannelJoinPayload payload) {
                     }
+                },
+                new MessageChannelPostingPermissionsHandler() {
+                    @Override
+                    public void handle(MessageChannelPostingPermissionsPayload payload) {
+                    }
                 }
         );
         for (EventHandler<?> handler : handlers) {

--- a/slack-app-backend/src/test/java/test_locally/sample_json_generation/EventsApiPayloadDumpTest.java
+++ b/slack-app-backend/src/test/java/test_locally/sample_json_generation/EventsApiPayloadDumpTest.java
@@ -106,6 +106,7 @@ public class EventsApiPayloadDumpTest {
                 new UserResourceRemovedPayload(),
                 new MessageGroupTopicPayload(),
                 new MessageChannelTopicPayload(),
+                new MessageChannelPostingPermissionsPayload(),
                 new WorkflowStepExecutePayload(),
                 new WorkflowDeletedPayload(),
                 new WorkflowPublishedPayload(),


### PR DESCRIPTION
This pull request adds supports for "channel_posting_permissions" subtyped message events in this SDK. The document team will udpate api.slack.com shortly.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
