### PR TITLE
Add built-in tokens_revoked/app_uninstalled event handlers

### DIFF
--- a/bolt-servlet/pom.xml
+++ b/bolt-servlet/pom.xml
@@ -65,6 +65,12 @@
             <version>${jetty-for-tests.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws.s3.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/bolt-servlet/src/test/java/samples/S3OAuthSample.java
+++ b/bolt-servlet/src/test/java/samples/S3OAuthSample.java
@@ -2,6 +2,8 @@ package samples;
 
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.service.builtin.AmazonS3InstallationService;
+import com.slack.api.bolt.service.builtin.AmazonS3OAuthStateService;
 import com.slack.api.model.event.AppMentionEvent;
 import util.ResourceLoader;
 import util.TestSlackAppServer;
@@ -9,11 +11,14 @@ import util.TestSlackAppServer;
 import java.util.HashMap;
 import java.util.Map;
 
-public class OAuthSample {
+public class S3OAuthSample {
 
     public static void main(String[] args) throws Exception {
+        String bucketName = System.getenv("SLACK_TEST_S3_BUCKET_NAME");
         AppConfig config = ResourceLoader.loadAppConfig("appConfig_oauth.json");
         App app = new App(config).asOAuthApp(true)
+                .service(new AmazonS3InstallationService(bucketName))
+                .service(new AmazonS3OAuthStateService(bucketName))
                 // Enable built-in tokens_revoked / app_uninstalled event handlers
                 .enableTokenRevocationHandlers();
 

--- a/bolt/src/main/java/com/slack/api/bolt/handler/builtin/DefaultAppUninstalledEventHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/handler/builtin/DefaultAppUninstalledEventHandler.java
@@ -1,0 +1,55 @@
+package com.slack.api.bolt.handler.builtin;
+
+import com.slack.api.app_backend.events.payload.EventsApiPayload;
+import com.slack.api.bolt.context.builtin.EventContext;
+import com.slack.api.bolt.handler.BoltEventHandler;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.model.event.AppUninstalledEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+public class DefaultAppUninstalledEventHandler implements BoltEventHandler<AppUninstalledEvent> {
+
+    private final InstallationService installationService;
+    private final ExecutorService executorService;
+    private final Logger logger = LoggerFactory.getLogger(DefaultAppUninstalledEventHandler.class);
+
+    public static DefaultAppUninstalledEventHandler getInstance(
+            InstallationService installationService,
+            ExecutorService executorService) {
+        return new DefaultAppUninstalledEventHandler(installationService, executorService);
+    }
+
+    public DefaultAppUninstalledEventHandler(
+            InstallationService installationService,
+            ExecutorService executorService) {
+        this.installationService = installationService;
+        this.executorService = executorService;
+    }
+
+    @Override
+    public Response apply(
+            EventsApiPayload<AppUninstalledEvent> payload,
+            EventContext context) throws IOException, SlackApiException {
+        // NOTE: this payload does not have authorizations[]
+        String enterpriseId = payload.getEnterpriseId();
+        String teamId = payload.getTeamId();
+
+        this.executorService.submit(() -> {
+            try {
+                installationService.deleteAll(enterpriseId, teamId);
+                logger.info("Deleted all installation data for enterprise_id: {}, team_id: {}",
+                        enterpriseId, teamId);
+            } catch (Exception e) {
+                logger.error("Failed to delete all installation data for enterprise_id: {}, team_id: {}",
+                        enterpriseId, teamId, e);
+            }
+        });
+        return context.ack();
+    }
+}

--- a/bolt/src/main/java/com/slack/api/bolt/handler/builtin/DefaultTokensRevokedEventHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/handler/builtin/DefaultTokensRevokedEventHandler.java
@@ -1,0 +1,77 @@
+package com.slack.api.bolt.handler.builtin;
+
+import com.slack.api.app_backend.events.payload.EventsApiPayload;
+import com.slack.api.bolt.context.builtin.EventContext;
+import com.slack.api.bolt.handler.BoltEventHandler;
+import com.slack.api.bolt.model.Bot;
+import com.slack.api.bolt.model.Installer;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.model.event.TokensRevokedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+public class DefaultTokensRevokedEventHandler implements BoltEventHandler<TokensRevokedEvent> {
+
+    private final InstallationService installationService;
+    private final ExecutorService executorService;
+    private final Logger logger = LoggerFactory.getLogger(DefaultTokensRevokedEventHandler.class);
+
+    public static DefaultTokensRevokedEventHandler getInstance(
+            InstallationService installationService,
+            ExecutorService executorService) {
+        return new DefaultTokensRevokedEventHandler(installationService, executorService);
+    }
+
+    public DefaultTokensRevokedEventHandler(
+            InstallationService installationService,
+            ExecutorService executorService) {
+        this.installationService = installationService;
+        this.executorService = executorService;
+    }
+
+    @Override
+    public Response apply(
+            EventsApiPayload<TokensRevokedEvent> payload,
+            EventContext context) throws IOException, SlackApiException {
+        // NOTE: this payload does not have authorizations[]
+        String enterpriseId = payload.getEnterpriseId();
+        String teamId = payload.getTeamId();
+
+        this.executorService.submit(() -> {
+            TokensRevokedEvent.Tokens tokens = payload.getEvent().getTokens();
+            if (tokens.getOauth() != null) { // user tokens
+                for (String userId : tokens.    getOauth()) {
+                    Installer installer = installationService.findInstaller(enterpriseId, teamId, userId);
+                    if (installer != null) {
+                        try {
+                            installationService.deleteInstaller(installer);
+                        } catch (Exception e) {
+                            logger.error(
+                                    "Failed to delete an installation - enterprise_id: {}, team_id: {}, user_id: {}",
+                                    enterpriseId, teamId, userId);
+                        }
+                    }
+                }
+            }
+            if (tokens.getBot() != null && tokens.getBot().size() > 0) { // bots
+                // actually only one bot per app in a workspace
+                Bot bot = installationService.findBot(enterpriseId, teamId);
+                if (bot != null) {
+                    try {
+                        installationService.deleteBot(bot);
+                    } catch (Exception e) {
+                        logger.error(
+                                "Failed to delete a bot installation - enterprise_id: {}, team_id: {}",
+                                enterpriseId, teamId);
+                    }
+                }
+            }
+        });
+        return context.ack();
+    }
+}

--- a/bolt/src/main/java/com/slack/api/bolt/service/InstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/InstallationService.java
@@ -60,4 +60,12 @@ public interface InstallationService extends Service {
         return null;
     }
 
+    /**
+     * Deletes all installation data for given workspace or organization.
+     */
+    default void deleteAll(String enterpriseId, String teamId) {
+        throw new UnsupportedOperationException(
+                "You can implement this method for better app_uninstalled event handling");
+    }
+
 }

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
@@ -4,10 +4,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectResult;
-import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.*;
 import com.amazonaws.util.IOUtils;
 import com.slack.api.bolt.Initializer;
 import com.slack.api.bolt.model.Bot;
@@ -197,6 +194,25 @@ public class AmazonS3InstallationService implements InstallationService {
             log.error("Failed to save a new Installer data for enterprise_id: {}, team_id: {}, user_id: {}",
                     enterpriseId, teamId, userId);
             return null;
+        }
+    }
+
+    @Override
+    public void deleteAll(String enterpriseId, String teamId) {
+        AmazonS3 s3 = this.createS3Client();
+        deleteAllObjectsMatchingPrefix(s3, "installer/"
+                + Optional.ofNullable(enterpriseId).orElse("none")
+                + "-"
+                + Optional.ofNullable(teamId).orElse("none"));
+        deleteAllObjectsMatchingPrefix(s3, "bot/"
+                + Optional.ofNullable(enterpriseId).orElse("none")
+                + "-"
+                + Optional.ofNullable(teamId).orElse("none"));
+    }
+
+    private void deleteAllObjectsMatchingPrefix(AmazonS3 s3, String prefix) {
+        for (S3ObjectSummary obj : s3.listObjects(bucketName, prefix).getObjectSummaries()) {
+            s3.deleteObject(bucketName, obj.getKey());
         }
     }
 

--- a/bolt/src/test/java/test_locally/app/EventUninstallationTest.java
+++ b/bolt/src/test/java/test_locally/app/EventUninstallationTest.java
@@ -1,0 +1,230 @@
+package test_locally.app;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.app_backend.SlackSignature;
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.model.Bot;
+import com.slack.api.bolt.model.Installer;
+import com.slack.api.bolt.model.builtin.DefaultBot;
+import com.slack.api.bolt.model.builtin.DefaultInstaller;
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.builtin.EventRequest;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.service.InstallationService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import util.MockSlackApi;
+import util.MockSlackApiServer;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+@Slf4j
+public class EventUninstallationTest {
+
+    MockSlackApiServer server = new MockSlackApiServer();
+    SlackConfig config = new SlackConfig();
+    Slack slack = Slack.getInstance(config);
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    final String secret = "foo-bar-baz";
+    final SlackSignature.Generator generator = new SlackSignature.Generator(secret);
+
+    void setRequestHeaders(String requestBody, Map<String, List<String>> rawHeaders, String timestamp) {
+        rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP, Arrays.asList(timestamp));
+        rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_SIGNATURE, Arrays.asList(generator.generate(timestamp, requestBody)));
+    }
+
+    String appUninstalledEvent = "{\n" +
+            "    \"token\": \"fixed-value\",\n" +
+            "    \"team_id\": \"T111\",\n" +
+            "    \"enterprise_id\": \"E111\",\n" +
+            "    \"api_app_id\": \"A111\",\n" +
+            "    \"event\": {\n" +
+            "        \"type\": \"app_uninstalled\",\n" +
+            "        \"event_ts\": \"1614847360.124850\"\n" +
+            "    },\n" +
+            "    \"type\": \"event_callback\",\n" +
+            "    \"event_id\": \"Ev111\",\n" +
+            "    \"event_time\": 1614847360\n" +
+            "}";
+
+    @Test
+    public void appUninstalled() throws Exception {
+        AtomicBoolean botDeleted = new AtomicBoolean(false);
+        AtomicBoolean userDeleted = new AtomicBoolean(false);
+        AtomicBoolean allDeletion = new AtomicBoolean(false);
+        App app = buildApp(botDeleted, userDeleted, allDeletion);
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(appUninstalledEvent, rawHeaders, timestamp);
+
+        EventRequest req = new EventRequest(appUninstalledEvent, new RequestHeaders(rawHeaders));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(100L);
+        assertFalse(botDeleted.get());
+        assertFalse(userDeleted.get());
+        assertTrue(allDeletion.get());
+    }
+
+    String userTokenRevokedEvent = "{\n" +
+            "    \"token\": \"fixed-value\",\n" +
+            "    \"team_id\": \"T111\",\n" +
+            "    \"enterprise_id\": \"E111\",\n" +
+            "    \"api_app_id\": \"A111\",\n" +
+            "    \"event\": {\n" +
+            "        \"type\": \"tokens_revoked\",\n" +
+            "        \"tokens\": {\n" +
+            "            \"oauth\": [\n" +
+            "                \"W111\"\n" +
+            "            ],\n" +
+            "            \"bot\": []\n" +
+            "        },\n" +
+            "        \"event_ts\": \"1614847360.131900\"\n" +
+            "    },\n" +
+            "    \"type\": \"event_callback\",\n" +
+            "    \"event_id\": \"Ev111\",\n" +
+            "    \"event_time\": 1614847360\n" +
+            "}";
+
+    @Test
+    public void tokensRevoked_users() throws Exception {
+        AtomicBoolean botDeleted = new AtomicBoolean(false);
+        AtomicBoolean userDeleted = new AtomicBoolean(false);
+        AtomicBoolean allDeletion = new AtomicBoolean(false);
+        App app = buildApp(botDeleted, userDeleted, allDeletion);
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(userTokenRevokedEvent, rawHeaders, timestamp);
+
+        EventRequest req = new EventRequest(userTokenRevokedEvent, new RequestHeaders(rawHeaders));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(100L);
+        assertFalse(botDeleted.get());
+        assertTrue(userDeleted.get());
+        assertFalse(allDeletion.get());
+    }
+
+    String botTokenRevokedEvent = "{\n" +
+            "    \"token\": \"fixed-value\",\n" +
+            "    \"team_id\": \"T111\",\n" +
+            "    \"enterprise_id\": \"E111\",\n" +
+            "    \"api_app_id\": \"A111\",\n" +
+            "    \"event\": {\n" +
+            "        \"type\": \"tokens_revoked\",\n" +
+            "        \"tokens\": {\n" +
+            "            \"oauth\": [],\n" +
+            "            \"bot\": [\n" +
+            "                \"W111\"\n" +
+            "            ]\n" +
+            "        },\n" +
+            "        \"event_ts\": \"1614847360.131900\"\n" +
+            "    },\n" +
+            "    \"type\": \"event_callback\",\n" +
+            "    \"event_id\": \"Ev111\",\n" +
+            "    \"event_time\": 1614847360\n" +
+            "}";
+
+    @Test
+    public void tokensRevoked_bots() throws Exception {
+        AtomicBoolean botDeleted = new AtomicBoolean(false);
+        AtomicBoolean userDeleted = new AtomicBoolean(false);
+        AtomicBoolean allDeletion = new AtomicBoolean(false);
+        App app = buildApp(botDeleted, userDeleted, allDeletion);
+        Map<String, List<String>> rawHeaders = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
+        setRequestHeaders(botTokenRevokedEvent, rawHeaders, timestamp);
+
+        EventRequest req = new EventRequest(botTokenRevokedEvent, new RequestHeaders(rawHeaders));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+
+        Thread.sleep(100L);
+        assertTrue(botDeleted.get());
+        assertFalse(userDeleted.get());
+        assertFalse(allDeletion.get());
+    }
+
+    App buildApp(AtomicBoolean botDeletion, AtomicBoolean userDeletion, AtomicBoolean allDeletion) {
+        App app = new App(AppConfig.builder()
+                .signingSecret(secret)
+                .clientId("111.222")
+                .clientSecret("secret")
+                .singleTeamBotToken(null)
+                .slack(slack)
+                .build());
+        app.service(new InstallationService() {
+            @Override
+            public boolean isHistoricalDataEnabled() {
+                return false;
+            }
+
+            @Override
+            public void setHistoricalDataEnabled(boolean isHistoricalDataEnabled) {
+
+            }
+
+            @Override
+            public void saveInstallerAndBot(Installer installer) throws Exception {
+
+            }
+
+            @Override
+            public void deleteBot(Bot bot) throws Exception {
+                botDeletion.set(true);
+            }
+
+            @Override
+            public void deleteInstaller(Installer installer) throws Exception {
+                userDeletion.set(true);
+            }
+
+            @Override
+            public Bot findBot(String enterpriseId, String teamId) {
+                DefaultBot bot = new DefaultBot();
+                bot.setBotAccessToken(MockSlackApi.ValidToken);
+                return bot;
+            }
+
+            @Override
+            public Installer findInstaller(String enterpriseId, String teamId, String userId) {
+                DefaultInstaller installer = new DefaultInstaller();
+                installer.setInstallerUserAccessToken(MockSlackApi.ValidToken);
+                return installer;
+            }
+
+            @Override
+            public void deleteAll(String enterpriseId, String teamId) {
+                allDeletion.set(true);
+            }
+        });
+        // enable tokens_revoked & app_uninstalled event handlers
+        app.enableTokenRevocationHandlers();
+
+        return app;
+    }
+
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/TokensRevokedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/TokensRevokedEvent.java
@@ -30,7 +30,7 @@ public class TokensRevokedEvent implements Event {
 
     @Data
     public static class Tokens {
-        private List<String> oauth;
-        private List<String> bot;
+        private List<String> oauth; // an array of user IDs
+        private List<String> bot; // an array of bot user IDs
     }
 }


### PR DESCRIPTION
As of today, developers have to implement their own logic to clean up database like this: https://github.com/seratch/send-it-later-for-slack/blob/e5f3555f347826576099f2f8551b03089ba7479d/app/listeners.py#L209-L226 

I came to think that Bolt should provide better abstraction of installation store operations for it. If other maintainers are fine with this approach, I'm happy to add the same functionalities to other Bolt frameworks.

This pull request adds built-in event handlers for token revocations and app uninstallation. The handy way to turn the additional features on is to use `enableTokenRevocationHandlers()` method as below:

```java
var app = new App().enableTokenRevocationHandlers();
```

This is equivalent to the following code:

```java
var app = new App();
app.event(TokensRevokedEvent.class, app.defaultTokensRevokedEventHandler());
app.event(AppUninstalledEvent.class, app.defaultAppUninstalledEventHandler());
```

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
