### PR TITLE
Fix #715 - add team property to TeamInfoRequest

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -1925,6 +1925,7 @@ public class RequestFormBuilder {
 
     public static FormBody.Builder toForm(TeamInfoRequest req) {
         FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("team", req.getTeam(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamInfoRequest.java
@@ -14,7 +14,7 @@ public class TeamInfoRequest implements SlackApiRequest {
     private String token;
 
     /**
-     * Id of the team to get info on, if omitted, will return information about the current team.
+     * Team to get info on, if omitted, will return information about the current team. Will only return team that the authenticated token is allowed to see through external shared channels
      */
     private String team;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamInfoRequest.java
@@ -13,4 +13,9 @@ public class TeamInfoRequest implements SlackApiRequest {
      */
     private String token;
 
+    /**
+     * Id of the team to get info on, if omitted, will return information about the current team.
+     */
+    private String team;
+
 }


### PR DESCRIPTION
Add `team` property to `TeamInfoRequest`. This property is currently missing on the SDK, but is documented [on the API docs](https://api.slack.com/methods/team.info#arg_team).

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
