### PR TITLE
Fix #766 by adding subteam to AdminConversationsSetConversationPrefsRequest.Pref

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/request/admin/conversations/AdminConversationsSetConversationPrefsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/admin/conversations/AdminConversationsSetConversationPrefsRequest.java
@@ -39,6 +39,7 @@ public class AdminConversationsSetConversationPrefsRequest implements SlackApiRe
     public static class Pref {
         private List<String> types = new ArrayList<>();
         private List<String> users = new ArrayList<>();
+        private List<String> subteams = new ArrayList<>();
 
         public String toValue() {
             List<String> elements = new ArrayList<>();
@@ -50,6 +51,11 @@ public class AdminConversationsSetConversationPrefsRequest implements SlackApiRe
             if (getUsers() != null) {
                 for (String user : getUsers()) {
                     elements.add("user:" + user);
+                }
+            }
+            if (getSubteams() != null) {
+                for (String subteam : getSubteams()) {
+                    elements.add("subteam:" + subteam);
                 }
             }
             return elements.stream().collect(Collectors.joining(","));

--- a/slack-api-client/src/test/java/test_locally/api/methods_admin_api/AdminConversationsSetConversationPrefsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods_admin_api/AdminConversationsSetConversationPrefsTest.java
@@ -1,0 +1,23 @@
+package test_locally.api.methods_admin_api;
+
+import com.slack.api.methods.request.admin.conversations.AdminConversationsSetConversationPrefsRequest;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+// see https://api.slack.com/methods/admin.conversations.setConversationPrefs
+public class AdminConversationsSetConversationPrefsTest {
+
+    @Test
+    public void pref() {
+        AdminConversationsSetConversationPrefsRequest.Pref pref =
+                new AdminConversationsSetConversationPrefsRequest.Pref();
+        pref.setTypes(Arrays.asList("admin"));
+        pref.setUsers(Arrays.asList("W111"));
+        pref.setSubteams(Arrays.asList("S111"));
+        assertThat(pref.toValue(), is("type:admin,user:W111,subteam:S111"));
+    }
+}


### PR DESCRIPTION
This pull request fixes #766 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
