### PR TITLE
Bump dependency versions for v1.15 release

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.16.3.0</http4k.version>
+        <http4k.version>4.17.2.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.5.6</spring-boot.version>
+        <spring-boot.version>2.6.1</spring-boot.version>
     </properties>
 
     <artifactId>bolt-spring-boot-examples</artifactId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,10 +7,10 @@ baseurl: /java-slack-sdk
 url: https://slack.dev
 
 sdkLatestVersion: 1.14.0
-okhttpVersion: 4.9.2
+okhttpVersion: 4.9.3
 slf4jApiVersion: 1.7.32
-kotlinVersion: 1.5.31
-springBootVersion: 2.5.6
+kotlinVersion: 1.6.0
+springBootVersion: 2.6.1
 compatibleMicronautVersion: 2.x
 quarkusVersion: 1.9.2.Final
 helidonVersion: 2.3.2

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
 
         <!-- For these compile scope dependencies, we don't use ranges of versions -->
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <okhttp.version>4.9.2</okhttp.version>
+        <okhttp.version>4.9.3</okhttp.version>
         <gson.version>2.8.9</gson.version>
-        <kotlin.version>1.5.31</kotlin.version>
+        <kotlin.version>1.6.0</kotlin.version>
         <slf4j.version>1.7.32</slf4j.version>
         <lombok.version>1.18.22</lombok.version>
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>


### PR DESCRIPTION
This pull request upgrades the required dependencies' patch versions and optional ones' minor/patch versions.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
