### PR TITLE
Fix #913 user-scope only OAuth does not work since v1.10

### DIFF
--- a/bolt-helidon/src/test/java/test_locally/MainTest.java
+++ b/bolt-helidon/src/test/java/test_locally/MainTest.java
@@ -75,7 +75,7 @@ public class MainTest {
         assertEquals(302, conn.getResponseCode());
         String authorizationUrl = conn.getHeaderField("Location");
         assertTrue(authorizationUrl, authorizationUrl.startsWith(
-                "https://slack.com/oauth/v2/authorize?client_id=123.123&scope=app_mention:read,chat:write,commands&user_scope=&state="));
+                "https://slack.com/oauth/v2/authorize?client_id=123.123&scope=app_mention%3Aread%2Cchat%3Awrite%2Ccommands&user_scope=&state="));
     }
 
 }

--- a/bolt-http4k/src/test/java/test_locally/Http4kSlackAppTest.java
+++ b/bolt-http4k/src/test/java/test_locally/Http4kSlackAppTest.java
@@ -154,7 +154,7 @@ public class Http4kSlackAppTest {
         Response installResponse = oauthSlackApp.invoke(installRequest);
         assertThat(installResponse.getStatus().getCode(), equalTo(302));
         assertTrue(installResponse.header("Location").startsWith(
-                "https://slack.com/oauth/v2/authorize?client_id=111.222&scope=commands,chat:write&user_scope=&state="));
+                "https://slack.com/oauth/v2/authorize?client_id=111.222&scope=commands%2Cchat%3Awrite&user_scope=&state="));
 
         assertThat(installResponse.getStatus().getCode(), equalTo(302));
 

--- a/bolt/src/main/java/com/slack/api/bolt/util/UrlEncodingOps.java
+++ b/bolt/src/main/java/com/slack/api/bolt/util/UrlEncodingOps.java
@@ -1,0 +1,26 @@
+package com.slack.api.bolt.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+public class UrlEncodingOps {
+
+    private UrlEncodingOps() {
+    }
+
+    public static String urlEncode(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            log.warn("Unexpectedly UnsupportedEncodingException was thrown while URL-encoding a string value.");
+            return value;
+        }
+    }
+}

--- a/bolt/src/test/java/test_locally/app/OAuthStartTest.java
+++ b/bolt/src/test/java/test_locally/app/OAuthStartTest.java
@@ -48,7 +48,7 @@ public class OAuthStartTest {
                 "</head>\n" +
                 "<body>\n" +
                 "<h2>Slack App Installation</h2>\n" +
-                "<p><a href=\"https://slack.com/oauth/v2/authorize?client_id=111.222&scope=commands,chat:write&user_scope=&state=generated-state-value\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
+                "<p><a href=\"https://slack.com/oauth/v2/authorize?client_id=111.222&scope=commands%2Cchat%3Awrite&user_scope=&state=generated-state-value\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
                 "</body>\n" +
                 "</html>", response.getBody());
     }
@@ -78,7 +78,7 @@ public class OAuthStartTest {
                 "</head>\n" +
                 "<body>\n" +
                 "<h2>Slack App Installation</h2>\n" +
-                "<p><a href=\"https://slack.com/oauth/v2/authorize?client_id=111.222&scope=commands,chat:write&user_scope=&state=\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
+                "<p><a href=\"https://slack.com/oauth/v2/authorize?client_id=111.222&scope=commands%2Cchat%3Awrite&user_scope=&state=\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
                 "</body>\n" +
                 "</html>", response.getBody());
     }

--- a/bolt/src/test/java/test_locally/app/OpenIDConnectTest.java
+++ b/bolt/src/test/java/test_locally/app/OpenIDConnectTest.java
@@ -66,7 +66,7 @@ public class OpenIDConnectTest {
             "</head>\n" +
             "<body>\n" +
             "<h2>Slack App Installation</h2>\n" +
-            "<p><a href=\"https://slack.com/openid/connect/authorize?client_id=111.222&response_type=code&scope=openid,email,profile&state=generated-state-value&nonce=generated-nonce-value\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
+            "<p><a href=\"https://slack.com/openid/connect/authorize?client_id=111.222&response_type=code&scope=openid%2Cemail%2Cprofile&state=generated-state-value&nonce=generated-nonce-value\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
             "</body>\n" +
             "</html>";
 

--- a/bolt/src/test/java/test_locally/util/UrlEncodingOpsTest.java
+++ b/bolt/src/test/java/test_locally/util/UrlEncodingOpsTest.java
@@ -1,0 +1,30 @@
+package test_locally.util;
+
+import org.junit.Test;
+
+import static com.slack.api.bolt.util.UrlEncodingOps.urlEncode;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UrlEncodingOpsTest {
+
+    @Test
+    public void testUrlEncode() {
+        String result = urlEncode("foo,bar,baz");
+        assertThat(result, is("foo%2Cbar%2Cbaz"));
+    }
+
+    @Test
+    public void testUrlEncode_CJK() {
+        String result = urlEncode("日本語");
+        assertThat(result, is("%E6%97%A5%E6%9C%AC%E8%AA%9E"));
+    }
+
+    @Test
+    public void testUrlEncode_null() {
+        String result = urlEncode(null);
+        assertThat(result, is(nullValue()));
+    }
+
+}


### PR DESCRIPTION
This pull request resolves #913 

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
