### PR TITLE
Remove cached slack, client in App to reflect changes in AppConfig

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -70,12 +70,16 @@ public class App {
     /**
      * Slack instance and its configurations to be used for API calls.
      */
-    private final Slack slack;
+    public Slack getSlack() {
+        return config().getSlack();
+    }
 
     /**
      * The default Web API client without any tokens.
      */
-    private final MethodsClient client;
+    public MethodsClient getClient() {
+        return config().getSlack().methods();
+    }
 
     /**
      * The built-in handy way to run operations asynchronously. It's totally fine to use your own one instead.
@@ -441,8 +445,6 @@ public class App {
 
     public App(AppConfig appConfig, Slack slack, List<Middleware> middlewareList) {
         this.appConfig = appConfig;
-        this.slack = slack;
-        this.client = this.slack.methods();
         this.executorService = ExecutorServiceFactory.createDaemonThreadPoolExecutor(
                 "bolt-app-threads",
                 this.appConfig.getThreadPoolSize());
@@ -482,11 +484,11 @@ public class App {
     }
 
     public Slack slack() {
-        return this.slack;
+        return getSlack();
     }
 
     public MethodsClient client() {
-        return this.client;
+        return getClient();
     }
 
     /**
@@ -560,7 +562,7 @@ public class App {
         if (request == null || request.getContext() == null) {
             return Response.builder().statusCode(400).body("Invalid Request").build();
         }
-        request.getContext().setSlack(this.slack); // use the properly configured API client
+        request.getContext().setSlack(slack()); // use the properly configured API client
 
         if (neverStarted.get()) {
             start();

--- a/bolt/src/test/java/test_locally/AppTest.java
+++ b/bolt/src/test/java/test_locally/AppTest.java
@@ -232,4 +232,22 @@ public class AppTest {
         });
     }
 
+    @Test
+    public void clientConfig() {
+        SlackConfig slackConfig = new SlackConfig();
+        slackConfig.setMethodsEndpointUrlPrefix("http://localhost:8080/old");
+        Slack slack = Slack.getInstance(slackConfig);
+        AppConfig appConfig = AppConfig.builder().slack(slack).build();
+        App app = new App(appConfig);
+
+        assertThat(app.slack().getConfig().getMethodsEndpointUrlPrefix(),
+                is("http://localhost:8080/old"));
+
+        slackConfig.setMethodsEndpointUrlPrefix("http://localhost:8080/new");
+        Slack newSlack = Slack.getInstance(slackConfig);
+        appConfig.setSlack(newSlack);
+        assertThat(app.slack().getConfig().getMethodsEndpointUrlPrefix(),
+                is("http://localhost:8080/new"));
+    }
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/TeamIdCache.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/TeamIdCache.java
@@ -40,7 +40,7 @@ public class TeamIdCache {
                     // for org admin user's token, this value can be an enterprise_id
                     return authTest.getTeamId();
                 } else {
-                    String error = authTest != null ? authTest.getError() : "";
+                    String error = authTest != null ? authTest.getError() : "(empty response)";
                     log.error("Got an unsuccessful response from auth.test API (error: {})", error);
                 }
             } catch (IOException | SlackApiException e) {

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/TeamIdCache.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/TeamIdCache.java
@@ -32,7 +32,7 @@ public class TeamIdCache {
                 FormBody.Builder form = toForm(AuthTestRequest.builder().token(newToken).build());
                 Response response = methodsImpl.runPostFormWithToken(form, Methods.AUTH_TEST, token);
                 AuthTestResponse authTest = methodsImpl.parseJsonResponseAndRunListeners(null, null, response, AuthTestResponse.class);
-                if (authTest.isOk()) {
+                if (authTest != null && authTest.isOk()) {
                     if (log.isDebugEnabled()) {
                         log.debug("Created cache for an auth.test API call (token: {}, team_id: {})",
                                 token.substring(0, 16) + "...", authTest.getTeamId());
@@ -40,7 +40,8 @@ public class TeamIdCache {
                     // for org admin user's token, this value can be an enterprise_id
                     return authTest.getTeamId();
                 } else {
-                    log.error("Got an unsuccessful response from auth.test API (error: {})", authTest.getError());
+                    String error = authTest != null ? authTest.getError() : "";
+                    log.error("Got an unsuccessful response from auth.test API (error: {})", error);
                 }
             } catch (IOException | SlackApiException e) {
                 log.error("Failed to call auth.test API (error: {})", e.getMessage(), e);


### PR DESCRIPTION
This pull request improves the internals of `App` class as below:

* `App#getSlack()` always returns a `Slack` instance with the latest configuration
* `App#getClient()` always returns a `MethodsClient` instance with the latest configuration
* Fix potential NPE error patterns

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
