### PR TITLE
Add focus_on_load support in Block Kit element classes

### DIFF
--- a/json-logs/samples/api/views.open.json
+++ b/json-logs/samples/api/views.open.json
@@ -48,7 +48,8 @@
             "trigger_actions_on": [
               ""
             ]
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -135,7 +136,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -236,7 +238,8 @@
             },
             "style": ""
           },
-          "response_url_enabled": false
+          "response_url_enabled": false,
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -291,7 +294,8 @@
           "filter": {
             "exclude_external_shared_channels": false,
             "exclude_bot_users": false
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -340,7 +344,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -389,7 +394,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -452,7 +458,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -582,7 +589,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -631,7 +639,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -711,7 +720,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -750,7 +760,8 @@
             "filter": {
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -783,7 +794,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "timepicker",
@@ -816,7 +828,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -863,7 +876,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -945,7 +959,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -978,7 +993,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/api/views.publish.json
+++ b/json-logs/samples/api/views.publish.json
@@ -48,7 +48,8 @@
             "trigger_actions_on": [
               ""
             ]
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -135,7 +136,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -236,7 +238,8 @@
             },
             "style": ""
           },
-          "response_url_enabled": false
+          "response_url_enabled": false,
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -291,7 +294,8 @@
           "filter": {
             "exclude_external_shared_channels": false,
             "exclude_bot_users": false
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -340,7 +344,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -389,7 +394,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -452,7 +458,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -582,7 +589,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -631,7 +639,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -711,7 +720,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -750,7 +760,8 @@
             "filter": {
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -783,7 +794,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "timepicker",
@@ -816,7 +828,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -863,7 +876,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -945,7 +959,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -978,7 +993,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/api/views.push.json
+++ b/json-logs/samples/api/views.push.json
@@ -48,7 +48,8 @@
             "trigger_actions_on": [
               ""
             ]
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -135,7 +136,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -236,7 +238,8 @@
             },
             "style": ""
           },
-          "response_url_enabled": false
+          "response_url_enabled": false,
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -291,7 +294,8 @@
           "filter": {
             "exclude_external_shared_channels": false,
             "exclude_bot_users": false
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -340,7 +344,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -389,7 +394,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -452,7 +458,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -582,7 +589,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -631,7 +639,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -711,7 +720,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -750,7 +760,8 @@
             "filter": {
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -783,7 +794,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "timepicker",
@@ -816,7 +828,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -863,7 +876,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -945,7 +959,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -978,7 +993,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/api/views.update.json
+++ b/json-logs/samples/api/views.update.json
@@ -48,7 +48,8 @@
             "trigger_actions_on": [
               ""
             ]
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -135,7 +136,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -236,7 +238,8 @@
             },
             "style": ""
           },
-          "response_url_enabled": false
+          "response_url_enabled": false,
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -291,7 +294,8 @@
           "filter": {
             "exclude_external_shared_channels": false,
             "exclude_bot_users": false
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -340,7 +344,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -389,7 +394,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -452,7 +458,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -582,7 +589,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -631,7 +639,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         "dispatch_action": false,
         "hint": {
@@ -711,7 +720,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -750,7 +760,8 @@
             "filter": {
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -783,7 +794,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "timepicker",
@@ -816,7 +828,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -863,7 +876,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -945,7 +959,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -978,7 +993,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
@@ -111,7 +111,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "multi_channels_select",
@@ -144,7 +145,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -186,7 +188,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_conversations_select",
@@ -227,7 +230,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -260,7 +264,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -307,7 +312,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_external_select",
@@ -341,7 +347,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -423,7 +430,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_static_select",
@@ -456,7 +464,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -489,7 +498,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_users_select",
@@ -522,7 +532,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
@@ -83,7 +83,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "multi_channels_select",
@@ -116,7 +117,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -158,7 +160,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_conversations_select",
@@ -199,7 +202,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -232,7 +236,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -279,7 +284,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_external_select",
@@ -313,7 +319,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -395,7 +402,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_static_select",
@@ -428,7 +436,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -461,7 +470,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_users_select",
@@ -494,7 +504,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/events/AppMentionPayload.json
+++ b/json-logs/samples/events/AppMentionPayload.json
@@ -106,7 +106,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "multi_channels_select",
@@ -139,7 +140,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -181,7 +183,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_conversations_select",
@@ -222,7 +225,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -255,7 +259,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -302,7 +307,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_external_select",
@@ -336,7 +342,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -418,7 +425,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_static_select",
@@ -451,7 +459,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -484,7 +493,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_users_select",
@@ -517,7 +527,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/events/MessageBotPayload.json
+++ b/json-logs/samples/events/MessageBotPayload.json
@@ -99,7 +99,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "multi_channels_select",
@@ -132,7 +133,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -174,7 +176,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_conversations_select",
@@ -215,7 +218,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -248,7 +252,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -295,7 +300,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_external_select",
@@ -329,7 +335,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -411,7 +418,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_static_select",
@@ -444,7 +452,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -477,7 +486,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_users_select",
@@ -510,7 +520,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/events/MessageChangedPayload.json
+++ b/json-logs/samples/events/MessageChangedPayload.json
@@ -115,7 +115,8 @@
                 },
                 "style": ""
               },
-              "response_url_enabled": false
+              "response_url_enabled": false,
+              "focus_on_load": false
             },
             {
               "type": "multi_channels_select",
@@ -148,7 +149,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "conversations_select",
@@ -190,7 +192,8 @@
                 ],
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_conversations_select",
@@ -231,7 +234,8 @@
                 ],
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "datepicker",
@@ -264,7 +268,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "external_select",
@@ -311,7 +316,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_external_select",
@@ -345,7 +351,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "image",
@@ -427,7 +434,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_static_select",
@@ -460,7 +468,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "users_select",
@@ -493,7 +502,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_users_select",
@@ -526,7 +536,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             }
           ],
           "block_id": ""
@@ -802,7 +813,8 @@
                 },
                 "style": ""
               },
-              "response_url_enabled": false
+              "response_url_enabled": false,
+              "focus_on_load": false
             },
             {
               "type": "multi_channels_select",
@@ -835,7 +847,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "conversations_select",
@@ -877,7 +890,8 @@
                 ],
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_conversations_select",
@@ -918,7 +932,8 @@
                 ],
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "datepicker",
@@ -951,7 +966,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "external_select",
@@ -998,7 +1014,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_external_select",
@@ -1032,7 +1049,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "image",
@@ -1114,7 +1132,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_static_select",
@@ -1147,7 +1166,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "users_select",
@@ -1180,7 +1200,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_users_select",
@@ -1213,7 +1234,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             }
           ],
           "block_id": ""

--- a/json-logs/samples/events/MessageDeletedPayload.json
+++ b/json-logs/samples/events/MessageDeletedPayload.json
@@ -102,7 +102,8 @@
                 },
                 "style": ""
               },
-              "response_url_enabled": false
+              "response_url_enabled": false,
+              "focus_on_load": false
             },
             {
               "type": "multi_channels_select",
@@ -135,7 +136,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "conversations_select",
@@ -177,7 +179,8 @@
                 ],
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_conversations_select",
@@ -218,7 +221,8 @@
                 ],
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "datepicker",
@@ -251,7 +255,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "external_select",
@@ -298,7 +303,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_external_select",
@@ -332,7 +338,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "image",
@@ -414,7 +421,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_static_select",
@@ -447,7 +455,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "users_select",
@@ -480,7 +489,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_users_select",
@@ -513,7 +523,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             }
           ],
           "block_id": ""

--- a/json-logs/samples/events/MessageEkmAccessDeniedPayload.json
+++ b/json-logs/samples/events/MessageEkmAccessDeniedPayload.json
@@ -92,7 +92,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "multi_channels_select",
@@ -125,7 +126,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -167,7 +169,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_conversations_select",
@@ -208,7 +211,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -241,7 +245,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -288,7 +293,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_external_select",
@@ -322,7 +328,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -404,7 +411,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_static_select",
@@ -437,7 +445,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -470,7 +479,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_users_select",
@@ -503,7 +513,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/events/MessageFileSharePayload.json
+++ b/json-logs/samples/events/MessageFileSharePayload.json
@@ -89,7 +89,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "multi_channels_select",
@@ -122,7 +123,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -164,7 +166,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_conversations_select",
@@ -205,7 +208,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -238,7 +242,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -285,7 +290,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_external_select",
@@ -319,7 +325,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -401,7 +408,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_static_select",
@@ -434,7 +442,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -467,7 +476,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_users_select",
@@ -500,7 +510,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/events/MessagePayload.json
+++ b/json-logs/samples/events/MessagePayload.json
@@ -106,7 +106,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "multi_channels_select",
@@ -139,7 +140,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -181,7 +183,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_conversations_select",
@@ -222,7 +225,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -255,7 +259,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -302,7 +307,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_external_select",
@@ -336,7 +342,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -418,7 +425,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_static_select",
@@ -451,7 +459,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -484,7 +493,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_users_select",
@@ -517,7 +527,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/events/MessageRepliedPayload.json
+++ b/json-logs/samples/events/MessageRepliedPayload.json
@@ -101,7 +101,8 @@
                 },
                 "style": ""
               },
-              "response_url_enabled": false
+              "response_url_enabled": false,
+              "focus_on_load": false
             },
             {
               "type": "multi_channels_select",
@@ -134,7 +135,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "conversations_select",
@@ -176,7 +178,8 @@
                 ],
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_conversations_select",
@@ -217,7 +220,8 @@
                 ],
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "datepicker",
@@ -250,7 +254,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "external_select",
@@ -297,7 +302,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_external_select",
@@ -331,7 +337,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "image",
@@ -413,7 +420,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_static_select",
@@ -446,7 +454,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             },
             {
               "type": "users_select",
@@ -479,7 +488,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "multi_users_select",
@@ -512,7 +522,8 @@
                 },
                 "style": ""
               },
-              "max_selected_items": 123
+              "max_selected_items": 123,
+              "focus_on_load": false
             }
           ],
           "block_id": ""

--- a/json-logs/samples/events/MessageThreadBroadcastPayload.json
+++ b/json-logs/samples/events/MessageThreadBroadcastPayload.json
@@ -135,7 +135,8 @@
               },
               "style": ""
             },
-            "response_url_enabled": false
+            "response_url_enabled": false,
+            "focus_on_load": false
           },
           {
             "type": "multi_channels_select",
@@ -168,7 +169,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "conversations_select",
@@ -210,7 +212,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_conversations_select",
@@ -251,7 +254,8 @@
               ],
               "exclude_external_shared_channels": false,
               "exclude_bot_users": false
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "datepicker",
@@ -284,7 +288,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "external_select",
@@ -331,7 +336,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_external_select",
@@ -365,7 +371,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "image",
@@ -447,7 +454,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_static_select",
@@ -480,7 +488,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           },
           {
             "type": "users_select",
@@ -513,7 +522,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "focus_on_load": false
           },
           {
             "type": "multi_users_select",
@@ -546,7 +556,8 @@
               },
               "style": ""
             },
-            "max_selected_items": 123
+            "max_selected_items": 123,
+            "focus_on_load": false
           }
         ],
         "block_id": ""

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -90,7 +90,8 @@
             },
             "style": ""
           },
-          "response_url_enabled": false
+          "response_url_enabled": false,
+          "focus_on_load": false
         },
         {
           "type": "conversations_select",
@@ -129,7 +130,8 @@
           "filter": {
             "exclude_external_shared_channels": false,
             "exclude_bot_users": false
-          }
+          },
+          "focus_on_load": false
         },
         {
           "type": "datepicker",
@@ -162,7 +164,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         {
           "type": "timepicker",
@@ -195,7 +198,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         {
           "type": "external_select",
@@ -242,7 +246,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         {
           "type": "image",
@@ -324,7 +329,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         },
         {
           "type": "users_select",
@@ -357,7 +363,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "focus_on_load": false
         }
       ],
       "block_id": ""

--- a/json-logs/samples/rtm/PinAddedEvent.json
+++ b/json-logs/samples/rtm/PinAddedEvent.json
@@ -98,7 +98,8 @@
                 },
                 "style": ""
               },
-              "response_url_enabled": false
+              "response_url_enabled": false,
+              "focus_on_load": false
             },
             {
               "type": "conversations_select",
@@ -137,7 +138,8 @@
               "filter": {
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "datepicker",
@@ -170,7 +172,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "timepicker",
@@ -203,7 +206,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "external_select",
@@ -250,7 +254,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "image",
@@ -332,7 +337,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "users_select",
@@ -365,7 +371,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             }
           ],
           "block_id": ""

--- a/json-logs/samples/rtm/PinRemovedEvent.json
+++ b/json-logs/samples/rtm/PinRemovedEvent.json
@@ -98,7 +98,8 @@
                 },
                 "style": ""
               },
-              "response_url_enabled": false
+              "response_url_enabled": false,
+              "focus_on_load": false
             },
             {
               "type": "conversations_select",
@@ -137,7 +138,8 @@
               "filter": {
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "datepicker",
@@ -170,7 +172,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "timepicker",
@@ -203,7 +206,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "external_select",
@@ -250,7 +254,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "image",
@@ -332,7 +337,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "users_select",
@@ -365,7 +371,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             }
           ],
           "block_id": ""

--- a/json-logs/samples/rtm/StarAddedEvent.json
+++ b/json-logs/samples/rtm/StarAddedEvent.json
@@ -98,7 +98,8 @@
                 },
                 "style": ""
               },
-              "response_url_enabled": false
+              "response_url_enabled": false,
+              "focus_on_load": false
             },
             {
               "type": "conversations_select",
@@ -137,7 +138,8 @@
               "filter": {
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "datepicker",
@@ -170,7 +172,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "timepicker",
@@ -203,7 +206,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "external_select",
@@ -250,7 +254,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "image",
@@ -332,7 +337,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "users_select",
@@ -365,7 +371,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             }
           ],
           "block_id": ""

--- a/json-logs/samples/rtm/StarRemovedEvent.json
+++ b/json-logs/samples/rtm/StarRemovedEvent.json
@@ -97,7 +97,8 @@
                 },
                 "style": ""
               },
-              "response_url_enabled": false
+              "response_url_enabled": false,
+              "focus_on_load": false
             },
             {
               "type": "conversations_select",
@@ -136,7 +137,8 @@
               "filter": {
                 "exclude_external_shared_channels": false,
                 "exclude_bot_users": false
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "datepicker",
@@ -169,7 +171,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "timepicker",
@@ -202,7 +205,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "external_select",
@@ -249,7 +253,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "image",
@@ -331,7 +336,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             },
             {
               "type": "users_select",
@@ -364,7 +370,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "focus_on_load": false
             }
           ],
           "block_id": ""

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/ChannelsSelectElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/ChannelsSelectElementBuilder.kt
@@ -15,6 +15,7 @@ class ChannelsSelectElementBuilder : Builder<ChannelsSelectElement> {
     private var initialChannel: String? = null
     private var responseUrlEnabled: Boolean? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Fills the placeholder field with a plain text object.
@@ -69,6 +70,16 @@ class ChannelsSelectElementBuilder : Builder<ChannelsSelectElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#channel_select">Channels select element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): ChannelsSelectElement {
         return ChannelsSelectElement.builder()
                 .actionId(actionId)
@@ -76,6 +87,7 @@ class ChannelsSelectElementBuilder : Builder<ChannelsSelectElement> {
                 .initialChannel(initialChannel)
                 .confirm(confirm)
                 .responseUrlEnabled(responseUrlEnabled)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/CheckboxesElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/CheckboxesElementBuilder.kt
@@ -16,6 +16,7 @@ class CheckboxesElementBuilder : Builder<CheckboxesElement> {
     private var options: List<OptionObject>? = null
     private var initialOptions: List<OptionObject>? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * An identifier for the action triggered when the checkbox group is changed. You can use this when you receive
@@ -55,12 +56,23 @@ class CheckboxesElementBuilder : Builder<CheckboxesElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#checkboxes">Checkboxes element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): CheckboxesElement {
         return CheckboxesElement.builder()
                 .actionId(actionId)
                 .options(options)
                 .initialOptions(initialOptions)
                 .confirm(confirm)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/ConversationsSelectElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/ConversationsSelectElementBuilder.kt
@@ -17,6 +17,7 @@ class ConversationsSelectElementBuilder : Builder<ConversationsSelectElement> {
     private var defaultToCurrentConversation: Boolean? = null
     private var filter: ConversationsFilter? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Fills the placeholder field with a plain text object.
@@ -111,6 +112,16 @@ class ConversationsSelectElementBuilder : Builder<ConversationsSelectElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#conversation_select">Conversations select element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): ConversationsSelectElement {
         return ConversationsSelectElement.builder()
                 .placeholder(placeholder)
@@ -120,6 +131,7 @@ class ConversationsSelectElementBuilder : Builder<ConversationsSelectElement> {
                 .responseUrlEnabled(responseUrlEnabled)
                 .defaultToCurrentConversation(defaultToCurrentConversation)
                 .filter(filter)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/DatePickerElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/DatePickerElementBuilder.kt
@@ -13,6 +13,7 @@ class DatePickerElementBuilder : Builder<DatePickerElement> {
     private var actionId: String? = null
     private var initialDate: String? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Creates a plain text object in the placeholder field.
@@ -54,12 +55,23 @@ class DatePickerElementBuilder : Builder<DatePickerElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#datepicker">Date picker element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): DatePickerElement {
         return DatePickerElement.builder()
                 .actionId(actionId)
                 .placeholder(placeholder)
                 .initialDate(initialDate)
                 .confirm(confirm)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/ExternalSelectElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/ExternalSelectElementBuilder.kt
@@ -16,6 +16,7 @@ class ExternalSelectElementBuilder : Builder<ExternalSelectElement> {
     private var initialOption: OptionObject? = null
     private var minQueryLength: Int? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Adds a plain text object to the placeholder field.
@@ -69,6 +70,16 @@ class ExternalSelectElementBuilder : Builder<ExternalSelectElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#external_select">External select element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): ExternalSelectElement {
         return ExternalSelectElement.builder()
                 .placeholder(placeholder)
@@ -76,6 +87,7 @@ class ExternalSelectElementBuilder : Builder<ExternalSelectElement> {
                 .initialOption(initialOption)
                 .minQueryLength(minQueryLength)
                 .confirm(confirm)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/MultiChannelsSelectElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/MultiChannelsSelectElementBuilder.kt
@@ -14,6 +14,7 @@ class MultiChannelsSelectElementBuilder : Builder<MultiChannelsSelectElement> {
     private var initialChannels: List<String>? = null
     private var maxSelectedItems: Int? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Adds a plain text object in the placeholder field.
@@ -65,6 +66,16 @@ class MultiChannelsSelectElementBuilder : Builder<MultiChannelsSelectElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#channel_multi_select">Multi channels select element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): MultiChannelsSelectElement {
         return MultiChannelsSelectElement.builder()
                 .placeholder(placeholder)
@@ -72,6 +83,7 @@ class MultiChannelsSelectElementBuilder : Builder<MultiChannelsSelectElement> {
                 .initialChannels(initialChannels)
                 .confirm(confirm)
                 .maxSelectedItems(maxSelectedItems)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/MultiConversationsSelectElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/MultiConversationsSelectElementBuilder.kt
@@ -17,6 +17,7 @@ class MultiConversationsSelectElementBuilder : Builder<MultiConversationsSelectE
     private var defaultToCurrentConversation: Boolean? = null
     private var filter: ConversationsFilter? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Adds a plain text object in the placeholder field.
@@ -109,6 +110,16 @@ class MultiConversationsSelectElementBuilder : Builder<MultiConversationsSelectE
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select">Multi conversations select element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): MultiConversationsSelectElement {
         return MultiConversationsSelectElement.builder()
                 .placeholder(placeholder)
@@ -118,6 +129,7 @@ class MultiConversationsSelectElementBuilder : Builder<MultiConversationsSelectE
                 .maxSelectedItems(maxSelectedItems)
                 .defaultToCurrentConversation(defaultToCurrentConversation)
                 .filter(filter)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/MultiExternalSelectElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/MultiExternalSelectElementBuilder.kt
@@ -18,6 +18,7 @@ class MultiExternalSelectElementBuilder : Builder<MultiExternalSelectElement> {
     private var minQueryLength: Int? = null
     private var maxSelectedItems: Int? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Adds a plain text object in the placeholder field.
@@ -81,6 +82,16 @@ class MultiExternalSelectElementBuilder : Builder<MultiExternalSelectElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#external_multi_select">Multi external select element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): MultiExternalSelectElement {
         return MultiExternalSelectElement.builder()
                 .placeholder(placeholder)
@@ -89,6 +100,7 @@ class MultiExternalSelectElementBuilder : Builder<MultiExternalSelectElement> {
                 .minQueryLength(minQueryLength)
                 .maxSelectedItems(maxSelectedItems)
                 .confirm(confirm)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/MultiStaticSelectElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/MultiStaticSelectElementBuilder.kt
@@ -22,6 +22,7 @@ class MultiStaticSelectElementBuilder : Builder<MultiStaticSelectElement> {
     private var optionGroups: List<OptionGroupObject>? = null
     private var initialOptions: List<OptionObject>? = null
     private var maxSelectedItems: Int? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Adds a plain text object in the placeholder field.
@@ -93,6 +94,16 @@ class MultiStaticSelectElementBuilder : Builder<MultiStaticSelectElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#static_multi_select">Multi static select element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): MultiStaticSelectElement {
         return MultiStaticSelectElement.builder()
                 .placeholder(placeholder)
@@ -102,6 +113,7 @@ class MultiStaticSelectElementBuilder : Builder<MultiStaticSelectElement> {
                 .initialOptions(initialOptions)
                 .confirm(confirm)
                 .maxSelectedItems(maxSelectedItems)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/MultiUsersSelectElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/MultiUsersSelectElementBuilder.kt
@@ -14,6 +14,7 @@ class MultiUsersSelectElementBuilder : Builder<MultiUsersSelectElement> {
     private var initialUsers: List<String>? = null
     private var confirm: ConfirmationDialogObject? = null
     private var maxSelectedItems: Int? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Adds a plain text element to the placeholder field.
@@ -64,6 +65,16 @@ class MultiUsersSelectElementBuilder : Builder<MultiUsersSelectElement> {
         maxSelectedItems = max
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#users_multi_select">Multi users select element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): MultiUsersSelectElement {
         return MultiUsersSelectElement.builder()
                 .placeholder(placeholder)
@@ -71,6 +82,7 @@ class MultiUsersSelectElementBuilder : Builder<MultiUsersSelectElement> {
                 .initialUsers(initialUsers)
                 .confirm(confirm)
                 .maxSelectedItems(maxSelectedItems)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/PlainTextInputElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/PlainTextInputElementBuilder.kt
@@ -16,6 +16,7 @@ class PlainTextInputElementBuilder : Builder<PlainTextInputElement> {
     private var minLength: Int? = null
     private var maxLength: Int? = null
     private var dispatchActionConfig: DispatchActionConfig? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * An identifier for the input value when the parent modal is submitted. You can use this when you receive a
@@ -84,6 +85,16 @@ class PlainTextInputElementBuilder : Builder<PlainTextInputElement> {
         dispatchActionConfig = DispatchActionConfigBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config">The document</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): PlainTextInputElement {
         return PlainTextInputElement.builder()
                 .actionId(actionId)
@@ -93,6 +104,7 @@ class PlainTextInputElementBuilder : Builder<PlainTextInputElement> {
                 .minLength(minLength)
                 .maxLength(maxLength)
                 .dispatchActionConfig(dispatchActionConfig)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/RadioButtonsElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/RadioButtonsElementBuilder.kt
@@ -16,6 +16,7 @@ class RadioButtonsElementBuilder : Builder<RadioButtonsElement> {
     private var options: List<OptionObject>? = null
     private var initialOption: OptionObject? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * An identifier for the action triggered when the radio button group is changed. You can use this when you
@@ -57,12 +58,23 @@ class RadioButtonsElementBuilder : Builder<RadioButtonsElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#radio">Radio buttons element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): RadioButtonsElement {
         return RadioButtonsElement.builder()
                 .actionId(actionId)
                 .options(options)
                 .initialOption(initialOption)
                 .confirm(confirm)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/StaticSelectElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/StaticSelectElementBuilder.kt
@@ -22,6 +22,7 @@ class StaticSelectElementBuilder : Builder<StaticSelectElement> {
     private var optionGroups: List<OptionGroupObject>? = null
     private var initialOption: OptionObject? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Adds a plain text object to the placeholder field.
@@ -84,6 +85,16 @@ class StaticSelectElementBuilder : Builder<StaticSelectElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#static_select">Static select element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): StaticSelectElement {
         return StaticSelectElement.builder()
                 .placeholder(placeholder)
@@ -92,6 +103,7 @@ class StaticSelectElementBuilder : Builder<StaticSelectElement> {
                 .optionGroups(optionGroups)
                 .initialOption(initialOption)
                 .confirm(confirm)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/TimePickerElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/TimePickerElementBuilder.kt
@@ -13,6 +13,7 @@ class TimePickerElementBuilder : Builder<TimePickerElement> {
     private var actionId: String? = null
     private var initialTime: String? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * A plain_text only text object that defines the placeholder text shown on the timepicker.
@@ -55,12 +56,23 @@ class TimePickerElementBuilder : Builder<TimePickerElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#timepicker">Time picker element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): TimePickerElement {
         return TimePickerElement.builder()
                 .actionId(actionId)
                 .placeholder(placeholder)
                 .initialTime(initialTime)
                 .confirm(confirm)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/UsersSelectElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/UsersSelectElementBuilder.kt
@@ -13,6 +13,7 @@ class UsersSelectElementBuilder : Builder<UsersSelectElement> {
     private var actionId: String? = null
     private var initialUser: String? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _focusOnLoad: Boolean? = null
 
     /**
      * Adds a plain text object to the placeholder field.
@@ -54,12 +55,23 @@ class UsersSelectElementBuilder : Builder<UsersSelectElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#users_select">Users select element documentation</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
     override fun build(): UsersSelectElement {
         return UsersSelectElement.builder()
                 .placeholder(placeholder)
                 .actionId(actionId)
                 .initialUser(initialUser)
                 .confirm(confirm)
+                .focusOnLoad(_focusOnLoad)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/ModalTemplateTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/ModalTemplateTest.kt
@@ -105,6 +105,7 @@ class ModalTemplateTest {
                 element {
                     plainTextInput {
                         multiline(true)
+                        focusOnLoad(true)
                     }
                 }
                 optional(true)
@@ -299,7 +300,8 @@ class ModalTemplateTest {
 			},
 			"element": {
 				"type": "plain_text_input",
-				"multiline": true
+				"multiline": true,
+                "focus_on_load":true
 			},
 			"optional": true
 		}

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ChannelsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ChannelsSelectElement.java
@@ -47,4 +47,10 @@ public class ChannelsSelectElement extends BlockElement {
      * The target conversation for the message will be determined by the value of this select menu.
      */
     private Boolean responseUrlEnabled;
+
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/CheckboxesElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/CheckboxesElement.java
@@ -49,4 +49,10 @@ public class CheckboxesElement extends BlockElement {
      * that appears after clicking one of the checkboxes in this element.
      */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ConversationsSelectElement.java
@@ -59,4 +59,9 @@ public class ConversationsSelectElement extends BlockElement {
      */
     private ConversationsFilter filter;
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/DatePickerElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/DatePickerElement.java
@@ -40,4 +40,10 @@ public class DatePickerElement extends BlockElement {
      */
     private ConfirmationDialogObject confirm;
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ExternalSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ExternalSelectElement.java
@@ -50,4 +50,9 @@ public class ExternalSelectElement extends BlockElement {
      */
     private ConfirmationDialogObject confirm;
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiChannelsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiChannelsSelectElement.java
@@ -49,4 +49,9 @@ public class MultiChannelsSelectElement extends BlockElement {
      */
     private Integer maxSelectedItems;
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiConversationsSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiConversationsSelectElement.java
@@ -60,4 +60,9 @@ public class MultiConversationsSelectElement extends BlockElement {
      */
     private ConversationsFilter filter;
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiExternalSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiExternalSelectElement.java
@@ -58,4 +58,9 @@ public class MultiExternalSelectElement extends BlockElement {
      */
     private Integer maxSelectedItems;
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiStaticSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiStaticSelectElement.java
@@ -75,4 +75,10 @@ public class MultiStaticSelectElement extends BlockElement {
      * Specifies the maximum number of items that can be selected in the menu. Minimum number is 1.
      */
     private Integer maxSelectedItems;
+
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiUsersSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/MultiUsersSelectElement.java
@@ -47,4 +47,10 @@ public class MultiUsersSelectElement extends BlockElement {
      * Minimum number is 1.
      */
     private Integer maxSelectedItems;
+
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/PlainTextInputElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/PlainTextInputElement.java
@@ -52,5 +52,15 @@ public class PlainTextInputElement extends BlockElement {
      */
     private Integer maxLength;
 
+    /**
+     * A dispatch configuration object that determines
+     * when during text input the element returns a block_actions payload.
+     */
     private DispatchActionConfig dispatchActionConfig;
+
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RadioButtonsElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RadioButtonsElement.java
@@ -49,4 +49,10 @@ public class RadioButtonsElement extends BlockElement {
      * that appears after clicking one of the radio buttons in this element.
      */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/StaticSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/StaticSelectElement.java
@@ -47,6 +47,20 @@ public class StaticSelectElement extends BlockElement {
      */
     private List<OptionGroupObject> optionGroups;
 
+    /**
+     * A single option that exactly matches one of the options within options or option_groups.
+     * This option will be selected when the menu initially loads.
+     */
     private OptionObject initialOption;
+
+    /**
+     * A confirm object that defines an optional confirmation dialog that appears after a menu item is selected.
+     */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/TimePickerElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/TimePickerElement.java
@@ -42,4 +42,9 @@ public class TimePickerElement extends BlockElement {
      */
     private ConfirmationDialogObject confirm;
 
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/UsersSelectElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/UsersSelectElement.java
@@ -39,4 +39,10 @@ public class UsersSelectElement extends BlockElement {
      * A confirm object that defines an optional confirmation dialog that appears after a menu item is selected.
      */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * Indicates whether the element will be set to auto focus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -428,4 +428,56 @@ public class BlocksTest {
         assertThat(output, is("{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Pick a date for the deadline.\"},\"block_id\":\"section1234\",\"accessory\":{\"type\":\"timepicker\",\"action_id\":\"timepicker123\",\"placeholder\":{\"type\":\"plain_text\",\"text\":\"Select a time\"},\"initial_time\":\"11:40\"}}"));
     }
 
+    @Test
+    public void focusOnLoad() {
+        String json = "{\"blocks\":[\n" +
+                "  {\n" +
+                "    \"type\": \"input\",\n" +
+                "    \"element\": {\n" +
+                "      \"type\": \"conversations_select\",\n" +
+                "      \"placeholder\": {\n" +
+                "        \"type\": \"plain_text\",\n" +
+                "        \"text\": \"Select a conversation\"\n" +
+                "      },\n" +
+                "      \"focus_on_load\": true\n" +
+                "    },\n" +
+                "    \"label\": {\n" +
+                "      \"type\": \"plain_text\",\n" +
+                "      \"text\": \"Choose the conversation to publish your result to:\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "]}";
+        View view = GsonFactory.createSnakeCase().fromJson(json, View.class);
+        assertNotNull(view);
+        assertEquals(1, view.getBlocks().size());
+        InputBlock block = (InputBlock) view.getBlocks().get(0);
+        ConversationsSelectElement element = (ConversationsSelectElement) block.getElement();
+        assertTrue(element.getFocusOnLoad());
+    }
+
+    @Test
+    public void noFocusOnLoad() {
+        String json = "{\"blocks\":[\n" +
+                "  {\n" +
+                "    \"type\": \"input\",\n" +
+                "    \"element\": {\n" +
+                "      \"type\": \"conversations_select\",\n" +
+                "      \"placeholder\": {\n" +
+                "        \"type\": \"plain_text\",\n" +
+                "        \"text\": \"Select a conversation\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"label\": {\n" +
+                "      \"type\": \"plain_text\",\n" +
+                "      \"text\": \"Choose the conversation to publish your result to:\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "]}";
+        View view = GsonFactory.createSnakeCase().fromJson(json, View.class);
+        assertNotNull(view);
+        assertEquals(1, view.getBlocks().size());
+        InputBlock block = (InputBlock) view.getBlocks().get(0);
+        ConversationsSelectElement element = (ConversationsSelectElement) block.getElement();
+        assertNull(element.getFocusOnLoad());
+    }
 }


### PR DESCRIPTION
This pull request adds a new property `focus_on_load` to block element classes.

>Block elements can now utilize the focus_on_load field within Block kit messages, which allows you to pick one specific Block element to auto focus on. Learn more.

* https://api.slack.com/changelog
* https://api.slack.com/reference/block-kit/block-elements

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
