### PR TITLE
Fix #887 by skipping to create team_id cache data for metrics

### DIFF
--- a/bolt-servlet/src/test/java/samples/OpenIDConnectSample.java
+++ b/bolt-servlet/src/test/java/samples/OpenIDConnectSample.java
@@ -49,6 +49,10 @@ public class OpenIDConnectSample {
                     OpenIDConnectUserInfoResponse userInfo = teamIdWiredClient.openIDConnectUserInfo(r -> r
                             .token(refreshedToken.getAccessToken()));
                     logger.info("userInfo: {}", userInfo);
+
+                    // To revoke this, you can use auth.revoke API method
+                    // Slack.getInstance().methods().authRevoke(r -> r.token(refreshedToken.getAccessToken()));
+
                 } else {
                     OpenIDConnectUserInfoResponse userInfo = client.openIDConnectUserInfo(r -> r
                             .token(token.getAccessToken()));

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
 
+import static com.slack.api.methods.impl.TeamIdCache.METHOD_NAMES_TO_SKIP_TEAM_ID_CACHE_RESOLUTION;
+
 @Slf4j
 public class AsyncRateLimitExecutor {
 
@@ -60,7 +62,9 @@ public class AsyncRateLimitExecutor {
             Map<String, String> params,
             AsyncExecutionSupplier<T> methodsSupplier) {
         String token = params.get("token");
-        final String teamId = token != null ? teamIdCache.lookupOrResolve(token) : null;
+        final String teamId = (token != null
+                && METHOD_NAMES_TO_SKIP_TEAM_ID_CACHE_RESOLUTION.contains(methodName)) ?
+                teamIdCache.lookupOrResolve(token) : null;
         final ExecutorService executorService = teamId != null ? ThreadPools.getOrCreate(config, teamId) : ThreadPools.getDefault(config);
         return CompletableFuture.supplyAsync(() -> {
             if (NO_TOKEN_METHOD_NAMES.contains(methodName) || teamId == null) {

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
@@ -63,7 +63,7 @@ public class AsyncRateLimitExecutor {
             AsyncExecutionSupplier<T> methodsSupplier) {
         String token = params.get("token");
         final String teamId = (token != null
-                && METHOD_NAMES_TO_SKIP_TEAM_ID_CACHE_RESOLUTION.contains(methodName)) ?
+                && !METHOD_NAMES_TO_SKIP_TEAM_ID_CACHE_RESOLUTION.contains(methodName)) ?
                 teamIdCache.lookupOrResolve(token) : null;
         final ExecutorService executorService = teamId != null ? ThreadPools.getOrCreate(config, teamId) : ThreadPools.getDefault(config);
         return CompletableFuture.supplyAsync(() -> {

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -219,6 +219,7 @@ import java.util.*;
 
 import static com.slack.api.methods.RequestFormBuilder.toForm;
 import static com.slack.api.methods.RequestFormBuilder.toMultipartBody;
+import static com.slack.api.methods.impl.TeamIdCache.METHOD_NAMES_TO_SKIP_TEAM_ID_CACHE_RESOLUTION;
 
 @Slf4j
 public class MethodsClientImpl implements MethodsClient {
@@ -3022,7 +3023,8 @@ public class MethodsClientImpl implements MethodsClient {
             String methodName,
             String token) throws IOException {
         String teamId = this.teamId.orElse(null);
-        if (statsEnabled && teamId == null) {
+        if (statsEnabled && teamId == null
+                && !METHOD_NAMES_TO_SKIP_TEAM_ID_CACHE_RESOLUTION.contains(methodName)) {
             teamId = teamIdCache.lookupOrResolve(token);
         }
         try {
@@ -3047,7 +3049,8 @@ public class MethodsClientImpl implements MethodsClient {
             String token,
             Class<T> clazz) throws IOException, SlackApiException {
         String teamId = this.teamId.orElse(null);
-        if (statsEnabled && teamId == null) {
+        if (statsEnabled && teamId == null
+                && !METHOD_NAMES_TO_SKIP_TEAM_ID_CACHE_RESOLUTION.contains(methodName)) {
             teamId = teamIdCache.lookupOrResolve(token);
         }
         try {
@@ -3089,7 +3092,8 @@ public class MethodsClientImpl implements MethodsClient {
             String token,
             Class<T> clazz) throws IOException, SlackApiException {
         String teamId = this.teamId.orElse(null);
-        if (statsEnabled && teamId == null) {
+        if (statsEnabled && teamId == null
+                && !METHOD_NAMES_TO_SKIP_TEAM_ID_CACHE_RESOLUTION.contains(methodName)) {
             teamId = teamIdCache.lookupOrResolve(token);
         }
         try {

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/TeamIdCache.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/TeamIdCache.java
@@ -9,6 +9,8 @@ import okhttp3.FormBody;
 import okhttp3.Response;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
@@ -17,6 +19,14 @@ import static com.slack.api.methods.RequestFormBuilder.toForm;
 
 @Slf4j
 public class TeamIdCache {
+
+    // As the tokens issued for "Sign in with Slack" does not work with auth.test API method,
+    // we skip creating team_id cache for these API methods.
+    public static final List<String> METHOD_NAMES_TO_SKIP_TEAM_ID_CACHE_RESOLUTION = Arrays.asList(
+            "auth.revoke",
+            "openid.connect.token",
+            "openid.connect.userInfo"
+    );
 
     private static final ConcurrentMap<String, String> TOKEN_TO_TEAM_ID = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
This pull request resolves #887 by updating the internals of `MethodsClient`.

Let me share a bit more about why the `MethodsClient` performs `auth.test` API internally. The Java SDK's API clients support a smart rate limiter out-of-the-box. Refer to the document for more details: https://slack.dev/java-slack-sdk/guides/web-api-basics#rate-limits

To make this feature work with multiple workspace with a single API client instance, the API clients determine `team_id` (this can be `enterprise_id` if the token is issued by org-wide installation) and use it to look up the dedicated thread pool for the workspace/organization. Of course, performing `auth.test` API every time is not optimal in terms of runtime performance. Thus, the API clients manage `team_id` cache data per token.

This pull request disables the metrics data update for the following API methods:
* auth.revoke
* openid.connect.token
* openid.connect.userInfo

I don't think the change in this PR can change the existing behavior. For `auth.revoke`, as the token will be disabled by this call, you don't need to worry about rate limited errors with it any more. For `openid.*` endpoints, the metrics update and auto rate limiter never worked as the team_id resolution does not succeed ("Sign in with Slack" tokens are not available for auth.test API method). For these reasons, I'm sure that it's fine to have the change here in the next minor release.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
