### PR TITLE
Mark rtm.start as deprecated

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/Slack.java
+++ b/slack-api-client/src/main/java/com/slack/api/Slack.java
@@ -241,7 +241,9 @@ public class Slack implements AutoCloseable {
      *
      * @see <a href="https://api.slack.com/rtm">Slack RTM API</a>
      * @see <a href="https://api.slack.com/docs/rate-limits#rtm">RTM's Rate Limits</a>
+     * @deprecated Use #rtmConnect() instead
      */
+    @Deprecated
     public RTMClient rtmStart(String apiToken) throws IOException {
         return rtmStart(apiToken, true);
     }
@@ -251,7 +253,9 @@ public class Slack implements AutoCloseable {
      *
      * @see <a href="https://api.slack.com/rtm">Slack RTM API</a>
      * @see <a href="https://api.slack.com/docs/rate-limits#rtm">RTM's Rate Limits</a>
+     * @deprecated Use #rtmConnect() instead
      */
+    @Deprecated
     public RTMClient rtmStart(String apiToken, boolean fullUserInfoRequired) throws IOException {
         try {
             RTMStartResponse response = methods().rtmStart(RTMStartRequest.builder().token(apiToken).build());

--- a/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
@@ -1034,8 +1034,10 @@ public interface AsyncMethodsClient {
 
     CompletableFuture<RTMConnectResponse> rtmConnect(RequestConfigurator<RTMConnectRequest.RTMConnectRequestBuilder> req);
 
+    @Deprecated
     CompletableFuture<RTMStartResponse> rtmStart(RTMStartRequest req);
 
+    @Deprecated
     CompletableFuture<RTMStartResponse> rtmStart(RequestConfigurator<RTMStartRequest.RTMStartRequestBuilder> req);
 
     // ------------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
@@ -519,6 +519,7 @@ public class Methods {
     // ------------------------------
 
     public static final String RTM_CONNECT = "rtm.connect";
+    @Deprecated // https://api.slack.com/changelog/2021-10-rtm-start-to-stop
     public static final String RTM_START = "rtm.start";
 
     // ------------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
@@ -1573,8 +1573,10 @@ public interface MethodsClient {
 
     RTMConnectResponse rtmConnect(RequestConfigurator<RTMConnectRequest.RTMConnectRequestBuilder> req) throws IOException, SlackApiException;
 
+    @Deprecated
     RTMStartResponse rtmStart(RTMStartRequest req) throws IOException, SlackApiException;
 
+    @Deprecated
     RTMStartResponse rtmStart(RequestConfigurator<RTMStartRequest.RTMStartRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
@@ -1857,11 +1857,13 @@ public class AsyncMethodsClientImpl implements AsyncMethodsClient {
     }
 
     @Override
+    @Deprecated
     public CompletableFuture<RTMStartResponse> rtmStart(RTMStartRequest req) {
         return executor.execute(RTM_START, toMap(req), () -> methods.rtmStart(req));
     }
 
     @Override
+    @Deprecated
     public CompletableFuture<RTMStartResponse> rtmStart(RequestConfigurator<RTMStartRequest.RTMStartRequestBuilder> req) {
         return rtmStart(req.configure(RTMStartRequest.builder()).build());
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -2469,11 +2469,13 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    @Deprecated
     public RTMStartResponse rtmStart(RTMStartRequest req) throws IOException, SlackApiException {
         return postFormWithTokenAndParseResponse(toForm(req), Methods.RTM_START, getToken(req), RTMStartResponse.class);
     }
 
     @Override
+    @Deprecated
     public RTMStartResponse rtmStart(RequestConfigurator<RTMStartRequest.RTMStartRequestBuilder> req) throws IOException, SlackApiException {
         return rtmStart(req.configure(RTMStartRequest.builder()).build());
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/rtm/RTMStartRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/rtm/RTMStartRequest.java
@@ -6,9 +6,11 @@ import lombok.Data;
 
 /**
  * @see <a href="https://api.slack.com/methods/rtm.start">rtm.start</a>
+ * @deprecated Use `rtm.connect` API method instead
  */
 @Data
 @Builder
+@Deprecated
 public class RTMStartRequest implements SlackApiRequest {
 
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/rtm/RTMStartResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/rtm/RTMStartResponse.java
@@ -9,8 +9,10 @@ import java.util.Map;
 
 /**
  * @see <a href="https://api.slack.com/methods/rtm.start">rtm.start</a>
+ * @deprecated Use `rtm.connect` API method instead
  */
 @Data
+@Deprecated
 public class RTMStartResponse implements SlackApiTextResponse {
 
     private boolean ok;


### PR DESCRIPTION
>The original way to connect to one of our oldest APIs is finally retiring. For existing apps, rtm.start will start behaving exactly like rtm.connect on September 20, 2022. Beginning November 30, 2021, newly created apps and integrations will only be able to use rtm.connect.

https://api.slack.com/changelog/2021-10-rtm-start-to-stop

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
