### PR TITLE
Add a test generating sample JSON data for interactivity APIs etc

### DIFF
--- a/json-logs/samples/api/dialog.open.json
+++ b/json-logs/samples/api/dialog.open.json
@@ -1,6 +1,12 @@
 {
   "ok": false,
+  "warning": "",
   "error": "",
   "needed": "",
-  "provided": ""
+  "provided": "",
+  "response_metadata": {
+    "messages": [
+      ""
+    ]
+  }
 }

--- a/json-logs/samples/api/migration.exchange.json
+++ b/json-logs/samples/api/migration.exchange.json
@@ -1,16 +1,13 @@
 {
   "ok": false,
-  "error": "not_enterprise_team",
-  "team_id": "T1KR7PE1W",
-  "enterprise_id": "E1KQTNXE1",
-  "user_id_map": {
-    "U06UBSUN5": "W06M56XJM",
-    "U06UEB62U": "W06PTT6GH",
-    "U06UBSVB3": "W06PUUDLY",
-    "U06UBSVDX": "W06PUUDMW",
-    "W06UAZ65Q": "W06UAZ65Q"
-  },
+  "warning": "",
+  "error": "",
+  "needed": "",
+  "provided": "",
+  "team_id": "",
+  "enterprise_id": "",
   "invalid_user_ids": [
-    "U21ABZZXX"
-  ]
+    ""
+  ],
+  "user_id_map": {}
 }

--- a/json-logs/samples/api/users.getPresence.json
+++ b/json-logs/samples/api/users.getPresence.json
@@ -1,7 +1,13 @@
 {
   "ok": false,
-  "presence": "",
+  "warning": "",
   "error": "",
   "needed": "",
-  "provided": ""
+  "provided": "",
+  "presence": "",
+  "online": false,
+  "auto_away": false,
+  "manual_away": false,
+  "connection_count": 123,
+  "last_activity": 123
 }

--- a/json-logs/samples/api/users.identity.json
+++ b/json-logs/samples/api/users.identity.json
@@ -1,6 +1,22 @@
 {
   "ok": false,
+  "warning": "",
   "error": "",
   "needed": "",
-  "provided": ""
+  "provided": "",
+  "user": {
+    "name": "",
+    "id": "",
+    "email": "",
+    "image_24": "",
+    "image_32": "",
+    "image_48": "",
+    "image_72": "",
+    "image_192": "",
+    "image_512": ""
+  },
+  "team": {
+    "name": "",
+    "id": ""
+  }
 }

--- a/json-logs/samples/api/views.open.json
+++ b/json-logs/samples/api/views.open.json
@@ -1,11 +1,1070 @@
 {
   "ok": false,
+  "warning": "",
   "error": "",
+  "needed": "",
+  "provided": "",
+  "view": {
+    "id": "",
+    "team_id": "",
+    "type": "",
+    "title": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "submit": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "close": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "blocks": [
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "plain_text_input",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_value": "",
+          "multiline": false,
+          "min_length": 123,
+          "max_length": 123,
+          "dispatch_action_config": {
+            "trigger_actions_on": [
+              ""
+            ]
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "radio_buttons",
+          "action_id": "",
+          "options": [
+            {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            {
+              "text": {
+                "type": "mrkdwn",
+                "text": "",
+                "verbatim": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            }
+          ],
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "url": "",
+          "value": "",
+          "style": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "channels_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_channel": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          },
+          "response_url_enabled": false
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "conversations_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_conversation": "",
+          "default_to_current_conversation": false,
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          },
+          "response_url_enabled": false,
+          "filter": {
+            "exclude_external_shared_channels": false,
+            "exclude_bot_users": false
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "datepicker",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_date": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "timepicker",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_time": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "external_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "min_query_length": 123,
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "image",
+          "image_url": "",
+          "alt_text": "",
+          "fallback": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "overflow",
+          "action_id": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "static_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "users_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_user": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "channels_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_channel": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "response_url_enabled": false
+          },
+          {
+            "type": "conversations_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "response_url_enabled": false,
+            "filter": {
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            }
+          },
+          {
+            "type": "datepicker",
+            "action_id": "",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_date": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "timepicker",
+            "action_id": "",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_time": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "external_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "min_query_length": 123,
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "image",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123
+          },
+          {
+            "type": "overflow",
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "static_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "users_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_user": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          }
+        ],
+        "block_id": ""
+      },
+      {
+        "type": "context",
+        "elements": [
+          {
+            "type": "image",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123
+          }
+        ],
+        "block_id": ""
+      },
+      {
+        "type": "divider",
+        "block_id": ""
+      },
+      {
+        "type": "image",
+        "fallback": "",
+        "image_url": "",
+        "image_width": 123,
+        "image_height": 123,
+        "image_bytes": 123,
+        "alt_text": "",
+        "title": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "block_id": ""
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "block_id": "",
+        "fields": [
+          {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          {
+            "type": "mrkdwn",
+            "text": "",
+            "verbatim": false
+          }
+        ],
+        "accessory": {
+          "type": "image",
+          "image_url": "",
+          "alt_text": "",
+          "fallback": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123
+        }
+      }
+    ],
+    "private_metadata": "",
+    "callback_id": "",
+    "external_id": "",
+    "state": {},
+    "hash": "",
+    "clear_on_close": false,
+    "notify_on_close": false,
+    "submit_disabled": false,
+    "root_view_id": "",
+    "previous_view_id": "",
+    "app_id": "",
+    "app_installed_team_id": "",
+    "bot_id": ""
+  },
   "response_metadata": {
     "messages": [
       ""
     ]
-  },
-  "needed": "",
-  "provided": ""
+  }
 }

--- a/json-logs/samples/api/views.publish.json
+++ b/json-logs/samples/api/views.publish.json
@@ -1,11 +1,1070 @@
 {
   "ok": false,
+  "warning": "",
   "error": "",
+  "needed": "",
+  "provided": "",
+  "view": {
+    "id": "",
+    "team_id": "",
+    "type": "",
+    "title": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "submit": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "close": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "blocks": [
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "plain_text_input",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_value": "",
+          "multiline": false,
+          "min_length": 123,
+          "max_length": 123,
+          "dispatch_action_config": {
+            "trigger_actions_on": [
+              ""
+            ]
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "radio_buttons",
+          "action_id": "",
+          "options": [
+            {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            {
+              "text": {
+                "type": "mrkdwn",
+                "text": "",
+                "verbatim": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            }
+          ],
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "url": "",
+          "value": "",
+          "style": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "channels_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_channel": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          },
+          "response_url_enabled": false
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "conversations_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_conversation": "",
+          "default_to_current_conversation": false,
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          },
+          "response_url_enabled": false,
+          "filter": {
+            "exclude_external_shared_channels": false,
+            "exclude_bot_users": false
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "datepicker",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_date": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "timepicker",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_time": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "external_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "min_query_length": 123,
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "image",
+          "image_url": "",
+          "alt_text": "",
+          "fallback": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "overflow",
+          "action_id": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "static_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "users_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_user": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "channels_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_channel": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "response_url_enabled": false
+          },
+          {
+            "type": "conversations_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "response_url_enabled": false,
+            "filter": {
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            }
+          },
+          {
+            "type": "datepicker",
+            "action_id": "",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_date": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "timepicker",
+            "action_id": "",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_time": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "external_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "min_query_length": 123,
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "image",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123
+          },
+          {
+            "type": "overflow",
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "static_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "users_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_user": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          }
+        ],
+        "block_id": ""
+      },
+      {
+        "type": "context",
+        "elements": [
+          {
+            "type": "image",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123
+          }
+        ],
+        "block_id": ""
+      },
+      {
+        "type": "divider",
+        "block_id": ""
+      },
+      {
+        "type": "image",
+        "fallback": "",
+        "image_url": "",
+        "image_width": 123,
+        "image_height": 123,
+        "image_bytes": 123,
+        "alt_text": "",
+        "title": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "block_id": ""
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "block_id": "",
+        "fields": [
+          {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          {
+            "type": "mrkdwn",
+            "text": "",
+            "verbatim": false
+          }
+        ],
+        "accessory": {
+          "type": "image",
+          "image_url": "",
+          "alt_text": "",
+          "fallback": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123
+        }
+      }
+    ],
+    "private_metadata": "",
+    "callback_id": "",
+    "external_id": "",
+    "state": {},
+    "hash": "",
+    "clear_on_close": false,
+    "notify_on_close": false,
+    "submit_disabled": false,
+    "root_view_id": "",
+    "previous_view_id": "",
+    "app_id": "",
+    "app_installed_team_id": "",
+    "bot_id": ""
+  },
   "response_metadata": {
     "messages": [
       ""
     ]
-  },
-  "needed": "",
-  "provided": ""
+  }
 }

--- a/json-logs/samples/api/views.push.json
+++ b/json-logs/samples/api/views.push.json
@@ -1,11 +1,1070 @@
 {
   "ok": false,
+  "warning": "",
   "error": "",
+  "needed": "",
+  "provided": "",
+  "view": {
+    "id": "",
+    "team_id": "",
+    "type": "",
+    "title": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "submit": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "close": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "blocks": [
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "plain_text_input",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_value": "",
+          "multiline": false,
+          "min_length": 123,
+          "max_length": 123,
+          "dispatch_action_config": {
+            "trigger_actions_on": [
+              ""
+            ]
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "radio_buttons",
+          "action_id": "",
+          "options": [
+            {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            {
+              "text": {
+                "type": "mrkdwn",
+                "text": "",
+                "verbatim": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            }
+          ],
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "url": "",
+          "value": "",
+          "style": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "channels_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_channel": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          },
+          "response_url_enabled": false
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "conversations_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_conversation": "",
+          "default_to_current_conversation": false,
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          },
+          "response_url_enabled": false,
+          "filter": {
+            "exclude_external_shared_channels": false,
+            "exclude_bot_users": false
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "datepicker",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_date": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "timepicker",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_time": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "external_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "min_query_length": 123,
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "image",
+          "image_url": "",
+          "alt_text": "",
+          "fallback": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "overflow",
+          "action_id": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "static_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "users_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_user": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "channels_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_channel": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "response_url_enabled": false
+          },
+          {
+            "type": "conversations_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "response_url_enabled": false,
+            "filter": {
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            }
+          },
+          {
+            "type": "datepicker",
+            "action_id": "",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_date": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "timepicker",
+            "action_id": "",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_time": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "external_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "min_query_length": 123,
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "image",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123
+          },
+          {
+            "type": "overflow",
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "static_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "users_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_user": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          }
+        ],
+        "block_id": ""
+      },
+      {
+        "type": "context",
+        "elements": [
+          {
+            "type": "image",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123
+          }
+        ],
+        "block_id": ""
+      },
+      {
+        "type": "divider",
+        "block_id": ""
+      },
+      {
+        "type": "image",
+        "fallback": "",
+        "image_url": "",
+        "image_width": 123,
+        "image_height": 123,
+        "image_bytes": 123,
+        "alt_text": "",
+        "title": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "block_id": ""
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "block_id": "",
+        "fields": [
+          {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          {
+            "type": "mrkdwn",
+            "text": "",
+            "verbatim": false
+          }
+        ],
+        "accessory": {
+          "type": "image",
+          "image_url": "",
+          "alt_text": "",
+          "fallback": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123
+        }
+      }
+    ],
+    "private_metadata": "",
+    "callback_id": "",
+    "external_id": "",
+    "state": {},
+    "hash": "",
+    "clear_on_close": false,
+    "notify_on_close": false,
+    "submit_disabled": false,
+    "root_view_id": "",
+    "previous_view_id": "",
+    "app_id": "",
+    "app_installed_team_id": "",
+    "bot_id": ""
+  },
   "response_metadata": {
     "messages": [
       ""
     ]
-  },
-  "needed": "",
-  "provided": ""
+  }
 }

--- a/json-logs/samples/api/views.update.json
+++ b/json-logs/samples/api/views.update.json
@@ -1,11 +1,1070 @@
 {
   "ok": false,
+  "warning": "",
   "error": "",
+  "needed": "",
+  "provided": "",
+  "view": {
+    "id": "",
+    "team_id": "",
+    "type": "",
+    "title": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "submit": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "close": {
+      "type": "",
+      "text": "",
+      "emoji": false
+    },
+    "blocks": [
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "plain_text_input",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_value": "",
+          "multiline": false,
+          "min_length": 123,
+          "max_length": 123,
+          "dispatch_action_config": {
+            "trigger_actions_on": [
+              ""
+            ]
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "radio_buttons",
+          "action_id": "",
+          "options": [
+            {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            {
+              "text": {
+                "type": "mrkdwn",
+                "text": "",
+                "verbatim": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            }
+          ],
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "url": "",
+          "value": "",
+          "style": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "channels_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_channel": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          },
+          "response_url_enabled": false
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "conversations_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_conversation": "",
+          "default_to_current_conversation": false,
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          },
+          "response_url_enabled": false,
+          "filter": {
+            "exclude_external_shared_channels": false,
+            "exclude_bot_users": false
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "datepicker",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_date": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "timepicker",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_time": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "external_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "min_query_length": 123,
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "image",
+          "image_url": "",
+          "alt_text": "",
+          "fallback": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "overflow",
+          "action_id": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "static_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_option": {
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "value": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "url": ""
+          },
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
+          "type": "users_select",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "action_id": "",
+          "initial_user": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "channels_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_channel": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "response_url_enabled": false
+          },
+          {
+            "type": "conversations_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "response_url_enabled": false,
+            "filter": {
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            }
+          },
+          {
+            "type": "datepicker",
+            "action_id": "",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_date": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "timepicker",
+            "action_id": "",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_time": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "external_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "min_query_length": 123,
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "image",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123
+          },
+          {
+            "type": "overflow",
+            "action_id": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "static_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          },
+          {
+            "type": "users_select",
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "initial_user": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            }
+          }
+        ],
+        "block_id": ""
+      },
+      {
+        "type": "context",
+        "elements": [
+          {
+            "type": "image",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123
+          }
+        ],
+        "block_id": ""
+      },
+      {
+        "type": "divider",
+        "block_id": ""
+      },
+      {
+        "type": "image",
+        "fallback": "",
+        "image_url": "",
+        "image_width": 123,
+        "image_height": 123,
+        "image_bytes": 123,
+        "alt_text": "",
+        "title": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "block_id": ""
+      },
+      {
+        "type": "section",
+        "text": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "block_id": "",
+        "fields": [
+          {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          {
+            "type": "mrkdwn",
+            "text": "",
+            "verbatim": false
+          }
+        ],
+        "accessory": {
+          "type": "image",
+          "image_url": "",
+          "alt_text": "",
+          "fallback": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123
+        }
+      }
+    ],
+    "private_metadata": "",
+    "callback_id": "",
+    "external_id": "",
+    "state": {},
+    "hash": "",
+    "clear_on_close": false,
+    "notify_on_close": false,
+    "submit_disabled": false,
+    "root_view_id": "",
+    "previous_view_id": "",
+    "app_id": "",
+    "app_installed_team_id": "",
+    "bot_id": ""
+  },
   "response_metadata": {
     "messages": [
       ""
     ]
-  },
-  "needed": "",
-  "provided": ""
+  }
 }

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -165,6 +165,39 @@
           }
         },
         {
+          "type": "timepicker",
+          "action_id": "",
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "initial_time": "",
+          "confirm": {
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "confirm": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "deny": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "style": ""
+          }
+        },
+        {
           "type": "external_select",
           "placeholder": {
             "type": "plain_text",

--- a/json-logs/samples/rtm/PinAddedEvent.json
+++ b/json-logs/samples/rtm/PinAddedEvent.json
@@ -173,6 +173,39 @@
               }
             },
             {
+              "type": "timepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_time": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              }
+            },
+            {
               "type": "external_select",
               "placeholder": {
                 "type": "plain_text",

--- a/json-logs/samples/rtm/PinRemovedEvent.json
+++ b/json-logs/samples/rtm/PinRemovedEvent.json
@@ -173,6 +173,39 @@
               }
             },
             {
+              "type": "timepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_time": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              }
+            },
+            {
               "type": "external_select",
               "placeholder": {
                 "type": "plain_text",

--- a/json-logs/samples/rtm/StarAddedEvent.json
+++ b/json-logs/samples/rtm/StarAddedEvent.json
@@ -173,6 +173,39 @@
               }
             },
             {
+              "type": "timepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_time": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              }
+            },
+            {
               "type": "external_select",
               "placeholder": {
                 "type": "plain_text",

--- a/json-logs/samples/rtm/StarRemovedEvent.json
+++ b/json-logs/samples/rtm/StarRemovedEvent.json
@@ -172,6 +172,39 @@
               }
             },
             {
+              "type": "timepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_time": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              }
+            },
+            {
               "type": "external_select",
               "placeholder": {
                 "type": "plain_text",

--- a/slack-api-client/src/test/java/test_locally/sample_json_generation/MethodsResponseDumpTest.java
+++ b/slack-api-client/src/test/java/test_locally/sample_json_generation/MethodsResponseDumpTest.java
@@ -1,0 +1,105 @@
+package test_locally.sample_json_generation;
+
+import com.slack.api.methods.response.dialog.DialogOpenResponse;
+import com.slack.api.methods.response.migration.MigrationExchangeResponse;
+import com.slack.api.methods.response.users.UsersGetPresenceResponse;
+import com.slack.api.methods.response.users.UsersIdentityResponse;
+import com.slack.api.methods.response.users.UsersSetPhotoResponse;
+import com.slack.api.methods.response.views.ViewsOpenResponse;
+import com.slack.api.methods.response.views.ViewsPublishResponse;
+import com.slack.api.methods.response.views.ViewsPushResponse;
+import com.slack.api.methods.response.views.ViewsUpdateResponse;
+import com.slack.api.model.ErrorResponseMetadata;
+import com.slack.api.model.dialog.DialogResponseMetadata;
+import com.slack.api.model.view.View;
+import org.junit.Test;
+import util.ObjectInitializer;
+import util.sample_json_generation.ObjectToJsonDumper;
+import util.sample_json_generation.SampleObjects;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class MethodsResponseDumpTest {
+    // This test class generates sample JSON data for the Web APIs
+    // that are not so easy to run in tests.
+    // (e.g., the ones requiring trigger_id for running)
+
+    ObjectToJsonDumper dumper = new ObjectToJsonDumper("../json-logs/samples/api");
+
+    static ErrorResponseMetadata errorResponseMetadata = ObjectInitializer.initProperties(new ErrorResponseMetadata());
+    static View view = ObjectInitializer.initProperties(new View());
+    static {
+        errorResponseMetadata.setMessages(Arrays.asList(""));
+        view.setBlocks(SampleObjects.ModalBlocks);
+    }
+
+    @Test
+    public void views_open() throws Exception {
+        ViewsOpenResponse response = new ViewsOpenResponse();
+        ObjectInitializer.initProperties(response);
+        response.setView(view);
+        response.setResponseMetadata(errorResponseMetadata);
+        dumper.dump("views.open", response);
+    }
+
+    @Test
+    public void views_push() throws Exception {
+        ViewsPushResponse response = new ViewsPushResponse();
+        ObjectInitializer.initProperties(response);
+        response.setView(view);
+        response.setResponseMetadata(errorResponseMetadata);
+        dumper.dump("views.push", response);
+    }
+
+    @Test
+    public void views_update() throws Exception {
+        ViewsUpdateResponse response = new ViewsUpdateResponse();
+        ObjectInitializer.initProperties(response);
+        response.setView(view);
+        response.setResponseMetadata(errorResponseMetadata);
+        dumper.dump("views.update", response);
+    }
+
+    @Test
+    public void views_publish() throws Exception {
+        ViewsPublishResponse response = new ViewsPublishResponse();
+        ObjectInitializer.initProperties(response);
+        response.setView(view);
+        response.setResponseMetadata(errorResponseMetadata);
+        dumper.dump("views.publish", response);
+    }
+
+    @Test
+    public void migration_exchange() throws Exception {
+        MigrationExchangeResponse response = new MigrationExchangeResponse();
+        response.setInvalidUserIds(Arrays.asList(""));
+        response.setUserIdMap(new HashMap<>());
+        ObjectInitializer.initProperties(response);
+        dumper.dump("migration.exchange", response);
+    }
+
+    @Test
+    public void users_identity() throws Exception {
+        UsersIdentityResponse response = new UsersIdentityResponse();
+        ObjectInitializer.initProperties(response);
+        dumper.dump("users.identity", response);
+    }
+
+    @Test
+    public void users_getPresence() throws Exception {
+        UsersGetPresenceResponse response = new UsersGetPresenceResponse();
+        ObjectInitializer.initProperties(response);
+        dumper.dump("users.getPresence", response);
+    }
+
+    @Test
+    public void dialog_open() throws Exception {
+        DialogOpenResponse response = new DialogOpenResponse();
+        DialogResponseMetadata metadata = new DialogResponseMetadata();
+        metadata.setMessages(Arrays.asList(""));
+        response.setResponseMetadata(metadata);
+        ObjectInitializer.initProperties(response);
+        dumper.dump("dialog.open", response);
+    }
+}

--- a/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
@@ -3,12 +3,11 @@ package util.sample_json_generation;
 import com.google.gson.JsonElement;
 import com.slack.api.model.*;
 import com.slack.api.model.block.*;
-import com.slack.api.model.block.composition.ConfirmationDialogObject;
-import com.slack.api.model.block.composition.OptionObject;
-import com.slack.api.model.block.composition.PlainTextObject;
-import com.slack.api.model.block.composition.TextObject;
+import com.slack.api.model.block.composition.*;
 import com.slack.api.model.block.element.BlockElement;
 import com.slack.api.model.block.element.ImageElement;
+import com.slack.api.model.block.element.PlainTextInputElement;
+import com.slack.api.model.block.element.RadioButtonsElement;
 import com.slack.api.util.json.GsonFactory;
 
 import java.util.Arrays;
@@ -78,6 +77,7 @@ public class SampleObjects {
             initProperties(channelsSelect(c -> c.confirm(Confirm))),
             initProperties(conversationsSelect(c -> c.confirm(Confirm))),
             initProperties(datePicker(d -> d.confirm(Confirm))),
+            initProperties(timePicker(d -> d.confirm(Confirm))),
             initProperties(externalSelect(e -> e.initialOption(Option).confirm(Confirm))),
             initProperties(com.slack.api.model.block.element.BlockElements.image(i -> i)),
             initProperties(overflowMenu(o -> o.confirm(Confirm))),
@@ -92,6 +92,44 @@ public class SampleObjects {
             initProperties(markdownText(m -> m))
     );
     public static List<LayoutBlock> Blocks = asBlocks(
+            initProperties(actions(a -> a.elements(BlockElements))),
+            initProperties(context(c -> c.elements(ContextBlockElements))),
+            initProperties(divider()),
+            initProperties(com.slack.api.model.block.Blocks.image(i -> i)),
+            initProperties(section(s -> s
+                    .accessory(initProperties(ImageElement.builder().build()))
+                    .text(TextObject)
+                    .fields(SectionBlockFieldElements)))
+    );
+
+    public static PlainTextInputElement plainTextInputElement = initProperties(PlainTextInputElement.builder()
+            .placeholder(initProperties(PlainTextObject.builder().build()))
+            .dispatchActionConfig(initProperties(DispatchActionConfig.builder().triggerActionsOn(Arrays.asList("")).build()))
+            .build());
+    public static RadioButtonsElement radioButtonsElement = initProperties(RadioButtonsElement.builder()
+            .confirm(initProperties(ConfirmationDialogObject.builder()
+                    .text(initProperties(PlainTextObject.builder().build()))
+                    .build()))
+            .options(Arrays.asList(
+                    initProperties(OptionObject.builder().text(initProperties(PlainTextObject.builder().build())).build()),
+                    initProperties(OptionObject.builder().text(initProperties(MarkdownTextObject.builder().build())).build())
+            ))
+            .initialOption(initProperties(OptionObject.builder().text(initProperties(PlainTextObject.builder().build())).build()))
+            .build());
+
+    public static List<LayoutBlock> ModalBlocks = asBlocks(
+            initProperties(input(i -> i.element(plainTextInputElement))),
+            initProperties(input(i -> i.element(radioButtonsElement))),
+            initProperties(input(i -> i.element(initProperties(button(b -> b.confirm(Confirm)))))),
+            initProperties(input(i -> i.element(initProperties(channelsSelect(c -> c.confirm(Confirm)))))),
+            initProperties(input(i -> i.element(initProperties(conversationsSelect(c -> c.confirm(Confirm)))))),
+            initProperties(input(i -> i.element(initProperties(datePicker(d -> d.confirm(Confirm)))))),
+            initProperties(input(i -> i.element(initProperties(timePicker(d -> d.confirm(Confirm)))))),
+            initProperties(input(i -> i.element(initProperties(externalSelect(e -> e.initialOption(Option).confirm(Confirm)))))),
+            initProperties(input(ip -> ip.element(initProperties(com.slack.api.model.block.element.BlockElements.image(i -> i))))),
+            initProperties(input(i -> i.element(initProperties(overflowMenu(o -> o.confirm(Confirm)))))),
+            initProperties(input(i -> i.element(initProperties(staticSelect(s -> s.initialOption(Option).confirm(Confirm)))))),
+            initProperties(input(i -> i.element(initProperties(usersSelect(u -> u.confirm(Confirm)))))),
             initProperties(actions(a -> a.elements(BlockElements))),
             initProperties(context(c -> c.elements(ContextBlockElements))),
             initProperties(divider()),


### PR DESCRIPTION
This pull request adds more sample JSON data generation for the APIs that we cannot run in integration tests.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
