### PR TITLE
Fix #828 Add stateValidationEnabled option to AppConfig

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -351,7 +351,7 @@ public class App {
         if (config.getClientId() == null
                 // OpenID Connect does not use require the bot scopes
                 || (!config.isOpenIDConnectEnabled() && config.getScope() == null)
-                || state == null) {
+                || (config.isStateValidationEnabled() && state == null)) {
             return null;
         }
 
@@ -996,7 +996,8 @@ public class App {
                         try {
                             Map<String, List<String>> responseHeaders = new HashMap<>();
                             Response response = Response.builder().statusCode(200).headers(responseHeaders).build();
-                            String state = oAuthStateService.issueNewState(slackRequest, response);
+                            String state = config().isStateValidationEnabled() ?
+                                    oAuthStateService.issueNewState(slackRequest, response) : "";
                             String nonce = openIDConnectNonceService.issueNewNonce(slackRequest, response);
                             String authorizeUrl = buildAuthorizeUrl(state, nonce);
                             if (authorizeUrl == null) {

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -339,6 +339,14 @@ public class AppConfig {
 
     // --------------------------
 
+    /**
+     * Enables the state parameter in the OAuth flow. Enabling the validation is highly recommended
+     * for better security in general. The only exception is to support the use case where Enterprise Grid
+     * Org admins install apps from app management page.
+     */
+    @Builder.Default
+    private boolean stateValidationEnabled = true;
+
     @Builder.Default
     private String oauthCancellationUrl = Optional.ofNullable(System.getenv(EnvVariableName.SLACK_OAUTH_CANCELLATION_URL))
             .orElse(System.getenv(EnvVariableName.SLACK_APP_OAUTH_CANCELLATION_URL));

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -340,9 +340,9 @@ public class AppConfig {
     // --------------------------
 
     /**
-     * Enables the state parameter in the OAuth flow. Enabling the validation is highly recommended
-     * for better security in general. The only exception is to support the use case where Enterprise Grid
-     * Org admins install apps from app management page.
+     * Enables validation of the state parameter in the OAuth flow.
+     * It is highly recommended to enable this validation for better security.
+     * A valid exception is when Enterprise Grid Org admins install apps from the app management page.
      */
     @Builder.Default
     private boolean stateValidationEnabled = true;

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/DefaultOAuthCallbackService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/DefaultOAuthCallbackService.java
@@ -95,11 +95,13 @@ public class DefaultOAuthCallbackService implements OAuthCallbackService {
             if (payload.getError() != null) {
                 return errorHandler.handle(request, response);
             }
-            if (stateService.isValid(request)) {
+            if (!config.isStateValidationEnabled() || stateService.isValid(request)) {
                 if (config.isClassicAppPermissionsEnabled()) {
                     OAuthAccessResponse oauthAccess = operator.callOAuthAccessMethod(payload);
                     if (oauthAccess.isOk()) {
-                        stateService.consume(request, response);
+                        if (config.isStateValidationEnabled()) {
+                            stateService.consume(request, response);
+                        }
                         return successHandler.handle(request, response, oauthAccess);
                     } else {
                         return accessErrorHandler.handle(request, response, oauthAccess);
@@ -107,7 +109,9 @@ public class DefaultOAuthCallbackService implements OAuthCallbackService {
                 } else if (config.isOpenIDConnectEnabled()) {
                     OpenIDConnectTokenResponse token = operator.callOpenIDConnectToken(payload);
                     if (token.isOk()) {
-                        stateService.consume(request, response);
+                        if (config.isStateValidationEnabled()) {
+                            stateService.consume(request, response);
+                        }
                         return openIDConnectSuccessHandler.handle(request, response, token);
                     } else {
                         return openIDConnectErrorHandler.handle(request, response, token);
@@ -115,7 +119,9 @@ public class DefaultOAuthCallbackService implements OAuthCallbackService {
                 } else {
                     OAuthV2AccessResponse oauthAccess = operator.callOAuthV2AccessMethod(payload);
                     if (oauthAccess.isOk()) {
-                        stateService.consume(request, response);
+                        if (config.isStateValidationEnabled()) {
+                            stateService.consume(request, response);
+                        }
                         return successV2Handler.handle(request, response, oauthAccess);
                     } else {
                         return accessV2ErrorHandler.handle(request, response, oauthAccess);

--- a/bolt/src/test/java/test_locally/app/OAuthStartTest.java
+++ b/bolt/src/test/java/test_locally/app/OAuthStartTest.java
@@ -52,4 +52,34 @@ public class OAuthStartTest {
                 "</body>\n" +
                 "</html>", response.getBody());
     }
+
+    @Test
+    public void start_state_validation_disabled() throws Exception {
+        App app = new App(AppConfig.builder()
+                .signingSecret("secret")
+                .clientId("111.222")
+                .clientSecret("secret")
+                .scope("commands,chat:write")
+                .stateValidationEnabled(false)
+                .build());
+        OAuthStartRequest req = new OAuthStartRequest(null, new RequestHeaders(Collections.emptyMap()));
+        Response response = app.run(req);
+        assertEquals(200L, response.getStatusCode().longValue());
+        assertEquals("text/html; charset=utf-8", response.getContentType());
+        assertEquals("<html>\n" +
+                "<head>\n" +
+                "<style>\n" +
+                "body {\n" +
+                "  padding: 10px 15px;\n" +
+                "  font-family: verdana;\n" +
+                "  text-align: center;\n" +
+                "}\n" +
+                "</style>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<h2>Slack App Installation</h2>\n" +
+                "<p><a href=\"https://slack.com/oauth/v2/authorize?client_id=111.222&scope=commands,chat:write&user_scope=&state=\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
+                "</body>\n" +
+                "</html>", response.getBody());
+    }
 }


### PR DESCRIPTION
This pull request resolves #828. Refer to the issue for details.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
