### PR TITLE
Add oauth.v2.exchange endpoint support #775

### DIFF
--- a/json-logs/samples/api/oauth.v2.exchange.json
+++ b/json-logs/samples/api/oauth.v2.exchange.json
@@ -1,0 +1,42 @@
+{
+  "ok": false,
+  "warning": "",
+  "error": "",
+  "needed": "",
+  "provided": "",
+  "app_id": "",
+  "authed_user": {
+    "id": "",
+    "scope": "",
+    "token_type": "",
+    "access_token": "",
+    "refresh_token": "",
+    "expires_in": 123
+  },
+  "scope": "",
+  "token_type": "",
+  "access_token": "",
+  "refresh_token": "",
+  "expires_in": 123,
+  "bot_user_id": "",
+  "team": {
+    "id": "",
+    "name": ""
+  },
+  "enterprise": {
+    "id": "",
+    "name": ""
+  },
+  "is_enterprise_install": false,
+  "incoming_webhook": {
+    "url": "",
+    "channel": "",
+    "channel_id": "",
+    "configuration_url": ""
+  },
+  "response_metadata": {
+    "messages": [
+      ""
+    ]
+  }
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
@@ -56,6 +56,7 @@ import com.slack.api.methods.request.migration.MigrationExchangeRequest;
 import com.slack.api.methods.request.oauth.OAuthAccessRequest;
 import com.slack.api.methods.request.oauth.OAuthTokenRequest;
 import com.slack.api.methods.request.oauth.OAuthV2AccessRequest;
+import com.slack.api.methods.request.oauth.OAuthV2ExchangeRequest;
 import com.slack.api.methods.request.pins.PinsAddRequest;
 import com.slack.api.methods.request.pins.PinsListRequest;
 import com.slack.api.methods.request.pins.PinsRemoveRequest;
@@ -145,6 +146,7 @@ import com.slack.api.methods.response.migration.MigrationExchangeResponse;
 import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 import com.slack.api.methods.response.oauth.OAuthTokenResponse;
 import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
+import com.slack.api.methods.response.oauth.OAuthV2ExchangeResponse;
 import com.slack.api.methods.response.pins.PinsAddResponse;
 import com.slack.api.methods.response.pins.PinsListResponse;
 import com.slack.api.methods.response.pins.PinsRemoveResponse;
@@ -904,6 +906,10 @@ public interface AsyncMethodsClient {
     CompletableFuture<OAuthV2AccessResponse> oauthV2Access(OAuthV2AccessRequest req);
 
     CompletableFuture<OAuthV2AccessResponse> oauthV2Access(RequestConfigurator<OAuthV2AccessRequest.OAuthV2AccessRequestBuilder> req);
+
+    CompletableFuture<OAuthV2ExchangeResponse> oauthV2Exchange(OAuthV2ExchangeRequest req);
+
+    CompletableFuture<OAuthV2ExchangeResponse> oauthV2Exchange(RequestConfigurator<OAuthV2ExchangeRequest.OAuthV2ExchangeRequestBuilder> req);
 
     CompletableFuture<OAuthTokenResponse> oauthToken(OAuthTokenRequest req);
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
@@ -467,6 +467,7 @@ public class Methods {
 
     public static final String OAUTH_ACCESS = "oauth.access";
     public static final String OAUTH_V2_ACCESS = "oauth.v2.access";
+    public static final String OAUTH_V2_EXCHANGE = "oauth.v2.exchange";
     public static final String OAUTH_TOKEN = "oauth.token";
 
     // ------------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
@@ -69,6 +69,7 @@ import com.slack.api.methods.request.mpim.*;
 import com.slack.api.methods.request.oauth.OAuthAccessRequest;
 import com.slack.api.methods.request.oauth.OAuthTokenRequest;
 import com.slack.api.methods.request.oauth.OAuthV2AccessRequest;
+import com.slack.api.methods.request.oauth.OAuthV2ExchangeRequest;
 import com.slack.api.methods.request.pins.PinsAddRequest;
 import com.slack.api.methods.request.pins.PinsListRequest;
 import com.slack.api.methods.request.pins.PinsRemoveRequest;
@@ -171,6 +172,7 @@ import com.slack.api.methods.response.mpim.*;
 import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 import com.slack.api.methods.response.oauth.OAuthTokenResponse;
 import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
+import com.slack.api.methods.response.oauth.OAuthV2ExchangeResponse;
 import com.slack.api.methods.response.pins.PinsAddResponse;
 import com.slack.api.methods.response.pins.PinsListResponse;
 import com.slack.api.methods.response.pins.PinsRemoveResponse;
@@ -1443,6 +1445,10 @@ public interface MethodsClient {
     OAuthV2AccessResponse oauthV2Access(OAuthV2AccessRequest req) throws IOException, SlackApiException;
 
     OAuthV2AccessResponse oauthV2Access(RequestConfigurator<OAuthV2AccessRequest.OAuthV2AccessRequestBuilder> req) throws IOException, SlackApiException;
+
+    OAuthV2ExchangeResponse oauthV2Exchange(OAuthV2ExchangeRequest req) throws IOException, SlackApiException;
+
+    OAuthV2ExchangeResponse oauthV2Exchange(RequestConfigurator<OAuthV2ExchangeRequest.OAuthV2ExchangeRequestBuilder> req) throws IOException, SlackApiException;
 
     OAuthTokenResponse oauthToken(OAuthTokenRequest req) throws IOException, SlackApiException;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
@@ -307,6 +307,7 @@ public class MethodsRateLimits {
         setRateLimitTier(OAUTH_ACCESS, Tier4);
         setRateLimitTier(OAUTH_TOKEN, Tier4);
         setRateLimitTier(OAUTH_V2_ACCESS, Tier4);
+        setRateLimitTier(OAUTH_V2_EXCHANGE, Tier3);
 
         setRateLimitTier(PINS_ADD, Tier2);
         setRateLimitTier(PINS_LIST, Tier2);

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -68,6 +68,7 @@ import com.slack.api.methods.request.migration.MigrationExchangeRequest;
 import com.slack.api.methods.request.mpim.*;
 import com.slack.api.methods.request.oauth.OAuthAccessRequest;
 import com.slack.api.methods.request.oauth.OAuthTokenRequest;
+import com.slack.api.methods.request.oauth.OAuthV2ExchangeRequest;
 import com.slack.api.methods.request.pins.PinsAddRequest;
 import com.slack.api.methods.request.pins.PinsListRequest;
 import com.slack.api.methods.request.pins.PinsRemoveRequest;
@@ -1803,6 +1804,13 @@ public class RequestFormBuilder {
         setIfNotNull("code", req.getCode(), form);
         setIfNotNull("redirect_uri", req.getRedirectUri(), form);
         setIfNotNull("single_channel", req.isSingleChannel(), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(OAuthV2ExchangeRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("client_id", req.getClientId(), form);
+        setIfNotNull("client_secret", req.getClientSecret(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
@@ -60,6 +60,7 @@ import com.slack.api.methods.request.migration.MigrationExchangeRequest;
 import com.slack.api.methods.request.oauth.OAuthAccessRequest;
 import com.slack.api.methods.request.oauth.OAuthTokenRequest;
 import com.slack.api.methods.request.oauth.OAuthV2AccessRequest;
+import com.slack.api.methods.request.oauth.OAuthV2ExchangeRequest;
 import com.slack.api.methods.request.pins.PinsAddRequest;
 import com.slack.api.methods.request.pins.PinsListRequest;
 import com.slack.api.methods.request.pins.PinsRemoveRequest;
@@ -149,6 +150,7 @@ import com.slack.api.methods.response.migration.MigrationExchangeResponse;
 import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 import com.slack.api.methods.response.oauth.OAuthTokenResponse;
 import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
+import com.slack.api.methods.response.oauth.OAuthV2ExchangeResponse;
 import com.slack.api.methods.response.pins.PinsAddResponse;
 import com.slack.api.methods.response.pins.PinsListResponse;
 import com.slack.api.methods.response.pins.PinsRemoveResponse;
@@ -1598,6 +1600,16 @@ public class AsyncMethodsClientImpl implements AsyncMethodsClient {
     @Override
     public CompletableFuture<OAuthV2AccessResponse> oauthV2Access(RequestConfigurator<OAuthV2AccessRequest.OAuthV2AccessRequestBuilder> req) {
         return oauthV2Access(req.configure(OAuthV2AccessRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<OAuthV2ExchangeResponse> oauthV2Exchange(OAuthV2ExchangeRequest req) {
+        return executor.execute(OAUTH_V2_EXCHANGE, toMap(req), () -> methods.oauthV2Exchange(req));
+    }
+
+    @Override
+    public CompletableFuture<OAuthV2ExchangeResponse> oauthV2Exchange(RequestConfigurator<OAuthV2ExchangeRequest.OAuthV2ExchangeRequestBuilder> req) {
+        return oauthV2Exchange(req.configure(OAuthV2ExchangeRequest.builder()).build());
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -71,6 +71,7 @@ import com.slack.api.methods.request.mpim.*;
 import com.slack.api.methods.request.oauth.OAuthAccessRequest;
 import com.slack.api.methods.request.oauth.OAuthTokenRequest;
 import com.slack.api.methods.request.oauth.OAuthV2AccessRequest;
+import com.slack.api.methods.request.oauth.OAuthV2ExchangeRequest;
 import com.slack.api.methods.request.pins.PinsAddRequest;
 import com.slack.api.methods.request.pins.PinsListRequest;
 import com.slack.api.methods.request.pins.PinsRemoveRequest;
@@ -173,6 +174,7 @@ import com.slack.api.methods.response.mpim.*;
 import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 import com.slack.api.methods.response.oauth.OAuthTokenResponse;
 import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
+import com.slack.api.methods.response.oauth.OAuthV2ExchangeResponse;
 import com.slack.api.methods.response.pins.PinsAddResponse;
 import com.slack.api.methods.response.pins.PinsListResponse;
 import com.slack.api.methods.response.pins.PinsRemoveResponse;
@@ -2193,6 +2195,16 @@ public class MethodsClientImpl implements MethodsClient {
     @Override
     public OAuthV2AccessResponse oauthV2Access(RequestConfigurator<OAuthV2AccessRequest.OAuthV2AccessRequestBuilder> req) throws IOException, SlackApiException {
         return oauthV2Access(req.configure(OAuthV2AccessRequest.builder()).build());
+    }
+
+    @Override
+    public OAuthV2ExchangeResponse oauthV2Exchange(OAuthV2ExchangeRequest req) throws IOException, SlackApiException {
+        return postFormAndParseResponse(toForm(req), Methods.OAUTH_V2_EXCHANGE, OAuthV2ExchangeResponse.class);
+    }
+
+    @Override
+    public OAuthV2ExchangeResponse oauthV2Exchange(RequestConfigurator<OAuthV2ExchangeRequest.OAuthV2ExchangeRequestBuilder> req) throws IOException, SlackApiException {
+        return oauthV2Exchange(req.configure(OAuthV2ExchangeRequest.builder()).build());
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthV2ExchangeRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthV2ExchangeRequest.java
@@ -1,0 +1,29 @@
+package com.slack.api.methods.request.oauth;
+
+import com.slack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/methods/oauth.v2.exchange
+ */
+@Data
+@Builder
+public class OAuthV2ExchangeRequest implements SlackApiRequest {
+
+    /**
+     * The legacy xoxb or xoxp token being migrated to use token rotation.
+     */
+    private String token;
+
+    /**
+     * Issued when you created your application.
+     */
+    private String clientId;
+
+    /**
+     * Issued when you created your application.
+     */
+    private String clientSecret;
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthV2ExchangeResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthV2ExchangeResponse.java
@@ -1,0 +1,63 @@
+package com.slack.api.methods.response.oauth;
+
+import com.slack.api.methods.SlackApiTextResponse;
+import com.slack.api.model.ErrorResponseMetadata;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/methods/oauth.v2.exchange
+ */
+@Data
+public class OAuthV2ExchangeResponse implements SlackApiTextResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private String appId;
+    private AuthedUser authedUser;
+    private String scope;
+    private String tokenType; // "bot"
+    private String accessToken; // xoxb-xxx-yyy
+    private String refreshToken; // only when enabling token rotation
+    private Integer expiresIn; // in seconds; only when enabling token rotation
+    private String botUserId;
+    private Team team;
+    private Enterprise enterprise;
+    private boolean isEnterpriseInstall;
+    private IncomingWebhook incomingWebhook;
+
+    @Data
+    public static class AuthedUser {
+        private String id;
+        private String scope;
+        private String tokenType; // "user"
+        private String accessToken; // xoxp-xxx-yyy
+        private String refreshToken; // only when enabling token rotation
+        private Integer expiresIn; // in seconds; only when enabling token rotation
+    }
+
+    @Data
+    public static class Team {
+        private String id;
+        private String name;
+    }
+
+    @Data
+    public static class Enterprise {
+        private String id;
+        private String name;
+    }
+
+    @Data
+    public static class IncomingWebhook {
+        private String url;
+        private String channel;
+        private String channelId;
+        private String configurationUrl;
+    }
+
+    private ErrorResponseMetadata responseMetadata;
+}

--- a/slack-api-client/src/test/java/test_locally/api/methods/OAuthTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/OAuthTest.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
+import com.slack.api.methods.response.oauth.OAuthV2ExchangeResponse;
 import com.slack.api.util.json.GsonFactory;
 import config.SlackTestConfig;
 import org.junit.After;
@@ -66,7 +67,7 @@ public class OAuthTest {
                 .get().isOk(), is(true));
     }
 
-    String oauth_v2_access_token_rotation_json = "{\n" +
+    static String oauth_v2_access_token_rotation_json = "{\n" +
             "  \"ok\": true,\n" +
             "  \"app_id\": \"A111\",\n" +
             "  \"authed_user\": {\n" +
@@ -104,6 +105,36 @@ public class OAuthTest {
         assertThat(response.getExpiresIn(), is(43201));
         assertThat(response.getAuthedUser().getRefreshToken(), is("xoxe-1-xxx"));
         assertThat(response.getAuthedUser().getExpiresIn(), is(43200));
+    }
+
+    static String exchange_json = "{\n" +
+            "    \"ok\": true,\n" +
+            "    \"app_id\": \"A111\",\n" +
+            "    \"token_type\": \"bot\",\n" +
+            "    \"scope\": \"commands\",\n" +
+            "    \"access_token\": \"xoxe.xoxb-1-xxx\",\n" +
+            "    \"expires_in\": 43200,\n" +
+            "    \"refresh_token\": \"xoxe-1-xxx\",\n" +
+            "    \"bot_user_id\": \"U111\",\n" +
+            "    \"team\": {\n" +
+            "        \"id\": \"T111\",\n" +
+            "        \"name\": \"Testing Workspace\"\n" +
+            "    },\n" +
+            "    \"enterprise\": {\n" +
+            "        \"id\": \"E111\",\n" +
+            "        \"name\": \"Sandbox Org\"\n" +
+            "    }\n" +
+            "}";
+
+    @Test
+    public void exchange() {
+        SlackTestConfig testConfig = SlackTestConfig.getInstance();
+        Gson gson = GsonFactory.createSnakeCase(testConfig.getConfig());
+        OAuthV2ExchangeResponse response = gson.fromJson(exchange_json, OAuthV2ExchangeResponse.class);
+        assertThat(response.getError(), is(nullValue()));
+        assertThat(response.getAccessToken(), is("xoxe.xoxb-1-xxx"));
+        assertThat(response.getRefreshToken(), is("xoxe-1-xxx"));
+        assertThat(response.getExpiresIn(), is(43200));
     }
 
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/oauth_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/oauth_Test.java
@@ -2,9 +2,12 @@ package test_with_remote_apis.methods;
 
 import com.slack.api.Slack;
 import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.oauth.OAuthV2ExchangeRequest;
 import com.slack.api.methods.response.oauth.OAuthAccessResponse;
 import com.slack.api.methods.response.oauth.OAuthTokenResponse;
 import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
+import com.slack.api.methods.response.oauth.OAuthV2ExchangeResponse;
+import com.slack.api.model.ErrorResponseMetadata;
 import config.SlackTestConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.AfterClass;
@@ -56,6 +59,17 @@ public class oauth_Test {
         }
     }
 
+    @Test
+    public void accessV2Exchange() throws IOException, SlackApiException {
+        OAuthV2ExchangeResponse response = slack.methods().oauthV2Exchange(r -> r
+                .token("xoxb-111")
+                .clientId("3485157640.XXXX")
+                .clientSecret("XXXXX")
+        );
+        assertThat(response.getError(), is("invalid_arguments"));
+        assertThat(response.isOk(), is(false));
+    }
+
     // TODO: valid test; currently just checking the API access
     @Test
     public void token() throws IOException, SlackApiException {
@@ -101,6 +115,22 @@ public class oauth_Test {
         response.setTeam(new OAuthV2AccessResponse.Team());
         ObjectInitializer.initProperties(response);
         dumper.dump("oauth.v2.access", response);
+    }
+
+    @Test
+    public void dumpFullJsonV2Exchange() throws IOException {
+        ObjectToJsonDumper dumper = new ObjectToJsonDumper("../json-logs/samples/api");
+        OAuthV2ExchangeResponse response = new OAuthV2ExchangeResponse();
+        response.setAuthedUser(new OAuthV2ExchangeResponse.AuthedUser());
+        response.setIncomingWebhook(new OAuthV2ExchangeResponse.IncomingWebhook());
+        response.setEnterprise(new OAuthV2ExchangeResponse.Enterprise());
+        response.setTeam(new OAuthV2ExchangeResponse.Team());
+        ErrorResponseMetadata responseMetadata = new ErrorResponseMetadata();
+        // e.g., [ERROR] missing required field: token
+        responseMetadata.setMessages(Arrays.asList(""));
+        response.setResponseMetadata(responseMetadata);
+        ObjectInitializer.initProperties(response);
+        dumper.dump("oauth.v2.exchange", response);
     }
 
 }


### PR DESCRIPTION
This pull request adds oauth.v2.exchange API method, which is related to #775  and will be available very soon. Once this pull request is merged, the generated JSON data can be used by node-slack-sdk.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
