### PR TITLE
Add new fields in admin.analytics.getFile API responses

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     # ubuntu-20.04 may be a bit unstable for this build
     runs-on: ubuntu-18.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         java-version: ['8', '11', '14']

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/analytics/AdminAnalyticsGetFileResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/analytics/AdminAnalyticsGetFileResponse.java
@@ -66,7 +66,10 @@ public class AdminAnalyticsGetFileResponse implements SlackApiBinaryResponse {
     }
 
     public void forEach(Consumer<AnalyticsData> handler) throws IOException {
-        Gson gson = GsonFactory.createSnakeCase();
+        this.forEach(GsonFactory.createSnakeCase(), handler);
+    }
+
+    public void forEach(Gson gson, Consumer<AnalyticsData> handler) throws IOException {
         InputStream is = getFileStream();
         if (loadedBytes.length > 0) {
             // already the whole data is loaded in heap memory
@@ -114,6 +117,12 @@ public class AdminAnalyticsGetFileResponse implements SlackApiBinaryResponse {
         private String name;
     }
 
+    @Data
+    public static class Organization {
+        private String name;
+        private String domain;
+    }
+
     /**
      * Parsed Analytics Data
      */
@@ -141,6 +150,11 @@ public class AdminAnalyticsGetFileResponse implements SlackApiBinaryResponse {
          * Example: W1F83A9F9
          */
         private String enterpriseUserId;
+
+        /**
+         * User ID
+         */
+        private String userId;
 
         /**
          * The email address of record for the same user
@@ -207,7 +221,7 @@ public class AdminAnalyticsGetFileResponse implements SlackApiBinaryResponse {
          * This metric is not de-duplicated by message—if a user adds 3 different reactions
          * to a single message, we will report 3 reactions
          * (public_channel)
-         * 	A count of emoji reactions left on any message in channel on that given day by human users
+         * A count of emoji reactions left on any message in channel on that given day by human users
          * Example: 20
          */
         private Integer reactionsAddedCount;
@@ -236,6 +250,50 @@ public class AdminAnalyticsGetFileResponse implements SlackApiBinaryResponse {
          * Example: 5
          */
         private Integer filesAddedCount;
+
+        /**
+         * (member)
+         * Returns true when this member has interacted with a Slack app
+         * or custom integration on the given day,
+         * or if such an app or integration has performed an action on the user's behalf,
+         * such as updating their custom status
+         */
+        private Boolean isActiveApps;
+
+        /**
+         * (member)
+         * Returns true when this member has interacted with at least one workflow on a given day
+         */
+        private Boolean isActiveWorkflows;
+
+        /**
+         * (member)
+         * Returns true when the member is considered active on Slack Connect,
+         * in that they've read or posted a message to a channel
+         * or direct message shared with at least one external workspace
+         */
+        private Boolean isActiveSlackConnect;
+
+        /**
+         * (member)
+         * Total number of Slack calls made or joined on a given day,
+         * excluding any calls using third party software besides Slack calls
+         */
+        private Integer slackCallsCount;
+
+        /**
+         * (member)
+         * The number of searches this user performed in Slack on a given day
+         */
+        private Integer searchCount;
+
+        /**
+         * (member)
+         * The date of the very first time the member signed in
+         * to any workspace within the grid organization,
+         * presented in seconds since the epoch (UNIX time)
+         */
+        private Integer dateClaimed;
 
         // public_channel type
 
@@ -382,6 +440,15 @@ public class AdminAnalyticsGetFileResponse implements SlackApiBinaryResponse {
          * Example: "Ask our editors all about their favorite literature"
          */
         private String description;
+
+        /**
+         * (public_channel)
+         * Indicates which, if any, external organizations this channel is shared with.
+         * Presented as an array of JSON objects containing an organization name and a slack domain.
+         * Only works with is_shared_externally set to true.
+         * Example: [{"name":"Away Org","domain":"away.enterprise.slack.com"}]
+         */
+        private List<Organization> externallySharedWithOrganizations;
 
     }
 

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApi_analytics_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApi_analytics_Test.java
@@ -1,8 +1,10 @@
 package test_with_remote_apis.methods_admin_api;
 
+import com.google.gson.Gson;
 import com.slack.api.Slack;
 import com.slack.api.methods.AsyncMethodsClient;
 import com.slack.api.methods.response.admin.analytics.AdminAnalyticsGetFileResponse;
+import com.slack.api.util.json.GsonFactory;
 import config.Constants;
 import config.SlackTestConfig;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +22,7 @@ public class AdminApi_analytics_Test {
 
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
+    static Gson gson = GsonFactory.createSnakeCase(testConfig.getConfig());
 
     @AfterClass
     public static void tearDown() throws InterruptedException {
@@ -30,7 +33,7 @@ public class AdminApi_analytics_Test {
     static AsyncMethodsClient methodsAsync = slack.methodsAsync(orgAdminUserToken);
 
     @Test
-    public void getFile_error() throws Exception {
+    public void getFile_member_error() throws Exception {
         if (orgAdminUserToken != null) {
             AdminAnalyticsGetFileResponse response = methodsAsync.adminAnalyticsGetFile(r -> r
                     .date("2035-12-31")
@@ -42,7 +45,7 @@ public class AdminApi_analytics_Test {
     }
 
     @Test
-    public void getFile_forEach() throws Exception {
+    public void getFile_member_forEach() throws Exception {
         if (orgAdminUserToken != null) {
             AdminAnalyticsGetFileResponse response = methodsAsync.adminAnalyticsGetFile(r -> r
                     .date("2020-10-20")
@@ -72,7 +75,23 @@ public class AdminApi_analytics_Test {
     }
 
     @Test
-    public void getFile_asBytes() throws Exception {
+    public void getFile_member_forEach_validation() throws Exception {
+        if (orgAdminUserToken != null) {
+            AdminAnalyticsGetFileResponse response = methodsAsync.adminAnalyticsGetFile(r -> r
+                    .date("2020-10-20")
+                    .type("member")
+            ).get();
+            assertNull(response.getError());
+            assertNotNull(response.getFileStream());
+            List<AdminAnalyticsGetFileResponse.AnalyticsData> results = new ArrayList<>();
+            response.forEach(gson, data -> results.add(data));
+            assertTrue(results.size() > 0);
+            assertNull(response.getFileStream());
+        }
+    }
+
+    @Test
+    public void getFile_member_asBytes() throws Exception {
         if (orgAdminUserToken != null) {
             AdminAnalyticsGetFileResponse response = methodsAsync.adminAnalyticsGetFile(r -> r
                     .date("2020-10-20")
@@ -128,6 +147,21 @@ public class AdminApi_analytics_Test {
     }
 
     @Test
+    public void getFile_public_channel_validation() throws Exception {
+        if (orgAdminUserToken != null) {
+            AdminAnalyticsGetFileResponse response = methodsAsync.adminAnalyticsGetFile(r -> r
+                    .date("2020-10-20")
+                    .type("public_channel")
+            ).get();
+            assertNull(response.getError());
+            assertNotNull(response.getFileStream());
+            List<AdminAnalyticsGetFileResponse.AnalyticsData> results = new ArrayList<>();
+            response.forEach(gson, data -> results.add(data));
+            assertTrue(results.size() > 0);
+        }
+    }
+
+    @Test
     public void getFile_public_channel_metadata_only() throws Exception {
         if (orgAdminUserToken != null) {
             AdminAnalyticsGetFileResponse response = methodsAsync.adminAnalyticsGetFile(r -> r
@@ -161,6 +195,21 @@ public class AdminApi_analytics_Test {
             } catch (IOException e) {
                 assertEquals("The byte stream has been already consumed.", e.getMessage());
             }
+        }
+    }
+
+    @Test
+    public void getFile_public_channel_metadata_only_validation() throws Exception {
+        if (orgAdminUserToken != null) {
+            AdminAnalyticsGetFileResponse response = methodsAsync.adminAnalyticsGetFile(r -> r
+                    .type("public_channel")
+                    .metadataOnly(true)
+            ).get();
+            assertNull(response.getError());
+            assertNotNull(response.getFileStream());
+            List<AdminAnalyticsGetFileResponse.AnalyticsData> results = new ArrayList<>();
+            response.forEach(gson, data -> results.add(data));
+            assertTrue(results.size() > 0);
         }
     }
 }


### PR DESCRIPTION
This pull request adds new fields in [admin.analytics.getFile](https://api.slack.com/methods/admin.analytics.getFile) API response class.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
