### PR TITLE
Add missing end-to-end test patterns for conversations.replies

### DIFF
--- a/json-logs/samples/api/conversations.replies.json
+++ b/json-logs/samples/api/conversations.replies.json
@@ -29,7 +29,238 @@
       ],
       "subscribed": false,
       "parent_user_id": "U00000000",
-      "is_locked": false
+      "is_locked": false,
+      "blocks": [
+        {
+          "type": "",
+          "block_id": "",
+          "text": {
+            "type": "",
+            "text": "",
+            "emoji": false
+          },
+          "elements": [
+            {
+              "type": "",
+              "text": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "placeholder": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "initial_channel": "",
+              "response_url_enabled": false,
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "filter": {
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "initial_date": "",
+              "initial_time": "",
+              "initial_option": {
+                "text": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "min_query_length": 12345,
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 12345,
+              "image_height": 12345,
+              "image_bytes": 12345,
+              "initial_user": ""
+            },
+            {
+              "type": "",
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 12345,
+              "image_height": 12345,
+              "image_bytes": 12345
+            }
+          ],
+          "fallback": "",
+          "image_url": "",
+          "image_width": 12345,
+          "image_height": 12345,
+          "image_bytes": 12345,
+          "alt_text": "",
+          "title": {
+            "type": "",
+            "text": "",
+            "emoji": false
+          },
+          "fields": [
+            {
+              "type": "",
+              "text": "",
+              "emoji": false,
+              "verbatim": false
+            }
+          ],
+          "accessory": {
+            "type": "",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 12345,
+            "image_height": 12345,
+            "image_bytes": 12345
+          }
+        }
+      ],
+      "attachments": [
+        {
+          "msg_subtype": "",
+          "fallback": "",
+          "callback_id": "",
+          "color": "",
+          "pretext": "",
+          "service_url": "",
+          "service_name": "",
+          "service_icon": "",
+          "author_id": "",
+          "author_name": "",
+          "author_link": "",
+          "author_icon": "",
+          "from_url": "",
+          "original_url": "",
+          "author_subname": "",
+          "channel_id": "",
+          "channel_name": "",
+          "id": 12345,
+          "bot_id": "",
+          "indent": false,
+          "is_msg_unfurl": false,
+          "is_reply_unfurl": false,
+          "is_thread_root_unfurl": false,
+          "is_app_unfurl": false,
+          "app_unfurl_url": "",
+          "title": "",
+          "title_link": "",
+          "text": "",
+          "fields": [
+            {
+              "title": "",
+              "value": "",
+              "short": false
+            }
+          ],
+          "image_url": "",
+          "image_width": 12345,
+          "image_height": 12345,
+          "image_bytes": 12345,
+          "thumb_url": "",
+          "thumb_width": 12345,
+          "thumb_height": 12345,
+          "video_url": "",
+          "video_html": "",
+          "video_html_width": 12345,
+          "video_html_height": 12345,
+          "footer": "",
+          "footer_icon": "",
+          "ts": "",
+          "mrkdwn_in": [
+            ""
+          ],
+          "actions": [
+            {
+              "id": "",
+              "name": "",
+              "text": "",
+              "style": "",
+              "type": "",
+              "value": "",
+              "confirm": {
+                "title": "",
+                "text": "",
+                "ok_text": "",
+                "dismiss_text": ""
+              },
+              "options": [
+                {
+                  "text": "",
+                  "value": ""
+                }
+              ],
+              "selected_options": [
+                {
+                  "text": "",
+                  "value": ""
+                }
+              ],
+              "data_source": "",
+              "min_query_length": 12345,
+              "option_groups": [
+                {
+                  "text": ""
+                }
+              ],
+              "url": ""
+            }
+          ],
+          "filename": "",
+          "size": 12345,
+          "mimetype": "",
+          "url": "",
+          "metadata": {
+            "thumb_64": false,
+            "thumb_80": false,
+            "thumb_160": false,
+            "original_w": 12345,
+            "original_h": 12345,
+            "thumb_360_w": 12345,
+            "thumb_360_h": 12345,
+            "format": "",
+            "extension": "",
+            "rotation": 12345,
+            "thumb_tiny": ""
+          }
+        }
+      ]
     }
   ],
   "has_more": false,


### PR DESCRIPTION
This pull request adds more end-to-end test patterns mainly for generating normalized JSON data for node-slack-sdk. The Java SDK code does not have any issues with this scenario.

For the people that are curious about the context: 

The integration tests in this project generate normalized JSON data from actual Slack API responses and save them under the `json-logs/samples` directory. And then, the JSON data are used to generate response types in `@slack/web-api` package: https://github.com/slackapi/node-slack-sdk/tree/main/packages/web-api/src/response This pull request improves `conversations.replies` API method response data to cover `blocks` and `attachments`.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
