### PR TITLE
Update OAuth document to have Spring Boot + S3 example

### DIFF
--- a/docs/guides/app-distribution.md
+++ b/docs/guides/app-distribution.md
@@ -225,6 +225,35 @@ public class SlackOAuthRedirectController extends SlackOAuthAppServlet {
 }
 ```
 
+If you want to use different implementations of `InstallationService` and `OAuthStateService`, you can have them as Spring components this way:
+
+```java
+public class SlackApp {
+    // Please be careful about the security policies on this bucket.
+    private static final String S3_BUCKET_NAME = "your-s3-bucket-name";
+
+    @Bean
+    public InstallationService initInstallationService() {
+        InstallationService installationService = new AmazonS3InstallationService(S3_BUCKET_NAME);
+        installationService.setHistoricalDataEnabled(true);
+        return installationService;
+    }
+
+    @Bean
+    public OAuthStateService initStateService() {
+        return new AmazonS3OAuthStateService(S3_BUCKET_NAME);
+    }
+
+    @Bean
+    public App initSlackApp(InstallationService installationService, OAuthStateService stateService) {
+        App app = new App().asOAuthApp(true);
+
+        app.service(installationService);
+        app.service(stateService);
+    }
+}
+```
+
 #### Serve the Completion/Cancellation Pages in Bolt Apps
 
 Although most apps tend to choose static pages for the completion/cancellation URLs, it's also possible to dynamically serve those URLs in the same app. Bolt doesn't offer any features to render web pages. Use your favorite template engine for it.

--- a/docs/guides/ja/app-distribution.md
+++ b/docs/guides/ja/app-distribution.md
@@ -223,6 +223,31 @@ public class SlackOAuthRedirectController extends SlackOAuthAppServlet {
 }
 ```
 
+もし `InstallationService` や `OAuthStateService` の他の実装を使用したい場合は、以下のように Spring のコンポーネントを設定してください。
+
+```java
+public class SlackApp {
+  // この bucket のセキュリティポリシーには十二分にご注意ください
+  private static final String S3_BUCKET_NAME = "your-s3-bucket-name";
+  @Bean
+  public InstallationService initInstallationService() {
+    InstallationService installationService = new AmazonS3InstallationService(S3_BUCKET_NAME);
+    installationService.setHistoricalDataEnabled(true);
+    return installationService;
+  }
+  @Bean
+  public OAuthStateService initStateService() {
+    return new AmazonS3OAuthStateService(S3_BUCKET_NAME);
+  }
+  @Bean
+  public App initSlackApp(InstallationService installationService, OAuthStateService stateService) {
+    App app = new App().asOAuthApp(true);
+    app.service(installationService);
+    app.service(stateService);
+  }
+}
+```
+
 #### 完了・エラーページを Bolt アプリでサーブする
 
 ほとんどのアプリは、完了・エラーページに静的なページを選択するかとは思いますが、これらの URL を Bolt アプリで動的に応答することも可能です。Bolt は Web ページをレンダリングするための機能は何も提供しません。お好みのテンプレートエンジンを使ってください。


### PR DESCRIPTION
This updates the `App Distribution (OAuth)` page with an example of S3 Storage integration for a Spring Boot application that implemetns Bolt for Java framework

### Category (place an `x` in each of the `[ ]`)

* [ X ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)


