### PR TITLE
Add is_bot_user_member to link_shared event payload

### DIFF
--- a/json-logs/samples/events/LinkSharedPayload.json
+++ b/json-logs/samples/events/LinkSharedPayload.json
@@ -26,6 +26,7 @@
         "url": ""
       }
     ],
+    "is_bot_user_member": false,
     "event_ts": ""
   }
 }

--- a/json-logs/samples/rtm/LinkSharedEvent.json
+++ b/json-logs/samples/rtm/LinkSharedEvent.json
@@ -10,5 +10,6 @@
       "url": ""
     }
   ],
+  "is_bot_user_member": false,
   "event_ts": ""
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/event/LinkSharedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/LinkSharedEvent.java
@@ -1,5 +1,6 @@
 package com.slack.api.model.event;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 
 import java.util.List;
@@ -20,6 +21,8 @@ public class LinkSharedEvent implements Event {
     private String messageTs;
     private String threadTs;
     private List<Link> links;
+    @SerializedName("is_bot_user_member")
+    private boolean botUserMember;
     private String eventTs;
 
     @Data

--- a/slack-api-model/src/test/java/test_locally/api/model/event/LinkSharedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/LinkSharedEventTest.java
@@ -52,7 +52,7 @@ public class LinkSharedEventTest {
         Gson gson = GsonFactory.createSnakeCase();
         LinkSharedEvent event = new LinkSharedEvent();
         String generatedJson = gson.toJson(event);
-        String expectedJson = "{\"type\":\"link_shared\"}";
+        String expectedJson = "{\"type\":\"link_shared\",\"is_bot_user_member\":false}";
         assertThat(generatedJson, is(expectedJson));
     }
 


### PR DESCRIPTION
Related to https://github.com/slackapi/bolt-js/issues/942, this pull request adds a missing field in `LinkSharedEvent` class.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
