### PR TITLE
Bump external dependency versions in v1.9

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <helidon.version>2.3.0</helidon.version>
+        <helidon.version>2.3.1</helidon.version>
         <!-- Helidon 2.x requires Java 11+ -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.9.5.0</http4k.version>
+        <http4k.version>4.9.9.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,8 +10,8 @@
     </parent>
 
     <properties>
-        <micronaut.version>2.5.4</micronaut.version>
-        <micronaut-test-junit5.version>2.3.6</micronaut-test-junit5.version>
+        <micronaut.version>2.5.7</micronaut.version>
+        <micronaut-test-junit5.version>2.3.7</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>
 

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.5.0</spring-boot.version>
+        <spring-boot.version>2.5.2</spring-boot.version>
     </properties>
 
     <artifactId>bolt-spring-boot-examples</artifactId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,8 +8,8 @@ url: https://slack.dev
 
 sdkLatestVersion: 1.8.1
 okhttpVersion: 4.9.1
-kotlinVersion: 1.5.10
-springBootVersion: 2.5.0
+kotlinVersion: 1.5.20
+springBootVersion: 2.5.2
 compatibleMicronautVersion: 2.x
 quarkusVersion: 1.9.2.Final
-helidonVersion: 2.3.0
+helidonVersion: 2.3.1

--- a/docs/guides/getting-started-with-bolt-socket-mode.md
+++ b/docs/guides/getting-started-with-bolt-socket-mode.md
@@ -99,7 +99,7 @@ dependencies {
   implementation("com.slack.api:bolt-socket-mode:{{ site.sdkLatestVersion }}")
   implementation("javax.websocket:javax.websocket-api:1.1")
   implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.17")
-  implementation("org.slf4j:slf4j-simple:1.7.30")
+  implementation("org.slf4j:slf4j-simple:1.7.31")
 }
 application {
   mainClassName = "hello.MyApp"
@@ -229,7 +229,7 @@ dependencies {
   implementation("com.slack.api:bolt-socket-mode:{{ site.sdkLatestVersion }}")
   implementation("javax.websocket:javax.websocket-api:1.1")
   implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.17")
-  implementation("org.slf4j:slf4j-simple:1.7.30") // or logback-classic
+  implementation("org.slf4j:slf4j-simple:1.7.31") // or logback-classic
 }
 application {
   mainClassName = "MyAppKt" // add "Kt" suffix for main function source file

--- a/docs/guides/getting-started-with-bolt.md
+++ b/docs/guides/getting-started-with-bolt.md
@@ -88,7 +88,7 @@ repositories {
 }
 dependencies {
   implementation("com.slack.api:bolt-jetty:{{ site.sdkLatestVersion }}")
-  implementation("org.slf4j:slf4j-simple:1.7.30")
+  implementation("org.slf4j:slf4j-simple:1.7.31")
 }
 application {
   mainClassName = "hello.MyApp"
@@ -248,7 +248,7 @@ dependencies {
   implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
   implementation("com.slack.api:bolt-jetty:{{ site.sdkLatestVersion }}")
-  implementation("org.slf4j:slf4j-simple:1.7.30") // or logback-classic
+  implementation("org.slf4j:slf4j-simple:1.7.31") // or logback-classic
 }
 application {
   mainClassName = "MyAppKt" // add "Kt" suffix for main function source file

--- a/docs/guides/ja/getting-started-with-bolt-socket-mode.md
+++ b/docs/guides/ja/getting-started-with-bolt-socket-mode.md
@@ -100,7 +100,7 @@ dependencies {
   implementation("com.slack.api:bolt-socket-mode:{{ site.sdkLatestVersion }}")
   implementation("javax.websocket:javax.websocket-api:1.1")
   implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.17")
-  implementation("org.slf4j:slf4j-simple:1.7.30")
+  implementation("org.slf4j:slf4j-simple:1.7.31")
 }
 application {
   mainClassName = "hello.MyApp"
@@ -230,7 +230,7 @@ dependencies {
   implementation("com.slack.api:bolt-socket-mode:{{ site.sdkLatestVersion }}")
   implementation("javax.websocket:javax.websocket-api:1.1")
   implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.17")
-  implementation("org.slf4j:slf4j-simple:1.7.30") // または logback-classic など
+  implementation("org.slf4j:slf4j-simple:1.7.31") // または logback-classic など
 }
 application {
   mainClassName = "MyAppKt" // ソースファイル名の末尾、拡張子の代わりに "Kt" をつけた命名になります

--- a/docs/guides/ja/getting-started-with-bolt.md
+++ b/docs/guides/ja/getting-started-with-bolt.md
@@ -88,7 +88,7 @@ repositories {
 }
 dependencies {
   implementation("com.slack.api:bolt-jetty:{{ site.sdkLatestVersion }}")
-  implementation("org.slf4j:slf4j-simple:1.7.30")
+  implementation("org.slf4j:slf4j-simple:1.7.31")
 }
 application {
   mainClassName = "hello.MyApp"
@@ -249,7 +249,7 @@ dependencies {
   implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
   implementation("com.slack.api:bolt-jetty:{{ site.sdkLatestVersion }}")
-  implementation("org.slf4j:slf4j-simple:1.7.30") // または logback-classic など
+  implementation("org.slf4j:slf4j-simple:1.7.31") // または logback-classic など
 }
 application {
   mainClassName = "MyAppKt" // ソースファイル名の末尾、拡張子の代わりに "Kt" をつけた命名になります

--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,13 @@
         <lombok.version>1.18.20</lombok.version>
         <lombok-maven-plugin.version>1.18.16.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
-        <kotlin.version>1.5.10</kotlin.version>
-        <slf4j.version>1.7.30</slf4j.version>
-        <aws.s3.version>1.11.1031</aws.s3.version>
+        <kotlin.version>1.5.20</kotlin.version>
+        <slf4j.version>1.7.31</slf4j.version>
+        <aws.s3.version>1.12.14</aws.s3.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>
-        <mockito-core.version>3.10.0</mockito-core.version>
+        <mockito-core.version>3.11.2</mockito-core.version>
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -18,7 +18,7 @@
         <!-- TODO upgrade to 2.0 in the next major version -->
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
         <java-websocket.version>1.5.2</java-websocket.version>
-        <jedis.version>3.6.0</jedis.version>
+        <jedis.version>3.6.1</jedis.version>
         <jedis-mock.version>0.1.20</jedis-mock.version>
     </properties>
 


### PR DESCRIPTION
Most of the dependency updates in this pull request should be safe enough. Just in case, I will check the compatibility of the AWS SDK 1.12 before merging this.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
