### PR TITLE
Fix #875 Add callback_options equivalent to Bolt for Java

### DIFF
--- a/bolt-servlet/src/test/java/samples/OAuthCallbacksSample.java
+++ b/bolt-servlet/src/test/java/samples/OAuthCallbacksSample.java
@@ -1,0 +1,89 @@
+package samples;
+
+import com.slack.api.SlackConfig;
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.service.builtin.oauth.OAuthV2AccessErrorHandler;
+import com.slack.api.model.event.AppMentionEvent;
+import com.slack.api.util.json.GsonFactory;
+import lombok.extern.slf4j.Slf4j;
+import util.TestSlackAppServer;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class OAuthCallbacksSample {
+
+    public static void main(String[] args) throws Exception {
+        String jsonString = Files.readAllLines(Paths.get("bolt-servlet/src/test/resources/appConfig_oauth.json"))
+                .stream().collect(Collectors.joining("\n"));
+        AppConfig config = GsonFactory.createCamelCase(SlackConfig.DEFAULT).fromJson(jsonString, AppConfig.class);
+        App app = new App(config).asOAuthApp(true);
+        app.initialize();
+
+        app.event(AppMentionEvent.class, (event, ctx) -> {
+            ctx.logger.info("new mention! - {}", event);
+            ctx.say("Hi there!");
+            return ctx.ack();
+        });
+
+        Map<String, App> apps = new HashMap<>();
+        apps.put("/slack/events", app);
+
+        App oauthApp = new App(config);
+
+        // in the case where the "error" parameter is passed from the Slack OAuth flow
+        oauthApp.oauthCallbackError((request, response) -> {
+            response.setStatusCode(401);
+            response.setContentType("text/plain; charset=utf-8");
+            response.setBody("Something wrong! (" + request.getPayload().getError() + ")");
+            return response;
+        });
+
+        // in the case where the "state" parameter is invalid
+        oauthApp.oauthCallbackStateError((request, response) -> {
+            response.setStatusCode(401);
+            response.setContentType("text/plain; charset=utf-8");
+            response.setBody("Something wrong! (state is invalid)");
+            return response;
+        });
+
+        // in the case where an error code is returned from the oauth.v2.access API
+        oauthApp.oauthCallbackAccessError((OAuthV2AccessErrorHandler) (request, response, apiResponse) -> {
+            response.setStatusCode(401);
+            response.setContentType("text/plain; charset=utf-8");
+            response.setBody("Something wrong! (" + apiResponse.getError() + ")");
+            return response;
+        });
+
+        // To customize the behavior after the installation persistence:
+        // The default behavior is to display the default completion web page
+        // or to redirect the installer to the pre-given completion URL.
+        oauthApp.oauthPersistenceCallback(arguments -> {
+            Response response = arguments.getResponse();
+            response.setStatusCode(200);
+            response.setContentType("text/plain; charset=utf-8");
+            response.setBody("OK!");
+        });
+
+        // To customize the behavior when the installation persistence fails:
+        // The default behavior is to display the default error web page
+        // or to redirect the installer to the pre-given failure URL.
+        oauthApp.oauthPersistenceErrorCallback(arguments -> {
+            Response response = arguments.getResponse();
+            response.setStatusCode(500);
+            response.setContentType("text/plain; charset=utf-8");
+            response.setBody("Something wrong! (" + arguments.getError().getMessage() + ")");
+        });
+
+        apps.put("/slack/oauth/", oauthApp.asOAuthApp(true));
+        TestSlackAppServer server = new TestSlackAppServer(apps);
+        server.start();
+    }
+
+}

--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -886,6 +886,26 @@ public class App {
         return this;
     }
 
+    public App oauthPersistenceCallback(OAuthV2SuccessPersistenceCallback persistenceCallback) {
+        if (this.oAuthV2SuccessHandler instanceof OAuthV2DefaultSuccessHandler) {
+            ((OAuthV2DefaultSuccessHandler) this.oAuthV2SuccessHandler).setPersistenceCallback(persistenceCallback);
+        } else {
+            throw new IllegalStateException("As you've set your own OAuthV2SuccessHandler, " +
+                    "you cannot set persistenceCallback for this App instance.");
+        }
+        return this;
+    }
+
+    public App oauthPersistenceErrorCallback(OAuthV2SuccessPersistenceErrorCallback persistenceErrorCallback) {
+        if (this.oAuthV2SuccessHandler instanceof OAuthV2DefaultSuccessHandler) {
+            ((OAuthV2DefaultSuccessHandler) this.oAuthV2SuccessHandler).setPersistenceErrorCallback(persistenceErrorCallback);
+        } else {
+            throw new IllegalStateException("As you've set your own OAuthV2SuccessHandler, " +
+                    "you cannot set persistenceErrorCallback for this App instance.");
+        }
+        return this;
+    }
+
     public App oauthCallbackError(OAuthErrorHandler handler) {
         oAuthErrorHandler = handler;
         return this;

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/OAuthV2SuccessPersistenceCallback.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/OAuthV2SuccessPersistenceCallback.java
@@ -1,0 +1,31 @@
+package com.slack.api.bolt.service.builtin.oauth;
+
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.model.Installer;
+import com.slack.api.bolt.request.builtin.OAuthCallbackRequest;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
+import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
+import lombok.Builder;
+import lombok.Data;
+
+@FunctionalInterface
+public interface OAuthV2SuccessPersistenceCallback {
+
+    @Data
+    @Builder
+    class Arguments {
+        private AppConfig appConfig;
+        private InstallationService installationService;
+        private OAuthRedirectUriPageRenderer pageRenderer;
+
+        private OAuthCallbackRequest request;
+        private Response response;
+        private OAuthV2AccessResponse apiResponse;
+        private Installer installer;
+    }
+
+    void handle(Arguments args);
+
+}

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/OAuthV2SuccessPersistenceErrorCallback.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/OAuthV2SuccessPersistenceErrorCallback.java
@@ -1,0 +1,32 @@
+package com.slack.api.bolt.service.builtin.oauth;
+
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.model.Installer;
+import com.slack.api.bolt.request.builtin.OAuthCallbackRequest;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
+import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
+import lombok.Builder;
+import lombok.Data;
+
+@FunctionalInterface
+public interface OAuthV2SuccessPersistenceErrorCallback {
+
+    @Data
+    @Builder
+    class Arguments {
+        private Exception error;
+        private AppConfig appConfig;
+        private InstallationService installationService;
+        private OAuthRedirectUriPageRenderer pageRenderer;
+
+        private OAuthCallbackRequest request;
+        private Response response;
+        private OAuthV2AccessResponse apiResponse;
+        private Installer installer;
+    }
+
+    void handle(Arguments args);
+
+}

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultSuccessHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultSuccessHandler.java
@@ -8,6 +8,8 @@ import com.slack.api.bolt.request.builtin.OAuthCallbackRequest;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.service.InstallationService;
 import com.slack.api.bolt.service.builtin.oauth.OAuthV2SuccessHandler;
+import com.slack.api.bolt.service.builtin.oauth.OAuthV2SuccessPersistenceCallback;
+import com.slack.api.bolt.service.builtin.oauth.OAuthV2SuccessPersistenceErrorCallback;
 import com.slack.api.bolt.service.builtin.oauth.view.OAuthRedirectUriPageRenderer;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.auth.AuthTestResponse;
@@ -23,6 +25,8 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
     private final AppConfig appConfig;
     private final InstallationService installationService;
     private final OAuthRedirectUriPageRenderer pageRenderer;
+    private OAuthV2SuccessPersistenceCallback persistenceCallback;
+    private OAuthV2SuccessPersistenceErrorCallback persistenceErrorCallback;
 
     public OAuthV2DefaultSuccessHandler(
             AppConfig appConfig,
@@ -30,6 +34,8 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
         this.appConfig = appConfig;
         this.installationService = installationService;
         this.pageRenderer = appConfig.getOAuthRedirectUriPageRenderer();
+        this.persistenceCallback = DEFAULT_PERSISTENCE_SUCCESS_CALLBACK;
+        this.persistenceErrorCallback = DEFAULT_PERSISTENCE_SUCCESS_ERROR_CALLBACK;
     }
 
     @Override
@@ -102,28 +108,81 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
 
         try {
             installationService.saveInstallerAndBot(installer);
-            String url = context.getOauthCompletionUrl();
-            if (url != null) {
-                response.setStatusCode(302);
-                response.getHeaders().put("Location", Arrays.asList(url));
-            } else {
-                response.setStatusCode(200);
-                response.setBody(pageRenderer.renderSuccessPage(installer, appConfig.getOauthCompletionUrl()));
-                response.setContentType("text/html; charset=utf-8");
-            }
-        } catch (Exception e) {
-            log.warn("Failed to store the installation - {}", e.getMessage(), e);
-            String url = context.getOauthCancellationUrl();
-            if (url != null) {
-                response.setStatusCode(302);
-                response.getHeaders().put("Location", Arrays.asList(url));
-            } else {
-                String reason = e.getMessage();
-                response.setStatusCode(200);
-                response.setBody(pageRenderer.renderFailurePage(appConfig.getOauthInstallRequestURI(), reason));
-                response.setContentType("text/html; charset=utf-8");
-            }
+            getPersistenceCallback().handle(OAuthV2SuccessPersistenceCallback.Arguments.builder()
+                    .appConfig(appConfig)
+                    .pageRenderer(pageRenderer)
+                    .installationService(installationService)
+                    .request(request)
+                    .response(response)
+                    .installer(installer)
+                    .apiResponse(o)
+                    .build());
+        } catch (Exception error) {
+            getPersistenceErrorCallback().handle(OAuthV2SuccessPersistenceErrorCallback.Arguments.builder()
+                    .error(error)
+                    .appConfig(appConfig)
+                    .pageRenderer(pageRenderer)
+                    .installationService(installationService)
+                    .request(request)
+                    .response(response)
+                    .installer(installer)
+                    .apiResponse(o)
+                    .build());
         }
         return response;
     }
+
+    private static final OAuthV2SuccessPersistenceCallback DEFAULT_PERSISTENCE_SUCCESS_CALLBACK = args -> {
+        OAuthCallbackRequest request = args.getRequest();
+        Response response = args.getResponse();
+        String url = request.getContext().getOauthCompletionUrl();
+        if (url != null) {
+            response.setStatusCode(302);
+            response.getHeaders().put("Location", Arrays.asList(url));
+        } else {
+            response.setStatusCode(200);
+            response.setBody(args.getPageRenderer().renderSuccessPage(
+                    args.getInstaller(),
+                    args.getAppConfig().getOauthCompletionUrl())
+            );
+            response.setContentType("text/html; charset=utf-8");
+        }
+    };
+
+    private static final OAuthV2SuccessPersistenceErrorCallback DEFAULT_PERSISTENCE_SUCCESS_ERROR_CALLBACK
+            = args -> {
+        Exception error = args.getError();
+        OAuthCallbackRequest request = args.getRequest();
+        Response response = args.getResponse();
+        log.warn("Failed to store the installation - {}", error.getMessage(), error);
+        String url = request.getContext().getOauthCancellationUrl();
+        if (url != null) {
+            response.setStatusCode(302);
+            response.getHeaders().put("Location", Arrays.asList(url));
+        } else {
+            String reason = error.getMessage();
+            response.setStatusCode(200);
+            response.setBody(args.getPageRenderer().renderFailurePage(
+                    args.getAppConfig().getOauthInstallRequestURI(), reason
+            ));
+            response.setContentType("text/html; charset=utf-8");
+        }
+    };
+
+    public OAuthV2SuccessPersistenceCallback getPersistenceCallback() {
+        return persistenceCallback;
+    }
+
+    public void setPersistenceCallback(OAuthV2SuccessPersistenceCallback persistenceCallback) {
+        this.persistenceCallback = persistenceCallback;
+    }
+
+    public OAuthV2SuccessPersistenceErrorCallback getPersistenceErrorCallback() {
+        return persistenceErrorCallback;
+    }
+
+    public void setPersistenceErrorCallback(OAuthV2SuccessPersistenceErrorCallback persistenceErrorCallback) {
+        this.persistenceErrorCallback = persistenceErrorCallback;
+    }
+
 }

--- a/bolt/src/test/java/test_locally/app/OAuthCallbacksTest.java
+++ b/bolt/src/test/java/test_locally/app/OAuthCallbacksTest.java
@@ -1,24 +1,154 @@
 package test_locally.app;
 
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.app_backend.oauth.payload.VerificationCodePayload;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.model.Bot;
+import com.slack.api.bolt.model.Installer;
+import com.slack.api.bolt.request.Request;
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.builtin.OAuthCallbackRequest;
+import com.slack.api.bolt.response.Response;
+import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.bolt.service.builtin.ClientOnlyOAuthStateService;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import util.MockSlackApiServer;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @Slf4j
 public class OAuthCallbacksTest {
 
+    MockSlackApiServer server = new MockSlackApiServer();
+    SlackConfig config = new SlackConfig();
+    Slack slack = Slack.getInstance(config);
+
+    String fixedStateValue = "generated-state-value";
+    ClientOnlyOAuthStateService stateService = new ClientOnlyOAuthStateService() {
+        @Override
+        public String issueNewState(Request request, Response response) {
+            return fixedStateValue;
+        }
+    };
+
+    InstallationService brokenInstallationService = new InstallationService() {
+        @Override
+        public boolean isHistoricalDataEnabled() {
+            return false;
+        }
+
+        @Override
+        public void setHistoricalDataEnabled(boolean isHistoricalDataEnabled) {
+        }
+
+        @Override
+        public void saveInstallerAndBot(Installer installer) {
+            throw new RuntimeException("Something is wrong!");
+        }
+
+        @Override
+        public void deleteBot(Bot bot) {
+        }
+
+        @Override
+        public void deleteInstaller(Installer installer) {
+        }
+
+        @Override
+        public Bot findBot(String enterpriseId, String teamId) {
+            return null;
+        }
+
+        @Override
+        public Installer findInstaller(String enterpriseId, String teamId, String userId) {
+            return null;
+        }
+    };
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    OAuthCallbackRequest buildOAuthCallbackRequest(String code) {
+        // query string data in /slack/oauth_redirect access
+        Map<String, List<String>> queryString = new HashMap<>();
+        queryString.put("state", Arrays.asList(fixedStateValue));
+        queryString.put("code", Arrays.asList(code));
+
+        // request headers in /slack/oauth_redirect access
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Cookie", Arrays.asList(stateService.getSessionCookieName() + "=" + fixedStateValue));
+
+        return new OAuthCallbackRequest(
+                queryString,
+                "",
+                VerificationCodePayload.from(queryString),
+                new RequestHeaders(headers)
+        );
+    }
+
     @Test
-    public void persistenceCallback() {
+    public void oauthPersistenceCallback() throws Exception {
         App app = new App(AppConfig.builder()
+                .slack(slack)
                 .signingSecret("secret")
                 .clientId("111.222")
                 .clientSecret("secret")
                 .scope("commands,chat:write")
-                .build());
-        app.oauthPersistenceCallback(args -> args.getResponse().setStatusCode(200));
+                .build()
+        ).asOAuthApp(true);
+        app.service(stateService);
+        app.initialize();
+
+        // Testing this here
+        Integer expectedStatusCode = 201;
+        app.oauthPersistenceCallback(args -> args.getResponse().setStatusCode(expectedStatusCode));
         app.oauthPersistenceErrorCallback(args -> args.getResponse().setStatusCode(404));
 
-        // TODO: assertions
+        OAuthCallbackRequest req = buildOAuthCallbackRequest("valid");
+        Response response = app.run(req);
+        assertThat(response.getStatusCode(), is(expectedStatusCode));
+    }
+
+    @Test
+    public void oauthPersistenceErrorCallback() throws Exception {
+        App app = new App(AppConfig.builder()
+                .slack(slack)
+                .signingSecret("secret")
+                .clientId("111.222")
+                .clientSecret("secret")
+                .scope("commands,chat:write")
+                .build()
+        ).asOAuthApp(true);
+        app.service(stateService);
+        app.service(brokenInstallationService);
+        app.initialize();
+
+        Integer expectedStatusCode = 202;
+        app.oauthPersistenceCallback(args -> args.getResponse().setStatusCode(201));
+        // Testing this here
+        app.oauthPersistenceErrorCallback(args -> args.getResponse().setStatusCode(expectedStatusCode));
+
+        OAuthCallbackRequest req = buildOAuthCallbackRequest("valid");
+        Response response = app.run(req);
+        assertThat(response.getStatusCode(), is(expectedStatusCode));
     }
 }

--- a/bolt/src/test/java/test_locally/app/OAuthCallbacksTest.java
+++ b/bolt/src/test/java/test_locally/app/OAuthCallbacksTest.java
@@ -1,0 +1,24 @@
+package test_locally.app;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+@Slf4j
+public class OAuthCallbacksTest {
+
+    @Test
+    public void persistenceCallback() {
+        App app = new App(AppConfig.builder()
+                .signingSecret("secret")
+                .clientId("111.222")
+                .clientSecret("secret")
+                .scope("commands,chat:write")
+                .build());
+        app.oauthPersistenceCallback(args -> args.getResponse().setStatusCode(200));
+        app.oauthPersistenceErrorCallback(args -> args.getResponse().setStatusCode(404));
+
+        // TODO: assertions
+    }
+}


### PR DESCRIPTION
This pull request resolves #875. 

The newly added callback functions are _almost_ equivalent to `callback_options.success` and `callback_options.failure` in bolt-js and bolt-python. The reason why I said "almost" is that bolt-java already has other error handlers in a different way (for new maintainers' information, the OAuth flow was first implemented in bolt-java and bolt-js went with a different design then). 

Refer to `bolt-servlet/src/test/java/samples/OAuthCallbacksSample.java` in this pull request to learn the available callbacks.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
