### PR TITLE
Fix #768 by adding a test verifying with a user ID in other org/workspace

### DIFF
--- a/json-logs/samples/api/users.info.json
+++ b/json-logs/samples/api/users.info.json
@@ -60,7 +60,8 @@
       "teams": [
         ""
       ]
-    }
+    },
+    "is_stranger": false
   },
   "error": "",
   "needed": "",

--- a/slack-api-client/src/test/java/config/Constants.java
+++ b/slack-api-client/src/test/java/config/Constants.java
@@ -25,6 +25,7 @@ public class Constants {
     public static final String SLACK_SDK_TEST_GRID_USER_ID_ADMIN_AUTH = "SLACK_SDK_TEST_GRID_USER_ID_ADMIN_AUTH";
     // Shared channel ID for testing with Grid
     public static final String SLACK_SDK_TEST_GRID_SHARED_CHANNEL_ID = "SLACK_SDK_TEST_GRID_SHARED_CHANNEL_ID";
+    public static final String SLACK_SDK_TEST_GRID_SHARED_CHANNEL_OTHER_ORG_USER_ID = "SLACK_SDK_TEST_GRID_SHARED_CHANNEL_OTHER_ORG_USER_ID";
     // Org level installed app
     public static final String SLACK_SDK_TEST_GRID_ORG_LEVEL_APP_BOT_TOKEN = "SLACK_SDK_TEST_GRID_ORG_LEVEL_APP_BOT_TOKEN";
     // --------------------------------------------

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/users_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/users_Test.java
@@ -19,10 +19,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import static config.Constants.SLACK_SDK_TEST_GRID_SHARED_CHANNEL_OTHER_ORG_USER_ID;
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @Slf4j
@@ -395,5 +397,15 @@ public class users_Test {
                 assertThat(conversations.getChannels().size(), is(greaterThan(0)));
             }
         }
+    }
+
+    // https://github.com/slackapi/java-slack-sdk/issues/768
+    @Test
+    public void issue_768_strangerLookup() throws Exception {
+        // is_stranger property is only available with user IDs in other org/workspace
+        String userId = System.getenv(SLACK_SDK_TEST_GRID_SHARED_CHANNEL_OTHER_ORG_USER_ID);
+        UsersInfoResponse user = slack.methods(enterpriseGridTeamAdminUserToken).usersInfo(r ->
+                r.user(userId));
+        assertNull(user.getError());
     }
 }


### PR DESCRIPTION
This pull request fixes #768 mainly for improving the response type definition improvements in Node SDK (`@slack/web-api`)

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
