### PR TITLE
Fix #891 Migrate Micronaut version to 3.2

### DIFF
--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,10 +10,12 @@
     </parent>
 
     <properties>
-        <!-- TODO: upgrade to v3 -->
-        <micronaut.version>2.5.12</micronaut.version>
-        <micronaut-test-junit5.version>2.3.7</micronaut-test-junit5.version>
+        <micronaut.version>3.2.2</micronaut.version>
+        <micronaut-test-junit5.version>3.0.5</micronaut-test-junit5.version>
+        <micronaut-rxjava3.version>2.1.1</micronaut-rxjava3.version>
+        <!-- Note that upgrading this library breaks other dependency resolution -->
         <mockito-all.version>1.10.19</mockito-all.version>
+        <jakarta.inject.version>2.0.1</jakarta.inject.version>
     </properties>
 
     <artifactId>bolt-micronaut</artifactId>
@@ -42,6 +44,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/jakarta.inject/jakarta.inject-api -->
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>${jakarta.inject.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-http-server-netty</artifactId>
@@ -52,6 +60,12 @@
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-http-client</artifactId>
             <version>${micronaut.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.rxjava3</groupId>
+            <artifactId>micronaut-rxjava3-http-client</artifactId>
+            <version>${micronaut-rxjava3.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppMicronautAdapter.java
+++ b/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppMicronautAdapter.java
@@ -10,9 +10,9 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.server.netty.NettyHttpResponseFactory;
+import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.inject.Singleton;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;

--- a/bolt-micronaut/src/test/java/example/app/AppFactory.java
+++ b/bolt-micronaut/src/test/java/example/app/AppFactory.java
@@ -6,8 +6,8 @@ import com.google.gson.JsonObject;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Singleton;
 
-import javax.inject.Singleton;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;

--- a/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
@@ -11,15 +11,15 @@ import io.micronaut.context.annotation.Primary;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpRequest;
-import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.rxjava3.http.client.Rx3HttpClient;
 import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
 import java.io.IOException;
 
 import static org.mockito.Mockito.*;
@@ -43,7 +43,7 @@ public class CommandsTest {
 
     @Inject
     @Client("/")
-    RxHttpClient client;
+    Rx3HttpClient client;
 
     String signingSecret = "test";
     String botToken = "xoxb-dummy";


### PR DESCRIPTION
This pull request resolves #891 by upgrading the required Micronaut version from v2.x to v3.x.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
