### PR TITLE
Update dependencies for v1.12 release

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <helidon.version>2.3.2</helidon.version>
+        <helidon.version>[2.3,2.4)</helidon.version>
         <!-- Helidon 2.x requires Java 11+ -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.11.0.1</http4k.version>
+        <http4k.version>4.12.0.1</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>1.6.2</ktor.version>
+        <ktor.version>[1.6.3,1.7.0)</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -42,20 +42,26 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>
+
+        <!-- For these compile scope dependencies, we don't use ranges of versions -->
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <okhttp.version>4.9.1</okhttp.version>
         <gson.version>2.8.8</gson.version>
+        <kotlin.version>1.5.30</kotlin.version>
+        <slf4j.version>1.7.32</slf4j.version>
         <lombok.version>1.18.20</lombok.version>
         <lombok-maven-plugin.version>1.18.16.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
-        <kotlin.version>1.5.30</kotlin.version>
-        <slf4j.version>1.7.32</slf4j.version>
-        <aws.s3.version>1.12.55</aws.s3.version>
+
+        <!-- optional / testing-only dependencies -->
+        <aws.s3.version>[1.12.62,1.13.0)</aws.s3.version>
         <junit.version>4.13.2</junit.version>
-        <hamcrest.version>1.3</hamcrest.version>
         <logback.version>1.2.5</logback.version>
-        <mockito-core.version>3.12.4</mockito-core.version>
+        <hamcrest.version>[1.3,2.0)</hamcrest.version>
+        <mockito-core.version>[3.12.4,3.13.0)</mockito-core.version>
+        <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>
+
+        <!-- Maven plugins: range versioning does not work -->
         <duplicate-finder-maven-plugin.version>1.3.0</duplicate-finder-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -70,6 +76,19 @@
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <dokka.version>1.4.32</dokka.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>http://repo1.maven.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <repositories>
         <repository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
This pull request upgrades patch / minor versions of optional / testing dependencies in v1.12 release.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
