### PR TITLE
Fix #857 Add the missing "pronouns" field to User.Profile data class

### DIFF
--- a/json-logs/samples/api/users.info.json
+++ b/json-logs/samples/api/users.info.json
@@ -39,7 +39,8 @@
       "first_name": "",
       "last_name": "",
       "image_1024": "https://www.example.com/",
-      "status_emoji_url": ""
+      "status_emoji_url": "",
+      "pronouns": ""
     },
     "is_admin": false,
     "is_owner": false,

--- a/json-logs/samples/api/users.lookupByEmail.json
+++ b/json-logs/samples/api/users.lookupByEmail.json
@@ -36,7 +36,8 @@
       "image_1024": "https://www.example.com/",
       "status_text_canonical": "",
       "team": "T00000000",
-      "status_emoji_url": ""
+      "status_emoji_url": "",
+      "pronouns": ""
     },
     "is_admin": false,
     "is_owner": false,

--- a/json-logs/samples/api/users.profile.get.json
+++ b/json-logs/samples/api/users.profile.get.json
@@ -35,7 +35,8 @@
     "image_512": "https://www.example.com/",
     "image_1024": "https://www.example.com/",
     "status_text_canonical": "",
-    "status_emoji_url": ""
+    "status_emoji_url": "",
+    "pronouns": ""
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/users.profile.set.json
+++ b/json-logs/samples/api/users.profile.set.json
@@ -34,7 +34,8 @@
     "image_512": "https://www.example.com/",
     "image_1024": "https://www.example.com/",
     "status_text_canonical": "",
-    "status_emoji_url": ""
+    "status_emoji_url": "",
+    "pronouns": ""
   },
   "ok": false,
   "username": "",

--- a/json-logs/samples/events/TeamJoinPayload.json
+++ b/json-logs/samples/events/TeamJoinPayload.json
@@ -34,6 +34,7 @@
         "status_text": "",
         "status_text_canonical": "",
         "status_emoji": "",
+        "status_emoji_url": "",
         "status_expiration": 123,
         "display_name": "",
         "display_name_normalized": "",
@@ -56,7 +57,7 @@
         "image_512": "",
         "image_1024": "",
         "is_custom_image": false,
-        "status_emoji_url": "",
+        "pronouns": "",
         "first_name": "",
         "last_name": ""
       },

--- a/json-logs/samples/events/UserChangePayload.json
+++ b/json-logs/samples/events/UserChangePayload.json
@@ -34,6 +34,7 @@
         "status_text": "",
         "status_text_canonical": "",
         "status_emoji": "",
+        "status_emoji_url": "",
         "status_expiration": 123,
         "display_name": "",
         "display_name_normalized": "",
@@ -56,7 +57,7 @@
         "image_512": "",
         "image_1024": "",
         "is_custom_image": false,
-        "status_emoji_url": "",
+        "pronouns": "",
         "first_name": "",
         "last_name": ""
       },

--- a/json-logs/samples/rtm/TeamJoinEvent.json
+++ b/json-logs/samples/rtm/TeamJoinEvent.json
@@ -18,6 +18,7 @@
       "status_text": "",
       "status_text_canonical": "",
       "status_emoji": "",
+      "status_emoji_url": "",
       "status_expiration": 123,
       "display_name": "",
       "display_name_normalized": "",
@@ -40,7 +41,7 @@
       "image_512": "",
       "image_1024": "",
       "is_custom_image": false,
-      "status_emoji_url": "",
+      "pronouns": "",
       "first_name": "",
       "last_name": ""
     },

--- a/json-logs/samples/rtm/UserChangeEvent.json
+++ b/json-logs/samples/rtm/UserChangeEvent.json
@@ -18,6 +18,7 @@
       "status_text": "",
       "status_text_canonical": "",
       "status_emoji": "",
+      "status_emoji_url": "",
       "status_expiration": 123,
       "display_name": "",
       "display_name_normalized": "",
@@ -40,7 +41,7 @@
       "image_512": "",
       "image_1024": "",
       "is_custom_image": false,
-      "status_emoji_url": "",
+      "pronouns": "",
       "first_name": "",
       "last_name": ""
     },

--- a/slack-api-model/src/main/java/com/slack/api/model/User.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/User.java
@@ -74,6 +74,7 @@ public class User {
         private String statusText;
         private String statusTextCanonical;
         private String statusEmoji;
+        private String statusEmojiUrl;
         private Long statusExpiration;
 
         private String displayName;
@@ -111,7 +112,7 @@ public class User {
         @SerializedName("is_custom_image")
         private boolean customImage;
 
-        private String statusEmojiUrl;
+        private String pronouns;
 
         private Map<String, Field> fields;
 


### PR DESCRIPTION
This pull request fixes #857. See the issue for details.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
