### PR TITLE
Fix spelling in socket example

### DIFF
--- a/docs/guides/ja/socket-mode.md
+++ b/docs/guides/ja/socket-mode.md
@@ -63,7 +63,7 @@ lang: ja
 実装を切り替える場合、`SocketModeClient.Backend.*` を **slack-api-client** の `SocketModeClient` か **bolt-socket-mode** の `SocketModeApp` のコンストラクターに渡します。まt、それ以外の実装が `SocketModeClient` インターフェースを実装しているなら、直接インスタンス化してもよいでしょう。
 
 ```java
-Stirng appToken = "xapp-";
+String appToken = "xapp-";
 App app = new App();
 SocketModeApp socketModeApp = new SocketModeApp(
   appToken,

--- a/docs/guides/socket-mode.md
+++ b/docs/guides/socket-mode.md
@@ -63,7 +63,7 @@ To manage the Socket Mode connections, in addition to the **bolt-socket-mode** l
 To switch the underlying implementation, you can pass a `SocketModeClient.Backend.*` to either `SocketModeClient` in **slack-api-client** or `SocketModeApp` in **bolt-socket-mode**. If your own one implements `SocketModeClient` interface, you can just instantiate the class.
 
 ```java
-Stirng appToken = "xapp-";
+String appToken = "xapp-";
 App app = new App();
 SocketModeApp socketModeApp = new SocketModeApp(
   appToken,


### PR DESCRIPTION
This pull request fixes a spelling mistake in the slack-bolt socket mode example.

### Category

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
