### PR TITLE
Support TimePickerElement in Block Kit Kotlin DSL

### DIFF
--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/TimePickerElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/TimePickerElementBuilder.kt
@@ -1,0 +1,66 @@
+package com.slack.api.model.kotlin_extension.block.element
+
+import com.slack.api.model.block.composition.ConfirmationDialogObject
+import com.slack.api.model.block.composition.PlainTextObject
+import com.slack.api.model.block.element.TimePickerElement
+import com.slack.api.model.kotlin_extension.block.BlockLayoutBuilder
+import com.slack.api.model.kotlin_extension.block.Builder
+import com.slack.api.model.kotlin_extension.block.composition.ConfirmationDialogObjectBuilder
+
+@BlockLayoutBuilder
+class TimePickerElementBuilder : Builder<TimePickerElement> {
+    private var placeholder: PlainTextObject? = null
+    private var actionId: String? = null
+    private var initialTime: String? = null
+    private var confirm: ConfirmationDialogObject? = null
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown on the timepicker.
+     * Maximum length for the text in this field is 150 characters.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#timepicker">Time picker element documentation</a>
+     */
+    fun placeholder(text: String, emoji: Boolean? = null) {
+        placeholder = PlainTextObject(text, emoji)
+    }
+
+    /**
+     * 	An identifier for the action triggered when a time is selected. You can use this when you receive an
+     * 	interaction payload to identify the source of the action. Should be unique among all other action_ids in
+     * 	the containing block. Maximum length for this field is 255 characters.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#timepicker">Time picker element documentation</a>
+     */
+    fun actionId(id: String) {
+        actionId = id
+    }
+
+    /**
+     * The initial time that is selected when the element is loaded. This should be in the format HH:mm,
+     * where HH is the 24-hour format of an hour (00 to 23) and mm is minutes with leading zeros (00 to 59),
+     * for example 22:25 for 10:25pm.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#timepicker">Time picker element documentation</a>
+     */
+    fun initialTime(time: String) {
+        initialTime = time
+    }
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears after a time is selected.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#timepicker">Time picker element documentation</a>
+     */
+    fun confirm(builder: ConfirmationDialogObjectBuilder.() -> Unit) {
+        confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
+    }
+
+    override fun build(): TimePickerElement {
+        return TimePickerElement.builder()
+                .actionId(actionId)
+                .placeholder(placeholder)
+                .initialTime(initialTime)
+                .confirm(confirm)
+                .build()
+    }
+}

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/container/MultiBlockElementContainer.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/container/MultiBlockElementContainer.kt
@@ -31,6 +31,10 @@ class MultiBlockElementContainer : BlockElementDsl {
         underlying += DatePickerElementBuilder().apply(builder).build()
     }
 
+    override fun timePicker(builder: TimePickerElementBuilder.() -> Unit) {
+        underlying += TimePickerElementBuilder().apply(builder).build()
+    }
+
     override fun externalSelect(builder: ExternalSelectElementBuilder.() -> Unit) {
         underlying += ExternalSelectElementBuilder().apply(builder).build()
     }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/container/SingleBlockElementContainer.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/container/SingleBlockElementContainer.kt
@@ -31,6 +31,10 @@ class SingleBlockElementContainer : BlockElementDsl {
         underlying = DatePickerElementBuilder().apply(builder).build()
     }
 
+    override fun timePicker(builder: TimePickerElementBuilder.() -> Unit) {
+        underlying = TimePickerElementBuilder().apply(builder).build()
+    }
+
     override fun externalSelect(builder: ExternalSelectElementBuilder.() -> Unit) {
         underlying = ExternalSelectElementBuilder().apply(builder).build()
     }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/dsl/BlockElementInputDsl.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/dsl/BlockElementInputDsl.kt
@@ -30,6 +30,17 @@ interface BlockElementInputDsl {
     fun datePicker(builder: DatePickerElementBuilder.() -> Unit)
 
     /**
+     * An element which allows selection of a time of day.
+     *
+     * On desktop clients, this time picker will take the form of a dropdown list with free-text entry for precise choices.
+     * On mobile clients, the time picker will use native time picker UIs.
+     *
+     * @see <a href="https://api.slack.com/interactivity/handling">Enabling interactivity guide</a>
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#timepicker">Time picker element documentation</a>
+     */
+    fun timePicker(builder: TimePickerElementBuilder.() -> Unit)
+
+    /**
      * This select menu will load its options from an external data source, allowing for a dynamic list of options.
      *
      * @see <a href="https://api.slack.com/reference/block-kit/block-elements#external_select">External select element documentation</a>

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/ActionsBlockTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/ActionsBlockTest.kt
@@ -99,7 +99,7 @@ class ActionsBlockTest {
     }
 
     @Test
-    fun `single-selects and datepicker`() {
+    fun `single-selects with date and time pickers`() {
         val gson = GsonFactory.createSnakeCase()
         val blocks = withBlocks {
             section {
@@ -163,6 +163,17 @@ class ActionsBlockTest {
                     confirm {
                         title("Are you sure?")
                         plainText("Check your calendar. Are you sure you are free on this date?")
+                        confirm("Yes, I am free.")
+                        deny("No, I can't make it.")
+                    }
+                }
+                timePicker {
+                    actionId("timepick-appt")
+                    initialTime("12:35")
+                    placeholder("Select appointment time...")
+                    confirm {
+                        title("Are you sure?")
+                        plainText("Check your calendar. Are you sure you are free at this time?")
                         confirm("Yes, I am free.")
                         deny("No, I can't make it.")
                     }
@@ -302,6 +313,33 @@ class ActionsBlockTest {
                         "deny": {
                           "type": "plain_text",
                           "text": "No, I can't make it."
+                        }
+                      }
+                    },
+                    {
+                      "type": "timepicker",
+                      "action_id": "timepick-appt",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "Select appointment time..."
+                      },
+                      "initial_time": "12:35",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "Are you sure?"
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "Check your calendar. Are you sure you are free at this time?"
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "Yes, I am free."
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "No, I can\u0027t make it."
                         }
                       }
                     },

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/HomeTemplateTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/HomeTemplateTest.kt
@@ -201,7 +201,7 @@ class HomeTemplateTest {
     fun calendar() {
         val blocks = withBlocks {
             section {
-                markdownText("*Today, 22 October*")
+                markdownText("*Today, 22 October, 12:35pm*")
                 accessory {
                     button {
                         text("Manage App Settings", emoji = true)
@@ -214,6 +214,10 @@ class HomeTemplateTest {
                     datePicker {
                         initialDate("2019-10-22")
                         placeholder("Select a date", emoji = true)
+                    }
+                    timePicker {
+                        initialTime("12:35")
+                        placeholder("Select a time", emoji = true)
                     }
                 }
             }
@@ -337,7 +341,7 @@ class HomeTemplateTest {
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "*Today, 22 October*"
+				"text": "*Today, 22 October, 12:35pm*"
 			},
 			"accessory": {
 				"type": "button",
@@ -358,6 +362,15 @@ class HomeTemplateTest {
 					"placeholder": {
 						"type": "plain_text",
 						"text": "Select a date",
+						"emoji": true
+					}
+				},
+				{
+					"type": "timepicker",
+					"initial_time": "12:35",
+					"placeholder": {
+						"type": "plain_text",
+						"text": "Select a time",
 						"emoji": true
 					}
 				}

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/validation/BlockElementBuilderValidationTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/validation/BlockElementBuilderValidationTest.kt
@@ -33,6 +33,11 @@ class BlockElementBuilderValidationTest {
     }
 
     @Test
+    fun testTimePickerElementBuilder() {
+        validateMethodNames(TimePickerElement::class.java, TimePickerElementBuilder::class.java)
+    }
+
+    @Test
     fun testExternalSelectElementBuilder() {
         validateMethodNames(ExternalSelectElement::class.java, ExternalSelectElementBuilder::class.java)
     }

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/validation/ValidationUtil.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/validation/ValidationUtil.kt
@@ -12,7 +12,7 @@ object ValidationUtil {
                 .filter { it.name.startsWith("set") and Modifier.isPublic(it.modifiers) }
                 .map {
                     val name = it.name.replaceFirst("set", "")
-                    name.first().toLowerCase() + name.substring(1)
+                    name.first().lowercaseChar() + name.substring(1)
                 }
 
         val builderMethodNames = builder


### PR DESCRIPTION
See issue https://github.com/slackapi/java-slack-sdk/issues/864

add support for Time picker element to Block Kit Kotlin DSL builder; replace deprecated toLowerCase() with lowercaseChar() in ValidationUtil.kt

### Category

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)