### PR TITLE
Fix #784 by making MessageDeletedEvent compatible with all possible patterns

### DIFF
--- a/bolt-servlet/src/test/java/test_with_remote_apis/EventsApiTest.java
+++ b/bolt-servlet/src/test/java/test_with_remote_apis/EventsApiTest.java
@@ -991,7 +991,7 @@ public class EventsApiTest {
             });
             app.event(MessageChangedEvent.class, (req, ctx) -> {
                 if (req.getEvent().getMessage().getFiles() != null && req.getEvent().getMessage().getFiles().size() > 0
-                        && req.getEvent().getPreviousMessage().getFiles() != null && req.getEvent().getPreviousMessage().getFiles().size() > 0) {
+                        && req.getEvent().getPreviousMessage().getMessage().getFiles() != null && req.getEvent().getPreviousMessage().getMessage().getFiles().size() > 0) {
                     state.messageChanged.incrementAndGet();
                 }
                 return ctx.ack();

--- a/json-logs/samples/events/MessageChangedPayload.json
+++ b/json-logs/samples/events/MessageChangedPayload.json
@@ -25,6 +25,20 @@
       "subtype": "",
       "user": "",
       "team": "",
+      "bot_id": "",
+      "bot_profile": {
+        "id": "",
+        "deleted": false,
+        "name": "",
+        "updated": 123,
+        "app_id": "",
+        "icons": {
+          "image_36": "",
+          "image_48": "",
+          "image_72": ""
+        },
+        "team_id": ""
+      },
       "edited": {
         "user": "",
         "ts": ""
@@ -680,10 +694,17 @@
       "display_as_bot": false,
       "thread_ts": "",
       "parent_user_id": "",
+      "hidden": false,
+      "is_locked": false,
+      "subscribed": false,
       "ts": "",
       "user_team": "",
       "source_team": "",
-      "is_starred": false
+      "is_starred": false,
+      "reply_count": 123,
+      "reply_users_count": 123,
+      "latest_reply": "",
+      "last_read": ""
     },
     "previous_message": {
       "client_msg_id": "",
@@ -691,6 +712,20 @@
       "subtype": "",
       "user": "",
       "team": "",
+      "bot_id": "",
+      "bot_profile": {
+        "id": "",
+        "deleted": false,
+        "name": "",
+        "updated": 123,
+        "app_id": "",
+        "icons": {
+          "image_36": "",
+          "image_48": "",
+          "image_72": ""
+        },
+        "team_id": ""
+      },
       "edited": {
         "user": "",
         "ts": ""
@@ -1346,10 +1381,17 @@
       "display_as_bot": false,
       "thread_ts": "",
       "parent_user_id": "",
+      "hidden": false,
+      "is_locked": false,
+      "subscribed": false,
       "ts": "",
       "user_team": "",
       "source_team": "",
-      "is_starred": false
+      "is_starred": false,
+      "reply_count": 123,
+      "reply_users_count": 123,
+      "latest_reply": "",
+      "last_read": ""
     },
     "event_ts": "",
     "ts": "",

--- a/json-logs/samples/events/MessageDeletedPayload.json
+++ b/json-logs/samples/events/MessageDeletedPayload.json
@@ -677,8 +677,35 @@
           }
         }
       ],
+      "upload": false,
+      "display_as_bot": false,
+      "thread_ts": "",
+      "parent_user_id": "",
+      "bot_id": "",
+      "bot_profile": {
+        "id": "",
+        "deleted": false,
+        "name": "",
+        "updated": 123,
+        "app_id": "",
+        "icons": {
+          "image_36": "",
+          "image_48": "",
+          "image_72": ""
+        },
+        "team_id": ""
+      },
+      "hidden": false,
+      "is_locked": false,
+      "subscribed": false,
+      "ts": "",
+      "user_team": "",
+      "source_team": "",
       "is_starred": false,
-      "ts": ""
+      "reply_count": 123,
+      "reply_users_count": 123,
+      "latest_reply": "",
+      "last_read": ""
     },
     "event_ts": "",
     "ts": "",

--- a/slack-api-client/src/main/java/com/slack/api/util/json/GsonFactory.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/json/GsonFactory.java
@@ -11,6 +11,7 @@ import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.model.block.composition.TextObject;
 import com.slack.api.model.block.element.BlockElement;
 import com.slack.api.model.block.element.RichTextElement;
+import com.slack.api.model.event.MessageChangedEvent;
 
 /**
  * Gson Factory for the entire SDK. This factory enables some Slack-specific settings.
@@ -50,7 +51,9 @@ public class GsonFactory {
                 .registerTypeAdapter(LogsResponse.DetailsChangedValue.class,
                         new GsonAuditLogsDetailsChangedValueFactory(failOnUnknownProps))
                 .registerTypeAdapter(Attachment.VideoHtml.class,
-                        new GsonMessageAttachmentVideoHtmlFactory(failOnUnknownProps));
+                        new GsonMessageAttachmentVideoHtmlFactory(failOnUnknownProps))
+                .registerTypeAdapter(MessageChangedEvent.PreviousMessage.class,
+                        new GsonMessageChangedEventPreviousMessageFactory());
         if (failOnUnknownProps || config.isLibraryMaintainerMode()) {
             gsonBuilder = gsonBuilder.registerTypeAdapterFactory(new UnknownPropertyDetectionAdapterFactory());
         }
@@ -72,7 +75,13 @@ public class GsonFactory {
                 .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory(failOnUnknownProps))
                 .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory(failOnUnknownProps))
                 .registerTypeAdapter(LogsResponse.DetailsChangedValue.class,
-                        new GsonAuditLogsDetailsChangedValueFactory(failOnUnknownProps));
+                        new GsonAuditLogsDetailsChangedValueFactory(failOnUnknownProps))
+                .registerTypeAdapter(MessageChangedEvent.PreviousMessage.class,
+                        new GsonMessageChangedEventPreviousMessageFactory(failOnUnknownProps))
+                .registerTypeAdapter(LogsResponse.DetailsChangedValue.class,
+                        new GsonAuditLogsDetailsChangedValueFactory(failOnUnknownProps))
+                .registerTypeAdapter(MessageChangedEvent.PreviousMessage.class,
+                        new GsonMessageChangedEventPreviousMessageFactory(failOnUnknownProps));
         if (failOnUnknownProps || config.isLibraryMaintainerMode()) {
             gsonBuilder = gsonBuilder.registerTypeAdapterFactory(new UnknownPropertyDetectionAdapterFactory());
         }

--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageChangedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageChangedEvent.java
@@ -2,6 +2,7 @@ package com.slack.api.model.event;
 
 import com.google.gson.annotations.SerializedName;
 import com.slack.api.model.Attachment;
+import com.slack.api.model.BotProfile;
 import com.slack.api.model.File;
 import com.slack.api.model.Reaction;
 import com.slack.api.model.block.LayoutBlock;
@@ -25,11 +26,16 @@ public class MessageChangedEvent implements Event {
     private boolean hidden;
 
     private Message message;
-    private Message previousMessage;
+    private PreviousMessage previousMessage;
 
     private String eventTs;
     private String ts;
     private String channelType; // app_home, channel, group, im, mpim
+
+    @Data
+    public static class PreviousMessage {
+        private Message message;
+    }
 
     @Data
     public static class Message {
@@ -40,6 +46,9 @@ public class MessageChangedEvent implements Event {
 
         private String user;
         private String team;
+
+        private String botId;
+        private BotProfile botProfile;
 
         private MessageEvent.Edited edited;
 
@@ -55,6 +64,10 @@ public class MessageChangedEvent implements Event {
         private String threadTs;
         private String parentUserId;
 
+        private Boolean hidden;
+        private Boolean isLocked;
+        private Boolean subscribed;
+
         private String ts;
         private String userTeam;
         private String sourceTeam;
@@ -63,6 +76,12 @@ public class MessageChangedEvent implements Event {
         private boolean starred;
         private List<String> pinnedTo;
         private List<Reaction> reactions;
+
+        private Integer replyCount;
+        private Integer replyUsersCount;
+        private String latestReply;
+        private List<String> replyUsers;
+        private String lastRead;
     }
 
     @Data

--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageDeletedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageDeletedEvent.java
@@ -2,6 +2,8 @@ package com.slack.api.model.event;
 
 import com.google.gson.annotations.SerializedName;
 import com.slack.api.model.Attachment;
+import com.slack.api.model.BotProfile;
+import com.slack.api.model.File;
 import com.slack.api.model.Reaction;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.Data;
@@ -36,6 +38,7 @@ public class MessageDeletedEvent implements Event {
 
         private final String type = TYPE_NAME;
         private String subtype;
+
         private String user;
         private String team;
 
@@ -45,12 +48,35 @@ public class MessageDeletedEvent implements Event {
         private List<LayoutBlock> blocks;
         private List<Attachment> attachments;
 
+        private List<File> files;
+        private Boolean upload;
+        private Boolean displayAsBot;
+        private List<String> xFiles;
+
+        private String threadTs;
+        private String parentUserId;
+
+        private String botId;
+        private BotProfile botProfile;
+
+        private Boolean hidden;
+        private Boolean isLocked;
+        private Boolean subscribed;
+
+        private String ts;
+        private String userTeam;
+        private String sourceTeam;
+
         @SerializedName("is_starred")
         private boolean starred;
         private List<String> pinnedTo;
         private List<Reaction> reactions;
 
-        private String ts;
+        private Integer replyCount;
+        private Integer replyUsersCount;
+        private String latestReply;
+        private List<String> replyUsers;
+        private String lastRead;
     }
 
     @Data

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonMessageAttachmentVideoHtmlFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonMessageAttachmentVideoHtmlFactory.java
@@ -2,13 +2,11 @@ package com.slack.api.util.json;
 
 import com.google.gson.*;
 import com.slack.api.model.Attachment;
-import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
-@Slf4j
 public class GsonMessageAttachmentVideoHtmlFactory implements JsonDeserializer<Attachment.VideoHtml>, JsonSerializer<Attachment.VideoHtml> {
 
     private static final String REPORT_THIS = "Please report this issue at https://github.com/slackapi/java-slack-sdk/issues";
@@ -69,7 +67,6 @@ public class GsonMessageAttachmentVideoHtmlFactory implements JsonDeserializer<A
             json.add("source", new JsonPrimitive(src.getSource()));
             return json;
         } else {
-            log.warn("Unsupported field in Attachment.VideoHtml is detected ({})", src);
             return JsonNull.INSTANCE;
         }
     }

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonMessageChangedEventPreviousMessageFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonMessageChangedEventPreviousMessageFactory.java
@@ -1,0 +1,48 @@
+package com.slack.api.util.json;
+
+import com.google.gson.*;
+import com.slack.api.model.event.MessageChangedEvent;
+
+import java.lang.reflect.Type;
+
+public class GsonMessageChangedEventPreviousMessageFactory implements JsonDeserializer<MessageChangedEvent.PreviousMessage>, JsonSerializer<MessageChangedEvent.PreviousMessage> {
+
+    private static final String REPORT_THIS = "Please report this issue at https://github.com/slackapi/java-slack-sdk/issues";
+
+    private final boolean failOnUnknownProperties;
+
+    public GsonMessageChangedEventPreviousMessageFactory() {
+        this(false);
+    }
+
+    public GsonMessageChangedEventPreviousMessageFactory(boolean failOnUnknownProperties) {
+        this.failOnUnknownProperties = failOnUnknownProperties;
+    }
+
+    @Override
+    public MessageChangedEvent.PreviousMessage deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        MessageChangedEvent.PreviousMessage result = new MessageChangedEvent.PreviousMessage();
+        if (json.isJsonArray()) {
+            return result;
+        } else if (json.isJsonObject()) {
+            result.setMessage(context.deserialize(json, MessageChangedEvent.Message.class));
+            return result;
+        } else {
+            if (failOnUnknownProperties) {
+                String message = "The whole value (" + json + ") is unsupported. " + REPORT_THIS;
+                throw new JsonParseException(message);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public JsonElement serialize(MessageChangedEvent.PreviousMessage src, Type typeOfSrc, JsonSerializationContext context) {
+        if (src.getMessage() != null) {
+            return context.serialize(src.getMessage());
+        } else {
+            return new JsonArray();
+        }
+    }
+}

--- a/slack-api-model/src/test/java/test_locally/api/model/event/MessageChangedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/MessageChangedEventTest.java
@@ -1,6 +1,7 @@
 package test_locally.api.model.event;
 
 import com.slack.api.model.event.MessageChangedEvent;
+import com.slack.api.model.event.MessageDeletedEvent;
 import org.junit.Test;
 import test_locally.unit.GsonFactory;
 
@@ -58,7 +59,83 @@ public class MessageChangedEventTest {
         assertThat(event.getType(), is("message"));
         assertThat(event.getSubtype(), is("message_changed"));
         assertThat(event.getMessage().getThreadTs(), is("1626342092.008500"));
-        assertThat(event.getPreviousMessage().getThreadTs(), is("1626342092.008500"));
+        assertThat(event.getPreviousMessage().getMessage().getThreadTs(), is("1626342092.008500"));
     }
 
+    @Test
+    public void with_tombstone() {
+        String json = "{\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"subtype\": \"message_changed\",\n" +
+                "  \"hidden\": true,\n" +
+                "  \"message\": {\n" +
+                "    \"type\": \"message\",\n" +
+                "    \"subtype\": \"tombstone\",\n" +
+                "    \"text\": \"This message was deleted.\",\n" +
+                "    \"user\": \"USLACKBOT\",\n" +
+                "    \"hidden\": true,\n" +
+                "    \"thread_ts\": \"1626774922.004400\",\n" +
+                "    \"reply_count\": 1,\n" +
+                "    \"reply_users_count\": 1,\n" +
+                "    \"latest_reply\": \"1626774934.004500\",\n" +
+                "    \"reply_users\": [\n" +
+                "      \"U111\"\n" +
+                "    ],\n" +
+                "    \"is_locked\": false,\n" +
+                "    \"ts\": \"1626774922.004400\"\n" +
+                "  },\n" +
+                "  \"channel\": \"C111\",\n" +
+                "  \"previous_message\": {\n" +
+                "    \"client_msg_id\": \"5a47c3eb-29a5-475f-8946-8677938c39a8\",\n" +
+                "    \"type\": \"message\",\n" +
+                "    \"text\": \"hi hi!\",\n" +
+                "    \"user\": \"U111\",\n" +
+                "    \"ts\": \"1626774922.004400\",\n" +
+                "    \"team\": \"T111\",\n" +
+                "    \"blocks\": [\n" +
+                "    ],\n" +
+                "    \"thread_ts\": \"1626774922.004400\",\n" +
+                "    \"reply_count\": 1,\n" +
+                "    \"reply_users_count\": 1,\n" +
+                "    \"latest_reply\": \"1626774934.004500\",\n" +
+                "    \"reply_users\": [\n" +
+                "      \"U111\"\n" +
+                "    ],\n" +
+                "    \"is_locked\": false,\n" +
+                "    \"subscribed\": true,\n" +
+                "    \"last_read\": \"1626774934.004500\"\n" +
+                "  },\n" +
+                "  \"event_ts\": \"1626774940.004700\",\n" +
+                "  \"ts\": \"1626774940.004700\",\n" +
+                "  \"channel_type\": \"channel\"\n" +
+                "}\n";
+        MessageChangedEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageChangedEvent.class);
+        assertThat(event.getType(), is("message"));
+        assertThat(event.getSubtype(), is("message_changed"));
+    }
+
+    // https://github.com/slackapi/java-slack-sdk/issues/784
+    @Test
+    public void issue_784_deleteParentMessageFirstAndThenDeleteAllMessagesInThread() {
+        String json = "{\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"subtype\": \"message_changed\",\n" +
+                "  \"hidden\": true,\n" +
+                "  \"message\": {\n" +
+                "    \"type\": \"message\",\n" +
+                "    \"subtype\": \"tombstone\",\n" +
+                "    \"text\": \"This message was deleted.\",\n" +
+                "    \"user\": \"USLACKBOT\",\n" +
+                "    \"hidden\": true,\n" +
+                "    \"ts\": \"1626775604.004900\"\n" +
+                "  },\n" +
+                "  \"channel\": \"C03E94MKU\",\n" +
+                "  \"previous_message\": [],\n" +
+                "  \"event_ts\": \"1626775673.006300\",\n" +
+                "  \"ts\": \"1626775673.006300\",\n" +
+                "  \"channel_type\": \"channel\"\n" +
+                "}";
+        MessageChangedEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageChangedEvent.class);
+        assertThat(event.getType(), is("message"));
+    }
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/event/MessageDeletedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/MessageDeletedEventTest.java
@@ -1,0 +1,55 @@
+package test_locally.api.model.event;
+
+import com.slack.api.model.event.MessageDeletedEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MessageDeletedEventTest {
+
+    @Test
+    public void typeName() {
+        assertThat(MessageDeletedEvent.TYPE_NAME, is("message"));
+        assertThat(MessageDeletedEvent.SUBTYPE_NAME, is("message_deleted"));
+    }
+
+    @Test
+    public void with_tombstone() {
+        String json = "{\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"subtype\": \"message_deleted\",\n" +
+                "  \"hidden\": true,\n" +
+                "  \"deleted_ts\": \"1626387317.008600\",\n" +
+                "  \"channel\": \"C111\",\n" +
+                "  \"previous_message\": {\n" +
+                "    \"bot_id\": \"B111\",\n" +
+                "    \"type\": \"message\",\n" +
+                "    \"text\": \"test prep\",\n" +
+                "    \"user\": \"U111\",\n" +
+                "    \"ts\": \"1626387317.008600\",\n" +
+                "    \"team\": \"T111\",\n" +
+                "    \"bot_profile\": {\n" +
+                "      \"id\": \"B111\",\n" +
+                "      \"deleted\": false,\n" +
+                "      \"name\": \"SDK Testing App\",\n" +
+                "      \"updated\": 1622167148,\n" +
+                "      \"app_id\": \"A111\",\n" +
+                "      \"icons\": {\n" +
+                "        \"image_36\": \"https://avatars.slack-edge.com/2021-05-27/xxx.png\",\n" +
+                "        \"image_48\": \"https://avatars.slack-edge.com/2021-05-27/xxx.png\",\n" +
+                "        \"image_72\": \"https://avatars.slack-edge.com/2021-05-27/xxx.png\"\n" +
+                "      },\n" +
+                "      \"team_id\": \"T111\"\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"event_ts\": \"1626387318.008700\",\n" +
+                "  \"ts\": \"1626387318.008700\",\n" +
+                "  \"channel_type\": \"channel\"\n" +
+                "}";
+        MessageDeletedEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageDeletedEvent.class);
+        assertThat(event.getType(), is("message"));
+        assertThat(event.getSubtype(), is("message_deleted"));
+    }
+}

--- a/slack-api-model/src/test/java/test_locally/api/model/event/MessageEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/MessageEventTest.java
@@ -389,8 +389,8 @@ public class MessageEventTest {
                 "}";
         MessageChangedEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageChangedEvent.class);
         assertThat(event.getMessage().getFiles(), is(notNullValue()));
-        assertThat(event.getPreviousMessage().getFiles(), is(notNullValue()));
-        assertThat(event.getMessage().getFiles(), is(equalTo(event.getPreviousMessage().getFiles())));
+        assertThat(event.getPreviousMessage().getMessage().getFiles(), is(notNullValue()));
+        assertThat(event.getMessage().getFiles(), is(equalTo(event.getPreviousMessage().getMessage().getFiles())));
     }
 
     @Test

--- a/slack-api-model/src/test/java/test_locally/unit/GsonFactory.java
+++ b/slack-api-model/src/test/java/test_locally/unit/GsonFactory.java
@@ -3,11 +3,13 @@ package test_locally.unit;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.slack.api.model.Attachment;
 import com.slack.api.model.block.ContextBlockElement;
 import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.model.block.composition.TextObject;
 import com.slack.api.model.block.element.BlockElement;
 import com.slack.api.model.block.element.RichTextElement;
+import com.slack.api.model.event.MessageChangedEvent;
 import com.slack.api.util.json.*;
 
 public class GsonFactory {
@@ -29,7 +31,11 @@ public class GsonFactory {
                 .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory(failOnUnknownProperties))
                 .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory(failOnUnknownProperties))
                 .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory(failOnUnknownProperties))
-                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory(failOnUnknownProperties));
+                .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory(failOnUnknownProperties))
+                .registerTypeAdapter(Attachment.VideoHtml.class,
+                        new GsonMessageAttachmentVideoHtmlFactory(failOnUnknownProperties))
+                .registerTypeAdapter(MessageChangedEvent.PreviousMessage.class,
+                        new GsonMessageChangedEventPreviousMessageFactory(failOnUnknownProperties));
 
         if (unknownPropertyDetection) {
             return builder.registerTypeAdapterFactory(new UnknownPropertyDetectionAdapterFactory()).create();

--- a/slack-app-backend/src/test/java/test_locally/sample_json_generation/EventsApiPayloadDumpTest.java
+++ b/slack-app-backend/src/test/java/test_locally/sample_json_generation/EventsApiPayloadDumpTest.java
@@ -249,7 +249,8 @@ public class EventsApiPayloadDumpTest {
         message.setAttachments(SampleObjects.Attachments);
         message.setBlocks(SampleObjects.Blocks);
         event.setMessage(message);
-        event.setPreviousMessage(message);
+        event.setPreviousMessage(new MessageChangedEvent.PreviousMessage());
+        event.getPreviousMessage().setMessage(message);
         payload.setEvent(event);
         return payload;
     }


### PR DESCRIPTION
This pull request fixes #784 by updating `MessageDeletedEvent` data structure. After this change, the setter/getter interface is not compatible with the past versions but it's inevitable because the sever-side can return dynamic & really unexpected data(=an empty array) in `previous_message` property in a specific pattern (=deleting the parent message of a thread first, and then deleting all the messages in the thread).


### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
