### PR TITLE
Add edited property to AppMentionEvent class

### DIFF
--- a/bolt-servlet/src/test/java/test_with_remote_apis/EventsApiTest.java
+++ b/bolt-servlet/src/test/java/test_with_remote_apis/EventsApiTest.java
@@ -356,6 +356,12 @@ public class EventsApiTest {
                 ChatPostMessageResponse mention = slack.methods(userToken).chatPostMessage(r ->
                         r.text(mentionText).channel(channelId));
                 assertNull(mention.getError());
+                ChatUpdateResponse editedMention = slack.methods(userToken).chatUpdate(r -> r
+                        .channel(channelId)
+                        .ts(mention.getTs())
+                        .text(mentionText + "(edited)")
+                );
+                assertNull(editedMention.getError());
 
                 // app_mention with blocks
                 ChatPostMessageResponse mention2 = slack.methods(userToken).chatPostMessage(r ->

--- a/json-logs/samples/events/AppMentionPayload.json
+++ b/json-logs/samples/events/AppMentionPayload.json
@@ -16,6 +16,7 @@
   "event_context": "",
   "event": {
     "type": "app_mention",
+    "client_msg_id": "",
     "user": "",
     "username": "",
     "bot_id": "",
@@ -589,6 +590,10 @@
     "ts": "",
     "team": "",
     "channel": "",
+    "edited": {
+      "user": "",
+      "ts": ""
+    },
     "event_ts": "",
     "thread_ts": ""
   }

--- a/json-logs/samples/rtm/AppMentionEvent.json
+++ b/json-logs/samples/rtm/AppMentionEvent.json
@@ -1,5 +1,6 @@
 {
   "type": "app_mention",
+  "client_msg_id": "",
   "user": "",
   "username": "",
   "bot_id": "",
@@ -21,6 +22,10 @@
   "ts": "",
   "team": "",
   "channel": "",
+  "edited": {
+    "user": "",
+    "ts": ""
+  },
   "event_ts": "",
   "thread_ts": ""
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/event/AppMentionEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/AppMentionEvent.java
@@ -31,6 +31,7 @@ public class AppMentionEvent implements Event {
     public static final String TYPE_NAME = "app_mention";
 
     private final String type = TYPE_NAME;
+    private String clientMsgId;
     private String user;
     private String username;
     private String botId;
@@ -42,8 +43,14 @@ public class AppMentionEvent implements Event {
     private String ts;
     private String team;
     private String channel;
+    private Edited edited;
     private String eventTs;
 
     private String threadTs;
 
+    @Data
+    public static class Edited {
+        private String user;
+        private String ts;
+    }
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/event/AppMentionEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/AppMentionEventTest.java
@@ -32,6 +32,49 @@ public class AppMentionEventTest {
     }
 
     @Test
+    public void deserialize_edited() {
+        String json = "{\n" +
+                "  \"client_msg_id\": \"xxx\",\n" +
+                "  \"type\": \"app_mention\",\n" +
+                "  \"text\": \"<@U111> edited message\",\n" +
+                "  \"user\": \"U222\",\n" +
+                "  \"ts\": \"1622877872.008800\",\n" +
+                "  \"team\": \"T111\",\n" +
+                "  \"edited\": {\n" +
+                "    \"user\": \"U222\",\n" +
+                "    \"ts\": \"1622877902.000000\"\n" +
+                "  },\n" +
+                "  \"blocks\": [\n" +
+                "    {\n" +
+                "      \"type\": \"rich_text\",\n" +
+                "      \"block_id\": \"3B2\",\n" +
+                "      \"elements\": [\n" +
+                "        {\n" +
+                "          \"type\": \"rich_text_section\",\n" +
+                "          \"elements\": [\n" +
+                "            {\n" +
+                "              \"type\": \"user\",\n" +
+                "              \"user_id\": \"U111\"\n" +
+                "            },\n" +
+                "            {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"text\": \" edited message\"\n" +
+                "            }\n" +
+                "          ]\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"channel\": \"C111\",\n" +
+                "  \"event_ts\": \"1622877872.008800\"\n" +
+                "}";
+        AppMentionEvent event = GsonFactory.createSnakeCase().fromJson(json, AppMentionEvent.class);
+        assertThat(event.getType(), is("app_mention"));
+        assertThat(event.getEdited().getTs(), is("1622877902.000000"));
+        assertThat(event.getEdited().getUser(), is("U222"));
+    }
+
+    @Test
     public void serialize() {
         Gson gson = GsonFactory.createSnakeCase();
         AppMentionEvent event = new AppMentionEvent();


### PR DESCRIPTION
As pointed out at https://github.com/slackapi/bolt-js/issues/960 , an `app_mention` event payload can have `edited` property as with `message` event payloads.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
