### PR TITLE
Fix for [slack-api-client] NullPointerException in runtime if proxy port is empty

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/util/http/ProxyUrlUtil.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/ProxyUrlUtil.java
@@ -48,14 +48,14 @@ public class ProxyUrlUtil {
                     .username(userAndPassword[0])
                     .password(userAndPassword[1])
                     .host(hostAndPort[0])
-                    .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1]) : 0)
+                    .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1]) : 80)
                     .build();
         } else {
             String[] hostAndPort = proxyUrl.split("://")[1].split(":");
             return ProxyUrl.builder()
                     .schema(schema)
                     .host(hostAndPort[0])
-                    .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1]) : 0)
+                    .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1]) : 80)
                     .build();
         }
     }

--- a/slack-api-client/src/main/java/com/slack/api/util/http/ProxyUrlUtil.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/ProxyUrlUtil.java
@@ -48,14 +48,14 @@ public class ProxyUrlUtil {
                     .username(userAndPassword[0])
                     .password(userAndPassword[1])
                     .host(hostAndPort[0])
-                    .port(hostAndPort.length == 2 ? Integer.valueOf(hostAndPort[1]) : null)
+                    .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1]) : 0)
                     .build();
         } else {
             String[] hostAndPort = proxyUrl.split("://")[1].split(":");
             return ProxyUrl.builder()
                     .schema(schema)
                     .host(hostAndPort[0])
-                    .port(hostAndPort.length == 2 ? Integer.valueOf(hostAndPort[1]) : null)
+                    .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1]) : 0)
                     .build();
         }
     }


### PR DESCRIPTION
## Fix [NullPointerException in runtime if proxy port is empty] (https://github.com/slackapi/java-slack-sdk/issues/749)

currently null is passed to java.net.InetSocketAddress constructor which raises NullPointerException
to overcome this 0 is passed as second param to java.net.InetSocketAddress constructor

* [x] **slack-api-client** (Slack API Clients)
