### PR TITLE
Fix #895 Calling chat.unfurl with user_auth_blocks resulting in error invalid_arguments

### DIFF
--- a/bolt-servlet/src/test/java/samples/AuthenticatedUnfurlsSample.java
+++ b/bolt-servlet/src/test/java/samples/AuthenticatedUnfurlsSample.java
@@ -1,0 +1,94 @@
+package samples;
+
+import com.slack.api.app_backend.events.payload.EventsApiPayload;
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.context.builtin.EventContext;
+import com.slack.api.methods.response.chat.ChatUnfurlResponse;
+import com.slack.api.model.event.LinkSharedEvent;
+import com.slack.api.model.event.MessageEvent;
+import util.ResourceLoader;
+import util.TestSlackAppServer;
+
+import java.util.concurrent.CompletableFuture;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static com.slack.api.model.block.element.BlockElements.asElements;
+import static com.slack.api.model.block.element.BlockElements.button;
+
+public class AuthenticatedUnfurlsSample {
+
+    public static CompletableFuture<ChatUnfurlResponse> displayUserAuthRequired(
+            EventsApiPayload<LinkSharedEvent> req,
+            EventContext ctx
+    ) {
+        return ctx.asyncClient().chatUnfurl(r -> r
+                .channel(ctx.getChannelId())
+                .ts(req.getEvent().getMessageTs())
+                .userAuthRequired(true)
+        );
+    }
+
+    public static CompletableFuture<ChatUnfurlResponse> displayUserAuthMessage(
+            EventsApiPayload<LinkSharedEvent> req,
+            EventContext ctx
+    ) {
+        return ctx.asyncClient().chatUnfurl(r -> r
+                .channel(ctx.getChannelId())
+                .ts(req.getEvent().getMessageTs())
+                .userAuthMessage("Loading the preview... <https://www.example.com/auth|Connect your account>")
+        );
+    }
+
+    public static CompletableFuture<ChatUnfurlResponse> displayUserAuthUrl(
+            EventsApiPayload<LinkSharedEvent> req,
+            EventContext ctx
+    ) {
+        return ctx.asyncClient().chatUnfurl(r -> r
+                .channel(ctx.getChannelId())
+                .ts(req.getEvent().getMessageTs())
+                .userAuthUrl("https://www.example.com/auth")
+        );
+    }
+
+    public static CompletableFuture<ChatUnfurlResponse> displayUserAuthBlocks(
+            EventsApiPayload<LinkSharedEvent> req,
+            EventContext ctx
+    ) {
+        return ctx.asyncClient().chatUnfurl(r -> r
+                .channel(ctx.getChannelId())
+                .ts(req.getEvent().getMessageTs())
+                .userAuthBlocks(asBlocks(
+                        section(s -> s
+                                .blockId("intro-section")
+                                .text(plainText("Loading the preview... :eyes:"))
+                        ),
+                        actions(a -> a.elements(asElements(
+                                button(b -> b
+                                        .actionId("button-click")
+                                        .url("https://www.example.com/auth")
+                                        .text(plainText("Connect your account"))
+                                )
+                        )))
+                ))
+        );
+    }
+
+    public static void main(String[] args) throws Exception {
+        AppConfig config = ResourceLoader.loadAppConfig();
+        App app = new App(config);
+        app.event(MessageEvent.class, (req, ctx) -> ctx.ack());
+        app.event(LinkSharedEvent.class, (req, ctx) -> {
+            displayUserAuthRequired(req, ctx);
+            displayUserAuthMessage(req, ctx);
+            displayUserAuthBlocks(req, ctx);
+            displayUserAuthUrl(req, ctx);
+            return ctx.ack();
+        });
+        app.blockAction("button-click", (req, ctx) -> ctx.ack());
+
+        TestSlackAppServer server = new TestSlackAppServer(app);
+        server.start();
+    }
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -1229,7 +1229,12 @@ public class RequestFormBuilder {
         }
         setIfNotNull("user_auth_required", req.isUserAuthRequired(), form);
         setIfNotNull("user_auth_message", req.getUserAuthMessage(), form);
-        setIfNotNull("user_auth_blocks", req.getUserAuthBlocks(), form);
+        if (req.getRawUserAuthBlocks() != null) {
+            setIfNotNull("user_auth_blocks", req.getRawUserAuthBlocks(), form);
+        } else if (req.getUserAuthBlocks() != null) {
+            String json = GSON.toJson(req.getUserAuthBlocks());
+            setIfNotNull("user_auth_blocks", json, form);
+        }
         setIfNotNull("user_auth_url", req.getUserAuthUrl(), form);
         setIfNotNull("unfurl_id", req.getUnfurlId(), form);
         setIfNotNull("source", req.getSource(), form);

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
@@ -28,6 +28,8 @@ public class ChatUnfurlRequest implements SlackApiRequest {
      */
     private String userAuthMessage;
 
+    private String rawUserAuthBlocks;
+
     /**
      * Provide an array of blocks to send as an ephemeral message to the user
      * as invitation to authenticate further and enable full unfurling behavior
@@ -40,6 +42,12 @@ public class ChatUnfurlRequest implements SlackApiRequest {
     private boolean userAuthRequired;
 
     /**
+     * Send users to this custom URL where they will complete authentication in your app to fully trigger unfurling.
+     * Value should be properly URL-encoded.
+     */
+    private String userAuthUrl;
+
+    /**
      * URL-encoded JSON map with keys set to URLs featured in the message, pointing to their unfurl message attachments.
      */
     private String rawUnfurls;
@@ -50,12 +58,6 @@ public class ChatUnfurlRequest implements SlackApiRequest {
      * Timestamp of the message to add unfurl behavior to.
      */
     private String ts;
-
-    /**
-     * Send users to this custom URL where they will complete authentication in your app to fully trigger unfurling.
-     * Value should be properly URL-encoded.
-     */
-    private String userAuthUrl;
 
     /**
      * Channel ID of the message


### PR DESCRIPTION
This pull request resolves #895 by correcting the parameter binding logic. Also, I've added a working example of the authenticated unfurling.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
