### PR TITLE
Do not use privileged port numbers in AuthTestMockServer

### DIFF
--- a/bolt-aws-lambda/src/test/java/util/PortProvider.java
+++ b/bolt-aws-lambda/src/test/java/util/PortProvider.java
@@ -11,6 +11,7 @@ public class PortProvider {
     private PortProvider() {
     }
 
+    private static final int MINIMUM = 1024;
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
 
@@ -21,8 +22,8 @@ public class PortProvider {
     private static int randomPort() {
         while (true) {
             int randomPort = RANDOM.nextInt(9999);
-            if (randomPort < 1000) {
-                randomPort += 1000;
+            if (randomPort < MINIMUM) {
+                randomPort += MINIMUM;
             }
             if (isAvailable(randomPort)) {
                 return randomPort;

--- a/bolt-helidon/src/test/java/util/PortProvider.java
+++ b/bolt-helidon/src/test/java/util/PortProvider.java
@@ -11,6 +11,7 @@ public class PortProvider {
     private PortProvider() {
     }
 
+    private static final int MINIMUM = 1024;
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
 
@@ -21,8 +22,8 @@ public class PortProvider {
     private static int randomPort() {
         while (true) {
             int randomPort = RANDOM.nextInt(9999);
-            if (randomPort < 1000) {
-                randomPort += 1000;
+            if (randomPort < MINIMUM) {
+                randomPort += MINIMUM;
             }
             if (isAvailable(randomPort)) {
                 return randomPort;

--- a/bolt-http4k/src/test/java/util/PortProvider.java
+++ b/bolt-http4k/src/test/java/util/PortProvider.java
@@ -11,6 +11,7 @@ public class PortProvider {
     private PortProvider() {
     }
 
+    private static final int MINIMUM = 1024;
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
 
@@ -21,8 +22,8 @@ public class PortProvider {
     private static int randomPort() {
         while (true) {
             int randomPort = RANDOM.nextInt(9999);
-            if (randomPort < 1000) {
-                randomPort += 1000;
+            if (randomPort < MINIMUM) {
+                randomPort += MINIMUM;
             }
             if (isAvailable(randomPort)) {
                 return randomPort;

--- a/bolt-ktor/src/test/kotlin/util/PortProvider.java
+++ b/bolt-ktor/src/test/kotlin/util/PortProvider.java
@@ -11,6 +11,7 @@ public class PortProvider {
     private PortProvider() {
     }
 
+    private static final int MINIMUM = 1024;
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
 
@@ -21,8 +22,8 @@ public class PortProvider {
     private static int randomPort() {
         while (true) {
             int randomPort = RANDOM.nextInt(9999);
-            if (randomPort < 1000) {
-                randomPort += 1000;
+            if (randomPort < MINIMUM) {
+                randomPort += MINIMUM;
             }
             if (isAvailable(randomPort)) {
                 return randomPort;

--- a/bolt-micronaut/src/test/java/util/PortProvider.java
+++ b/bolt-micronaut/src/test/java/util/PortProvider.java
@@ -11,6 +11,7 @@ public class PortProvider {
     private PortProvider() {
     }
 
+    private static final int MINIMUM = 1024;
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
 
@@ -21,8 +22,8 @@ public class PortProvider {
     private static int randomPort() {
         while (true) {
             int randomPort = RANDOM.nextInt(9999);
-            if (randomPort < 1000) {
-                randomPort += 1000;
+            if (randomPort < MINIMUM) {
+                randomPort += MINIMUM;
             }
             if (isAvailable(randomPort)) {
                 return randomPort;

--- a/bolt-socket-mode/src/test/java/util/PortProvider.java
+++ b/bolt-socket-mode/src/test/java/util/PortProvider.java
@@ -11,6 +11,7 @@ public class PortProvider {
     private PortProvider() {
     }
 
+    private static final int MINIMUM = 1024;
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
 
@@ -21,8 +22,8 @@ public class PortProvider {
     private static int randomPort() {
         while (true) {
             int randomPort = RANDOM.nextInt(9999);
-            if (randomPort < 1000) {
-                randomPort += 1000;
+            if (randomPort < MINIMUM) {
+                randomPort += MINIMUM;
             }
             if (isAvailable(randomPort)) {
                 return randomPort;

--- a/bolt/src/test/java/util/PortProvider.java
+++ b/bolt/src/test/java/util/PortProvider.java
@@ -11,6 +11,7 @@ public class PortProvider {
     private PortProvider() {
     }
 
+    private static final int MINIMUM = 1024;
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
 
@@ -21,8 +22,8 @@ public class PortProvider {
     private static int randomPort() {
         while (true) {
             int randomPort = RANDOM.nextInt(9999);
-            if (randomPort < 1000) {
-                randomPort += 1000;
+            if (randomPort < MINIMUM) {
+                randomPort += MINIMUM;
             }
             if (isAvailable(randomPort)) {
                 return randomPort;

--- a/slack-api-client/src/test/java/util/PortProvider.java
+++ b/slack-api-client/src/test/java/util/PortProvider.java
@@ -11,6 +11,7 @@ public class PortProvider {
     private PortProvider() {
     }
 
+    private static final int MINIMUM = 1024;
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
 
@@ -21,8 +22,8 @@ public class PortProvider {
     private static int randomPort() {
         while (true) {
             int randomPort = RANDOM.nextInt(9999);
-            if (randomPort < 1000) {
-                randomPort += 1000;
+            if (randomPort < MINIMUM) {
+                randomPort += MINIMUM;
             }
             if (isAvailable(randomPort)) {
                 return randomPort;

--- a/slack-app-backend/src/test/java/util/PortProvider.java
+++ b/slack-app-backend/src/test/java/util/PortProvider.java
@@ -11,6 +11,7 @@ public class PortProvider {
     private PortProvider() {
     }
 
+    private static final int MINIMUM = 1024;
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final ConcurrentMap<String, Integer> PORTS = new ConcurrentHashMap<>();
 
@@ -21,8 +22,8 @@ public class PortProvider {
     private static int randomPort() {
         while (true) {
             int randomPort = RANDOM.nextInt(9999);
-            if (randomPort < 1000) {
-                randomPort += 1000;
+            if (randomPort < MINIMUM) {
+                randomPort += MINIMUM;
             }
             if (isAvailable(randomPort)) {
                 return randomPort;


### PR DESCRIPTION
Do not try to bind to a privileged port number (less than 1024) when creating test servers. This PR is an attempt at mitigating #757 .

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
