### PR TITLE
Document fix: Code snippet error in the OAuth document section

### DIFF
--- a/docs/guides/app-distribution.md
+++ b/docs/guides/app-distribution.md
@@ -140,8 +140,8 @@ oauthApp.service(stateService);
 
 // Mount the two apps with their root path
 SlackAppServer server = new SlackAppServer(Map.of(
-  entry("/slack/events", apiApp), // POST /slack/events (incomng API requests from the Slack Platform)
-  entry("/slack/oauth", oauthApp) // GET  /slack/oauth/start, /slack/oauth/callback (user access)
+  "/slack/events", apiApp, // POST /slack/events (incomng API requests from the Slack Platform)
+  "/slack/oauth", oauthApp // GET  /slack/oauth/start, /slack/oauth/callback (user access)
 ));
 
 server.start(); // http://localhost:3000


### PR DESCRIPTION
One of the `SlackAppServer` constructors takes a single `Map<String, App>`.  In the current example, the `Map` is a `Map<Map.Entry<String, App>, Map.Entry<String, App>>`.

### Category (place an `x` in each of the `[ ]`)

* [x ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
