### PR TITLE
Fix #862 Add "urn:scim:schemas:extension:slack:guest:1.0" schema support in the SCIM API client

### DIFF
--- a/json-logs/samples/scim/v1/Users/00000000000.json
+++ b/json-logs/samples/scim/v1/Users/00000000000.json
@@ -68,5 +68,9 @@
   ],
   "urn:scim:schemas:extension:enterprise:1.0": {
     "manager": {}
+  },
+  "urn:scim:schemas:extension:slack:guest:1.0": {
+    "type": "",
+    "expiration": ""
   }
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/model/Schemas.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/model/Schemas.java
@@ -7,5 +7,6 @@ public class Schemas {
 
     public static final String SCHEMA_CORE = "urn:scim:schemas:core:1.0";
     public static final String SCHEMA_EXTENSION_ENTERPRISE = "urn:scim:schemas:extension:enterprise:1.0";
+    public static final String SCHEMA_EXTENSION_SLACK_GUEST = "urn:scim:schemas:extension:slack:guest:1.0";
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/model/User.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/model/User.java
@@ -1,7 +1,10 @@
 package com.slack.api.scim.model;
 
 import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -9,7 +12,11 @@ import java.util.List;
 @Data
 public class User {
 
-    private List<String> schemas = Arrays.asList(Schemas.SCHEMA_CORE, Schemas.SCHEMA_EXTENSION_ENTERPRISE);
+    private List<String> schemas = Arrays.asList(
+            Schemas.SCHEMA_CORE,
+            Schemas.SCHEMA_EXTENSION_ENTERPRISE,
+            Schemas.SCHEMA_EXTENSION_SLACK_GUEST
+    );
 
     private String id;
     private String externalId;
@@ -37,16 +44,24 @@ public class User {
 
     @SerializedName(Schemas.SCHEMA_EXTENSION_ENTERPRISE)
     private Extension extension;
+    @SerializedName(Schemas.SCHEMA_EXTENSION_SLACK_GUEST)
+    private SlackGuest slackGuest;
 
     private List<Group> groups;
 
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Meta {
         private String created;
         private String location;
     }
 
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Name {
         private String givenName;
         private String familyName;
@@ -54,6 +69,9 @@ public class User {
     }
 
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Email {
         private String value;
         private String type;
@@ -61,6 +79,9 @@ public class User {
     }
 
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Address {
         private String streetAddress;
         private String locality;
@@ -71,6 +92,9 @@ public class User {
     }
 
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class PhoneNumber {
         private String value;
         private String type;
@@ -78,12 +102,18 @@ public class User {
     }
 
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Photo {
         private String value;
         private String type;
     }
 
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Role {
         private String value;
         private String type;
@@ -91,6 +121,9 @@ public class User {
     }
 
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Extension {
         private String employeeNumber;
         private String costCenter;
@@ -106,9 +139,33 @@ public class User {
     }
 
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Group {
         private String value;
         private String display;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SlackGuest {
+        public static class Types {
+            public static final String MULTI = "multi";
+        }
+
+        /**
+         * This value is mandatory.
+         * possible values: "multi"
+         */
+        private String type;
+        /**
+         * This value is optional.
+         * possible values: ISO 8601 date time string (e.g., "2020-11-30T23:59:59Z")
+         */
+        private String expiration;
     }
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/model/User.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/model/User.java
@@ -153,6 +153,9 @@ public class User {
     @AllArgsConstructor
     public static class SlackGuest {
         public static class Types {
+            private Types() {
+            }
+
             public static final String MULTI = "multi";
         }
 

--- a/slack-api-client/src/test/java/test_locally/api/scim/ModelsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim/ModelsTest.java
@@ -12,6 +12,8 @@ public class ModelsTest {
 
     @Test
     public void extensions() {
+        assertEquals(User.SlackGuest.Types.MULTI, "multi");
+
         User user = new User();
         user.setId("W1234567890");
         User.Extension enterprise = new User.Extension();

--- a/slack-api-client/src/test/java/test_locally/api/scim/ModelsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim/ModelsTest.java
@@ -1,0 +1,38 @@
+package test_locally.api.scim;
+
+import com.slack.api.SlackConfig;
+import com.slack.api.scim.model.User;
+import com.slack.api.util.json.GsonFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ModelsTest {
+
+    @Test
+    public void extensions() {
+        User user = new User();
+        user.setId("W1234567890");
+        User.Extension enterprise = new User.Extension();
+        enterprise.setDivision("Engineering");
+        user.setExtension(User.Extension.builder()
+                .employeeNumber("123-456")
+                .organization("PDE")
+                .division("Product")
+                .department("Product")
+                .build());
+        user.setSlackGuest(User.SlackGuest.builder()
+                .type("multi")
+                .expiration("2020-11-30T23:59:59Z")
+                .build());
+
+        assertNotNull(user);
+        assertNotNull(user.getExtension().getDivision());
+        assertNotNull(user.getSlackGuest().getType());
+
+        String json = GsonFactory.createCamelCase(SlackConfig.DEFAULT).toJson(user);
+        String expectedJson = "{\"schemas\":[\"urn:scim:schemas:core:1.0\",\"urn:scim:schemas:extension:enterprise:1.0\",\"urn:scim:schemas:extension:slack:guest:1.0\"],\"id\":\"W1234567890\",\"urn:scim:schemas:extension:enterprise:1.0\":{\"employeeNumber\":\"123-456\",\"organization\":\"PDE\",\"division\":\"Product\",\"department\":\"Product\"},\"urn:scim:schemas:extension:slack:guest:1.0\":{\"type\":\"multi\",\"expiration\":\"2020-11-30T23:59:59Z\"}}";
+        assertEquals(expectedJson, json);
+    }
+}


### PR DESCRIPTION
This pull request resolves #862 by adding the Slack's custom extension schema support. 

To learn what it is, refer to the issue #862 and [the official document](https://api.slack.com/scim#post-multi-channel-guest).

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
