### PR TITLE
Correct users.conversations property type - created

### DIFF
--- a/json-logs/samples/api/users.conversations.json
+++ b/json-logs/samples/api/users.conversations.json
@@ -2,137 +2,59 @@
   "ok": false,
   "channels": [
     {
-      "enterprise_id": "",
-      "id": "",
+      "id": "C00000000",
       "name": "",
-      "created": "",
-      "creator": "",
-      "unlinked": 123,
+      "is_channel": false,
+      "is_group": false,
+      "is_im": false,
+      "created": 12345,
+      "is_archived": false,
+      "is_general": false,
+      "unlinked": 12345,
       "name_normalized": "",
-      "last_read": "",
+      "is_shared": false,
+      "creator": "U00000000",
+      "is_ext_shared": false,
+      "is_org_shared": false,
+      "shared_team_ids": [
+        "T00000000"
+      ],
+      "pending_shared": [
+        ""
+      ],
+      "pending_connected_team_ids": [
+        ""
+      ],
+      "is_pending_ext_shared": false,
+      "is_private": false,
+      "is_mpim": false,
       "topic": {
         "value": "",
         "creator": "",
-        "last_set": 123
+        "last_set": 12345
       },
       "purpose": {
         "value": "",
         "creator": "",
-        "last_set": 123
+        "last_set": 12345
       },
-      "num_members": 123,
-      "latest": {
-        "client_msg_id": "",
-        "type": "",
-        "subtype": "",
-        "team": "",
-        "user": "",
-        "username": "",
-        "parent_user_id": "",
-        "text": "",
-        "topic": "",
-        "root": {
-          "text": "",
-          "user": "",
-          "parent_user_id": "",
-          "username": "",
-          "team": "",
-          "bot_id": "",
-          "mrkdwn": false,
-          "type": "",
-          "subtype": "",
-          "thread_ts": "",
-          "icons": {
-            "emoji": "",
-            "image_36": "",
-            "image_48": "",
-            "image_64": "",
-            "image_72": ""
-          },
-          "bot_profile": {
-            "id": "",
-            "deleted": false,
-            "name": "",
-            "updated": 123,
-            "app_id": "",
-            "icons": {
-              "image_36": "",
-              "image_48": "",
-              "image_72": ""
-            },
-            "team_id": ""
-          },
-          "edited": {
-            "user": "",
-            "ts": ""
-          },
-          "reply_count": 123,
-          "reply_users_count": 123,
-          "latest_reply": "",
-          "subscribed": false,
-          "last_read": "",
-          "unread_count": 123,
-          "ts": ""
-        },
-        "upload": false,
-        "display_as_bot": false,
-        "bot_id": "",
-        "bot_link": "",
-        "bot_profile": {
-          "id": "",
-          "deleted": false,
-          "name": "",
-          "updated": 123,
-          "app_id": "",
-          "icons": {
-            "image_36": "",
-            "image_48": "",
-            "image_72": ""
-          },
-          "team_id": ""
-        },
-        "thread_ts": "",
-        "ts": "",
-        "icons": {
-          "emoji": "",
-          "image_36": "",
-          "image_48": "",
-          "image_64": "",
-          "image_72": ""
-        },
-        "edited": {
-          "user": "",
-          "ts": ""
-        }
-      },
-      "locale": "",
-      "unread_count": 123,
-      "unread_count_display": 123,
-      "user": "",
-      "priority": 12.3,
-      "date_connected": 123,
-      "parent_conversation": "",
-      "conversation_host_id": "",
-      "is_channel": false,
-      "is_group": false,
-      "is_im": false,
-      "is_archived": false,
-      "is_general": false,
-      "is_read_only": false,
-      "is_thread_only": false,
-      "is_non_threadable": false,
-      "is_shared": false,
-      "is_ext_shared": false,
-      "is_org_shared": false,
-      "is_pending_ext_shared": false,
+      "previous_names": [
+        ""
+      ],
+      "conversation_host_id": "T00000000",
+      "is_moved": 12345,
+      "internal_team_ids": [
+        "T00000000"
+      ],
       "is_global_shared": false,
       "is_org_default": false,
       "is_org_mandatory": false,
-      "is_moved": 123,
-      "is_member": false,
+      "enterprise_id": "E00000000",
+      "last_read": "0000000000.000000",
       "is_open": false,
-      "is_private": false,
-      "is_mpim": false
+      "priority": 12345,
+      "user": "U00000000",
+      "is_user_deleted": false
     }
   ],
   "response_metadata": {

--- a/slack-api-client/src/test/java/test_locally/api/methods/FieldValidation_a_to_c_Test.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/FieldValidation_a_to_c_Test.java
@@ -407,7 +407,8 @@ public class FieldValidation_a_to_c_Test {
                 "getSharedTeamIds",
                 "getPreviousNames",
                 "getPendingConnectedTeamIds",
-                "getConnectedLimitedTeamIds"
+                "getConnectedLimitedTeamIds",
+                "getIsUserDeleted"
         );
     }
 
@@ -518,7 +519,8 @@ public class FieldValidation_a_to_c_Test {
                     "getThreadTs",
                     "getUsername",
                     "getParentUserId",
-                    "getBotProfile"
+                    "getBotProfile",
+                    "getIsUserDeleted"
             );
         }
         {

--- a/slack-api-model/src/main/java/com/slack/api/model/Conversation.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/Conversation.java
@@ -23,7 +23,7 @@ public class Conversation {
     private String enterpriseId;
     private String id;
     private String name;
-    private String created;
+    private Integer created;
     private String creator;
     private Integer unlinked;
     @SerializedName("name_normalized")
@@ -45,6 +45,7 @@ public class Conversation {
     @SerializedName("unread_count_display")
     private Integer unreadCountDisplay;
     private String user; // conversations.open
+    private Boolean isUserDeleted; // users.conversations
     private Double priority;
 
     private Integer dateConnected;


### PR DESCRIPTION
This pull request applies the two changes:
* Change the `channels[].created` type from string to integer
* Update `users.conversations` response types with the latest data

Some conditional properties may be missing but we can improve it afterwards. We will include this change in the next minor version - v1.9. Java compiler detects if the change affects existing apps.

This is the upstream fix for https://github.com/slackapi/node-slack-sdk/pull/1252

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
