### PR TITLE
Upgrade patch versions of external dependencies for v1.9 release

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <helidon.version>2.3.1</helidon.version>
+        <helidon.version>2.3.2</helidon.version>
         <!-- Helidon 2.x requires Java 11+ -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.9.9.0</http4k.version>
+        <http4k.version>4.9.10.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>1.6.0</ktor.version>
+        <ktor.version>1.6.1</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.version>2.5.7</micronaut.version>
+        <micronaut.version>2.5.9</micronaut.version>
         <micronaut-test-junit5.version>2.3.7</micronaut-test-junit5.version>
         <mockito-all.version>1.10.19</mockito-all.version>
     </properties>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,8 +8,8 @@ url: https://slack.dev
 
 sdkLatestVersion: 1.8.1
 okhttpVersion: 4.9.1
-kotlinVersion: 1.5.20
+kotlinVersion: 1.5.21
 springBootVersion: 2.5.2
 compatibleMicronautVersion: 2.x
 quarkusVersion: 1.9.2.Final
-helidonVersion: 2.3.1
+helidonVersion: 2.3.2

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
         <lombok.version>1.18.20</lombok.version>
         <lombok-maven-plugin.version>1.18.16.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
-        <kotlin.version>1.5.20</kotlin.version>
+        <kotlin.version>1.5.21</kotlin.version>
         <slf4j.version>1.7.31</slf4j.version>
-        <aws.s3.version>1.12.14</aws.s3.version>
+        <aws.s3.version>1.12.25</aws.s3.version>
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.3</logback.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -18,8 +18,8 @@
         <!-- TODO upgrade to 2.0 in the next major version -->
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
         <java-websocket.version>1.5.2</java-websocket.version>
-        <jedis.version>3.6.1</jedis.version>
-        <jedis-mock.version>0.1.20</jedis-mock.version>
+        <jedis.version>3.6.2</jedis.version>
+        <jedis-mock.version>0.1.21</jedis-mock.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This pull request bumps the patch versions of a few external dependencies in the v1.9 release. I'm running integration tests just in case but upgrading these should be safe enough.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
