### PR TITLE
Add the browser version URL in OAuth completion page

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/default_impl/OAuthDefaultRedirectUriPageRenderer.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/default_impl/OAuthDefaultRedirectUriPageRenderer.java
@@ -5,7 +5,7 @@ import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRendere
 
 public class OAuthDefaultRedirectUriPageRenderer implements OAuthRedirectUriPageRenderer {
 
-    // variables: __URL__
+    // variables: __URL__, __BROWSER_URL__
     public static final String SUCCESS_PAGE_TEMPLATE = "<html>\n" +
             "<head>\n" +
             "<meta http-equiv=\"refresh\" content=\"0; URL=__URL__\">\n" +
@@ -19,7 +19,7 @@ public class OAuthDefaultRedirectUriPageRenderer implements OAuthRedirectUriPage
             "</head>\n" +
             "<body>\n" +
             "<h2>Thank you!</h2>\n" +
-            "<p>Redirecting to the Slack App... click <a href=\"__URL__\">here</a></p>\n" +
+            "<p>Redirecting to the Slack App... click <a href=\"__URL__\">here</a>. If you use the browser version of Slack, click <a href=\"__BROWSER_URL__\" target=\"_blank\">this link</a> instead.</p>\n" +
             "</body>\n" +
             "</html>";
 
@@ -58,7 +58,10 @@ public class OAuthDefaultRedirectUriPageRenderer implements OAuthRedirectUriPage
                 url = "slack://app?team=" + installer.getTeamId() + "&id=" + installer.getAppId();
             }
         }
-        return SUCCESS_PAGE_TEMPLATE.replaceAll("__URL__", url == null ? "" : url);
+        String browserUrl = "https://app.slack.com/client/" + installer.getTeamId();
+        return SUCCESS_PAGE_TEMPLATE
+                .replaceAll("__URL__", url == null ? "" : url)
+                .replaceAll("__BROWSER_URL__", browserUrl);
     }
 
     @Override

--- a/bolt/src/test/java/test_locally/service/oauth/OAuthDefaultSuccessHandlerTest.java
+++ b/bolt/src/test/java/test_locally/service/oauth/OAuthDefaultSuccessHandlerTest.java
@@ -28,6 +28,7 @@ public class OAuthDefaultSuccessHandlerTest {
 
         Response response = new Response();
         OAuthAccessResponse apiResponse = new OAuthAccessResponse();
+        apiResponse.setTeamId("T111");
 
         Response processedResponse = handler.handle(request, response, apiResponse);
         assertEquals(200, processedResponse.getStatusCode().longValue());
@@ -45,7 +46,7 @@ public class OAuthDefaultSuccessHandlerTest {
                 "</head>\n" +
                 "<body>\n" +
                 "<h2>Thank you!</h2>\n" +
-                "<p>Redirecting to the Slack App... click <a href=\"slack://open\">here</a></p>\n" +
+                "<p>Redirecting to the Slack App... click <a href=\"slack://open\">here</a>. If you use the browser version of Slack, click <a href=\"https://app.slack.com/client/T111\" target=\"_blank\">this link</a> instead.</p>\n" +
                 "</body>\n" +
                 "</html>", processedResponse.getBody());
     }

--- a/bolt/src/test/java/test_locally/service/oauth/OAuthV2DefaultSuccessHandlerTest.java
+++ b/bolt/src/test/java/test_locally/service/oauth/OAuthV2DefaultSuccessHandlerTest.java
@@ -29,6 +29,7 @@ public class OAuthV2DefaultSuccessHandlerTest {
         Response response = new Response();
         OAuthV2AccessResponse apiResponse = new OAuthV2AccessResponse();
         apiResponse.setTeam(new OAuthV2AccessResponse.Team());
+        apiResponse.getTeam().setId("T111");
         apiResponse.setAuthedUser(new OAuthV2AccessResponse.AuthedUser());
 
         Response processedResponse = handler.handle(request, response, apiResponse);
@@ -47,7 +48,7 @@ public class OAuthV2DefaultSuccessHandlerTest {
                 "</head>\n" +
                 "<body>\n" +
                 "<h2>Thank you!</h2>\n" +
-                "<p>Redirecting to the Slack App... click <a href=\"slack://open\">here</a></p>\n" +
+                "<p>Redirecting to the Slack App... click <a href=\"slack://open\">here</a>. If you use the browser version of Slack, click <a href=\"https://app.slack.com/client/T111\" target=\"_blank\">this link</a> instead.</p>\n" +
                 "</body>\n" +
                 "</html>", processedResponse.getBody());
     }


### PR DESCRIPTION
This pull request brings https://github.com/slackapi/python-slack-sdk/pull/963 improvements to Bolt for Java. This is just an improvement on the default page rendering. If an app serves its own web pages, this change does not affect the app.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
