### PR TITLE
Update the oauth.v2.access req/resp for supporting token rotation #775

### DIFF
--- a/json-logs/samples/api/oauth.v2.access.json
+++ b/json-logs/samples/api/oauth.v2.access.json
@@ -9,11 +9,15 @@
     "id": "",
     "scope": "",
     "token_type": "",
-    "access_token": ""
+    "access_token": "",
+    "refresh_token": "",
+    "expires_in": 123
   },
   "scope": "",
   "token_type": "",
   "access_token": "",
+  "refresh_token": "",
+  "expires_in": 123,
   "bot_user_id": "",
   "team": {
     "id": "",

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -2174,9 +2174,17 @@ public class MethodsClientImpl implements MethodsClient {
     @Override
     public OAuthV2AccessResponse oauthV2Access(OAuthV2AccessRequest req) throws IOException, SlackApiException {
         FormBody.Builder form = new FormBody.Builder();
-        form.add("code", req.getCode());
+        if (req.getCode() != null) {
+            form.add("code", req.getCode());
+        }
         if (req.getRedirectUri() != null) {
             form.add("redirect_uri", req.getRedirectUri());
+        }
+        if (req.getGrantType() != null) {
+            form.add("grant_type", req.getGrantType());
+        }
+        if (req.getRefreshToken() != null) {
+            form.add("refresh_token", req.getRefreshToken());
         }
         String authorizationHeader = Credentials.basic(req.getClientId(), req.getClientSecret());
         return postFormWithAuthorizationHeaderAndParseResponse(form, endpointUrlPrefix + Methods.OAUTH_V2_ACCESS, authorizationHeader, OAuthV2AccessResponse.class);

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthV2AccessRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthV2AccessRequest.java
@@ -32,6 +32,16 @@ public class OAuthV2AccessRequest implements SlackApiRequest {
      */
     private String redirectUri;
 
+    /**
+     * The grant_type param as described in the OAuth spec.
+     */
+    private String grantType;
+
+    /**
+     * The refresh_token param as described in the OAuth spec.
+     */
+    private String refreshToken;
+
     @Override
     public String getToken() {
         return null;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthV2AccessResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthV2AccessResponse.java
@@ -20,6 +20,8 @@ public class OAuthV2AccessResponse implements SlackApiTextResponse {
     private String scope;
     private String tokenType; // "bot"
     private String accessToken; // xoxb-xxx-yyy
+    private String refreshToken; // only when enabling token rotation
+    private Integer expiresIn; // in seconds; only when enabling token rotation
     private String botUserId;
     private Team team;
     private Enterprise enterprise;
@@ -32,6 +34,8 @@ public class OAuthV2AccessResponse implements SlackApiTextResponse {
         private String scope;
         private String tokenType; // "user"
         private String accessToken; // xoxp-xxx-yyy
+        private String refreshToken; // only when enabling token rotation
+        private Integer expiresIn; // in seconds; only when enabling token rotation
     }
 
     @Data


### PR DESCRIPTION
This pull request updates the oauth.v2.access endpoint support to have more parameters in a request and more fields in a response. Let me self-merge for making type definition updates for node-slack-sdk right away.

ref #775 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
