### PR TITLE
Mitigate #757 by having retries for mock server bootstrap

### DIFF
--- a/bolt-http4k/src/test/java/util/AuthTestMockServer.java
+++ b/bolt-http4k/src/test/java/util/AuthTestMockServer.java
@@ -8,6 +8,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.SocketException;
 
 public class AuthTestMockServer {
 
@@ -70,16 +71,20 @@ public class AuthTestMockServer {
         }
     }
 
-    private final int port;
-    private final Server server;
+    private int port;
+    private Server server;
 
     public AuthTestMockServer() {
         this(PortProvider.getPort(AuthTestMockServer.class.getName()));
     }
 
     public AuthTestMockServer(int port) {
+        setup(port);
+    }
+
+    private void setup(int port) {
         this.port = port;
-        server = new Server(this.port);
+        this.server = new Server(this.port);
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);
         handler.addServletWithMapping(AuthTestMockEndpoint.class, "/*");
@@ -90,7 +95,18 @@ public class AuthTestMockServer {
     }
 
     public void start() throws Exception {
-        server.start();
+        int retryCount = 0;
+        while (retryCount < 5) {
+            try {
+                server.start();
+                return;
+            } catch (SocketException e) {
+                // java.net.SocketException: Permission denied may arise
+                // only on the GitHub Actions environment.
+                setup(PortProvider.getPort(AuthTestMockServer.class.getName()));
+                retryCount++;
+            }
+        }
     }
 
     public void stop() throws Exception {

--- a/bolt-socket-mode/src/test/java/test_locally/SocketModeAppTest.java
+++ b/bolt-socket-mode/src/test/java/test_locally/SocketModeAppTest.java
@@ -69,7 +69,7 @@ public class SocketModeAppTest {
         SocketModeApp socketModeApp = new SocketModeApp(VALID_APP_TOKEN, app);
         socketModeApp.startAsync();
         try {
-            Thread.sleep(1500L);
+            Thread.sleep(3_000L);
             assertTrue(commandCalled.get());
             assertTrue(actionCalled.get());
             assertTrue(eventCalled.get());
@@ -105,7 +105,7 @@ public class SocketModeAppTest {
         );
         socketModeApp.startAsync();
         try {
-            Thread.sleep(1500L);
+            Thread.sleep(3_000L);
             assertTrue(commandCalled.get());
             assertTrue(actionCalled.get());
         } finally {

--- a/bolt-socket-mode/src/test/java/util/socket_mode/MockWebApiServer.java
+++ b/bolt-socket-mode/src/test/java/util/socket_mode/MockWebApiServer.java
@@ -4,18 +4,24 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
 import util.PortProvider;
 
+import java.net.SocketException;
+
 public class MockWebApiServer {
 
-    private final int port;
-    private final Server server;
+    private int port;
+    private Server server;
 
     public MockWebApiServer() {
         this(PortProvider.getPort(MockWebApiServer.class.getName()));
     }
 
     public MockWebApiServer(int port) {
+        setup(port);
+    }
+
+    private void setup(int port) {
         this.port = port;
-        server = new Server(this.port);
+        this.server = new Server(this.port);
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);
         handler.addServletWithMapping(MockWebApi.class, "/*");
@@ -26,11 +32,21 @@ public class MockWebApiServer {
     }
 
     public void start() throws Exception {
-        server.start();
+        int retryCount = 0;
+        while (retryCount < 5) {
+            try {
+                server.start();
+                return;
+            } catch (SocketException e) {
+                // java.net.SocketException: Permission denied may arise
+                // only on the GitHub Actions environment.
+                setup(PortProvider.getPort(MockWebApiServer.class.getName()));
+                retryCount++;
+            }
+        }
     }
 
     public void stop() throws Exception {
         server.stop();
     }
-
 }

--- a/bolt/src/test/java/test_locally/app/MultiTeamsAuthTestCacheTest.java
+++ b/bolt/src/test/java/test_locally/app/MultiTeamsAuthTestCacheTest.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.SocketException;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -247,16 +248,20 @@ public class MultiTeamsAuthTestCacheTest {
             }
         }
 
-        private final int port;
-        private final Server server;
+        private int port;
+        private Server server;
 
         public CountdownAuthTestServer() {
             this(PortProvider.getPort(CountdownAuthTestServer.class.getName()));
         }
 
         public CountdownAuthTestServer(int port) {
+            setup(port);
+        }
+
+        private void setup(int port) {
             this.port = port;
-            server = new Server(this.port);
+            this.server = new Server(this.port);
             ServletHandler handler = new ServletHandler();
             server.setHandler(handler);
             handler.addServletWithMapping(CountdownAuthTestMockEndpoint.class, "/*");
@@ -267,7 +272,18 @@ public class MultiTeamsAuthTestCacheTest {
         }
 
         public void start() throws Exception {
-            server.start();
+            int retryCount = 0;
+            while (retryCount < 5) {
+                try {
+                    server.start();
+                    return;
+                } catch (SocketException e) {
+                    // java.net.SocketException: Permission denied may arise
+                    // only on the GitHub Actions environment.
+                    setup(PortProvider.getPort(CountdownAuthTestMockEndpoint.class.getName()));
+                    retryCount++;
+                }
+            }
         }
 
         public void stop() throws Exception {

--- a/bolt/src/test/java/util/MockSlackApiServer.java
+++ b/bolt/src/test/java/util/MockSlackApiServer.java
@@ -3,21 +3,27 @@ package util;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
 
+import java.net.SocketException;
+
 /**
  * A mock server that just returns JSON data under the json-logs/sample directory.
  */
 public class MockSlackApiServer {
 
-    private final int port;
-    private final Server server;
+    private int port;
+    private Server server;
 
     public MockSlackApiServer() {
         this(PortProvider.getPort(MockSlackApiServer.class.getName()));
     }
 
     public MockSlackApiServer(int port) {
+        setup(port);
+    }
+
+    private void setup(int port) {
         this.port = port;
-        server = new Server(this.port);
+        this.server = new Server(this.port);
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);
         handler.addServletWithMapping(MockSlackApi.class, "/*");
@@ -28,7 +34,18 @@ public class MockSlackApiServer {
     }
 
     public void start() throws Exception {
-        server.start();
+        int retryCount = 0;
+        while (retryCount < 5) {
+            try {
+                server.start();
+                return;
+            } catch (SocketException e) {
+                // java.net.SocketException: Permission denied may arise
+                // only on the GitHub Actions environment.
+                setup(PortProvider.getPort(MockSlackApiServer.class.getName()));
+                retryCount++;
+            }
+        }
     }
 
     public void stop() throws Exception {

--- a/slack-api-client/src/test/java/util/MockSlackApiServer.java
+++ b/slack-api-client/src/test/java/util/MockSlackApiServer.java
@@ -3,21 +3,27 @@ package util;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
 
+import java.net.SocketException;
+
 /**
  * A mock server that just returns JSON data under the json-logs/sample directory.
  */
 public class MockSlackApiServer {
 
-    private final int port;
-    private final Server server;
+    private int port;
+    private Server server;
 
     public MockSlackApiServer() {
         this(PortProvider.getPort(MockSlackApiServer.class.getName()));
     }
 
     public MockSlackApiServer(int port) {
+        setup(port);
+    }
+
+    private void setup(int port) {
         this.port = port;
-        server = new Server(this.port);
+        this.server = new Server(this.port);
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);
         handler.addServletWithMapping(MockSlackApi.class, "/*");
@@ -28,7 +34,18 @@ public class MockSlackApiServer {
     }
 
     public void start() throws Exception {
-        server.start();
+        int retryCount = 0;
+        while (retryCount < 5) {
+            try {
+                server.start();
+                return;
+            } catch (SocketException e) {
+                // java.net.SocketException: Permission denied may arise
+                // only on the GitHub Actions environment.
+                setup(PortProvider.getPort(MockSlackApiServer.class.getName()));
+                retryCount++;
+            }
+        }
     }
 
     public void stop() throws Exception {

--- a/slack-api-client/src/test/java/util/socket_mode/MockWebApiServer.java
+++ b/slack-api-client/src/test/java/util/socket_mode/MockWebApiServer.java
@@ -2,23 +2,30 @@ package util.socket_mode;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
+import util.MockSlackApi;
 import util.PortProvider;
+
+import java.net.SocketException;
 
 public class MockWebApiServer {
 
-    private final int port;
-    private final Server server;
+    private int port;
+    private Server server;
 
     public MockWebApiServer() {
         this(PortProvider.getPort(MockWebApiServer.class.getName()));
     }
 
     public MockWebApiServer(int port) {
+        setup(port);
+    }
+
+    private void setup(int port) {
         this.port = port;
-        server = new Server(this.port);
+        this.server = new Server(this.port);
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);
-        handler.addServletWithMapping(MockWebApi.class, "/*");
+        handler.addServletWithMapping(MockSlackApi.class, "/*");
     }
 
     public String getMethodsEndpointPrefix() {
@@ -26,11 +33,21 @@ public class MockWebApiServer {
     }
 
     public void start() throws Exception {
-        server.start();
+        int retryCount = 0;
+        while (retryCount < 5) {
+            try {
+                server.start();
+                return;
+            } catch (SocketException e) {
+                // java.net.SocketException: Permission denied may arise
+                // only on the GitHub Actions environment.
+                setup(PortProvider.getPort(MockWebApiServer.class.getName()));
+                retryCount++;
+            }
+        }
     }
 
     public void stop() throws Exception {
         server.stop();
     }
-
 }

--- a/slack-api-client/src/test/java/util/socket_mode/MockWebApiServer.java
+++ b/slack-api-client/src/test/java/util/socket_mode/MockWebApiServer.java
@@ -25,7 +25,7 @@ public class MockWebApiServer {
         this.server = new Server(this.port);
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);
-        handler.addServletWithMapping(MockSlackApi.class, "/*");
+        handler.addServletWithMapping(MockWebApi.class, "/*");
     }
 
     public String getMethodsEndpointPrefix() {

--- a/slack-app-backend/src/test/java/util/MockSlackApiServer.java
+++ b/slack-app-backend/src/test/java/util/MockSlackApiServer.java
@@ -3,21 +3,27 @@ package util;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletHandler;
 
+import java.net.SocketException;
+
 /**
  * A mock server that just returns JSON data under the json-logs/sample directory.
  */
 public class MockSlackApiServer {
 
-    private final int port;
-    private final Server server;
+    private int port;
+    private Server server;
 
     public MockSlackApiServer() {
         this(PortProvider.getPort(MockSlackApiServer.class.getName()));
     }
 
     public MockSlackApiServer(int port) {
+        setup(port);
+    }
+
+    private void setup(int port) {
         this.port = port;
-        server = new Server(this.port);
+        this.server = new Server(this.port);
         ServletHandler handler = new ServletHandler();
         server.setHandler(handler);
         handler.addServletWithMapping(MockSlackApi.class, "/*");
@@ -28,7 +34,18 @@ public class MockSlackApiServer {
     }
 
     public void start() throws Exception {
-        server.start();
+        int retryCount = 0;
+        while (retryCount < 5) {
+            try {
+                server.start();
+                return;
+            } catch (SocketException e) {
+                // java.net.SocketException: Permission denied may arise
+                // only on the GitHub Actions environment.
+                setup(PortProvider.getPort(MockSlackApiServer.class.getName()));
+                retryCount++;
+            }
+        }
     }
 
     public void stop() throws Exception {


### PR DESCRIPTION
This pull request can mitigate the issue described at #757  - we still may have other causes of occasional build failures.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
