### PR TITLE
Fix non-closed response bug in bolt-ktor package

### DIFF
--- a/bolt-ktor/src/main/kotlin/com/slack/api/bolt/ktor/package.kt
+++ b/bolt-ktor/src/main/kotlin/com/slack/api/bolt/ktor/package.kt
@@ -33,8 +33,8 @@ suspend fun respond(call: ApplicationCall, boltResponse: Response) {
             call.response.header(header.key, value)
         }
     }
-    call.response.status(HttpStatusCode.fromValue(boltResponse.statusCode))
+    val status = HttpStatusCode.fromValue(boltResponse.statusCode)
     if (boltResponse.body != null) {
-        call.respond(TextContent(boltResponse.body, ContentType.parse(boltResponse.contentType)))
-    }
+        call.respondText(boltResponse.body, ContentType.parse(boltResponse.contentType), status)
+    } else call.respond(status)
 }

--- a/bolt-ktor/src/main/kotlin/com/slack/api/bolt/ktor/package.kt
+++ b/bolt-ktor/src/main/kotlin/com/slack/api/bolt/ktor/package.kt
@@ -35,6 +35,11 @@ suspend fun respond(call: ApplicationCall, boltResponse: Response) {
     }
     val status = HttpStatusCode.fromValue(boltResponse.statusCode)
     if (boltResponse.body != null) {
-        call.respondText(boltResponse.body, ContentType.parse(boltResponse.contentType), status)
+        val message = TextContent(
+            boltResponse.body,
+            ContentType.parse(boltResponse.contentType),
+            status
+        )
+        call.respond(message)
     } else call.respond(status)
 }

--- a/bolt-ktor/src/test/kotlin/test_locally/app/events/test.kt
+++ b/bolt-ktor/src/test/kotlin/test_locally/app/events/test.kt
@@ -11,6 +11,7 @@ import com.slack.api.bolt.util.SlackRequestParser
 import com.slack.api.model.event.AppMentionEvent
 import io.ktor.application.*
 import io.ktor.http.*
+import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.server.testing.*
 import org.junit.After
@@ -77,6 +78,9 @@ class KtorAppTest {
         }
         with(req) {
             assertEquals(HttpStatusCode.OK, response.status())
+            // assert that response is properly flushed and closed
+            // we can check it by content-length header, for example
+            assertEquals("0", response.headers["content-length"])
         }
     }
 


### PR DESCRIPTION
* Fix bug when bolt's empty ctx.ack() resulted in response that was not
  closed properly
* Also add check for that situation by content-length header check
  in one of the existing tests

This PR closes #730 -- I discovered that if you call `ctx.ack()` on any event handling, then response would only partial (only status code), also not being closed. Tests didn't checked that, I guess because of Ktor test engine behaviour, so I added check for least for content-length header.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-ktor** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
