### PR TITLE
Fix #769 A new option to auto-acknowledge Events API requests

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -1067,6 +1067,20 @@ public class App {
                         EventsApiPayload<Event> payload = buildEventPayload(request);
                         return handler.apply(payload, request.getContext());
                     }
+                    if (config().isAllEventsApiAutoAckEnabled()) {
+                        // If the flag is true, Bolt acknowledges all the events anyway
+                        // This behavior is compatible with bolt-js.
+                        log.debug("{} is auto-acknowledged as AppConfig#isAllEventsApiAutoAckEnabled() is true",
+                                request.getEventTypeAndSubtype());
+                        return request.getContext().ack();
+                    }
+                    boolean isSubtypedMessageEvents = request.getEventTypeAndSubtype() != null
+                            && request.getEventTypeAndSubtype().startsWith(MessageEvent.TYPE_NAME + ":");
+                    if (config().isSubtypedMessageEventsAutoAckEnabled() && isSubtypedMessageEvents) {
+                        log.debug("{} is auto-acknowledged as AppConfig#isSubtypedMessageEventsAutoAckEnabled() is true",
+                                request.getEventTypeAndSubtype());
+                        return request.getContext().ack();
+                    }
                     log.warn("No BoltEventHandler registered for event: {}\n{}",
                             request.getEventTypeAndSubtype(), ListenerCodeSuggestion.event(request.getEventTypeAndSubtype()));
                     break;

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -352,6 +352,20 @@ public class AppConfig {
     @Builder.Default
     private boolean appInitializersEnabled = true;
 
+    /**
+     * Automatically acknowledge message events that have subtype if true.
+     * Find the list of available subtypes at https://api.slack.com/events/message
+     */
+    @Builder.Default
+    private boolean subtypedMessageEventsAutoAckEnabled = false;
+
+    /**
+     * Automatically acknowledge all Event API events if true.
+     * This behavior is compatible with bolt-js.
+     */
+    @Builder.Default
+    private boolean allEventsApiAutoAckEnabled = false;
+
     // ---------------------------------
     // Default middleware configuration
     // ---------------------------------


### PR DESCRIPTION
This pull request resolves #769 by adding the following new two options.

* `AppConfig#allEventsApiAutoAckEnabled: Boolean`: If true, Bolt enables auto-acknowledging for all Events API requests even when corresponding listeners are missing.
* `AppConfig#subtypedMessageEventsAutoAckEnabled: Boolean`: If true, Bolt enables auto-acknowledging for message + subtype Events API requests even when corresponding listeners are missing.

```java
AppConfig config = new AppConfig();
// config.setAllEventsApiAutoAckEnabled(true);
// config.setSubtypedMessageEventsAutoAckEnabled(true);
App app = new App(config);
app.start();
```

As the test code shows, registered listeners are used even if these options are true.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
