### PR TITLE
Update dependencies in v1.8

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <helidon.version>2.2.1</helidon.version>
+        <helidon.version>2.2.2</helidon.version>
         <!-- Helidon 2.x requires Java 11+ -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.5.0.1</http4k.version>
+        <http4k.version>4.8.0.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>1.5.2</ktor.version>
+        <ktor.version>1.5.4</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.version>2.4.1</micronaut.version>
+        <micronaut.version>2.5.1</micronaut.version>
         <micronaut-test-junit5.version>2.3.3</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>

--- a/bolt-socket-mode/pom.xml
+++ b/bolt-socket-mode/pom.xml
@@ -13,7 +13,7 @@
         <javax.websocket-api.version>1.1</javax.websocket-api.version>
         <!-- TODO upgrade to 2.0 in the next major version -->
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
-        <java-websocket.version>1.5.1</java-websocket.version>
+        <java-websocket.version>1.5.2</java-websocket.version>
     </properties>
 
     <artifactId>bolt-socket-mode</artifactId>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.4.4</spring-boot.version>
+        <spring-boot.version>2.4.5</spring-boot.version>
     </properties>
 
     <artifactId>bolt-spring-boot-examples</artifactId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,8 +8,8 @@ url: https://slack.dev
 
 sdkLatestVersion: 1.7.1
 okhttpVersion: 4.9.1
-kotlinVersion: 1.4.32
-springBootVersion: 2.4.4
+kotlinVersion: 1.5.0
+springBootVersion: 2.4.5
 compatibleMicronautVersion: 2.x
 quarkusVersion: 1.9.2.Final
-helidonVersion: 2.2.1
+helidonVersion: 2.2.2

--- a/pom.xml
+++ b/pom.xml
@@ -46,16 +46,16 @@
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <okhttp.version>4.9.1</okhttp.version>
         <gson.version>2.8.6</gson.version>
-        <lombok.version>1.18.18</lombok.version>
+        <lombok.version>1.18.20</lombok.version>
         <lombok-maven-plugin.version>1.18.16.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
-        <kotlin.version>1.4.32</kotlin.version>
+        <kotlin.version>1.5.0</kotlin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.987</aws.s3.version>
+        <aws.s3.version>1.11.1016</aws.s3.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.8.0</mockito-core.version>
+        <mockito-core.version>3.9.0</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -63,12 +63,12 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-        <maven-versions-plugin.version>2.7</maven-versions-plugin.version>
+        <maven-versions-plugin.version>2.8.1</maven-versions-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-        <dokka.version>1.4.10.2 </dokka.version>
+        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <dokka.version>1.4.32</dokka.version>
     </properties>
 
     <licenses>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -17,8 +17,8 @@
         <javax.websocket-api.version>1.1</javax.websocket-api.version>
         <!-- TODO upgrade to 2.0 in the next major version -->
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
-        <java-websocket.version>1.5.1</java-websocket.version>
-        <jedis.version>3.5.2</jedis.version>
+        <java-websocket.version>1.5.2</java-websocket.version>
+        <jedis.version>3.6.0</jedis.version>
         <jedis-mock.version>0.1.16</jedis-mock.version>
     </properties>
 


### PR DESCRIPTION
This pull request upgrades a few dependency versions for the v1.8.0 release. Remarkable ones are:

* Lombok from 1.18.18 to 1.18.20 (affecting all)
* Kotlin from 1.4 to 1.5 (affecting kotlin extensions, http4k, ktor)
* Java-WebSocket from 1.5.1 to 1.5.2 (affecting Socket Mode client if you explicitly switch to this library)
* http4k, ktor, micronaut to the latest

I've run all the tests and haven't detected any issues.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
