### PR TITLE
Upgrade slf4j-api patch version and other optionals ones

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.17.3.0</http4k.version>
+        <http4k.version>4.17.9.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.version>3.2.3</micronaut.version>
+        <micronaut.version>3.2.6</micronaut.version>
         <micronaut-test-junit5.version>3.0.5</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>2.1.1</micronaut-rxjava3.version>
         <!-- Note that upgrading this library breaks other dependency resolution -->

--- a/bolt-servlet/pom.xml
+++ b/bolt-servlet/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <!-- TODO: Upgrade to 11.x in the next major version - v2 -->
         <jetty.version>9.4.24.v20191120</jetty.version>
-        <java-jwt.version>3.18.2</java-jwt.version>
+        <java-jwt.version>3.18.3</java-jwt.version>
     </properties>
 
     <artifactId>bolt-servlet</artifactId>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.6.1</spring-boot.version>
+        <spring-boot.version>2.6.2</spring-boot.version>
     </properties>
 
     <artifactId>bolt-spring-boot-examples</artifactId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,9 +8,9 @@ url: https://slack.dev
 
 sdkLatestVersion: 1.16.0
 okhttpVersion: 4.9.3
-slf4jApiVersion: 1.7.32
+slf4jApiVersion: 1.7.33
 kotlinVersion: 1.6.0
-springBootVersion: 2.6.1
+springBootVersion: 2.6.2
 compatibleMicronautVersion: 3.x
 quarkusVersion: 1.9.2.Final
 helidonVersion: 2.3.2

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <okhttp.version>4.9.3</okhttp.version>
         <gson.version>2.8.9</gson.version>
         <kotlin.version>1.6.10</kotlin.version>
-        <slf4j.version>1.7.32</slf4j.version>
+        <slf4j.version>1.7.33</slf4j.version>
         <lombok.version>1.18.22</lombok.version>
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
@@ -56,7 +56,7 @@
         <!-- optional / testing-only dependencies -->
         <aws.s3.version>[1.12.62,1.13.0)</aws.s3.version>
         <junit.version>4.13.2</junit.version>
-        <logback.version>1.2.8</logback.version>
+        <logback.version>1.2.10</logback.version>
         <hamcrest.version>[1.3,2.0)</hamcrest.version>
         <mockito-core.version>[4.1.0,5.0.0)</mockito-core.version>
         <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -18,8 +18,8 @@
         <!-- TODO upgrade to 2.0 in the next major version -->
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
         <java-websocket.version>1.5.2</java-websocket.version>
-        <jedis.version>3.7.1</jedis.version>
-        <jedis-mock.version>0.1.23</jedis-mock.version>
+        <jedis.version>4.0.1</jedis.version>
+        <jedis-mock.version>1.0.0</jedis-mock.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This pull request upgrades a few external dependency versions. The only compile-scope dependency is slf4j-api. Others are optional or only for this SDK's tests.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
