### PR TITLE
Bump dependency versions for v1.7 release

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.4.0.1</http4k.version>
+        <http4k.version>4.4.1.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
         <kotlin.version>1.4.31</kotlin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.971</aws.s3.version>
+        <aws.s3.version>1.11.974</aws.s3.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>


### PR DESCRIPTION
In addition to #706, this pull request upgrades optional module dependency versions to the latest patch versions.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
