### PR TITLE
Fix #705 Add document about tokens_revoked / app_uninstalled event handlers

### DIFF
--- a/docs/guides/app-distribution.md
+++ b/docs/guides/app-distribution.md
@@ -254,6 +254,35 @@ public class SlackApp {
 }
 ```
 
+#### Use the Built-in tokens_revoked / app_uninstalled Event Handlers
+
+For secure data management for your customers and end-users, properly handling [tokens_revoked](https://api.slack.com/events/tokens_revoked) and [app_uninstalled](https://api.slack.com/events/app_uninstalled) events is crucial. Bolt for Java provides the built-in event handlers for these events, which seamlessly integrated with your `InstallationService`'s deletion methods.
+
+```java
+App app = new App();
+InstallationService installationService = new MyInstallationService();
+app.service(installationService);
+// Turn the event handlers on
+app.enableTokenRevocationHandlers();
+```
+
+The above code is equivalent to the following:
+
+```java
+App app = new App();
+InstallationService installationService = new MyInstallationService();
+app.service(installationService);
+// Turn the event handlers on
+app.event(TokensRevokedEvent.class, app.defaultTokensRevokedEventHandler());
+app.event(AppUninstalledEvent.class, app.defaultAppUninstalledEventHandler());
+```
+
+To enable your own custom `InstallationService` classes to work with the built-in event handlers, the classes need to implement the following methods in [the `InstallationService` interface](https://github.com/seratch/java-slack-sdk/blob/main/bolt/src/main/java/com/slack/api/bolt/service/InstallationService.java):
+
+* `void deleteBot(Bot bot)`
+* `void deleteInstaller(Installer installer)`
+* `void deleteAll(String enterpriseId, String teamId)`
+
 #### Serve the Completion/Cancellation Pages in Bolt Apps
 
 Although most apps tend to choose static pages for the completion/cancellation URLs, it's also possible to dynamically serve those URLs in the same app. Bolt doesn't offer any features to render web pages. Use your favorite template engine for it.

--- a/docs/guides/ja/app-distribution.md
+++ b/docs/guides/ja/app-distribution.md
@@ -249,6 +249,35 @@ public class SlackApp {
 }
 ```
 
+#### 組み込みの tokens_revoked / app_uninstalled イベントハンドラーを利用する
+
+あなたの顧客やエンドユーザーのデータを安全に管理するために [tokens_revoked](https://api.slack.com/events/tokens_revoked) と [app_uninstalled](https://api.slack.com/events/app_uninstalled) というイベントを適切にハンドリングすることは非常に重要です。Bolt for Java は、これらのイベントのための組み込みのハンドラーを提供しており、それは `InstallationService` が提供するデータ削除系メソッドとシームレスに連携します。
+
+```java
+App app = new App();
+InstallationService installationService = new MyInstallationService();
+app.service(installationService);
+// 組み込みのイベントハンドラーを有効にします
+app.enableTokenRevocationHandlers();
+```
+
+上記のコードは以下のコード例と等価です：
+
+```java
+App app = new App();
+InstallationService installationService = new MyInstallationService();
+app.service(installationService);
+// 組み込みのイベントハンドラーを有効にします
+app.event(TokensRevokedEvent.class, app.defaultTokensRevokedEventHandler());
+app.event(AppUninstalledEvent.class, app.defaultAppUninstalledEventHandler());
+```
+
+あなたが実装したカスタムの `InstallationService` の実装クラスをこれらの組み込みのイベントハンドラーと連携して動作させるためには、[`InstallationService` インターフェース](https://github.com/seratch/java-slack-sdk/blob/main/bolt/src/main/java/com/slack/api/bolt/service/InstallationService.java)に定義されている以下のメソッドを適切に実装してください：
+
+* `void deleteBot(Bot bot)`
+* `void deleteInstaller(Installer installer)`
+* `void deleteAll(String enterpriseId, String teamId)`
+
 #### 完了・エラーページを Bolt アプリでサーブする
 
 ほとんどのアプリは、完了・エラーページに静的なページを選択するかとは思いますが、これらの URL を Bolt アプリで動的に応答することも可能です。Bolt は Web ページをレンダリングするための機能は何も提供しません。お好みのテンプレートエンジンを使ってください。


### PR DESCRIPTION
This pull request fixes #705 by update the OAuth app document.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
