### PR TITLE
Fix #719 Enable developers to customize the way to handle unmatched requests

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -25,6 +25,7 @@ import com.slack.api.bolt.service.builtin.DefaultOAuthCallbackService;
 import com.slack.api.bolt.service.builtin.FileInstallationService;
 import com.slack.api.bolt.service.builtin.oauth.*;
 import com.slack.api.bolt.service.builtin.oauth.default_impl.*;
+import com.slack.api.bolt.util.ListenerCodeSuggestion;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.auth.AuthTestResponse;
@@ -993,7 +994,9 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No SlashCommandHandler registered for command: {}", request.getPayload().getCommand());
+                    command = request.getPayload().getCommand();
+                    log.warn("No SlashCommandHandler registered for command: {}\n{}",
+                            command, ListenerCodeSuggestion.command(command));
                     break;
                 }
                 case Event: {
@@ -1007,7 +1010,8 @@ public class App {
                         EventsApiPayload<Event> payload = buildEventPayload(request);
                         return handler.apply(payload, request.getContext());
                     }
-                    log.warn("No BoltEventHandler registered for event: {}", request.getEventTypeAndSubtype());
+                    log.warn("No BoltEventHandler registered for event: {}\n{}",
+                            request.getEventTypeAndSubtype(), ListenerCodeSuggestion.event(request.getEventTypeAndSubtype()));
                     break;
                 }
                 case UrlVerification: {
@@ -1029,7 +1033,9 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No AttachmentActionHandler registered for callback_id: {}", request.getPayload().getCallbackId());
+                    callbackId = request.getPayload().getCallbackId();
+                    log.warn("No AttachmentActionHandler registered for callback_id: {}\n{}",
+                            callbackId, ListenerCodeSuggestion.attachmentAction(callbackId));
                     break;
                 }
                 case BlockAction: {
@@ -1048,7 +1054,9 @@ public class App {
                                 }
                             }
                         }
-                        log.warn("No BlockActionHandler registered for action_id: {}", actions.get(0).getActionId());
+                        actionId = actions.get(0).getActionId();
+                        log.warn("No BlockActionHandler registered for action_id: {}\n{}",
+                                actionId, ListenerCodeSuggestion.blockAction(actionId));
                     } else {
                         for (BlockActionPayload.Action action : request.getPayload().getActions()) {
                             // Returned response values will be ignored
@@ -1070,7 +1078,8 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No BlockSuggestionHandler registered for action_id: {}", actionId);
+                    log.warn("No BlockSuggestionHandler registered for action_id: {}\n{}",
+                            actionId, ListenerCodeSuggestion.blockSuggestion(actionId));
                     break;
                 }
                 case GlobalShortcut: {
@@ -1084,7 +1093,8 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No GlobalShortcutHandler registered for callback_id: {}", callbackId);
+                    log.warn("No GlobalShortcutHandler registered for callback_id: {}\n{}",
+                            callbackId, ListenerCodeSuggestion.globalShortcut(callbackId));
                     break;
                 }
                 case MessageShortcut: {
@@ -1098,7 +1108,8 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No MessageShortcutHandler registered for callback_id: {}", callbackId);
+                    log.warn("No MessageShortcutHandler registered for callback_id: {}\n{}",
+                            callbackId, ListenerCodeSuggestion.messageShortcut(callbackId));
                     break;
                 }
                 case DialogSubmission: {
@@ -1112,7 +1123,8 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No DialogSubmissionHandler registered for callback_id: {}", callbackId);
+                    log.warn("No DialogSubmissionHandler registered for callback_id: {}\n{}",
+                            callbackId, ListenerCodeSuggestion.dialogSubmission(callbackId));
                     break;
                 }
                 case DialogCancellation: {
@@ -1126,7 +1138,8 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No DialogCancellationHandler registered for callback_id: {}", callbackId);
+                    log.warn("No DialogCancellationHandler registered for callback_id: {}\n{}",
+                            callbackId, ListenerCodeSuggestion.dialogCancellation(callbackId));
                     break;
                 }
                 case DialogSuggestion: {
@@ -1140,7 +1153,8 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No DialogSuggestionHandler registered for callback_id: {}", callbackId);
+                    log.warn("No DialogSuggestionHandler registered for callback_id: {}\n{}",
+                            callbackId, ListenerCodeSuggestion.dialogSuggestion(callbackId));
                     break;
                 }
                 case ViewSubmission: {
@@ -1154,7 +1168,8 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No ViewSubmissionHandler registered for callback_id: {}", callbackId);
+                    log.warn("No ViewSubmissionHandler registered for callback_id: {}\n{}",
+                            callbackId, ListenerCodeSuggestion.viewSubmission(callbackId));
                     break;
                 }
                 case ViewClosed: {
@@ -1168,7 +1183,8 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No ViewClosedHandler registered for callback_id: {}", callbackId);
+                    log.warn("No ViewClosedHandler registered for callback_id: {}\n{}",
+                            callbackId, ListenerCodeSuggestion.viewClosed(callbackId));
                     break;
                 }
                 case WorkflowStepEdit: {
@@ -1182,7 +1198,8 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No WorkflowStepEditHandler registered for callback_id: {}", callbackId);
+                    log.warn("No WorkflowStepEditHandler registered for callback_id: {}\n{}",
+                            callbackId, ListenerCodeSuggestion.WORKFLOW_STEP);
                     break;
                 }
                 case WorkflowStepSave: {
@@ -1196,7 +1213,8 @@ public class App {
                             }
                         }
                     }
-                    log.warn("No WorkflowStepSaveHandler registered for callback_id: {}", callbackId);
+                    log.warn("No WorkflowStepSaveHandler registered for callback_id: {}\n{}",
+                            callbackId, ListenerCodeSuggestion.WORKFLOW_STEP);
                     break;
                 }
                 case WorkflowStepExecute: {
@@ -1221,12 +1239,13 @@ public class App {
                         EventsApiPayload<Event> payload = buildEventPayload(request);
                         return handler.apply(payload, request.getContext());
                     }
-                    log.warn("No BoltEventHandler registered for event: {}", request.getEventTypeAndSubtype());
+                    log.warn("No BoltEventHandler registered for event: {}\n{}",
+                            request.getEventTypeAndSubtype(), ListenerCodeSuggestion.WORKFLOW_STEP);
                     break;
                 }
                 default:
             }
-            return Response.json(404, "{\"error\":\"no handler found\"}");
+            return appConfig.getUnmatchedRequestHandler().handle(slackRequest);
         } finally {
             if (log.isDebugEnabled()) {
                 log.debug("The handler completed (request type: {})", slackRequest.getRequestType());

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -2,6 +2,8 @@ package com.slack.api.bolt;
 
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
+import com.slack.api.bolt.handler.UnmatchedRequestHandler;
+import com.slack.api.bolt.handler.builtin.DefaultUnmatchedRequestHandler;
 import com.slack.api.bolt.meta.BoltLibraryVersion;
 import com.slack.api.bolt.service.builtin.oauth.view.OAuthInstallPageRenderer;
 import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
@@ -156,6 +158,13 @@ public class AppConfig {
     @Builder.Default
     private transient OAuthRedirectUriPageRenderer oAuthRedirectUriPageRenderer =
             new OAuthDefaultRedirectUriPageRenderer();
+
+    /**
+     * Handles unmatched requests (default behavior is simply returning 404 Not Found).
+     */
+    @Builder.Default
+    private transient UnmatchedRequestHandler unmatchedRequestHandler =
+            new DefaultUnmatchedRequestHandler();
 
     // --------------------------
 

--- a/bolt/src/main/java/com/slack/api/bolt/handler/UnmatchedRequestHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/handler/UnmatchedRequestHandler.java
@@ -1,0 +1,11 @@
+package com.slack.api.bolt.handler;
+
+import com.slack.api.bolt.request.Request;
+import com.slack.api.bolt.response.Response;
+
+@FunctionalInterface
+public interface UnmatchedRequestHandler {
+
+    Response handle(Request<?> request);
+
+}

--- a/bolt/src/main/java/com/slack/api/bolt/handler/builtin/DefaultUnmatchedRequestHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/handler/builtin/DefaultUnmatchedRequestHandler.java
@@ -1,0 +1,12 @@
+package com.slack.api.bolt.handler.builtin;
+
+import com.slack.api.bolt.request.Request;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.handler.UnmatchedRequestHandler;
+
+public class DefaultUnmatchedRequestHandler implements UnmatchedRequestHandler {
+    @Override
+    public Response handle(Request<?> request) {
+        return Response.json(404, "{\"error\":\"no handler found\"}");
+    }
+}

--- a/bolt/src/main/java/com/slack/api/bolt/util/ListenerCodeSuggestion.java
+++ b/bolt/src/main/java/com/slack/api/bolt/util/ListenerCodeSuggestion.java
@@ -1,0 +1,142 @@
+package com.slack.api.bolt.util;
+
+public class ListenerCodeSuggestion {
+    private ListenerCodeSuggestion() {
+    }
+
+    public static final String COMMON_PREFIX = "---\n" +
+            "[Suggestion] You can handle this type of event with the following listener function:\n\n";
+
+    public static final String WORKFLOW_STEP = COMMON_PREFIX +
+            "WorkflowStep step = WorkflowStep.builder()\n" +
+            "  .callbackId(\"copy_review\")\n" +
+            "  .edit((req, ctx) -> { return ctx.ack(); })\n" +
+            "  .save((req, ctx) -> { return ctx.ack(); })\n" +
+            "  .execute((req, ctx) -> { return ctx.ack(); })\n" +
+            "  .build();\n" +
+            "\n" +
+            "app.step(step);\n";
+
+    public static final String viewSubmission(String callbackId) {
+        return COMMON_PREFIX +
+                "app.viewSubmission(\"" + callbackId + "\", (req, ctx) -> {\n" +
+                "  // Sent inputs: req.getPayload().getView().getState().getValues()\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+    }
+
+    public static final String viewClosed(String callbackId) {
+        return COMMON_PREFIX +
+                "app.viewClosed(\"" + callbackId + "\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+    }
+
+    public static final String dialogSubmission(String callbackId) {
+        return COMMON_PREFIX +
+                "app.dialogSubmission(\"" + callbackId + "\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+    }
+
+    public static final String dialogSuggestion(String callbackId) {
+        return COMMON_PREFIX +
+                "app.dialogSubmission(\"" + callbackId + "\", (req, ctx) -> {\n" +
+                "  List<Option> options = Arrays.asList(Option.builder().label(\"label\").value(\"value\").build());\n" +
+                "  return ctx.ack(r -> r.options(options));\n" +
+                "});\n";
+    }
+
+    public static String dialogCancellation(String callbackId) {
+        return COMMON_PREFIX +
+                "app.dialogCancellation(\"" + callbackId + "\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+    }
+
+    public static final String command(String command) {
+        return COMMON_PREFIX +
+                "app.command(\"" + command + "\", (req, ctx) -> {\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+    }
+
+    public static final String attachmentAction(String callbackId) {
+        return COMMON_PREFIX +
+                "app.attachmentAction(\"" + callbackId + "\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+    }
+
+    public static final String blockAction(String actionId) {
+        return COMMON_PREFIX +
+                "app.blockAction(\"" + actionId + "\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+    }
+
+    public static final String blockSuggestion(String actionId) {
+        return COMMON_PREFIX +
+                "app.blockSuggestion(\"" + actionId + "\", (req, ctx) -> {\n" +
+                "  List<Option> options = Arrays.asList(Option.builder().text(plainText(\"label\")).value(\"v\").build());\n" +
+                "  return ctx.ack(r -> r.options(options));\n" +
+                "});\n";
+    }
+
+    public static final String event(String eventTypeAndSubtype) {
+        String className = toEventClassName(eventTypeAndSubtype);
+        return COMMON_PREFIX +
+                "app.event(" + className + ".class, (payload, ctx) -> {\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+    }
+
+    public static final String toEventClassName(String eventTypeAndSubtype) {
+        String eventType = eventTypeAndSubtype;
+        String[] elements = eventTypeAndSubtype.split(":");
+        if (elements.length == 2) {
+            // message events with subtype
+            eventType = elements[0] + "_" + elements[1]
+                    .replaceFirst("_message", "")
+                    .replaceFirst("message_", "");
+        }
+        if (eventType == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        char[] cs = eventType.toCharArray();
+        for (int i = 0; i < cs.length; i++) {
+            char c = cs[i];
+            if (i == 0) {
+                sb.append(Character.toUpperCase(c));
+            } else if (c == '_') {
+                i++;
+                sb.append(Character.toUpperCase(cs[i]));
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString() + "Event";
+    }
+
+    public static String globalShortcut(String callbackId) {
+        return COMMON_PREFIX +
+                "app.globalShortcut(\"" + callbackId + "\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+    }
+
+    public static String messageShortcut(String callbackId) {
+        return COMMON_PREFIX +
+                "app.messageShortcut(\"" + callbackId + "\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+    }
+}

--- a/bolt/src/test/java/test_locally/util/ListenerCodeSuggestionTest.java
+++ b/bolt/src/test/java/test_locally/util/ListenerCodeSuggestionTest.java
@@ -1,0 +1,174 @@
+package test_locally.util;
+
+import com.slack.api.bolt.util.ListenerCodeSuggestion;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ListenerCodeSuggestionTest {
+
+    @Test
+    public void toEventClassName() {
+        assertEquals("AppMentionEvent", ListenerCodeSuggestion.toEventClassName("app_mention"));
+        assertEquals("MessageEvent", ListenerCodeSuggestion.toEventClassName("message"));
+        assertEquals("MessageBotEvent", ListenerCodeSuggestion.toEventClassName("message:bot_message"));
+        assertEquals("MessageChangedEvent", ListenerCodeSuggestion.toEventClassName("message:message_changed"));
+        assertEquals("MessageChannelPostingPermissionsEvent",
+                ListenerCodeSuggestion.toEventClassName("message:channel_posting_permissions"));
+    }
+
+    @Test
+    public void event() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.event(AppMentionEvent.class, (payload, ctx) -> {\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.event("app_mention");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void command() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.command(\"/hello\", (req, ctx) -> {\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.command("/hello");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void globalShortcut() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.globalShortcut(\"callback-id\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.globalShortcut("callback-id");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void messageShortcut() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.messageShortcut(\"callback-id\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.messageShortcut("callback-id");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void dialogSuggestion() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.dialogSubmission(\"the-id\", (req, ctx) -> {\n" +
+                "  List<Option> options = Arrays.asList(Option.builder().label(\"label\").value(\"value\").build());\n" +
+                "  return ctx.ack(r -> r.options(options));\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.dialogSuggestion("the-id");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void dialogSubmission() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.dialogSubmission(\"the-id\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.dialogSubmission("the-id");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void dialogCancellation() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.dialogCancellation(\"the-id\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.dialogCancellation("the-id");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void blockAction() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.blockAction(\"the-id\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.blockAction("the-id");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void blockSuggestion() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.blockSuggestion(\"the-id\", (req, ctx) -> {\n" +
+                "  List<Option> options = Arrays.asList(Option.builder().text(plainText(\"label\")).value(\"v\").build());\n" +
+                "  return ctx.ack(r -> r.options(options));\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.blockSuggestion("the-id");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void attachmentAction() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.attachmentAction(\"the-id\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.attachmentAction("the-id");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void viewSubmission() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.viewSubmission(\"the-id\", (req, ctx) -> {\n" +
+                "  // Sent inputs: req.getPayload().getView().getState().getValues()\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.viewSubmission("the-id");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void viewClosed() {
+        String expected = "---\n" +
+                "[Suggestion] You can handle this type of event with the following listener function:\n" +
+                "\n" +
+                "app.viewClosed(\"the-id\", (req, ctx) -> {\n" +
+                "  // Do something where\n" +
+                "  return ctx.ack();\n" +
+                "});\n";
+        String actual = ListenerCodeSuggestion.viewClosed("the-id");
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
This pull request resolves #719 by adding new option named `unmatchedRequestHandler` in `AppConfig`. 

```java
App app = new App(AppConfig.builder()
  .unmatchedRequestHandler((req) -> Response.builder().statusCode(400).build())
  .build());
```

Also, I've added code snippet suggestion in the unmatched pattern warning logs like we did in Python https://github.com/slackapi/bolt-python/pull/323

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
