### PR TITLE
Fix #836 NPE in bolt-google-cloud-functions when the response body coming from Bolt app is null

### DIFF
--- a/bolt-google-cloud-functions/src/test/java/test_locally/ResponseUtilityTest.java
+++ b/bolt-google-cloud-functions/src/test/java/test_locally/ResponseUtilityTest.java
@@ -1,13 +1,73 @@
 package test_locally;
 
+import com.google.cloud.functions.HttpResponse;
 import com.slack.api.bolt.response.Response;
 import org.junit.Test;
 
+import java.io.*;
+import java.util.*;
+
 import static com.slack.api.bolt.google_cloud_functions.SlackApiFunction.buildNotNullResponseBody;
+import static com.slack.api.bolt.google_cloud_functions.SlackApiFunction.writeResponse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class ResponseUtilityTest {
+    private static HttpResponse buildNullHttpResponse() {
+        return new HttpResponse() {
+            @Override
+            public void setStatusCode(int code) {
+            }
+
+            @Override
+            public void setStatusCode(int code, String message) {
+            }
+
+            @Override
+            public void setContentType(String contentType) {
+            }
+
+            @Override
+            public Optional<String> getContentType() {
+                return Optional.empty();
+            }
+
+            @Override
+            public void appendHeader(String header, String value) {
+            }
+
+            @Override
+            public Map<String, List<String>> getHeaders() {
+                return null;
+            }
+
+            @Override
+            public OutputStream getOutputStream() throws IOException {
+                return new ByteArrayOutputStream();
+            }
+
+            @Override
+            public BufferedWriter getWriter() throws IOException {
+                return new BufferedWriter(new StringWriter());
+            }
+        };
+    }
+
+    @Test
+    public void writeResponse_null_headers() throws IOException {
+        Response response = Response.builder().statusCode(200).body(null).headers(null).build();
+        HttpResponse httpResponse = buildNullHttpResponse();
+        writeResponse(response, httpResponse);
+    }
+
+    @Test
+    public void writeResponse_non_null_values() throws IOException {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Set-Cookie", Arrays.asList("1", "2"));
+        Response response = Response.builder().statusCode(200).body("foo").headers(headers).build();
+        HttpResponse httpResponse = buildNullHttpResponse();
+        writeResponse(response, httpResponse);
+    }
 
     @Test
     public void toNotNullResponseBody_null() {

--- a/bolt-google-cloud-functions/src/test/java/test_locally/ResponseUtilityTest.java
+++ b/bolt-google-cloud-functions/src/test/java/test_locally/ResponseUtilityTest.java
@@ -1,0 +1,25 @@
+package test_locally;
+
+import com.slack.api.bolt.response.Response;
+import org.junit.Test;
+
+import static com.slack.api.bolt.google_cloud_functions.SlackApiFunction.buildNotNullResponseBody;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ResponseUtilityTest {
+
+    @Test
+    public void toNotNullResponseBody_null() {
+        Response response = Response.builder().statusCode(200).body(null).build();
+        String textBody = buildNotNullResponseBody(response);
+        assertNotNull(textBody);
+    }
+
+    @Test
+    public void toNotNullResponseBody_some_value() {
+        Response response = Response.builder().statusCode(200).body("ok").build();
+        String textBody = buildNotNullResponseBody(response);
+        assertEquals("ok", textBody);
+    }
+}


### PR DESCRIPTION
This pull request fixes #836. Refer to the issue for details.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
