### PR TITLE
Update link_shared event payload for the changes starting on September 1

### DIFF
--- a/json-logs/samples/events/LinkSharedPayload.json
+++ b/json-logs/samples/events/LinkSharedPayload.json
@@ -27,6 +27,8 @@
       }
     ],
     "is_bot_user_member": false,
+    "unfurl_id": "",
+    "source": "",
     "event_ts": ""
   }
 }

--- a/json-logs/samples/rtm/LinkSharedEvent.json
+++ b/json-logs/samples/rtm/LinkSharedEvent.json
@@ -11,5 +11,7 @@
     }
   ],
   "is_bot_user_member": false,
+  "unfurl_id": "",
+  "source": "",
   "event_ts": ""
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -1198,6 +1198,7 @@ public class RequestFormBuilder {
         setIfNotNull("user_auth_message", req.getUserAuthMessage(), form);
         setIfNotNull("user_auth_blocks", req.getUserAuthBlocks(), form);
         setIfNotNull("user_auth_url", req.getUserAuthUrl(), form);
+        setIfNotNull("unfurl_id", req.getUnfurlId(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
@@ -62,6 +62,8 @@ public class ChatUnfurlRequest implements SlackApiRequest {
      */
     private String channel;
 
+    // https://api.slack.com/changelog/2021-08-changes-to-unfurls
+    private String unfurlId;
 
     // https://api.slack.com/docs/message-link-unfurling#unfurls_parameter
     @Data

--- a/slack-api-model/src/main/java/com/slack/api/model/event/LinkSharedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/LinkSharedEvent.java
@@ -16,13 +16,19 @@ public class LinkSharedEvent implements Event {
     public static final String TYPE_NAME = "link_shared";
 
     private final String type = TYPE_NAME;
-    private String channel;
+    private String channel; // This can be "COMPOSER"
     private String user;
     private String messageTs;
     private String threadTs;
     private List<Link> links;
     @SerializedName("is_bot_user_member")
     private boolean botUserMember;
+
+    // https://api.slack.com/changelog/2021-08-changes-to-unfurls
+    private String unfurlId;
+    // https://api.slack.com/changelog/2021-08-changes-to-unfurls
+    private String source; // "composer"
+
     private String eventTs;
 
     @Data

--- a/slack-api-model/src/main/java/com/slack/api/model/event/LinkSharedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/LinkSharedEvent.java
@@ -27,7 +27,7 @@ public class LinkSharedEvent implements Event {
     // https://api.slack.com/changelog/2021-08-changes-to-unfurls
     private String unfurlId;
     // https://api.slack.com/changelog/2021-08-changes-to-unfurls
-    private String source; // "composer"
+    private String source; // "composer" / "conversations_history"
 
     private String eventTs;
 

--- a/slack-api-model/src/test/java/test_locally/api/model/event/LinkSharedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/LinkSharedEventTest.java
@@ -56,4 +56,34 @@ public class LinkSharedEventTest {
         assertThat(generatedJson, is(expectedJson));
     }
 
+    @Test
+    public void newUnfurls_2021_08() {
+        // https://api.slack.com/changelog/2021-08-changes-to-unfurls
+        String json = "{\n" +
+                "    \"type\": \"link_shared\",\n" +
+                "    \"channel\": \"COMPOSER\",\n" +
+                "    \"is_bot_user_member\": true,\n" +
+                "    \"user\": \"Uxxxxxxx\",\n" +
+                "    \"message_ts\": \"Uxxxxxxx-909b5454-75f8-4ac4-b325-1b40e230bbd8-gryl3kb80b3wm49ihzoo35fyqoq08n2y\",\n" +
+                "    \"unfurl_id\": \"Uxxxxxxx-909b5454-75f8-4ac4-b325-1b40e230bbd8-gryl3kb80b3wm49ihzoo35fyqoq08n2y\",\n" +
+                "    \"source\": \"composer\",\n" +
+                "    \"links\": [\n" +
+                "        {\n" +
+                "            \"domain\": \"example.com\",\n" +
+                "            \"url\": \"https://example.com/12345\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "            \"domain\": \"example.com\",\n" +
+                "            \"url\": \"https://example.com/67890\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "            \"domain\": \"another-example.com\",\n" +
+                "            \"url\": \"https://yet.another-example.com/v/abcde\"\n" +
+                "        }\n" +
+                "    ]\n" +
+                "}\n";
+        LinkSharedEvent event = GsonFactory.createSnakeCase().fromJson(json, LinkSharedEvent.class);
+        assertThat(event.getType(), is("link_shared"));
+    }
+
 }


### PR DESCRIPTION
This pull request updates link_shared event data class to support the new fields that are available since September 1. Refer to the changelog for more details: https://api.slack.com/changelog/2021-08-changes-to-unfurls

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
