### PR TITLE
Fix #759 by adding common fields in Block Kit model interfaces

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/model/block/ContextBlockElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/ContextBlockElement.java
@@ -13,4 +13,7 @@ import com.slack.api.model.block.element.ImageElement;
  * Block's elements</a>
  */
 public interface ContextBlockElement {
+
+    String getType();
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/LayoutBlock.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/LayoutBlock.java
@@ -16,4 +16,10 @@ public interface LayoutBlock {
      * and image.
      */
     String getType();
+
+    /**
+     * Returns the block_id string; the value can be null if the object is manually crafted.
+     */
+    String getBlockId();
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/composition/TextObject.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/composition/TextObject.java
@@ -6,4 +6,7 @@ import com.slack.api.model.block.ContextBlockElement;
  * https://api.slack.com/reference/messaging/composition-objects#text
  */
 public abstract class TextObject implements ContextBlockElement {
+
+    public abstract String getText();
+
 }


### PR DESCRIPTION
This pull request fixes #759 Refer to the issue for learning the purpose and use cases. All the suggestions in the issue are reasonable. Also, they are fully backward compatible.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
