### PR TITLE
Fix #713 Add admin.users.session.* API support

### DIFF
--- a/json-logs/samples/api/admin.users.session.clearSettings.json
+++ b/json-logs/samples/api/admin.users.session.clearSettings.json
@@ -1,0 +1,6 @@
+{
+  "ok": false,
+  "error": "",
+  "needed": "",
+  "provided": ""
+}

--- a/json-logs/samples/api/admin.users.session.getSettings.json
+++ b/json-logs/samples/api/admin.users.session.getSettings.json
@@ -1,0 +1,16 @@
+{
+  "ok": false,
+  "session_settings": [
+    {
+      "user_id": "",
+      "desktop_app_browser_quit": false,
+      "duration": 123
+    }
+  ],
+  "no_settings_applied": [
+    "U00000000"
+  ],
+  "error": "",
+  "needed": "",
+  "provided": ""
+}

--- a/json-logs/samples/api/admin.users.session.setSettings.json
+++ b/json-logs/samples/api/admin.users.session.setSettings.json
@@ -1,0 +1,6 @@
+{
+  "ok": false,
+  "error": "",
+  "needed": "",
+  "provided": ""
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
@@ -534,6 +534,18 @@ public interface AsyncMethodsClient {
 
     CompletableFuture<AdminUsersSessionResetResponse> adminUsersSessionReset(RequestConfigurator<AdminUsersSessionResetRequest.AdminUsersSessionResetRequestBuilder> req);
 
+    CompletableFuture<AdminUsersSessionGetSettingsResponse> adminUsersSessionGetSettings(AdminUsersSessionGetSettingsRequest req);
+
+    CompletableFuture<AdminUsersSessionGetSettingsResponse> adminUsersSessionGetSettings(RequestConfigurator<AdminUsersSessionGetSettingsRequest.AdminUsersSessionGetSettingsRequestBuilder> req);
+
+    CompletableFuture<AdminUsersSessionSetSettingsResponse> adminUsersSessionSetSettings(AdminUsersSessionSetSettingsRequest req);
+
+    CompletableFuture<AdminUsersSessionSetSettingsResponse> adminUsersSessionSetSettings(RequestConfigurator<AdminUsersSessionSetSettingsRequest.AdminUsersSessionSetSettingsRequestBuilder> req);
+
+    CompletableFuture<AdminUsersSessionClearSettingsResponse> adminUsersSessionClearSettings(AdminUsersSessionClearSettingsRequest req);
+
+    CompletableFuture<AdminUsersSessionClearSettingsResponse> adminUsersSessionClearSettings(RequestConfigurator<AdminUsersSessionClearSettingsRequest.AdminUsersSessionClearSettingsRequestBuilder> req);
+
     // ------------------------------
     // api
     // ------------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
@@ -154,6 +154,9 @@ public class Methods {
     public static final String ADMIN_USERS_SESSION_INVALIDATE = "admin.users.session.invalidate";
     public static final String ADMIN_USERS_SESSION_LIST = "admin.users.session.list";
     public static final String ADMIN_USERS_SESSION_RESET = "admin.users.session.reset";
+    public static final String ADMIN_USERS_SESSION_SET_SETTINGS = "admin.users.session.setSettings";
+    public static final String ADMIN_USERS_SESSION_GET_SETTINGS = "admin.users.session.getSettings";
+    public static final String ADMIN_USERS_SESSION_CLEAR_SETTINGS = "admin.users.session.clearSettings";
 
     // ------------------------------
     // api

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
@@ -622,6 +622,18 @@ public interface MethodsClient {
 
     AdminUsersSessionResetResponse adminUsersSessionReset(RequestConfigurator<AdminUsersSessionResetRequest.AdminUsersSessionResetRequestBuilder> req) throws IOException, SlackApiException;
 
+    AdminUsersSessionGetSettingsResponse adminUsersSessionGetSettings(AdminUsersSessionGetSettingsRequest req) throws IOException, SlackApiException;
+
+    AdminUsersSessionGetSettingsResponse adminUsersSessionGetSettings(RequestConfigurator<AdminUsersSessionGetSettingsRequest.AdminUsersSessionGetSettingsRequestBuilder> req) throws IOException, SlackApiException;
+
+    AdminUsersSessionSetSettingsResponse adminUsersSessionSetSettings(AdminUsersSessionSetSettingsRequest req) throws IOException, SlackApiException;
+
+    AdminUsersSessionSetSettingsResponse adminUsersSessionSetSettings(RequestConfigurator<AdminUsersSessionSetSettingsRequest.AdminUsersSessionSetSettingsRequestBuilder> req) throws IOException, SlackApiException;
+
+    AdminUsersSessionClearSettingsResponse adminUsersSessionClearSettings(AdminUsersSessionClearSettingsRequest req) throws IOException, SlackApiException;
+
+    AdminUsersSessionClearSettingsResponse adminUsersSessionClearSettings(RequestConfigurator<AdminUsersSessionClearSettingsRequest.AdminUsersSessionClearSettingsRequestBuilder> req) throws IOException, SlackApiException;
+
     // ------------------------------
     // api
     // ------------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
@@ -135,6 +135,16 @@ public class MethodsRateLimits {
             setRateLimitTier(methods, Tier3);
         }
 
+        // Tier4
+        final List<String> adminApiMethods_Tier4 = Arrays.asList(
+                ADMIN_USERS_SESSION_GET_SETTINGS,
+                ADMIN_USERS_SESSION_SET_SETTINGS,
+                ADMIN_USERS_SESSION_CLEAR_SETTINGS
+        );
+        for (String methods : adminApiMethods_Tier4) {
+            setRateLimitTier(methods, Tier4);
+        }
+
         // --------------------------
         // Workspace App APIs
         // --------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -154,6 +154,32 @@ public class RequestFormBuilder {
         return form;
     }
 
+    public static FormBody.Builder toForm(AdminUsersSessionGetSettingsRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        if (req.getUserIds() != null) {
+            setIfNotNull("user_ids", req.getUserIds().stream().collect(joining(",")), form);
+        }
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AdminUsersSessionSetSettingsRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        if (req.getUserIds() != null) {
+            setIfNotNull("user_ids", req.getUserIds().stream().collect(joining(",")), form);
+        }
+        setIfNotNull("desktop_app_browser_quit", req.getDesktopAppBrowserQuit(), form);
+        setIfNotNull("duration", req.getDuration(), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AdminUsersSessionClearSettingsRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        if (req.getUserIds() != null) {
+            setIfNotNull("user_ids", req.getUserIds().stream().collect(joining(",")), form);
+        }
+        return form;
+    }
+
     public static FormBody.Builder toForm(AdminAppsApproveRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("app_id", req.getAppId(), form);

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
@@ -882,6 +882,36 @@ public class AsyncMethodsClientImpl implements AsyncMethodsClient {
     }
 
     @Override
+    public CompletableFuture<AdminUsersSessionGetSettingsResponse> adminUsersSessionGetSettings(AdminUsersSessionGetSettingsRequest req) {
+        return executor.execute(ADMIN_USERS_SESSION_GET_SETTINGS, toMap(req), () -> methods.adminUsersSessionGetSettings(req));
+    }
+
+    @Override
+    public CompletableFuture<AdminUsersSessionGetSettingsResponse> adminUsersSessionGetSettings(RequestConfigurator<AdminUsersSessionGetSettingsRequest.AdminUsersSessionGetSettingsRequestBuilder> req) {
+        return adminUsersSessionGetSettings(req.configure(AdminUsersSessionGetSettingsRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<AdminUsersSessionSetSettingsResponse> adminUsersSessionSetSettings(AdminUsersSessionSetSettingsRequest req) {
+        return executor.execute(ADMIN_USERS_SESSION_SET_SETTINGS, toMap(req), () -> methods.adminUsersSessionSetSettings(req));
+    }
+
+    @Override
+    public CompletableFuture<AdminUsersSessionSetSettingsResponse> adminUsersSessionSetSettings(RequestConfigurator<AdminUsersSessionSetSettingsRequest.AdminUsersSessionSetSettingsRequestBuilder> req) {
+        return adminUsersSessionSetSettings(req.configure(AdminUsersSessionSetSettingsRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<AdminUsersSessionClearSettingsResponse> adminUsersSessionClearSettings(AdminUsersSessionClearSettingsRequest req) {
+        return executor.execute(ADMIN_USERS_SESSION_CLEAR_SETTINGS, toMap(req), () -> methods.adminUsersSessionClearSettings(req));
+    }
+
+    @Override
+    public CompletableFuture<AdminUsersSessionClearSettingsResponse> adminUsersSessionClearSettings(RequestConfigurator<AdminUsersSessionClearSettingsRequest.AdminUsersSessionClearSettingsRequestBuilder> req) {
+        return adminUsersSessionClearSettings(req.configure(AdminUsersSessionClearSettingsRequest.builder()).build());
+    }
+
+    @Override
     public CompletableFuture<ApiTestResponse> apiTest(ApiTestRequest req) {
         return executor.execute(API_TEST, toMap(req), () -> methods.apiTest(req));
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -897,6 +897,36 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    public AdminUsersSessionGetSettingsResponse adminUsersSessionGetSettings(AdminUsersSessionGetSettingsRequest req) throws IOException, SlackApiException {
+        return postFormWithTokenAndParseResponse(toForm(req), Methods.ADMIN_USERS_SESSION_GET_SETTINGS, getToken(req), AdminUsersSessionGetSettingsResponse.class);
+    }
+
+    @Override
+    public AdminUsersSessionGetSettingsResponse adminUsersSessionGetSettings(RequestConfigurator<AdminUsersSessionGetSettingsRequest.AdminUsersSessionGetSettingsRequestBuilder> req) throws IOException, SlackApiException {
+        return adminUsersSessionGetSettings(req.configure(AdminUsersSessionGetSettingsRequest.builder()).build());
+    }
+
+    @Override
+    public AdminUsersSessionSetSettingsResponse adminUsersSessionSetSettings(AdminUsersSessionSetSettingsRequest req) throws IOException, SlackApiException {
+        return postFormWithTokenAndParseResponse(toForm(req), Methods.ADMIN_USERS_SESSION_SET_SETTINGS, getToken(req), AdminUsersSessionSetSettingsResponse.class);
+    }
+
+    @Override
+    public AdminUsersSessionSetSettingsResponse adminUsersSessionSetSettings(RequestConfigurator<AdminUsersSessionSetSettingsRequest.AdminUsersSessionSetSettingsRequestBuilder> req) throws IOException, SlackApiException {
+        return adminUsersSessionSetSettings(req.configure(AdminUsersSessionSetSettingsRequest.builder()).build());
+    }
+
+    @Override
+    public AdminUsersSessionClearSettingsResponse adminUsersSessionClearSettings(AdminUsersSessionClearSettingsRequest req) throws IOException, SlackApiException {
+        return postFormWithTokenAndParseResponse(toForm(req), Methods.ADMIN_USERS_SESSION_CLEAR_SETTINGS, getToken(req), AdminUsersSessionClearSettingsResponse.class);
+    }
+
+    @Override
+    public AdminUsersSessionClearSettingsResponse adminUsersSessionClearSettings(RequestConfigurator<AdminUsersSessionClearSettingsRequest.AdminUsersSessionClearSettingsRequestBuilder> req) throws IOException, SlackApiException {
+        return adminUsersSessionClearSettings(req.configure(AdminUsersSessionClearSettingsRequest.builder()).build());
+    }
+
+    @Override
     public AdminUsersSessionInvalidateResponse adminUsersSessionInvalidate(AdminUsersSessionInvalidateRequest req) throws IOException, SlackApiException {
         return postFormWithTokenAndParseResponse(toForm(req), Methods.ADMIN_USERS_SESSION_INVALIDATE, getToken(req), AdminUsersSessionInvalidateResponse.class);
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/admin/users/AdminUsersSessionClearSettingsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/admin/users/AdminUsersSessionClearSettingsRequest.java
@@ -1,0 +1,25 @@
+package com.slack.api.methods.request.admin.users;
+
+import com.slack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/methods/admin.users.session.clearSettings
+ */
+@Data
+@Builder
+public class AdminUsersSessionClearSettingsRequest implements SlackApiRequest {
+
+    /**
+     * Authentication token bearing required scopes.
+     */
+    private String token;
+
+    /**
+     * The IDs of users you'd like to clear session settings for.
+     */
+    private List<String> userIds;
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/admin/users/AdminUsersSessionGetSettingsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/admin/users/AdminUsersSessionGetSettingsRequest.java
@@ -1,0 +1,26 @@
+package com.slack.api.methods.request.admin.users;
+
+import com.slack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/methods/admin.users.session.getSettings
+ */
+@Data
+@Builder
+public class AdminUsersSessionGetSettingsRequest implements SlackApiRequest {
+
+    /**
+     * Authentication token bearing required scopes.
+     */
+    private String token;
+
+    /**
+     * The IDs of users you'd like to fetch session settings for.
+     * Note: if a user does not have any active sessions, they will not be returned in the response.
+     */
+    private List<String> userIds;
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/admin/users/AdminUsersSessionSetSettingsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/admin/users/AdminUsersSessionSetSettingsRequest.java
@@ -1,0 +1,36 @@
+package com.slack.api.methods.request.admin.users;
+
+import com.slack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/methods/admin.users.session.setSettings
+ */
+@Data
+@Builder
+public class AdminUsersSessionSetSettingsRequest implements SlackApiRequest {
+
+    /**
+     * Authentication token bearing required scopes.
+     */
+    private String token;
+
+    /**
+     * The list of user IDs to apply the session settings for.
+     */
+    private List<String> userIds;
+
+    /**
+     * Terminate the session when the client—either the desktop app or a browser window—is closed.
+     */
+    private Boolean desktopAppBrowserQuit;
+
+    /**
+     * The session duration, in seconds. The minimum value is 28800,
+     * which represents 8 hours; the max value is 315569520 or 10 years (that's a long Slack session).
+     */
+    private Integer duration;
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionClearSettingsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionClearSettingsResponse.java
@@ -1,0 +1,17 @@
+package com.slack.api.methods.response.admin.users;
+
+import com.slack.api.methods.SlackApiTextResponse;
+import com.slack.api.model.ErrorResponseMetadata;
+import lombok.Data;
+
+@Data
+public class AdminUsersSessionClearSettingsResponse implements SlackApiTextResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private ErrorResponseMetadata responseMetadata;
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionGetSettingsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionGetSettingsResponse.java
@@ -1,0 +1,29 @@
+package com.slack.api.methods.response.admin.users;
+
+import com.slack.api.methods.SlackApiTextResponse;
+import com.slack.api.model.ErrorResponseMetadata;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AdminUsersSessionGetSettingsResponse implements SlackApiTextResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private List<SessionSetting> sessionSettings;
+    private List<String> noSettingsApplied; // user IDs
+
+    @Data
+    public static class SessionSetting {
+        private String userId;
+        private Boolean desktopAppBrowserQuit;
+        private Integer duration;
+    }
+
+    private ErrorResponseMetadata responseMetadata;
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionSetSettingsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionSetSettingsResponse.java
@@ -1,0 +1,17 @@
+package com.slack.api.methods.response.admin.users;
+
+import com.slack.api.methods.SlackApiTextResponse;
+import com.slack.api.model.ErrorResponseMetadata;
+import lombok.Data;
+
+@Data
+public class AdminUsersSessionSetSettingsResponse implements SlackApiTextResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private ErrorResponseMetadata responseMetadata;
+}

--- a/slack-api-client/src/test/java/test_locally/api/MethodsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/MethodsTest.java
@@ -39,12 +39,8 @@ public class MethodsTest {
                 // TODO: https://github.com/slackapi/java-slack-sdk/issues/634
                 "admin.conversations.getCustomRetention",
                 "admin.conversations.removeCustomRetention",
-                "admin.conversations.setCustomRetention",
-                // TODO: https://github.com/slackapi/python-slack-sdk/issues/982
-                "admin.users.session.clearSettings",
-                "admin.users.session.getSettings",
-                "admin.users.session.setSettings"
-                );
+                "admin.conversations.setCustomRetention"
+        );
         List<String> methodNames = new ArrayList<>();
         for (String methodName : allMethodNames) {
             if (!excludedMethodNames.contains(methodName)) {

--- a/slack-api-client/src/test/java/test_locally/api/methods_admin_api/AdminApiAsyncTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods_admin_api/AdminApiAsyncTest.java
@@ -191,6 +191,12 @@ public class AdminApiAsyncTest {
                 .get().isOk(), is(true));
         assertThat(methods.adminUsersSessionList(r -> r.cursor("XXXX").limit(10).teamId("T123").userId("U123"))
                 .get().isOk(), is(true));
+        assertThat(methods.adminUsersSessionGetSettings(r -> r.userIds(Arrays.asList("U123")))
+                .get().isOk(), is(true));
+        assertThat(methods.adminUsersSessionSetSettings(r -> r.userIds(Arrays.asList("U123")))
+                .get().isOk(), is(true));
+        assertThat(methods.adminUsersSessionClearSettings(r -> r.userIds(Arrays.asList("U123")))
+                .get().isOk(), is(true));
     }
 
     @Test

--- a/slack-api-client/src/test/java/test_locally/api/methods_admin_api/AdminApiTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods_admin_api/AdminApiTest.java
@@ -201,6 +201,12 @@ public class AdminApiTest {
                 .isOk(), is(true));
         assertThat(methods.adminUsersSessionList(r -> r.cursor("XXXX").limit(10).teamId("T123").userId("U123"))
                 .isOk(), is(true));
+        assertThat(methods.adminUsersSessionGetSettings(r -> r.userIds(Arrays.asList("U123")))
+                .isOk(), is(true));
+        assertThat(methods.adminUsersSessionSetSettings(r -> r.userIds(Arrays.asList("U123")))
+                .isOk(), is(true));
+        assertThat(methods.adminUsersSessionClearSettings(r -> r.userIds(Arrays.asList("U123")))
+                .isOk(), is(true));
     }
 
     @Test

--- a/slack-api-client/src/test/java/test_locally/api/methods_admin_api/FieldValidationTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods_admin_api/FieldValidationTest.java
@@ -332,6 +332,18 @@ public class FieldValidationTest {
             AdminUsersSessionListResponse obj = parse(prefix + "session.list", AdminUsersSessionListResponse.class);
             verifyIfAllGettersReturnNonNull(obj);
         }
+        {
+            AdminUsersSessionGetSettingsResponse obj = parse(prefix + "session.getSettings", AdminUsersSessionGetSettingsResponse.class);
+            verifyIfAllGettersReturnNonNull(obj);
+        }
+        {
+            AdminUsersSessionSetSettingsResponse obj = parse(prefix + "session.setSettings", AdminUsersSessionSetSettingsResponse.class);
+            verifyIfAllGettersReturnNonNull(obj);
+        }
+        {
+            AdminUsersSessionClearSettingsResponse obj = parse(prefix + "session.clearSettings", AdminUsersSessionClearSettingsResponse.class);
+            verifyIfAllGettersReturnNonNull(obj);
+        }
     }
 
     @Test

--- a/slack-api-client/src/test/java/util/sample_json_generation/JsonDataRecorder.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/JsonDataRecorder.java
@@ -2,6 +2,7 @@ package util.sample_json_generation;
 
 import com.google.gson.*;
 import com.slack.api.SlackConfig;
+import com.slack.api.methods.response.admin.users.AdminUsersSessionGetSettingsResponse;
 import com.slack.api.methods.response.chat.scheduled_messages.ChatScheduledMessagesListResponse;
 import com.slack.api.model.Conversation;
 import com.slack.api.model.FileComment;
@@ -284,6 +285,9 @@ public class JsonDataRecorder {
                     address.setOriginal("");
                     JsonElement elem = gson.toJsonTree(address);
                     array.add(elem);
+                } else if (path.equals("/api/admin.users.session.getSettings") && name.equals("session_settings")) {
+                    array.add(gson.toJsonTree(ObjectInitializer.initProperties(
+                            new AdminUsersSessionGetSettingsResponse.SessionSetting())));
                 } else if (path.equals("/api/conversations.list") && name.equals("channels")) {
                     array.add(gson.toJsonTree(ObjectInitializer.initProperties(new Conversation())));
                 } else if (path.equals("/api/users.conversations") && name.equals("channels")) {


### PR DESCRIPTION
This pull request fixes #713 by adding new Web APIs.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
