### PR TITLE
Upgrade patch/minor versions of dependencies for v1.13 release

### DIFF
--- a/bolt-aws-lambda/pom.xml
+++ b/bolt-aws-lambda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -14,7 +14,7 @@
     </properties>
 
     <artifactId>bolt-aws-lambda</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-google-cloud-functions/pom.xml
+++ b/bolt-google-cloud-functions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -17,7 +17,7 @@
     </properties>
 
     <artifactId>bolt-google-cloud-functions</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -17,7 +17,7 @@
     </properties>
 
     <artifactId>bolt-helidon</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -6,15 +6,15 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <http4k.version>4.12.0.1</http4k.version>
+        <http4k.version>4.16.2.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencyManagement>

--- a/bolt-jetty/pom.xml
+++ b/bolt-jetty/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -14,7 +14,7 @@
     </properties>
 
     <artifactId>bolt-jetty</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-kotlin-examples/pom.xml
+++ b/bolt-kotlin-examples/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bolt-kotlin-examples</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bolt-ktor</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -17,7 +17,7 @@
     </properties>
 
     <artifactId>bolt-micronaut</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -22,7 +22,7 @@
     </properties>
 
     <artifactId>bolt-quarkus-examples</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-servlet/pom.xml
+++ b/bolt-servlet/pom.xml
@@ -6,17 +6,17 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <properties>
         <!-- TODO: Upgrade to 11.x in the next major version - v2 -->
         <jetty.version>9.4.24.v20191120</jetty.version>
-        <java-jwt.version>3.18.1</java-jwt.version>
+        <java-jwt.version>3.18.2</java-jwt.version>
     </properties>
 
     <artifactId>bolt-servlet</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-socket-mode/pom.xml
+++ b/bolt-socket-mode/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -17,7 +17,7 @@
     </properties>
 
     <artifactId>bolt-socket-mode</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -6,15 +6,15 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <spring-boot.version>2.5.4</spring-boot.version>
+        <spring-boot.version>2.5.6</spring-boot.version>
     </properties>
 
     <artifactId>bolt-spring-boot-examples</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt/pom.xml
+++ b/bolt/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bolt</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/bolt/src/main/java/com/slack/api/bolt/meta/BoltLibraryVersion.java
+++ b/bolt/src/main/java/com/slack/api/bolt/meta/BoltLibraryVersion.java
@@ -5,7 +5,7 @@ public final class BoltLibraryVersion {
     }
 
     public static final String get() {
-        return "1.12.2-SNAPSHOT";
+        return "1.13.0-SNAPSHOT";
     }
 }
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,10 +7,10 @@ baseurl: /java-slack-sdk
 url: https://slack.dev
 
 sdkLatestVersion: 1.12.1
-okhttpVersion: 4.9.1
+okhttpVersion: 4.9.2
 slf4jApiVersion: 1.7.32
-kotlinVersion: 1.5.30
-springBootVersion: 2.5.4
+kotlinVersion: 1.5.31
+springBootVersion: 2.5.6
 compatibleMicronautVersion: 2.x
 quarkusVersion: 1.9.2.Final
 helidonVersion: 2.3.2

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.slack.api</groupId>
     <artifactId>slack-sdk-parent</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Java Slack SDK Project</name>
@@ -45,18 +45,18 @@
 
         <!-- For these compile scope dependencies, we don't use ranges of versions -->
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <okhttp.version>4.9.1</okhttp.version>
+        <okhttp.version>4.9.2</okhttp.version>
         <gson.version>2.8.8</gson.version>
-        <kotlin.version>1.5.30</kotlin.version>
+        <kotlin.version>1.5.31</kotlin.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <lombok.version>1.18.20</lombok.version>
-        <lombok-maven-plugin.version>1.18.16.0</lombok-maven-plugin.version>
+        <lombok.version>1.18.22</lombok.version>
+        <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
 
         <!-- optional / testing-only dependencies -->
         <aws.s3.version>[1.12.62,1.13.0)</aws.s3.version>
         <junit.version>4.13.2</junit.version>
-        <logback.version>1.2.5</logback.version>
+        <logback.version>1.2.6</logback.version>
         <hamcrest.version>[1.3,2.0)</hamcrest.version>
         <mockito-core.version>[3.12.4,3.13.0)</mockito-core.version>
         <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>

--- a/slack-api-client-kotlin-extension/pom.xml
+++ b/slack-api-client-kotlin-extension/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>slack-api-client-kotlin-extension</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>slack-api-client</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -18,7 +18,7 @@
         <!-- TODO upgrade to 2.0 in the next major version -->
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
         <java-websocket.version>1.5.2</java-websocket.version>
-        <jedis.version>3.6.3</jedis.version>
+        <jedis.version>3.7.0</jedis.version>
         <jedis-mock.version>0.1.22</jedis-mock.version>
     </properties>
 

--- a/slack-api-client/src/main/java/com/slack/api/meta/SlackApiClientLibraryVersion.java
+++ b/slack-api-client/src/main/java/com/slack/api/meta/SlackApiClientLibraryVersion.java
@@ -5,7 +5,7 @@ public final class SlackApiClientLibraryVersion {
     }
 
     public static final String get() {
-        return "1.12.2-SNAPSHOT";
+        return "1.13.0-SNAPSHOT";
     }
 }
 

--- a/slack-api-model-kotlin-extension/pom.xml
+++ b/slack-api-model-kotlin-extension/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>slack-api-model-kotlin-extension</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <pluginRepositories>

--- a/slack-api-model/pom.xml
+++ b/slack-api-model/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>slack-api-model</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <dependencies>

--- a/slack-api-model/src/main/java/com/slack/api/meta/SlackApiModelLibraryVersion.java
+++ b/slack-api-model/src/main/java/com/slack/api/meta/SlackApiModelLibraryVersion.java
@@ -5,7 +5,7 @@ public final class SlackApiModelLibraryVersion {
     }
 
     public static final String get() {
-        return "1.12.2-SNAPSHOT";
+        return "1.13.0-SNAPSHOT";
     }
 }
 

--- a/slack-app-backend/pom.xml
+++ b/slack-app-backend/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.slack.api</groupId>
         <artifactId>slack-sdk-parent</artifactId>
-        <version>1.12.2-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>slack-app-backend</artifactId>
-    <version>1.12.2-SNAPSHOT</version>
+    <version>1.13.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <dependencies>


### PR DESCRIPTION
This pull request upgrades path/minor versions of dependencies before the v1.13 release.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
