### PR TITLE
Add getHttpResponseHeaders() method to Web API responses

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiErrorResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiErrorResponse.java
@@ -2,6 +2,9 @@ package com.slack.api.methods;
 
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class SlackApiErrorResponse implements SlackApiTextResponse {
 
@@ -10,4 +13,5 @@ public class SlackApiErrorResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiResponse.java
@@ -1,4 +1,17 @@
 package com.slack.api.methods;
 
+import java.util.List;
+import java.util.Map;
+
 public interface SlackApiResponse {
+
+    /**
+     * Returns all the HTTP response headers in the API response. The keys are lower-cased.
+     */
+    Map<String, List<String>> getHttpResponseHeaders();
+
+    /**
+     * Sets the response headers. Pass a Map object with lower-cased keys.
+     */
+    void setHttpResponseHeaders(Map<String, List<String>> headers);
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/analytics/AdminAnalyticsGetFileResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/analytics/AdminAnalyticsGetFileResponse.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.*;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.zip.GZIPInputStream;
 
@@ -23,6 +24,7 @@ public class AdminAnalyticsGetFileResponse implements SlackApiBinaryResponse {
     private boolean ok;
     private String error;
     private ResponseMetadata responseMetadata;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     /**
      * This method is almost completely unlike other Web API methods you encounter.

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsApproveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsApproveResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.admin.apps;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminAppsApproveResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class AdminAppsApproveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsApprovedListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsApprovedListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.admin.ApprovedApp;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminAppsApprovedListResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class AdminAppsApprovedListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<ApprovedApp> approvedApps;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsClearResolutionResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsClearResolutionResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.admin.apps;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminAppsClearResolutionResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class AdminAppsClearResolutionResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsRequestsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsRequestsListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.admin.AppRequest;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminAppsRequestsListResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class AdminAppsRequestsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<AppRequest> appRequests;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsRestrictResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsRestrictResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.admin.apps;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminAppsRestrictResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class AdminAppsRestrictResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsRestrictedListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsRestrictedListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.admin.RestrictedApp;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminAppsRestrictedListResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class AdminAppsRestrictedListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<RestrictedApp> restrictedApps;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsUninstallResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/apps/AdminAppsUninstallResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.admin.apps;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminAppsUninstallResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class AdminAppsUninstallResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/auth/policy/AdminAuthPolicyAssignEntitiesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/auth/policy/AdminAuthPolicyAssignEntitiesResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminAuthPolicyAssignEntitiesResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminAuthPolicyAssignEntitiesResponse implements SlackApiTextRespon
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Integer entityTotalCount;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/auth/policy/AdminAuthPolicyGetEntitiesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/auth/policy/AdminAuthPolicyGetEntitiesResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminAuthPolicyGetEntitiesResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminAuthPolicyGetEntitiesResponse implements SlackApiTextResponse 
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Entity> entities;
     private Integer entityTotalCount;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/auth/policy/AdminAuthPolicyRemoveEntitiesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/auth/policy/AdminAuthPolicyRemoveEntitiesResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminAuthPolicyRemoveEntitiesResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminAuthPolicyRemoveEntitiesResponse implements SlackApiTextRespon
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Integer entityTotalCount;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/barriers/AdminBarriersCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/barriers/AdminBarriersCreateResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.ResponseMetadata;
 import com.slack.api.model.admin.InformationBarrier;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminBarriersCreateResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class AdminBarriersCreateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private InformationBarrier barrier;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/barriers/AdminBarriersDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/barriers/AdminBarriersDeleteResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminBarriersDeleteResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminBarriersDeleteResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/barriers/AdminBarriersListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/barriers/AdminBarriersListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.admin.InformationBarrier;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminBarriersListResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class AdminBarriersListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<InformationBarrier> barriers;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/barriers/AdminBarriersUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/barriers/AdminBarriersUpdateResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.ResponseMetadata;
 import com.slack.api.model.admin.InformationBarrier;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminBarriersUpdateResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class AdminBarriersUpdateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private InformationBarrier barrier;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsArchiveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsArchiveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsArchiveResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsArchiveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsConvertToPrivateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsConvertToPrivateResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsConvertToPrivateResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsConvertToPrivateResponse implements SlackApiTextR
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsCreateResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsCreateResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsCreateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String channelId;
     private ErrorResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsDeleteResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsDeleteResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsDeleteResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsDisconnectSharedResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsDisconnectSharedResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsDisconnectSharedResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsDisconnectSharedResponse implements SlackApiTextR
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsGetConversationPrefsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsGetConversationPrefsResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminConversationsGetConversationPrefsResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminConversationsGetConversationPrefsResponse implements SlackApiT
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ConversationPrefs prefs;
     private ErrorResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsGetCustomRetentionResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsGetCustomRetentionResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsGetCustomRetentionResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsGetCustomRetentionResponse implements SlackApiTex
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean isPolicyEnabled;
     private Integer durationDays;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsGetTeamsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsGetTeamsResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminConversationsGetTeamsResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminConversationsGetTeamsResponse implements SlackApiTextResponse 
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> teamIds;
     private ErrorResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsInviteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsInviteResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -14,6 +15,7 @@ public class AdminConversationsInviteResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Map<String, String> failedUserIds;
     private ErrorResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsRemoveCustomRetentionResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsRemoveCustomRetentionResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsRemoveCustomRetentionResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsRemoveCustomRetentionResponse implements SlackApi
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsRenameResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsRenameResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsRenameResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsRenameResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsSearchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsSearchResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminConversationsSearchResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminConversationsSearchResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Conversation> conversations;
     private String nextCursor;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsSetConversationPrefsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsSetConversationPrefsResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsSetConversationPrefsResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsSetConversationPrefsResponse implements SlackApiT
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsSetCustomRetentionResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsSetCustomRetentionResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsSetCustomRetentionResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsSetCustomRetentionResponse implements SlackApiTex
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsSetTeamsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsSetTeamsResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsSetTeamsResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsSetTeamsResponse implements SlackApiTextResponse 
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String channel; // channel id
     private ErrorResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsUnarchiveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsUnarchiveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsUnarchiveResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsUnarchiveResponse implements SlackApiTextResponse
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/ekm/AdminConversationsEkmListOriginalConnectedChannelInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/ekm/AdminConversationsEkmListOriginalConnectedChannelInfoResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsEkmListOriginalConnectedChannelInfoResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsEkmListOriginalConnectedChannelInfoResponse imple
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/restrict_access/AdminConversationsRestrictAccessAddGroupResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/restrict_access/AdminConversationsRestrictAccessAddGroupResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsRestrictAccessAddGroupResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsRestrictAccessAddGroupResponse implements SlackAp
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/restrict_access/AdminConversationsRestrictAccessListGroupsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/restrict_access/AdminConversationsRestrictAccessListGroupsResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminConversationsRestrictAccessListGroupsResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminConversationsRestrictAccessListGroupsResponse implements Slack
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> groupIds;
     private ErrorResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/restrict_access/AdminConversationsRestrictAccessRemoveGroupResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/restrict_access/AdminConversationsRestrictAccessRemoveGroupResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminConversationsRestrictAccessRemoveGroupResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminConversationsRestrictAccessRemoveGroupResponse implements Slac
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/whitelist/AdminConversationsWhitelistAddResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/whitelist/AdminConversationsWhitelistAddResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated
 @Data
 public class AdminConversationsWhitelistAddResponse implements SlackApiTextResponse {
@@ -13,6 +16,7 @@ public class AdminConversationsWhitelistAddResponse implements SlackApiTextRespo
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/whitelist/AdminConversationsWhitelistListGroupsLinkedToChannelResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/whitelist/AdminConversationsWhitelistListGroupsLinkedToChannelResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated
 @Data
@@ -15,6 +16,7 @@ public class AdminConversationsWhitelistListGroupsLinkedToChannelResponse implem
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> groupIds;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/whitelist/AdminConversationsWhitelistRemoveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/whitelist/AdminConversationsWhitelistRemoveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated
 @Data
 public class AdminConversationsWhitelistRemoveResponse implements SlackApiTextResponse {
@@ -13,6 +16,7 @@ public class AdminConversationsWhitelistRemoveResponse implements SlackApiTextRe
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/emoji/AdminEmojiAddAliasResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/emoji/AdminEmojiAddAliasResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminEmojiAddAliasResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminEmojiAddAliasResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/emoji/AdminEmojiAddResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/emoji/AdminEmojiAddResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminEmojiAddResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminEmojiAddResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/emoji/AdminEmojiListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/emoji/AdminEmojiListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import com.slack.api.model.admin.Emoji;
 import lombok.Data;
 
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -15,6 +16,7 @@ public class AdminEmojiListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Map<String, Emoji> emoji;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/emoji/AdminEmojiRemoveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/emoji/AdminEmojiRemoveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminEmojiRemoveResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminEmojiRemoveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/emoji/AdminEmojiRenameResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/emoji/AdminEmojiRenameResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminEmojiRenameResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminEmojiRenameResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsApproveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsApproveResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.admin.invite_requests;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminInviteRequestsApproveResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class AdminInviteRequestsApproveResponse implements SlackApiTextResponse 
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsApprovedListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsApprovedListResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminInviteRequestsApprovedListResponse implements SlackApiTextResponse {
@@ -13,6 +14,7 @@ public class AdminInviteRequestsApprovedListResponse implements SlackApiTextResp
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> approvedRequests;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsDeniedListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsDeniedListResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminInviteRequestsDeniedListResponse implements SlackApiTextResponse {
@@ -13,6 +14,7 @@ public class AdminInviteRequestsDeniedListResponse implements SlackApiTextRespon
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> deniedRequests;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsDenyResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsDenyResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.admin.invite_requests;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminInviteRequestsDenyResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class AdminInviteRequestsDenyResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsListResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminInviteRequestsListResponse implements SlackApiTextResponse {
@@ -13,6 +14,7 @@ public class AdminInviteRequestsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> inviteRequests;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/AdminTeamsAdminsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/AdminTeamsAdminsListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminTeamsAdminsListResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminTeamsAdminsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> adminIds;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/AdminTeamsCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/AdminTeamsCreateResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminTeamsCreateResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminTeamsCreateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String team; // created team id
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/AdminTeamsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/AdminTeamsListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminTeamsListResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminTeamsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Team> teams;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/owners/AdminTeamsOwnersListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/owners/AdminTeamsOwnersListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminTeamsOwnersListResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminTeamsOwnersListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> ownerIds;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsInfoResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Team;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminTeamsSettingsInfoResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminTeamsSettingsInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Team team;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsSetDefaultChannelsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsSetDefaultChannelsResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminTeamsSettingsSetDefaultChannelsResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminTeamsSettingsSetDefaultChannelsResponse implements SlackApiTex
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsSetDescriptionResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsSetDescriptionResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.admin.teams.settings;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminTeamsSettingsSetDescriptionResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class AdminTeamsSettingsSetDescriptionResponse implements SlackApiTextRes
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsSetDiscoverabilityResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsSetDiscoverabilityResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminTeamsSettingsSetDiscoverabilityResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminTeamsSettingsSetDiscoverabilityResponse implements SlackApiTex
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsSetIconResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsSetIconResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminTeamsSettingsSetIconResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminTeamsSettingsSetIconResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsSetNameResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/teams/settings/AdminTeamsSettingsSetNameResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.admin.teams.settings;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminTeamsSettingsSetNameResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class AdminTeamsSettingsSetNameResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/usergroups/AdminUsergroupsAddChannelsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/usergroups/AdminUsergroupsAddChannelsResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminUsergroupsAddChannelsResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminUsergroupsAddChannelsResponse implements SlackApiTextResponse 
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> invalidChannels;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/usergroups/AdminUsergroupsAddTeamsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/usergroups/AdminUsergroupsAddTeamsResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsergroupsAddTeamsResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsergroupsAddTeamsResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/usergroups/AdminUsergroupsListChannelsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/usergroups/AdminUsergroupsListChannelsResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminUsergroupsListChannelsResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class AdminUsergroupsListChannelsResponse implements SlackApiTextResponse
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Conversation> channels;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/usergroups/AdminUsergroupsRemoveChannelsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/usergroups/AdminUsergroupsRemoveChannelsResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsergroupsRemoveChannelsResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsergroupsRemoveChannelsResponse implements SlackApiTextRespon
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersAssignResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersAssignResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersAssignResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsersAssignResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersInviteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersInviteResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersInviteResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsersInviteResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminUsersListResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class AdminUsersListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<User> users;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersRemoveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersRemoveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersRemoveResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsersRemoveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionClearSettingsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionClearSettingsResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersSessionClearSettingsResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsersSessionClearSettingsResponse implements SlackApiTextRespo
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionGetSettingsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionGetSettingsResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminUsersSessionGetSettingsResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminUsersSessionGetSettingsResponse implements SlackApiTextRespons
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<SessionSetting> sessionSettings;
     private List<String> noSettingsApplied; // user IDs

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionInvalidateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionInvalidateResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersSessionInvalidateResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsersSessionInvalidateResponse implements SlackApiTextResponse
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AdminUsersSessionListResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AdminUsersSessionListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<ActiveSession> activeSessions;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionResetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionResetResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.admin.users;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersSessionResetResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class AdminUsersSessionResetResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionSetSettingsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSessionSetSettingsResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersSessionSetSettingsResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsersSessionSetSettingsResponse implements SlackApiTextRespons
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSetAdminResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSetAdminResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersSetAdminResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsersSetAdminResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSetExpirationResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSetExpirationResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersSetExpirationResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsersSetExpirationResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSetOwnerResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSetOwnerResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersSetOwnerResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsersSetOwnerResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSetRegularResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersSetRegularResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AdminUsersSetRegularResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class AdminUsersSetRegularResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/api/ApiTestResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/api/ApiTestResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.api;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ApiTestResponse implements SlackApiTextResponse {
     @Data
@@ -17,5 +20,6 @@ public class ApiTestResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/apps/AppsUninstallResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/apps/AppsUninstallResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.apps;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AppsUninstallResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class AppsUninstallResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/apps/connections/AppsConnectionsOpenResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/apps/connections/AppsConnectionsOpenResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.apps.connections;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * https://api.slack.com/methods/apps.connections.open
  */
@@ -14,6 +17,7 @@ public class AppsConnectionsOpenResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String url;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/apps/event/authorizations/AppsEventAuthorizationsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/apps/event/authorizations/AppsEventAuthorizationsListResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * https://api.slack.com/methods/apps.event.authorizations.list
@@ -17,6 +18,7 @@ public class AppsEventAuthorizationsListResponse implements SlackApiTextResponse
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Authorization> authorizations;
     private String cursorNext;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/AppsPermissionsInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/AppsPermissionsInfoResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AppsPermissionsInfoResponse implements SlackApiTextResponse {
@@ -13,6 +14,7 @@ public class AppsPermissionsInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Info info;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/AppsPermissionsRequestResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/AppsPermissionsRequestResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.apps.permissions;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AppsPermissionsRequestResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class AppsPermissionsRequestResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/resources/AppsPermissionsResourcesListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/resources/AppsPermissionsResourcesListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AppsPermissionsResourcesListResponse implements SlackApiTextResponse {
@@ -17,6 +18,7 @@ public class AppsPermissionsResourcesListResponse implements SlackApiTextRespons
 
     private List<Resource> resources;
     private ResponseMetadata responseMetadata;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     @Data
     public static class Resource {

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/scopes/AppsPermissionsScopesListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/scopes/AppsPermissionsScopesListResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AppsPermissionsScopesListResponse implements SlackApiTextResponse {
@@ -13,6 +14,7 @@ public class AppsPermissionsScopesListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Scope> scopes;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/users/AppsPermissionsUsersListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/users/AppsPermissionsUsersListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AppsPermissionsUsersListResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AppsPermissionsUsersListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Resource> resources;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/users/AppsPermissionsUsersRequestResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/apps/permissions/users/AppsPermissionsUsersRequestResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.apps.permissions.users;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AppsPermissionsUsersRequestResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class AppsPermissionsUsersRequestResponse implements SlackApiTextResponse
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/auth/AuthRevokeResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/auth/AuthRevokeResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.auth;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AuthRevokeResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class AuthRevokeResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean revoked;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/auth/AuthTestResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/auth/AuthTestResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.auth;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class AuthTestResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class AuthTestResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String url;
     private String team;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/auth/teams/AuthTeamsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/auth/teams/AuthTeamsListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class AuthTeamsListResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class AuthTeamsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Team> teams;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/bots/BotsInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/bots/BotsInfoResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.BotIcons;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class BotsInfoResponse implements SlackApiTextResponse {
 
@@ -23,6 +26,7 @@ public class BotsInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Bot bot;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/calls/CallsAddResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/calls/CallsAddResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Call;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class CallsAddResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class CallsAddResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Call call;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/calls/CallsEndResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/calls/CallsEndResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Call;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class CallsEndResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class CallsEndResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Call call;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/calls/CallsInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/calls/CallsInfoResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Call;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class CallsInfoResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class CallsInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Call call;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/calls/CallsUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/calls/CallsUpdateResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Call;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class CallsUpdateResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class CallsUpdateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Call call;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/calls/participants/CallsParticipantsAddResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/calls/participants/CallsParticipantsAddResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Call;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class CallsParticipantsAddResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class CallsParticipantsAddResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Call call;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/calls/participants/CallsParticipantsRemoveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/calls/participants/CallsParticipantsRemoveResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Call;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class CallsParticipantsRemoveResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class CallsParticipantsRemoveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Call call;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsArchiveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsArchiveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsArchiveResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class ChannelsArchiveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsCreateResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Channel;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsCreateResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class ChannelsCreateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Channel channel;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsHistoryResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsHistoryResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -16,6 +17,7 @@ public class ChannelsHistoryResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String latest;
     private List<Message> messages;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsInfoResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Channel;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsInfoResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class ChannelsInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Channel channel;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsInviteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsInviteResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Channel;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsInviteResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class ChannelsInviteResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Channel channel;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsJoinResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsJoinResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Channel;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsJoinResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class ChannelsJoinResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Channel channel;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsKickResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsKickResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsKickResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class ChannelsKickResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsLeaveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsLeaveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsLeaveResponse implements SlackApiTextResponse {
@@ -13,6 +16,7 @@ public class ChannelsLeaveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean notInChannel;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -16,6 +17,7 @@ public class ChannelsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Channel> channels;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsMarkResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsMarkResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsMarkResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class ChannelsMarkResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsRenameResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsRenameResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Channel;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsRenameResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class ChannelsRenameResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Channel channel;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsRepliesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsRepliesResponse.java
@@ -7,6 +7,7 @@ import com.slack.api.model.ThreadInfo;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -17,6 +18,7 @@ public class ChannelsRepliesResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Message> messages;
     private boolean hasMore;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsSetPurposeResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsSetPurposeResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsSetPurposeResponse implements SlackApiTextResponse {
@@ -13,6 +16,7 @@ public class ChannelsSetPurposeResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String purpose;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsSetTopicResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsSetTopicResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsSetTopicResponse implements SlackApiTextResponse {
@@ -13,6 +16,7 @@ public class ChannelsSetTopicResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String topic;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsUnarchiveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/ChannelsUnarchiveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ChannelsUnarchiveResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class ChannelsUnarchiveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/channels/UsersLookupByEmailResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/channels/UsersLookupByEmailResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.User;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // use com.slack.api.methods.response.users.UsersLookupByEmailResponse instead
 @Data
 public class UsersLookupByEmailResponse implements SlackApiTextResponse {
@@ -13,6 +16,7 @@ public class UsersLookupByEmailResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private User user;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatDeleteResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.chat;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ChatDeleteResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class ChatDeleteResponse implements SlackApiTextResponse {
     private String needed;
     private String provided;
     private String deprecatedArgument;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String channel;
     private String ts;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatDeleteScheduledMessageResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatDeleteScheduledMessageResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.chat;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ChatDeleteScheduledMessageResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class ChatDeleteScheduledMessageResponse implements SlackApiTextResponse 
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatGetPermalinkResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatGetPermalinkResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.chat;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ChatGetPermalinkResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class ChatGetPermalinkResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String channel;
     private String permalink;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatMeMessageResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatMeMessageResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.chat;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ChatMeMessageResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class ChatMeMessageResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String channel;
     private String ts;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatPostEphemeralResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatPostEphemeralResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.chat;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ChatPostEphemeralResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,8 @@ public class ChatPostEphemeralResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private String deprecatedArgument;
 
     private String messageTs;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatPostMessageResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatPostMessageResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.Message;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ChatPostMessageResponse implements SlackApiTextResponse {
@@ -15,6 +16,8 @@ public class ChatPostMessageResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private String deprecatedArgument;
 
     // "error": "invalid_attachments",

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatScheduleMessageResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatScheduleMessageResponse.java
@@ -8,6 +8,7 @@ import com.slack.api.model.block.LayoutBlock;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ChatScheduleMessageResponse implements SlackApiTextResponse {
@@ -17,6 +18,7 @@ public class ChatScheduleMessageResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String scheduledMessageId;
     private String channel;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatUnfurlResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatUnfurlResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.chat;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ChatUnfurlResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,6 @@ public class ChatUnfurlResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatUpdateResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Message;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ChatUpdateResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,8 @@ public class ChatUpdateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private String deprecatedArgument;
 
     private String channel;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/scheduled_messages/ChatScheduledMessagesListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/scheduled_messages/ChatScheduledMessagesListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ChatScheduledMessagesListResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class ChatScheduledMessagesListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<ScheduledMessage> scheduledMessages;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsAcceptSharedInviteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsAcceptSharedInviteResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.conversations;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsAcceptSharedInviteResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class ConversationsAcceptSharedInviteResponse implements SlackApiTextResp
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean implicitApproval;
     private String channelId;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsApproveSharedInviteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsApproveSharedInviteResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.conversations;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsApproveSharedInviteResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class ConversationsApproveSharedInviteResponse implements SlackApiTextRes
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsArchiveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsArchiveResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.conversations;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsArchiveResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class ConversationsArchiveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsCloseResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsCloseResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.conversations;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsCloseResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,8 @@ public class ConversationsCloseResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private Boolean noOp;
     private Boolean alreadyClosed;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsCreateResponse.java
@@ -4,12 +4,16 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Conversation;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsCreateResponse implements SlackApiTextResponse {
 
     private boolean ok;
     private String warning;
     private String error;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     // {
     //   "ok": false,

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsDeclineSharedInviteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsDeclineSharedInviteResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.conversations;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsDeclineSharedInviteResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class ConversationsDeclineSharedInviteResponse implements SlackApiTextRes
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsHistoryResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsHistoryResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ConversationsHistoryResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class ConversationsHistoryResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String latest;
     private List<Message> messages;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsInfoResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Conversation;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsInfoResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class ConversationsInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Conversation channel;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsInviteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsInviteResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.Conversation;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ConversationsInviteResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class ConversationsInviteResponse implements SlackApiTextResponse {
     private List<Error> errors;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Conversation channel;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsInviteSharedResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsInviteSharedResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.conversations;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsInviteSharedResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class ConversationsInviteSharedResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String url; // https://join.slack.com/share/...
     private String inviteId; // I12345

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsJoinResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsJoinResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Conversation;
 import com.slack.api.model.WarningResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsJoinResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class ConversationsJoinResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Conversation channel;
     private WarningResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsKickResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsKickResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.conversations;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsKickResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class ConversationsKickResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsLeaveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsLeaveResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.conversations;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsLeaveResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class ConversationsLeaveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean notInChannel;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsListConnectInvitesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsListConnectInvitesResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.connect.ConnectInvite;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ConversationsListConnectInvitesResponse implements SlackApiTextResponse {
@@ -15,6 +16,8 @@ public class ConversationsListConnectInvitesResponse implements SlackApiTextResp
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private String arg; // for missing argument error (e.g., "team_id")
 
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ConversationsListResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class ConversationsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Conversation> channels;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsMarkResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsMarkResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsMarkResponse implements SlackApiTextResponse {
 
@@ -12,5 +15,7 @@ public class ConversationsMarkResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsMembersResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsMembersResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ConversationsMembersResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class ConversationsMembersResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> members;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsOpenResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsOpenResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Conversation;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsOpenResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class ConversationsOpenResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean noOp;
     private boolean alreadyOpen;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsRenameResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsRenameResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Conversation;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsRenameResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class ConversationsRenameResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Conversation channel;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsRepliesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsRepliesResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ConversationsRepliesResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class ConversationsRepliesResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Message> messages;
     private boolean hasMore;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsSetPurposeResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsSetPurposeResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Conversation;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsSetPurposeResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class ConversationsSetPurposeResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Conversation channel;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsSetTopicResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsSetTopicResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Conversation;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsSetTopicResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class ConversationsSetTopicResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Conversation channel;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsUnarchiveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsUnarchiveResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.conversations;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ConversationsUnarchiveResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class ConversationsUnarchiveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/dialog/DialogOpenResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/dialog/DialogOpenResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.dialog.DialogResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class DialogOpenResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class DialogOpenResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private DialogResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/dnd/DndEndDndResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/dnd/DndEndDndResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.dnd;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class DndEndDndResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class DndEndDndResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/dnd/DndEndSnoozeResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/dnd/DndEndSnoozeResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.dnd;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class DndEndSnoozeResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class DndEndSnoozeResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean dndEnabled;
     private Integer nextDndStartTs;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/dnd/DndInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/dnd/DndInfoResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.dnd;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class DndInfoResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class DndInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean dndEnabled;
     private Integer nextDndStartTs;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/dnd/DndSetSnoozeResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/dnd/DndSetSnoozeResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.dnd;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class DndSetSnoozeResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class DndSetSnoozeResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean snoozeEnabled;
     private Integer snoozeEndtime;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/dnd/DndTeamInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/dnd/DndTeamInfoResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.methods.response.dnd;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -13,6 +14,7 @@ public class DndTeamInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     // user.id -> info
     private Map<String, DndTeamMemberInfo> users;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/emoji/EmojiListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/emoji/EmojiListResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.methods.response.emoji;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -13,6 +14,7 @@ public class EmojiListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Map<String, String> emoji;
     private String cacheTs;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesDeleteResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.files;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesDeleteResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class FilesDeleteResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesInfoResponse.java
@@ -8,6 +8,7 @@ import com.slack.api.model.Paging;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class FilesInfoResponse implements SlackApiTextResponse {
@@ -17,6 +18,7 @@ public class FilesInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private File file;
     private String content;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.Paging;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class FilesListResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class FilesListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<File> files;
     private Paging paging;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesRevokePublicURLResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesRevokePublicURLResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.File;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesRevokePublicURLResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class FilesRevokePublicURLResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private File file;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesSharedPublicURLResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesSharedPublicURLResponse.java
@@ -7,6 +7,7 @@ import com.slack.api.model.Paging;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class FilesSharedPublicURLResponse implements SlackApiTextResponse {
@@ -16,6 +17,7 @@ public class FilesSharedPublicURLResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private File file;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesUploadResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/FilesUploadResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.File;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesUploadResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class FilesUploadResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private File file;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/comments/FilesCommentsAddResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/comments/FilesCommentsAddResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.FileComment;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesCommentsAddResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class FilesCommentsAddResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String reqMethod;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/comments/FilesCommentsDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/comments/FilesCommentsDeleteResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.files.comments;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesCommentsDeleteResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class FilesCommentsDeleteResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/comments/FilesCommentsEditResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/comments/FilesCommentsEditResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.FileComment;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesCommentsEditResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class FilesCommentsEditResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private FileComment comment;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteAddResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteAddResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.File;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesRemoteAddResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class FilesRemoteAddResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private File file;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteInfoResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.File;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesRemoteInfoResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class FilesRemoteInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private File file;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class FilesRemoteListResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class FilesRemoteListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<File> files;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteRemoveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteRemoveResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.files.remote;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesRemoteRemoveResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class FilesRemoteRemoveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteShareResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteShareResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.File;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesRemoteShareResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class FilesRemoteShareResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private File file;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/files/remote/FilesRemoteUpdateResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.File;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class FilesRemoteUpdateResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class FilesRemoteUpdateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private File file;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsArchiveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsArchiveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsArchiveResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class GroupsArchiveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsCloseResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsCloseResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsCloseResponse implements SlackApiTextResponse {
@@ -13,6 +16,7 @@ public class GroupsCloseResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean noOp;
     private boolean alreadyClosed;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsCreateChildResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsCreateChildResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Group;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsCreateChildResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class GroupsCreateChildResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Group group;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsCreateResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Group;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsCreateResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class GroupsCreateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Group group;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsHistoryResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsHistoryResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -16,6 +17,7 @@ public class GroupsHistoryResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String latest;
     private List<Message> messages;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsInfoResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Group;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsInfoResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class GroupsInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Group group;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsInviteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsInviteResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Group;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsInviteResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class GroupsInviteResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Group group;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsKickResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsKickResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsKickResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class GroupsKickResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsLeaveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsLeaveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsLeaveResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class GroupsLeaveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -16,6 +17,7 @@ public class GroupsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Group> groups;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsMarkResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsMarkResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsMarkResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class GroupsMarkResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsOpenResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsOpenResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsOpenResponse implements SlackApiTextResponse {
@@ -13,6 +16,7 @@ public class GroupsOpenResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean noOp;
     private boolean alreadyOpen;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsRenameResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsRenameResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Channel;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsRenameResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class GroupsRenameResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Channel channel;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsRepliesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsRepliesResponse.java
@@ -7,6 +7,7 @@ import com.slack.api.model.ThreadInfo;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -17,6 +18,7 @@ public class GroupsRepliesResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Message> messages;
     private ThreadInfo threadInfo;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsSetPurposeResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsSetPurposeResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsSetPurposeResponse implements SlackApiTextResponse {
@@ -13,6 +16,7 @@ public class GroupsSetPurposeResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String purpose;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsSetTopicResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsSetTopicResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsSetTopicResponse implements SlackApiTextResponse {
@@ -13,6 +16,7 @@ public class GroupsSetTopicResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String topic;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsUnarchiveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/groups/GroupsUnarchiveResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class GroupsUnarchiveResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class GroupsUnarchiveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImCloseResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImCloseResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ImCloseResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class ImCloseResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImHistoryResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImHistoryResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -16,6 +17,7 @@ public class ImHistoryResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String latest;
     private List<Message> messages;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -16,6 +17,7 @@ public class ImListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Im> ims;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImMarkResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImMarkResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ImMarkResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class ImMarkResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImOpenResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImOpenResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Channel;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class ImOpenResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class ImOpenResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private boolean noOp;
     private boolean alreadyOpen;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImRepliesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/im/ImRepliesResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -16,6 +17,7 @@ public class ImRepliesResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Message.MessageRoot> messages;
     private boolean hasMore;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/migration/MigrationExchangeResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/migration/MigrationExchangeResponse.java
@@ -14,6 +14,7 @@ public class MigrationExchangeResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     /**
      * The workspace/team ID containing the mapped users

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimCloseResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimCloseResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class MpimCloseResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class MpimCloseResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimHistoryResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimHistoryResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -16,6 +17,7 @@ public class MpimHistoryResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String latest;
     private List<Message> messages;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -16,6 +17,7 @@ public class MpimListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Group> groups;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimMarkResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimMarkResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class MpimMarkResponse implements SlackApiTextResponse {
@@ -13,5 +16,7 @@ public class MpimMarkResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+
     private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimOpenResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimOpenResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Group;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
 public class MpimOpenResponse implements SlackApiTextResponse {
@@ -14,6 +17,7 @@ public class MpimOpenResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Group group;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimRepliesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/mpim/MpimRepliesResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Deprecated // https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api
 @Data
@@ -16,6 +17,7 @@ public class MpimRepliesResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Message> messages;
     private boolean hasMore;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthAccessResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthAccessResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class OAuthAccessResponse implements SlackApiTextResponse {
@@ -13,6 +14,7 @@ public class OAuthAccessResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String tokenType;
     private String accessToken;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthTokenResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthTokenResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.oauth;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class OAuthTokenResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class OAuthTokenResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String accessToken;
     private String scope;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthV2AccessResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthV2AccessResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.oauth;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * https://api.slack.com/methods/oauth.v2.access
  */
@@ -14,6 +17,7 @@ public class OAuthV2AccessResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String appId;
     private AuthedUser authedUser;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthV2ExchangeResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/oauth/OAuthV2ExchangeResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * https://api.slack.com/methods/oauth.v2.exchange
  */
@@ -15,6 +18,7 @@ public class OAuthV2ExchangeResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String appId;
     private AuthedUser authedUser;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/openid/connect/OpenIDConnectTokenResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/openid/connect/OpenIDConnectTokenResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.openid.connect;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * https://api.slack.com/methods/openid.connect.token
  */
@@ -14,6 +17,7 @@ public class OpenIDConnectTokenResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String accessToken;
     private String tokenType;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/openid/connect/OpenIDConnectUserInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/openid/connect/OpenIDConnectUserInfoResponse.java
@@ -4,6 +4,9 @@ import com.google.gson.annotations.SerializedName;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * https://api.slack.com/methods/openid.connect.userInfo
  */
@@ -15,6 +18,7 @@ public class OpenIDConnectUserInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String sub; // W1234567890
     @SerializedName("https://slack.com/user_id")

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/pins/PinsAddResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/pins/PinsAddResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class PinsAddResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class PinsAddResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private ErrorResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/pins/PinsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/pins/PinsListResponse.java
@@ -7,6 +7,7 @@ import com.slack.api.model.Message;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class PinsListResponse implements SlackApiTextResponse {
@@ -16,6 +17,7 @@ public class PinsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<MessageItem> items;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/pins/PinsRemoveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/pins/PinsRemoveResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.pins;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class PinsRemoveResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class PinsRemoveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsAddResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsAddResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.reactions;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ReactionsAddResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class ReactionsAddResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsGetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsGetResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.Reaction;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ReactionsGetResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class ReactionsGetResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String type;
     private String channel;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsListResponse.java
@@ -7,6 +7,7 @@ import com.slack.api.model.block.LayoutBlock;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class ReactionsListResponse implements SlackApiTextResponse {
@@ -16,6 +17,7 @@ public class ReactionsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Item> items;
     private Paging paging;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsRemoveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsRemoveResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.reactions;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ReactionsRemoveResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class ReactionsRemoveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reminders/RemindersAddResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reminders/RemindersAddResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Reminder;
 import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class RemindersAddResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class RemindersAddResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Reminder reminder;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reminders/RemindersCompleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reminders/RemindersCompleteResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.reminders;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class RemindersCompleteResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class RemindersCompleteResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reminders/RemindersDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reminders/RemindersDeleteResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.reminders;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class RemindersDeleteResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class RemindersDeleteResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reminders/RemindersInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reminders/RemindersInfoResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Reminder;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class RemindersInfoResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class RemindersInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Reminder reminder;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reminders/RemindersListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reminders/RemindersListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.Reminder;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class RemindersListResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class RemindersListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Reminder> reminders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/rtm/RTMConnectResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/rtm/RTMConnectResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.Team;
 import com.slack.api.model.User;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * @see <a href="https://api.slack.com/methods/rtm.connect">rtm.connect</a>
  */
@@ -16,6 +19,7 @@ public class RTMConnectResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String url;
     private User self;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/rtm/RTMStartResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/rtm/RTMStartResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.*;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * @see <a href="https://api.slack.com/methods/rtm.start">rtm.start</a>
@@ -17,6 +18,7 @@ public class RTMStartResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String url;
     private User self;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/search/SearchAllResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/search/SearchAllResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.SearchResult;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class SearchAllResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class SearchAllResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String query;
     private SearchResult messages;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/search/SearchFilesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/search/SearchFilesResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.SearchResult;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class SearchFilesResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class SearchFilesResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String query;
     private SearchResult files;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/search/SearchMessagesResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/search/SearchMessagesResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.SearchResult;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class SearchMessagesResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class SearchMessagesResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String query;
     private SearchResult messages;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/stars/StarsAddResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/stars/StarsAddResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.stars;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class StarsAddResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class StarsAddResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/stars/StarsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/stars/StarsListResponse.java
@@ -7,6 +7,7 @@ import com.slack.api.model.block.LayoutBlock;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class StarsListResponse implements SlackApiTextResponse {
@@ -16,6 +17,7 @@ public class StarsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Item> items;
     private Paging paging;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/stars/StarsRemoveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/stars/StarsRemoveResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.stars;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class StarsRemoveResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class StarsRemoveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamAccessLogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamAccessLogsResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.Paging;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class TeamAccessLogsResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class TeamAccessLogsResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Login> logins;
     private Paging paging;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamBillableInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamBillableInfoResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.BillableInfo;
 import lombok.Data;
 
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -14,6 +15,7 @@ public class TeamBillableInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Map<String, BillableInfo> billableInfo;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamInfoResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Team;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class TeamInfoResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class TeamInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Team team;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamIntegrationLogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamIntegrationLogsResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.Paging;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class TeamIntegrationLogsResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class TeamIntegrationLogsResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<IntegrationLog> logs;
     private Paging paging;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/team/profile/TeamProfileGetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/team/profile/TeamProfileGetResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.Team;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class TeamProfileGetResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class TeamProfileGetResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Profiles profile;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/UsergroupsCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/UsergroupsCreateResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Usergroup;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsergroupsCreateResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class UsergroupsCreateResponse implements SlackApiTextResponse {
     private String error;
     private String needed; // "usergroups:write"
     private String provided; // some permissions
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Usergroup usergroup;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/UsergroupsDisableResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/UsergroupsDisableResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Usergroup;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsergroupsDisableResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class UsergroupsDisableResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Usergroup usergroup;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/UsergroupsEnableResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/UsergroupsEnableResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Usergroup;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsergroupsEnableResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class UsergroupsEnableResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Usergroup usergroup;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/UsergroupsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/UsergroupsListResponse.java
@@ -5,6 +5,7 @@ import com.slack.api.model.Usergroup;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class UsergroupsListResponse implements SlackApiTextResponse {
@@ -14,6 +15,7 @@ public class UsergroupsListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Usergroup> usergroups;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/UsergroupsUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/UsergroupsUpdateResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Usergroup;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsergroupsUpdateResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class UsergroupsUpdateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Usergroup usergroup;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/users/UsergroupsUsersListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/users/UsergroupsUsersListResponse.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class UsergroupsUsersListResponse implements SlackApiTextResponse {
@@ -13,6 +14,7 @@ public class UsergroupsUsersListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<String> users;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/users/UsergroupsUsersUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/usergroups/users/UsergroupsUsersUpdateResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Usergroup;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsergroupsUsersUpdateResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class UsergroupsUsersUpdateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private Usergroup usergroup;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersConversationsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersConversationsResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class UsersConversationsResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class UsersConversationsResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Conversation> channels;
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersDeletePhotoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersDeletePhotoResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.users;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsersDeletePhotoResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class UsersDeletePhotoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersGetPresenceResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersGetPresenceResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.users;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsersGetPresenceResponse implements SlackApiTextResponse {
 
@@ -11,6 +14,7 @@ public class UsersGetPresenceResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String presence;
     private boolean online;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersIdentityResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersIdentityResponse.java
@@ -4,6 +4,9 @@ import com.google.gson.annotations.SerializedName;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsersIdentityResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class UsersIdentityResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private User user;
     private Team team;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersInfoResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.User;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsersInfoResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class UsersInfoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private User user;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersListResponse.java
@@ -6,6 +6,7 @@ import com.slack.api.model.User;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 public class UsersListResponse implements SlackApiTextResponse {
@@ -15,6 +16,7 @@ public class UsersListResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private String offset; // user id
     private List<User> members;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersSetActiveResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersSetActiveResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.users;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsersSetActiveResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class UsersSetActiveResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersSetPhotoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersSetPhotoResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.User;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsersSetPhotoResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class UsersSetPhotoResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private User.Profile profile;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersSetPresenceResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/UsersSetPresenceResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.users;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsersSetPresenceResponse implements SlackApiTextResponse {
 
@@ -11,4 +14,5 @@ public class UsersSetPresenceResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/profile/UsersProfileGetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/profile/UsersProfileGetResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.User;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsersProfileGetResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class UsersProfileGetResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private User.Profile profile;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/users/profile/UsersProfileSetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/users/profile/UsersProfileSetResponse.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.User;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class UsersProfileSetResponse implements SlackApiTextResponse {
 
@@ -12,6 +15,7 @@ public class UsersProfileSetResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private User.Profile profile;
     private String username;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/views/ViewsOpenResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/views/ViewsOpenResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.ErrorResponseMetadata;
 import com.slack.api.model.view.View;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ViewsOpenResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class ViewsOpenResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private View view;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/views/ViewsPublishResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/views/ViewsPublishResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.ErrorResponseMetadata;
 import com.slack.api.model.view.View;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ViewsPublishResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class ViewsPublishResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private View view;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/views/ViewsPushResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/views/ViewsPushResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.ErrorResponseMetadata;
 import com.slack.api.model.view.View;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ViewsPushResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class ViewsPushResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private View view;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/views/ViewsUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/views/ViewsUpdateResponse.java
@@ -5,6 +5,9 @@ import com.slack.api.model.ErrorResponseMetadata;
 import com.slack.api.model.view.View;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class ViewsUpdateResponse implements SlackApiTextResponse {
 
@@ -13,6 +16,7 @@ public class ViewsUpdateResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
 
     private View view;
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/workflows/WorkflowsStepCompletedResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/workflows/WorkflowsStepCompletedResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.workflows;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class WorkflowsStepCompletedResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,5 @@ public class WorkflowsStepCompletedResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
-
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/workflows/WorkflowsStepFailedResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/workflows/WorkflowsStepFailedResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.workflows;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class WorkflowsStepFailedResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,5 @@ public class WorkflowsStepFailedResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
-
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/workflows/WorkflowsUpdateStepResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/workflows/WorkflowsUpdateStepResponse.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.response.workflows;
 import com.slack.api.methods.SlackApiTextResponse;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 public class WorkflowsUpdateStepResponse implements SlackApiTextResponse {
 
@@ -11,5 +14,5 @@ public class WorkflowsUpdateStepResponse implements SlackApiTextResponse {
     private String error;
     private String needed;
     private String provided;
-
+    private transient Map<String, List<String>> httpResponseHeaders;
 }

--- a/slack-api-client/src/test/java/test_locally/api/methods/ApiTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/ApiTest.java
@@ -9,11 +9,16 @@ import org.junit.Test;
 import util.MockSlackApiServer;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static util.MockSlackApi.ValidToken;
 
 public class ApiTest {
 
@@ -30,6 +35,20 @@ public class ApiTest {
     @After
     public void tearDown() throws Exception {
         server.stop();
+    }
+
+    @Test
+    public void headers() throws Exception {
+        Map<String, List<String>> headers = slack.methods().apiTest(r -> r).getHttpResponseHeaders();
+        assertThat(headers, is(notNullValue()));
+        assertThat(headers.size(), is(greaterThan(0)));
+    }
+
+    @Test
+    public void headers_async() throws Exception {
+        Map<String, List<String>> headers = slack.methodsAsync().apiTest(r -> r).get().getHttpResponseHeaders();
+        assertThat(headers, is(notNullValue()));
+        assertThat(headers.size(), is(greaterThan(0)));
     }
 
     @Test

--- a/slack-api-client/src/test/java/test_locally/api/methods/AuthTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/AuthTest.java
@@ -7,8 +7,13 @@ import org.junit.Before;
 import org.junit.Test;
 import util.MockSlackApiServer;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static util.MockSlackApi.ValidToken;
 
 public class AuthTest {
@@ -26,6 +31,22 @@ public class AuthTest {
     @After
     public void tearDown() throws Exception {
         server.stop();
+    }
+
+    @Test
+    public void headers() throws Exception {
+        Map<String, List<String>> headers =
+                slack.methods(ValidToken).authTest(r -> r).getHttpResponseHeaders();
+        assertThat(headers, is(notNullValue()));
+        assertThat(headers.size(), is(greaterThan(0)));
+    }
+
+    @Test
+    public void headers_async() throws Exception {
+        Map<String, List<String>> headers =
+                slack.methodsAsync(ValidToken).authTest(r -> r).get().getHttpResponseHeaders();
+        assertThat(headers, is(notNullValue()));
+        assertThat(headers.size(), is(greaterThan(0)));
     }
 
     @Test

--- a/slack-api-client/src/test/java/test_locally/api/util/FieldVerification.java
+++ b/slack-api-client/src/test/java/test_locally/api/util/FieldVerification.java
@@ -42,6 +42,7 @@ public class FieldVerification {
             _skipGetterNames.add(name);
         }
         _skipGetterNames.add("getBytes"); // String#getBytes()
+        _skipGetterNames.add("getHttpResponseHeaders");
 
         for (Method method : methods) {
             int m = method.getModifiers();

--- a/slack-api-client/src/test/java/test_with_remote_apis/UserDefinedMethodsTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/UserDefinedMethodsTest.java
@@ -10,6 +10,8 @@ import org.junit.AfterClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -24,6 +26,7 @@ public class UserDefinedMethodsTest {
         private String error;
         private String needed;
         private String provided;
+        private transient Map<String, List<String>> httpResponseHeaders;
 
         private String url;
         private String team;

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/auth_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/auth_Test.java
@@ -216,4 +216,12 @@ public class auth_Test {
         }
     }
 
+    @Test
+    public void authTest_x_oauth_scopes() throws IOException, SlackApiException {
+        AuthTestResponse response = slack.methods().authTest(req -> req.token(botToken));
+        assertThat(response.getError(), is(nullValue()));
+        String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+        assertThat(scopes, is(notNullValue()));
+    }
+
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
@@ -160,6 +160,9 @@ public class chat_Test {
                 .text("You can also do slack.methods(token)"));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.getMessage().getText(), is("You can also do slack.methods(token)"));
+
+        String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+        assertThat(scopes, is(notNullValue()));
     }
 
     @Test
@@ -170,6 +173,9 @@ public class chat_Test {
                 .text("You can also do slack.methods(token)"));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.getMessage().getText(), is("You can also do slack.methods(token)"));
+
+        String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+        assertThat(scopes, is(notNullValue()));
     }
 
     // https://github.com/slackapi/java-slack-sdk/issues/157
@@ -286,6 +292,9 @@ public class chat_Test {
         assertThat(postResponse.isOk(), is(true));
         assertThat(postResponse.getMessage().getText(),
                 is("Hi, this is a test message from Java Slack SDK's unit tests"));
+
+        String scopes = postResponse.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+        assertThat(scopes, is(notNullValue()));
 
         ChatGetPermalinkResponse permalink = slack.methodsAsync().chatGetPermalink(req -> req
                 .token(botToken)

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApi_analytics_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApi_analytics_Test.java
@@ -15,6 +15,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 @Slf4j
@@ -41,6 +44,8 @@ public class AdminApi_analytics_Test {
             ).get();
             assertEquals("file_not_yet_available", response.getError());
             assertFalse(response.isOk());
+            String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+            assertThat(scopes, is(notNullValue()));
         }
     }
 
@@ -53,6 +58,9 @@ public class AdminApi_analytics_Test {
             ).get();
             assertNull(response.getError());
             assertNotNull(response.getFileStream());
+            String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+            assertThat(scopes, is(notNullValue()));
+
             List<AdminAnalyticsGetFileResponse.AnalyticsData> results = new ArrayList<>();
             response.forEach(data -> results.add(data));
             assertTrue(results.size() > 0);
@@ -83,6 +91,9 @@ public class AdminApi_analytics_Test {
             ).get();
             assertNull(response.getError());
             assertNotNull(response.getFileStream());
+            String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+            assertThat(scopes, is(notNullValue()));
+
             List<AdminAnalyticsGetFileResponse.AnalyticsData> results = new ArrayList<>();
             response.forEach(gson, data -> results.add(data));
             assertTrue(results.size() > 0);
@@ -101,6 +112,8 @@ public class AdminApi_analytics_Test {
             byte[] bytes = response.asBytes();
             assertTrue(bytes.length > 0);
             assertTrue(response.isOk());
+            String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+            assertThat(scopes, is(notNullValue()));
 
             // Even after consuming the input stream,
             // #asBytes() should be available for multiple calls as the loaded bytes are cached
@@ -122,6 +135,9 @@ public class AdminApi_analytics_Test {
             ).get();
             assertNull(response.getError());
             assertNotNull(response.getFileStream());
+            String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+            assertThat(scopes, is(notNullValue()));
+
             List<AdminAnalyticsGetFileResponse.AnalyticsData> results = new ArrayList<>();
             response.forEach(data -> results.add(data));
             assertTrue(results.size() > 0);
@@ -155,6 +171,9 @@ public class AdminApi_analytics_Test {
             ).get();
             assertNull(response.getError());
             assertNotNull(response.getFileStream());
+            String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+            assertThat(scopes, is(notNullValue()));
+
             List<AdminAnalyticsGetFileResponse.AnalyticsData> results = new ArrayList<>();
             response.forEach(gson, data -> results.add(data));
             assertTrue(results.size() > 0);
@@ -170,6 +189,9 @@ public class AdminApi_analytics_Test {
             ).get();
             assertNull(response.getError());
             assertNotNull(response.getFileStream());
+            String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+            assertThat(scopes, is(notNullValue()));
+
             List<AdminAnalyticsGetFileResponse.AnalyticsData> results = new ArrayList<>();
             response.forEach(data -> results.add(data));
             assertTrue(results.size() > 0);
@@ -207,6 +229,9 @@ public class AdminApi_analytics_Test {
             ).get();
             assertNull(response.getError());
             assertNotNull(response.getFileStream());
+            String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
+            assertThat(scopes, is(notNullValue()));
+
             List<AdminAnalyticsGetFileResponse.AnalyticsData> results = new ArrayList<>();
             response.forEach(gson, data -> results.add(data));
             assertTrue(results.size() > 0);


### PR DESCRIPTION
This pull request adds two new methods to the Web API's response types.

* getHttpResponseHeaders
* setHttpResponseHeaders

These methods are useful for developers that would like to access any of the returned HTTP response headers of Web APIs. Particularly, the `x-oauth-scopes` header is useful to get the list of the associated OAuth scopes with the used OAuth token.

```java
public static void main(String[] args) throws Exception {
  String token = System.getenv("SLACK_BOT_TOKEN");
  AuthTestResponse response = Slack.getInstance().methods().authTest(r -> r.token(token));
  // To support the situation where a header appears in a response several times, #get(key) returns List<String>
  String scopes = response.getHttpResponseHeaders().get("x-oauth-scopes").get(0);
  System.out.println(scopes); // app_mentions:read,chat:write,files:read ...
}
```

As I mentioned at https://github.com/slackapi/bolt-js/issues/1106#issuecomment-925443768, node-slack-sdk merges the `x-oauth-scopes` value into `response_metadata`.

In the Python SDK, [the response class](https://github.com/slackapi/python-slack-sdk/blob/v3.11.2/slack_sdk/web/slack_response.py#L61-L63) has the following properties:

* data (dict or str)
* headers (dict)
* status_code (int)

Also, the response class provides getter methods for the properties under the `data` (= both `response.data.ok` and `response.ok` work).

For this Java SDK, I prefer the Python's approach that does not modify the response body (=data in the response class).

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
