### PR TITLE
Upgrade dependencies for v1.8.1

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <helidon.version>2.2.2</helidon.version>
+        <helidon.version>2.3.0</helidon.version>
         <!-- Helidon 2.x requires Java 11+ -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.8.0.0</http4k.version>
+        <http4k.version>4.9.5.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>1.5.4</ktor.version>
+        <ktor.version>1.6.0</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,8 +10,8 @@
     </parent>
 
     <properties>
-        <micronaut.version>2.5.1</micronaut.version>
-        <micronaut-test-junit5.version>2.3.3</micronaut-test-junit5.version>
+        <micronaut.version>2.5.4</micronaut.version>
+        <micronaut-test-junit5.version>2.3.6</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>
 

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.4.5</spring-boot.version>
+        <spring-boot.version>2.5.0</spring-boot.version>
     </properties>
 
     <artifactId>bolt-spring-boot-examples</artifactId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,8 +8,8 @@ url: https://slack.dev
 
 sdkLatestVersion: 1.8.0
 okhttpVersion: 4.9.1
-kotlinVersion: 1.5.0
-springBootVersion: 2.4.5
+kotlinVersion: 1.5.10
+springBootVersion: 2.5.0
 compatibleMicronautVersion: 2.x
 quarkusVersion: 1.9.2.Final
-helidonVersion: 2.2.2
+helidonVersion: 2.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -45,17 +45,17 @@
         <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <okhttp.version>4.9.1</okhttp.version>
-        <gson.version>2.8.6</gson.version>
+        <gson.version>2.8.7</gson.version>
         <lombok.version>1.18.20</lombok.version>
         <lombok-maven-plugin.version>1.18.16.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
-        <kotlin.version>1.5.0</kotlin.version>
+        <kotlin.version>1.5.10</kotlin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.1016</aws.s3.version>
+        <aws.s3.version>1.11.1031</aws.s3.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.9.0</mockito-core.version>
+        <mockito-core.version>3.10.0</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -19,7 +19,7 @@
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
         <java-websocket.version>1.5.2</java-websocket.version>
         <jedis.version>3.6.0</jedis.version>
-        <jedis-mock.version>0.1.16</jedis-mock.version>
+        <jedis-mock.version>0.1.20</jedis-mock.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This pull request upgrades the following dependencies in the next patch release - v1.8.1

* Essential dependencies (only patch version upgrades)
  * Gson from 2.8.6 to 2.8.7
  * Kotlin language from 1.5.0 to 1.5.10
  * AWS S3 SDK from 1.11.1016 to 1.11.1031
* Optional bolt extensions' dependencies (including minor version updates)
  * Micronaut from 2.5.1 to 2.5.4
  * Helidon SE from 2.2.2 to 2.3.0
  * HTTP4K from 4.8.0.0 to 4.9.5.0
  * Ktor from 1.5.4 to 1.6.0

The rest affects only examples and tests.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
