### PR TITLE
Fix #784 by adding the gson adapter

### DIFF
--- a/bolt-socket-mode/src/test/java/samples/SimpleApp.java
+++ b/bolt-socket-mode/src/test/java/samples/SimpleApp.java
@@ -4,6 +4,8 @@ import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.socket_mode.SocketModeApp;
 import com.slack.api.model.event.AppMentionEvent;
+import com.slack.api.model.event.MessageChangedEvent;
+import com.slack.api.model.event.MessageDeletedEvent;
 import com.slack.api.model.event.MessageEvent;
 import config.Constants;
 
@@ -41,6 +43,9 @@ public class SimpleApp {
             );
             return ctx.ack();
         });
+
+        app.event(MessageChangedEvent.class, (req, ctx) -> ctx.ack());
+        app.event(MessageDeletedEvent.class, (req, ctx) -> ctx.ack());
 
         app.globalShortcut("socket-mode-global-shortcut", (req, ctx) -> {
             ctx.asyncClient().viewsOpen(r -> r

--- a/slack-api-client/src/main/java/com/slack/api/util/json/GsonFactory.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/json/GsonFactory.java
@@ -33,6 +33,7 @@ public class GsonFactory {
                 .registerTypeAdapter(RichTextElement.class, new GsonRichTextElementFactory())
                 .registerTypeAdapter(LogsResponse.DetailsChangedValue.class, new GsonAuditLogsDetailsChangedValueFactory())
                 .registerTypeAdapter(Attachment.VideoHtml.class, new GsonMessageAttachmentVideoHtmlFactory())
+                .registerTypeAdapter(MessageChangedEvent.PreviousMessage.class, new GsonMessageChangedEventPreviousMessageFactory())
                 .create();
     }
 


### PR DESCRIPTION
This pull request re-fixes #784 by updating the GsonFactory properly. #791 was an incomplete solution for this issue.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
