### PR TITLE
Add more labels to exempt-issue-labels in stale GitHub action

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -26,7 +26,7 @@ jobs:
           stale-issue-label: auto-triage-stale
           stale-issue-message: 👋 It looks like this issue has been open for 30 days with no activity. We'll mark this as stale for now, and wait 10 days for an update or for further comment before closing this issue out.
           close-issue-message: As this issue has been inactive for more than one month, we will be closing it. Thank you to all the participants! If you would like to raise a related issue, please create a new issue which includes your specific details and references this issue number.
-          exempt-issue-labels: auto-triage-skip
+          exempt-issue-labels: auto-triage-skip,bug,discussion,docs,enhancement,security,area:examples,dependencies,server-side-issue,tests
           exempt-all-milestones: true
           remove-stale-when-updated: true
           enable-statistics: true


### PR DESCRIPTION
This pull request improves the stale GitHub Action job not to mark stale to issues with enhancement etc.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
