### PR TITLE
Fix #802 Add files.upload integration tests using private channels

### DIFF
--- a/json-logs/samples/api/files.info.json
+++ b/json-logs/samples/api/files.info.json
@@ -59,13 +59,41 @@
             "share_user_id": "U00000000"
           }
         ]
+      },
+      "private": {
+        "C00000000": [
+          {
+            "reply_users": [
+              ""
+            ],
+            "reply_users_count": 12345,
+            "reply_count": 12345,
+            "ts": "0000000000.000000",
+            "channel_name": "",
+            "team_id": "T00000000",
+            "share_user_id": "U00000000"
+          }
+        ],
+        "C00000001": [
+          {
+            "reply_users": [
+              ""
+            ],
+            "reply_users_count": 12345,
+            "reply_count": 12345,
+            "ts": "0000000000.000000",
+            "channel_name": "",
+            "team_id": "T00000000",
+            "share_user_id": "U00000000"
+          }
+        ]
       }
     },
     "channels": [
       "C00000000"
     ],
     "groups": [
-      ""
+      "C00000000"
     ],
     "ims": [
       ""

--- a/json-logs/samples/api/files.upload.json
+++ b/json-logs/samples/api/files.upload.json
@@ -63,13 +63,41 @@
             "latest_reply": "0000000000.000000"
           }
         ]
+      },
+      "private": {
+        "C00000000": [
+          {
+            "reply_users": [
+              ""
+            ],
+            "reply_users_count": 12345,
+            "reply_count": 12345,
+            "ts": "0000000000.000000",
+            "channel_name": "",
+            "team_id": "T00000000",
+            "share_user_id": "U00000000"
+          }
+        ],
+        "C00000001": [
+          {
+            "reply_users": [
+              ""
+            ],
+            "reply_users_count": 12345,
+            "reply_count": 12345,
+            "ts": "0000000000.000000",
+            "channel_name": "",
+            "team_id": "T00000000",
+            "share_user_id": "U00000000"
+          }
+        ]
       }
     },
     "channels": [
       "C00000000"
     ],
     "groups": [
-      ""
+      "C00000000"
     ],
     "ims": [
       ""


### PR DESCRIPTION
This pull request fixes #802 by adding some integration tests and generating JSON data.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
