### PR TITLE
Improve the error caused in the #792 scenario

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/Slack.java
+++ b/slack-api-client/src/main/java/com/slack/api/Slack.java
@@ -173,7 +173,7 @@ public class Slack implements AutoCloseable {
         } catch (SlackApiException e) {
             String message = "Failed to connect to the Socket Mode API endpoint. (" +
                     "status: " + e.getResponse().code() + ", " +
-                    "error: " + e.getError().getError() +
+                    "error: " + (e.getError() != null ? e.getError().getError() : "") +
                     ")";
             throw new IOException(message, e);
         }

--- a/slack-api-client/src/main/java/com/slack/api/util/http/ProxyUrlUtil.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/ProxyUrlUtil.java
@@ -48,14 +48,14 @@ public class ProxyUrlUtil {
                     .username(userAndPassword[0])
                     .password(userAndPassword[1])
                     .host(hostAndPort[0])
-                    .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1]) : 80)
+                    .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1].replace("/", "")) : 80)
                     .build();
         } else {
             String[] hostAndPort = proxyUrl.split("://")[1].split(":");
             return ProxyUrl.builder()
                     .schema(schema)
                     .host(hostAndPort[0])
-                    .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1]) : 80)
+                    .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1].replace("/", "")) : 80)
                     .build();
         }
     }

--- a/slack-api-client/src/test/java/test_locally/api/socket_mode/SocketModeClientTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/socket_mode/SocketModeClientTest.java
@@ -68,11 +68,16 @@ public class SocketModeClientTest {
         try (SocketModeClient client = slack.socketMode(VALID_APP_TOKEN)) {
             AtomicBoolean received = new AtomicBoolean(false);
             client.addWebSocketMessageListener(helloListener(received));
-            client.addWebSocketErrorListener(error -> {});
-            client.addWebSocketCloseListener((code, reason) -> {});
-            client.addEventsApiEnvelopeListener(envelope -> {});
-            client.addInteractiveEnvelopeListener(envelope -> {});
-            client.addSlashCommandsEnvelopeListener(envelope -> {});
+            client.addWebSocketErrorListener(error -> {
+            });
+            client.addWebSocketCloseListener((code, reason) -> {
+            });
+            client.addEventsApiEnvelopeListener(envelope -> {
+            });
+            client.addInteractiveEnvelopeListener(envelope -> {
+            });
+            client.addSlashCommandsEnvelopeListener(envelope -> {
+            });
 
             client.connect();
             Thread.sleep(500L);
@@ -146,15 +151,6 @@ public class SocketModeClientTest {
     // JavaWebSocket implementation
     // -------------------------------------------------
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void proxyAuth() throws Exception {
-        SlackConfig config = new SlackConfig();
-        config.setMethodsEndpointUrlPrefix(webApiServer.getMethodsEndpointPrefix());
-        config.setProxyUrl("http://user:pass@localhost:9000/");
-        Slack slack = Slack.getInstance(config);
-        slack.socketMode(VALID_APP_TOKEN, SocketModeClient.Backend.JavaWebSocket);
-    }
-
     @Test
     public void attributes_JavaWebSocket() throws Exception {
         try (SocketModeClient client = slack.socketMode(VALID_APP_TOKEN, SocketModeClient.Backend.JavaWebSocket)) {
@@ -172,11 +168,16 @@ public class SocketModeClientTest {
         try (SocketModeClient client = slack.socketMode(VALID_APP_TOKEN, SocketModeClient.Backend.JavaWebSocket)) {
             AtomicBoolean received = new AtomicBoolean(false);
             client.addWebSocketMessageListener(helloListener(received));
-            client.addWebSocketErrorListener(error -> {});
-            client.addWebSocketCloseListener((code, reason) -> {});
-            client.addEventsApiEnvelopeListener(envelope -> {});
-            client.addInteractiveEnvelopeListener(envelope -> {});
-            client.addSlashCommandsEnvelopeListener(envelope -> {});
+            client.addWebSocketErrorListener(error -> {
+            });
+            client.addWebSocketCloseListener((code, reason) -> {
+            });
+            client.addEventsApiEnvelopeListener(envelope -> {
+            });
+            client.addInteractiveEnvelopeListener(envelope -> {
+            });
+            client.addSlashCommandsEnvelopeListener(envelope -> {
+            });
 
             client.connect();
             Thread.sleep(500L);

--- a/slack-api-client/src/test/java/test_locally/api/socket_mode/SocketModeClientTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/socket_mode/SocketModeClientTest.java
@@ -146,6 +146,15 @@ public class SocketModeClientTest {
     // JavaWebSocket implementation
     // -------------------------------------------------
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void proxyAuth() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix(webApiServer.getMethodsEndpointPrefix());
+        config.setProxyUrl("http://user:pass@localhost:9000/");
+        Slack slack = Slack.getInstance(config);
+        slack.socketMode(VALID_APP_TOKEN, SocketModeClient.Backend.JavaWebSocket);
+    }
+
     @Test
     public void attributes_JavaWebSocket() throws Exception {
         try (SocketModeClient client = slack.socketMode(VALID_APP_TOKEN, SocketModeClient.Backend.JavaWebSocket)) {

--- a/slack-api-client/src/test/java/test_locally/api/socket_mode/SocketModeClient_Proxies_Test.java
+++ b/slack-api-client/src/test/java/test_locally/api/socket_mode/SocketModeClient_Proxies_Test.java
@@ -1,0 +1,108 @@
+package test_locally.api.socket_mode;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.socket_mode.SocketModeClient;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Credentials;
+import org.eclipse.jetty.proxy.ConnectHandler;
+import org.eclipse.jetty.proxy.ProxyServlet;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import test_with_remote_apis.AuthProxyHeadersTest;
+import util.PortProvider;
+import util.socket_mode.MockWebApiServer;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+public class SocketModeClient_Proxies_Test {
+
+    static final String VALID_APP_TOKEN = "xapp-valid-123123123123123123123123123123123123";
+
+    MockWebApiServer webApiServer = new MockWebApiServer();
+    SlackConfig config = new SlackConfig();
+
+    static Server proxyServer = new Server();
+    static ServerConnector proxyServerConnector = new ServerConnector(proxyServer);
+    static Integer proxyServerPort;
+
+    AtomicInteger proxyCallCount = new AtomicInteger(0);
+
+    @Before
+    public void setUp() throws Exception {
+        webApiServer.start();
+        config.setMethodsEndpointUrlPrefix(webApiServer.getMethodsEndpointPrefix());
+
+        // https://github.com/eclipse/jetty.project/blob/jetty-9.2.30.v20200428/examples/embedded/src/main/java/org/eclipse/jetty/embedded/ProxyServer.java
+        proxyServerPort = PortProvider.getPort(AuthProxyHeadersTest.class.getName());
+        proxyServerConnector.setPort(proxyServerPort);
+        proxyServer.addConnector(proxyServerConnector);
+        ConnectHandler proxy = new ConnectHandler() {
+            @Override
+            public void handle(String target, Request br, HttpServletRequest request, HttpServletResponse res)
+                    throws ServletException, IOException {
+                log.info("Proxy server handles a new connection (target: {})", target);
+                super.handle(target, br, request, res);
+                if (res.getStatus() != 407) {
+                    proxyCallCount.incrementAndGet();
+                }
+            }
+
+            @Override
+            protected boolean handleAuthentication(HttpServletRequest request, HttpServletResponse response, String address) {
+                for (String name : Collections.list(request.getHeaderNames())) {
+                    log.info("{}: {}", name, request.getHeader(name));
+                    if (name.toLowerCase(Locale.ENGLISH).equals("proxy-authorization")) {
+                        return request.getHeader(name).equals("Basic bXktdXNlcm5hbWU6bXktcGFzc3dvcmQ=");
+                    }
+                }
+                return false;
+            }
+        };
+        proxyServer.setHandler(proxy);
+        ServletContextHandler context = new ServletContextHandler(proxy, "/", ServletContextHandler.SESSIONS);
+        ServletHolder proxyServlet = new ServletHolder(ProxyServlet.class);
+        context.addServlet(proxyServlet, "/*");
+        proxyServer.start();
+
+        config.setProxyUrl("http://127.0.0.1:" + proxyServerPort);
+
+        Map<String, String> proxyHeaders = new HashMap<>();
+        String username = "my-username";
+        String password = "my-password";
+        proxyHeaders.put("Proxy-Authorization", Credentials.basic(username, password));
+        config.setProxyHeaders(proxyHeaders);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        webApiServer.stop();
+
+        proxyServer.removeConnector(proxyServerConnector);
+        proxyServer.stop();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void proxyAuth() throws Exception {
+        SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix(webApiServer.getMethodsEndpointPrefix());
+        config.setProxyUrl("http://my-username:my-password@localhost:" + proxyServerPort + "/");
+        Slack slack = Slack.getInstance(config);
+        slack.socketMode(VALID_APP_TOKEN, SocketModeClient.Backend.JavaWebSocket);
+    }
+}


### PR DESCRIPTION
This pull request improves the developer experience in the scenario described in #792 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
