### PR TITLE
Fix #915 by adding ExecutorServiceProvider to enable developers to use their own ExecutorService

### DIFF
--- a/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/JsonDataRecordingListener.java
+++ b/bolt-servlet/src/test/java/test_with_remote_apis/sample_json_generation/JsonDataRecordingListener.java
@@ -1,7 +1,7 @@
 package test_with_remote_apis.sample_json_generation;
 
 import com.slack.api.util.http.listener.HttpResponseListener;
-import com.slack.api.util.thread.ExecutorServiceFactory;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -15,7 +15,8 @@ public class JsonDataRecordingListener extends HttpResponseListener {
 
     private final CopyOnWriteArrayList<String> remaining = new CopyOnWriteArrayList<>();
     private final String threadGroupName = "slack-unit-test-JsonDataRecordingListener";
-    private final ExecutorService executorService = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, 5);
+    private final ExecutorService executorService = DaemonThreadExecutorServiceProvider.getInstance()
+            .createThreadPoolExecutor(threadGroupName, 5);
 
     public boolean isAllDone() {
         if (remaining.size() > 0) {

--- a/bolt-socket-mode/src/test/java/util/socket_mode/MockSocketMode.java
+++ b/bolt-socket-mode/src/test/java/util/socket_mode/MockSocketMode.java
@@ -1,6 +1,6 @@
 package util.socket_mode;
 
-import com.slack.api.util.thread.ExecutorServiceFactory;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.StatusCode;
@@ -22,7 +22,7 @@ public class MockSocketMode extends WebSocketAdapter {
     private CountDownLatch closureLatch = new CountDownLatch(1);
 
     private CopyOnWriteArrayList<Session> activeSessions = new CopyOnWriteArrayList<>();
-    private ScheduledExecutorService service = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(
+    private ScheduledExecutorService service = DaemonThreadExecutorServiceProvider.getInstance().createThreadScheduledExecutor(
             MockSocketMode.class.getCanonicalName());
 
     public MockSocketMode() {

--- a/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
+++ b/bolt/src/main/java/com/slack/api/bolt/AppConfig.java
@@ -11,6 +11,8 @@ import com.slack.api.bolt.service.builtin.oauth.view.default_impl.OAuthDefaultIn
 import com.slack.api.bolt.service.builtin.oauth.view.default_impl.OAuthDefaultRedirectUriPageRenderer;
 import com.slack.api.token_rotation.TokenRotator;
 import com.slack.api.util.http.SlackHttpClient;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -67,8 +69,12 @@ public class AppConfig {
         public static final String SLACK_APP_OAUTH_COMPLETION_URL = "SLACK_APP_OAUTH_COMPLETION_URL";
     }
 
+    // We don't use SlackConfig.DEFAULT here to enable developers to customize the properties later on
     @Builder.Default
-    private transient Slack slack = Slack.getInstance(SlackConfig.DEFAULT, buildSlackHttpClient());
+    private transient Slack slack = Slack.getInstance(new SlackConfig(), buildSlackHttpClient());
+
+    @Builder.Default
+    private transient ExecutorServiceProvider executorServiceProvider = DaemonThreadExecutorServiceProvider.getInstance();
 
     private static SlackHttpClient buildSlackHttpClient() {
         Map<String, String> userAgentCustomInfo = new HashMap<>();

--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/MultiTeamsAuthorization.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/MultiTeamsAuthorization.java
@@ -98,7 +98,7 @@ public class MultiTeamsAuthorization implements Middleware {
     private ScheduledExecutorService buildTokenToAuthTestCacheCleaner(Runnable task) {
         String threadGroupName = MultiTeamsAuthorization.class.getSimpleName();
         ScheduledExecutorService tokenToAuthTestCacheCleaner =
-                ExecutorServiceFactory.createDaemonThreadScheduledExecutor(threadGroupName);
+                this.config.getExecutorServiceProvider().createThreadScheduledExecutor(threadGroupName);
         tokenToAuthTestCacheCleaner.scheduleAtFixedRate(task, 120_000, 30_000, TimeUnit.MILLISECONDS);
         log.debug("The tokenToAuthTestCacheCleaner (daemon thread) started");
         return tokenToAuthTestCacheCleaner;

--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/WorkflowStep.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/WorkflowStep.java
@@ -132,7 +132,7 @@ public class WorkflowStep implements Middleware, AutoCloseable {
         int poolSize = 3;
         // If you want to use own ExecutorService, pass it using the builder method instead:
         // `WorkflowStep.builder().executorService(executorService).build()`
-        ExecutorService service = new DaemonThreadExecutorServiceProvider().createThreadPoolExecutor(
+        ExecutorService service = DaemonThreadExecutorServiceProvider.getInstance().createThreadPoolExecutor(
                 threadGroupName,
                 poolSize
         );

--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/WorkflowStep.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/WorkflowStep.java
@@ -10,7 +10,7 @@ import com.slack.api.bolt.request.builtin.WorkflowStepEditRequest;
 import com.slack.api.bolt.request.builtin.WorkflowStepExecuteRequest;
 import com.slack.api.bolt.request.builtin.WorkflowStepSaveRequest;
 import com.slack.api.bolt.response.Response;
-import com.slack.api.util.thread.ExecutorServiceFactory;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,8 +30,13 @@ public class WorkflowStep implements Middleware, AutoCloseable {
     private WorkflowStepEditHandler edit;
     private WorkflowStepSaveHandler save;
     private WorkflowStepExecuteHandler execute;
+
     @Builder.Default
     private boolean executeAutoAcknowledgement = true;
+
+    // If a developer would like to use their own ExecutorService here,
+    // the recommended way would be to pass the one using the builder method:
+    // `WorkflowStep.builder().executorService(executorService).build()`
     @Builder.Default
     private ExecutorService executorService = buildDefaultExecutorService();
 
@@ -94,7 +99,7 @@ public class WorkflowStep implements Middleware, AutoCloseable {
                                 // Auto acknowledgement
                                 return new Response();
                             } else {
-                                // In the execute handler, workflows.stepCompleted/stepFailed
+                                // In the `execute` handler, workflows.stepCompleted/stepFailed
                                 // needs to be called asynchronously
                                 return execute.apply(request, request.getContext());
                             }
@@ -125,7 +130,9 @@ public class WorkflowStep implements Middleware, AutoCloseable {
     protected static ExecutorService buildDefaultExecutorService() {
         String threadGroupName = WorkflowStep.class.getSimpleName();
         int poolSize = 3;
-        ExecutorService service = ExecutorServiceFactory.createDaemonThreadPoolExecutor(
+        // If you want to use own ExecutorService, pass it using the builder method instead:
+        // `WorkflowStep.builder().executorService(executorService).build()`
+        ExecutorService service = new DaemonThreadExecutorServiceProvider().createThreadPoolExecutor(
                 threadGroupName,
                 poolSize
         );

--- a/bolt/src/test/java/test_locally/app/WorkflowStepTest.java
+++ b/bolt/src/test/java/test_locally/app/WorkflowStepTest.java
@@ -10,6 +10,7 @@ import com.slack.api.bolt.request.RequestHeaders;
 import com.slack.api.bolt.request.builtin.WorkflowStepEditRequest;
 import com.slack.api.bolt.request.builtin.WorkflowStepSaveRequest;
 import com.slack.api.bolt.response.Response;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
@@ -18,7 +19,11 @@ import util.AuthTestMockServer;
 
 import java.net.URLEncoder;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 @Slf4j
@@ -315,6 +320,15 @@ public class WorkflowStepTest {
     void setRequestHeaders(String requestBody, Map<String, List<String>> rawHeaders, String timestamp) {
         rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP, Arrays.asList(timestamp));
         rawHeaders.put(SlackSignature.HeaderNames.X_SLACK_SIGNATURE, Arrays.asList(generator.generate(timestamp, requestBody)));
+    }
+
+    @Test
+    public void buildWithCustomExecutorService() {
+        ExecutorService executorService = DaemonThreadExecutorServiceProvider.getInstance()
+                .createThreadPoolExecutor("foo", 3);
+        WorkflowStep step = WorkflowStep.builder().executorService(executorService).build();
+        assertThat(step, is(notNullValue()));
+        assertThat(step.getExecutorService(), is(executorService));
     }
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/Slack.java
+++ b/slack-api-client/src/main/java/com/slack/api/Slack.java
@@ -77,6 +77,9 @@ public class Slack implements AutoCloseable {
 
     private Slack(SlackConfig config, SlackHttpClient httpClient) {
         this.config = config;
+        if (!this.config.equals(SlackConfig.DEFAULT)) {
+            this.config.synchronizeExecutorServiceProviders();
+        }
         this.httpClient = httpClient;
         this.httpClient.setConfig(this.config);
     }

--- a/slack-api-client/src/main/java/com/slack/api/audit/AuditConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/AuditConfig.java
@@ -2,6 +2,8 @@ package com.slack.api.audit;
 
 import com.slack.api.audit.metrics.MemoryMetricsDatastore;
 import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -63,6 +65,11 @@ public class AuditConfig {
         public void setCustomThreadPoolSizes(Map<String, Integer> customThreadPoolSizes) {
             throwException();
         }
+
+        @Override
+        public void setExecutorServiceProvider(ExecutorServiceProvider executorServiceProvider) {
+            throwException();
+        }
     };
 
     @Builder.Default
@@ -91,6 +98,9 @@ public class AuditConfig {
      */
     @Builder.Default
     private Map<String, Integer> customThreadPoolSizes = new HashMap<>();
+
+    @Builder.Default
+    private ExecutorServiceProvider executorServiceProvider = DaemonThreadExecutorServiceProvider.getInstance();
 
     /**
      * The metrics datastore to track the traffic associated to this executor name.

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/ThreadPools.java
@@ -1,7 +1,6 @@
 package com.slack.api.audit.impl;
 
 import com.slack.api.audit.AuditConfig;
-import com.slack.api.util.thread.ExecutorServiceFactory;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -34,7 +33,7 @@ public class ThreadPools {
             ExecutorService orgExecutor = allOrgs.get(enterpriseId);
             if (orgExecutor == null) {
                 String threadGroupName = "slack-audit-logs-" + config.getExecutorName() + "-" + enterpriseId;
-                orgExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, customPoolSize);
+                orgExecutor = config.getExecutorServiceProvider().createThreadPoolExecutor(threadGroupName, customPoolSize);
                 allOrgs.put(enterpriseId, orgExecutor);
             }
             return orgExecutor;
@@ -44,7 +43,7 @@ public class ThreadPools {
             if (defaultExecutor == null) {
                 String threadGroupName = "slack-audit-logs-" + config.getExecutorName();
                 int poolSize = config.getDefaultThreadPoolSize();
-                defaultExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, poolSize);
+                defaultExecutor = config.getExecutorServiceProvider().createThreadPoolExecutor(threadGroupName, poolSize);
                 ALL_DEFAULT.put(config.getExecutorName(), defaultExecutor);
             }
             return defaultExecutor;

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsConfig.java
@@ -2,6 +2,8 @@ package com.slack.api.methods;
 
 import com.slack.api.methods.metrics.MemoryMetricsDatastore;
 import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -63,6 +65,11 @@ public class MethodsConfig {
         public void setCustomThreadPoolSizes(Map<String, Integer> customThreadPoolSizes) {
             throwException();
         }
+
+        @Override
+        public void setExecutorServiceProvider(ExecutorServiceProvider executorServiceProvider) {
+            throwException();
+        }
     };
 
     @Builder.Default
@@ -85,6 +92,9 @@ public class MethodsConfig {
      */
     @Builder.Default
     private int defaultThreadPoolSize = 5;
+
+    @Builder.Default
+    private ExecutorServiceProvider executorServiceProvider = DaemonThreadExecutorServiceProvider.getInstance();
 
     /**
      * Team ID -> thread pool size

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java
@@ -1,7 +1,6 @@
 package com.slack.api.methods.impl;
 
 import com.slack.api.methods.MethodsConfig;
-import com.slack.api.util.thread.ExecutorServiceFactory;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -33,7 +32,7 @@ public class ThreadPools {
             ExecutorService teamExecutor = allTeams.get(teamId);
             if (teamExecutor == null) {
                 String threadGroupName = "slack-methods-" + config.getExecutorName() + "-" + teamId;
-                teamExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, customPoolSize);
+                teamExecutor = config.getExecutorServiceProvider().createThreadPoolExecutor(threadGroupName, customPoolSize);
                 allTeams.put(teamId, teamExecutor);
             }
             return teamExecutor;
@@ -43,7 +42,7 @@ public class ThreadPools {
             if (defaultExecutor == null) {
                 String threadGroupName = "slack-methods-" + config.getExecutorName();
                 int poolSize = config.getDefaultThreadPoolSize();
-                defaultExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, poolSize);
+                defaultExecutor = config.getExecutorServiceProvider().createThreadPoolExecutor(threadGroupName, poolSize);
                 ALL_DEFAULT.put(config.getExecutorName(), defaultExecutor);
             }
             return defaultExecutor;

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
@@ -4,8 +4,13 @@ import com.slack.api.methods.SlackApiResponse;
 import com.slack.api.methods.impl.AsyncExecutionSupplier;
 import com.slack.api.methods.impl.AsyncRateLimitQueue;
 import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 
 public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<AsyncExecutionSupplier<? extends SlackApiResponse>, AsyncRateLimitQueue.Message> {
+
+    public MemoryMetricsDatastore(int numberOfNodes, ExecutorServiceProvider executorServiceProvider) {
+        super(numberOfNodes, executorServiceProvider);
+    }
 
     public MemoryMetricsDatastore(int numberOfNodes) {
         super(numberOfNodes);

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
@@ -1,5 +1,7 @@
 package com.slack.api.rate_limits.metrics;
 
+import com.slack.api.util.thread.ExecutorServiceProvider;
+
 import java.util.Map;
 
 public interface MetricsDatastore {
@@ -47,5 +49,9 @@ public interface MetricsDatastore {
     void addToWaitingMessageIds(String executorName, String teamId, String methodName, String messageId);
 
     void deleteFromWaitingMessageIds(String executorName, String teamId, String methodName, String messageId);
+
+    ExecutorServiceProvider getExecutorServiceProvider();
+
+    void setExecutorServiceProvider(ExecutorServiceProvider executorServiceProvider);
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/SCIMConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/SCIMConfig.java
@@ -2,6 +2,8 @@ package com.slack.api.scim;
 
 import com.slack.api.rate_limits.metrics.MetricsDatastore;
 import com.slack.api.scim.metrics.MemoryMetricsDatastore;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -63,6 +65,11 @@ public class SCIMConfig {
         public void setCustomThreadPoolSizes(Map<String, Integer> customThreadPoolSizes) {
             throwException();
         }
+
+        @Override
+        public void setExecutorServiceProvider(ExecutorServiceProvider executorServiceProvider) {
+            throwException();
+        }
     };
 
     @Builder.Default
@@ -85,6 +92,9 @@ public class SCIMConfig {
      */
     @Builder.Default
     private int defaultThreadPoolSize = 5;
+
+    @Builder.Default
+    private ExecutorServiceProvider executorServiceProvider = DaemonThreadExecutorServiceProvider.getInstance();
 
     /**
      * Enterprise ID -> thread pool size

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/ThreadPools.java
@@ -1,7 +1,6 @@
 package com.slack.api.scim.impl;
 
 import com.slack.api.scim.SCIMConfig;
-import com.slack.api.util.thread.ExecutorServiceFactory;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -34,7 +33,7 @@ public class ThreadPools {
             ExecutorService orgExecutor = allOrgs.get(enterpriseId);
             if (orgExecutor == null) {
                 String threadGroupName = "slack-scim-" + config.getExecutorName() + "-" + enterpriseId;
-                orgExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, customPoolSize);
+                orgExecutor = config.getExecutorServiceProvider().createThreadPoolExecutor(threadGroupName, customPoolSize);
                 allOrgs.put(enterpriseId, orgExecutor);
             }
             return orgExecutor;
@@ -44,7 +43,7 @@ public class ThreadPools {
             if (defaultExecutor == null) {
                 String threadGroupName = "slack-scim-" + config.getExecutorName();
                 int poolSize = config.getDefaultThreadPoolSize();
-                defaultExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, poolSize);
+                defaultExecutor = config.getExecutorServiceProvider().createThreadPoolExecutor(threadGroupName, poolSize);
                 ALL_DEFAULT.put(config.getExecutorName(), defaultExecutor);
             }
             return defaultExecutor;

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
@@ -4,13 +4,22 @@ import com.slack.api.rate_limits.metrics.impl.BaseRedisMetricsDatastore;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.impl.AsyncExecutionSupplier;
 import com.slack.api.scim.impl.AsyncRateLimitQueue;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import redis.clients.jedis.JedisPool;
 
 public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
         AsyncExecutionSupplier<? extends SCIMApiResponse>, AsyncRateLimitQueue.SCIMMessage> {
 
     public RedisMetricsDatastore(String appName, JedisPool jedisPool) {
-        super(appName, jedisPool);
+        super(appName, jedisPool, DaemonThreadExecutorServiceProvider.getInstance());
+    }
+
+    public RedisMetricsDatastore(
+            String appName,
+            JedisPool jedisPool,
+            ExecutorServiceProvider executorServiceProvider) {
+        super(appName, jedisPool, executorServiceProvider);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/socket_mode/SocketModeClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/socket_mode/SocketModeClient.java
@@ -146,8 +146,10 @@ public interface SocketModeClient extends Closeable {
 
     default void initializeMessageProcessorExecutor(int concurrency) {
         String processorName = getExecutorGroupNamePrefix() + "-message-processor";
-        ScheduledExecutorService messageProcessorExecutor =
-                ExecutorServiceFactory.createDaemonThreadScheduledExecutor(processorName);
+        ScheduledExecutorService messageProcessorExecutor = getSlack()
+                .getConfig()
+                .getExecutorServiceProvider()
+                .createThreadScheduledExecutor(processorName);
         for (int i = 0; i < concurrency; i++) {
             int num = i;
             messageProcessorExecutor.scheduleAtFixedRate(() -> {
@@ -169,7 +171,10 @@ public interface SocketModeClient extends Closeable {
     default void initializeSessionMonitorExecutor(long intervalMillis) {
         if (isSessionMonitorEnabled()) {
             String groupName = getExecutorGroupNamePrefix() + "-session-monitor";
-            ScheduledExecutorService executorService = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(groupName);
+            ScheduledExecutorService executorService = getSlack()
+                    .getConfig()
+                    .getExecutorServiceProvider()
+                    .createThreadScheduledExecutor(groupName);
             final AtomicLong nextInvocationMillis = new AtomicLong(System.currentTimeMillis());
             executorService.scheduleWithFixedDelay(() -> {
                 long startMillis = System.currentTimeMillis();

--- a/slack-api-client/src/main/java/com/slack/api/socket_mode/impl/SocketModeClientTyrusImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/socket_mode/impl/SocketModeClientTyrusImpl.java
@@ -125,8 +125,9 @@ public class SocketModeClientTyrusImpl implements SocketModeClient {
         setSessionMonitorEnabled(sessionMonitorEnabled);
         initializeSessionMonitorExecutor(sessionMonitorIntervalMillis);
         initializeMessageProcessorExecutor(concurrency);
-        sessionCleanerExecutor = ExecutorServiceFactory.createDaemonThreadPoolExecutor(
-                getExecutorGroupNamePrefix() + "-session-cleaner", 3);
+        sessionCleanerExecutor = slack.getConfig()
+                .getExecutorServiceProvider()
+                .createThreadPoolExecutor(getExecutorGroupNamePrefix() + "-session-cleaner", 3);
     }
 
     @Override

--- a/slack-api-client/src/test/java/test_locally/SlackConfigTest.java
+++ b/slack-api-client/src/test/java/test_locally/SlackConfigTest.java
@@ -114,12 +114,14 @@ public class SlackConfigTest {
         ExecutorServiceProvider custom = new ExecutorServiceProvider() {
             @Override
             public ExecutorService createThreadPoolExecutor(String threadGroupName, int poolSize) {
-                return null;
+                return DaemonThreadExecutorServiceProvider.getInstance()
+                        .createThreadPoolExecutor(threadGroupName, poolSize);
             }
 
             @Override
             public ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName) {
-                return null;
+                return DaemonThreadExecutorServiceProvider.getInstance()
+                        .createThreadScheduledExecutor(threadGroupName);
             }
         };
         config.setExecutorServiceProvider(custom);

--- a/slack-api-client/src/test/java/test_locally/SlackConfigTest.java
+++ b/slack-api-client/src/test/java/test_locally/SlackConfigTest.java
@@ -1,10 +1,15 @@
 package test_locally;
 
+import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.methods.MethodsConfig;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -90,6 +95,40 @@ public class SlackConfigTest {
             SlackConfig.DEFAULT.setSCIMConfig(null);
             fail();
         } catch (UnsupportedOperationException ignored) {
+        }
+        try {
+            SlackConfig.DEFAULT.setExecutorServiceProvider(null);
+            fail();
+        } catch (UnsupportedOperationException ignored) {
+        }
+    }
+
+    @Test
+    public void customizeExecutorServiceProvider() throws Exception {
+        // the default
+        assertThat(Slack.getInstance().getConfig().getExecutorServiceProvider(),
+                is(DaemonThreadExecutorServiceProvider.getInstance()));
+
+        // the customized one
+        SlackConfig config = new SlackConfig();
+        ExecutorServiceProvider custom = new ExecutorServiceProvider() {
+            @Override
+            public ExecutorService createThreadPoolExecutor(String threadGroupName, int poolSize) {
+                return null;
+            }
+
+            @Override
+            public ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName) {
+                return null;
+            }
+        };
+        config.setExecutorServiceProvider(custom);
+
+        try (Slack slack = Slack.getInstance(config)) {
+            assertThat(slack.getConfig().getExecutorServiceProvider(), is(custom));
+            assertThat(slack.getConfig().getMethodsConfig().getExecutorServiceProvider(), is(custom));
+            assertThat(slack.getConfig().getAuditConfig().getExecutorServiceProvider(), is(custom));
+            assertThat(slack.getConfig().getSCIMConfig().getExecutorServiceProvider(), is(custom));
         }
     }
 

--- a/slack-api-client/src/test/java/test_locally/api/methods/ApiTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/ApiTest.java
@@ -3,6 +3,8 @@ package test_locally.api.methods;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.methods.response.api.ApiTestResponse;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,11 +13,13 @@ import util.MockSlackApiServer;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static util.MockSlackApi.ValidToken;
@@ -107,6 +111,39 @@ public class ApiTest {
             retryCount++;
         }
         assertTrue(retryCount <= 100);
+    }
+
+    @Test
+    public void customExecutorService() throws Exception {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        SlackConfig config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+        config.setExecutorServiceProvider(new ExecutorServiceProvider() {
+            @Override
+            public ExecutorService createThreadPoolExecutor(String threadGroupName, int poolSize) {
+                called.set(true);
+                return DaemonThreadExecutorServiceProvider.getInstance()
+                        .createThreadPoolExecutor(threadGroupName, poolSize);
+            }
+
+            @Override
+            public ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName) {
+                return DaemonThreadExecutorServiceProvider.getInstance()
+                        .createThreadScheduledExecutor(threadGroupName);
+            }
+        });
+        Slack slack = Slack.getInstance(config);
+        {
+            ApiTestResponse response = slack.methods().apiTest(r -> r);
+            assertThat(response.getError(), is(""));
+            // the sync client does not use ExecutorService under the hood
+            assertThat(called.get(), is(false));
+        }
+        {
+            ApiTestResponse response = slack.methodsAsync().apiTest(r -> r).get();
+            assertThat(response.getError(), is(""));
+            assertThat(called.get(), is(true));
+        }
     }
 
 }

--- a/slack-api-client/src/test/java/test_locally/api/socket_mode/SocketModeClientTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/socket_mode/SocketModeClientTest.java
@@ -44,6 +44,7 @@ public class SocketModeClientTest {
         wsServer.start();
         config = new SlackConfig();
         config.setMethodsEndpointUrlPrefix(webApiServer.getMethodsEndpointPrefix());
+        slack = Slack.getInstance(config);
     }
 
     @After

--- a/slack-api-client/src/test/java/test_locally/api/socket_mode/SocketModeClientTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/socket_mode/SocketModeClientTest.java
@@ -10,6 +10,8 @@ import com.slack.api.socket_mode.response.AckResponse;
 import com.slack.api.socket_mode.response.MessagePayload;
 import com.slack.api.socket_mode.response.MessageResponse;
 import com.slack.api.util.json.GsonFactory;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +21,8 @@ import util.socket_mode.MockWebSocketServer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertNotNull;
@@ -38,6 +42,7 @@ public class SocketModeClientTest {
     public void setup() throws Exception {
         webApiServer.start();
         wsServer.start();
+        config = new SlackConfig();
         config.setMethodsEndpointUrlPrefix(webApiServer.getMethodsEndpointPrefix());
     }
 
@@ -94,6 +99,59 @@ public class SocketModeClientTest {
             client.removeInteractiveEnvelopeListener(client.getInteractiveEnvelopeListeners().get(0));
             client.removeSlashCommandsEnvelopeListener(client.getSlashCommandsEnvelopeListeners().get(0));
         }
+    }
+
+    @Test
+    public void connect_with_custom_ExecutorService() throws Exception {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final AtomicBoolean called2 = new AtomicBoolean(false);
+        config.setExecutorServiceProvider(new ExecutorServiceProvider() {
+            @Override
+            public ExecutorService createThreadPoolExecutor(String threadGroupName, int poolSize) {
+                called.set(true);
+                return DaemonThreadExecutorServiceProvider.getInstance()
+                        .createThreadPoolExecutor(threadGroupName, poolSize);
+            }
+
+            @Override
+            public ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName) {
+                called2.set(true);
+                return DaemonThreadExecutorServiceProvider.getInstance()
+                        .createThreadScheduledExecutor(threadGroupName);
+            }
+        });
+        Slack slack = Slack.getInstance(config);
+        try (SocketModeClient client = slack.socketMode(VALID_APP_TOKEN)) {
+            AtomicBoolean received = new AtomicBoolean(false);
+            client.addWebSocketMessageListener(helloListener(received));
+            client.addWebSocketErrorListener(error -> {
+            });
+            client.addWebSocketCloseListener((code, reason) -> {
+            });
+            client.addEventsApiEnvelopeListener(envelope -> {
+            });
+            client.addInteractiveEnvelopeListener(envelope -> {
+            });
+            client.addSlashCommandsEnvelopeListener(envelope -> {
+            });
+
+            client.connect();
+            Thread.sleep(500L);
+            assertTrue(received.get());
+
+            client.disconnect();
+            client.runCloseListenersAndAutoReconnectAsNecessary(1000, null);
+
+            client.removeWebSocketMessageListener(client.getWebSocketMessageListeners().get(0));
+            client.removeWebSocketErrorListener(client.getWebSocketErrorListeners().get(0));
+            client.removeWebSocketCloseListener(client.getWebSocketCloseListeners().get(0));
+
+            client.removeEventsApiEnvelopeListener(client.getEventsApiEnvelopeListeners().get(0));
+            client.removeInteractiveEnvelopeListener(client.getInteractiveEnvelopeListeners().get(0));
+            client.removeSlashCommandsEnvelopeListener(client.getSlashCommandsEnvelopeListeners().get(0));
+        }
+        assertTrue(called.get());
+        assertTrue(called2.get());
     }
 
     @Test

--- a/slack-api-client/src/test/java/test_with_remote_apis/scim/AsyncApiTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/scim/AsyncApiTest.java
@@ -7,7 +7,7 @@ import com.slack.api.scim.model.Group;
 import com.slack.api.scim.model.User;
 import com.slack.api.scim.request.GroupsPatchRequest;
 import com.slack.api.scim.response.*;
-import com.slack.api.util.thread.ExecutorServiceFactory;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import config.Constants;
 import config.SlackTestConfig;
 import org.junit.AfterClass;
@@ -381,7 +381,7 @@ public class AsyncApiTest {
     public void demonstrateRateLimitedErrors() throws Exception {
         Logger logger = LoggerFactory.getLogger(AsyncApiTest.class);
         int concurrency = 10;
-        ExecutorService executorService = ExecutorServiceFactory.createDaemonThreadPoolExecutor("test", concurrency);
+        ExecutorService executorService = DaemonThreadExecutorServiceProvider.getInstance().createThreadPoolExecutor("test", concurrency);
         for (int i = 0; i < concurrency; i++) {
             executorService.execute(() -> {
                 while (true) {

--- a/slack-api-client/src/test/java/util/sample_json_generation/JsonDataRecordingListener.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/JsonDataRecordingListener.java
@@ -1,7 +1,7 @@
 package util.sample_json_generation;
 
 import com.slack.api.util.http.listener.HttpResponseListener;
-import com.slack.api.util.thread.ExecutorServiceFactory;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -15,7 +15,7 @@ public class JsonDataRecordingListener extends HttpResponseListener {
 
     private final CopyOnWriteArrayList<String> remaining = new CopyOnWriteArrayList<>();
     private final String threadGroupName = "slack-unit-test-JsonDataRecordingListener";
-    private final ExecutorService executorService = ExecutorServiceFactory.createDaemonThreadPoolExecutor(threadGroupName, 5);
+    private final ExecutorService executorService = DaemonThreadExecutorServiceProvider.getInstance().createThreadPoolExecutor(threadGroupName, 5);
 
     public boolean isAllDone() {
         if (remaining.size() > 0) {

--- a/slack-api-client/src/test/java/util/socket_mode/MockSocketMode.java
+++ b/slack-api-client/src/test/java/util/socket_mode/MockSocketMode.java
@@ -1,6 +1,6 @@
 package util.socket_mode;
 
-import com.slack.api.util.thread.ExecutorServiceFactory;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.StatusCode;
@@ -22,8 +22,8 @@ public class MockSocketMode extends WebSocketAdapter {
     private CountDownLatch closureLatch = new CountDownLatch(1);
 
     private CopyOnWriteArrayList<Session> activeSessions = new CopyOnWriteArrayList<>();
-    private ScheduledExecutorService service = ExecutorServiceFactory.createDaemonThreadScheduledExecutor(
-            MockSocketMode.class.getCanonicalName());
+    private ScheduledExecutorService service = DaemonThreadExecutorServiceProvider.getInstance()
+            .createThreadScheduledExecutor(MockSocketMode.class.getCanonicalName());
 
     public MockSocketMode() {
         super();

--- a/slack-api-model/src/main/java/com/slack/api/util/thread/DaemonThreadExecutorServiceFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/thread/DaemonThreadExecutorServiceFactory.java
@@ -1,0 +1,17 @@
+package com.slack.api.util.thread;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+// Use ExecutorServiceProvider interface instead
+public abstract class DaemonThreadExecutorServiceFactory {
+
+    public static ExecutorService createDaemonThreadPoolExecutor(String threadGroupName, int poolSize) {
+        return Executors.newFixedThreadPool(poolSize, new DaemonThreadFactory(threadGroupName));
+    }
+
+    public static ScheduledExecutorService createDaemonThreadScheduledExecutor(String threadGroupName) {
+        return Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory(threadGroupName));
+    }
+}

--- a/slack-api-model/src/main/java/com/slack/api/util/thread/DaemonThreadExecutorServiceProvider.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/thread/DaemonThreadExecutorServiceProvider.java
@@ -1,0 +1,27 @@
+package com.slack.api.util.thread;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.slack.api.util.thread.DaemonThreadExecutorServiceFactory.createDaemonThreadPoolExecutor;
+import static com.slack.api.util.thread.DaemonThreadExecutorServiceFactory.createDaemonThreadScheduledExecutor;
+
+public class DaemonThreadExecutorServiceProvider implements ExecutorServiceProvider {
+
+    private static final DaemonThreadExecutorServiceProvider SINGLETON = new DaemonThreadExecutorServiceProvider();
+
+    public static DaemonThreadExecutorServiceProvider getInstance() {
+        return SINGLETON;
+    }
+
+    @Override
+    public ExecutorService createThreadPoolExecutor(String threadGroupName, int poolSize) {
+        return createDaemonThreadPoolExecutor(threadGroupName, poolSize);
+    }
+
+    @Override
+    public ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName) {
+        return createDaemonThreadScheduledExecutor(threadGroupName);
+    }
+
+}

--- a/slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceFactory.java
@@ -4,16 +4,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-public class ExecutorServiceFactory {
+// Use ExecutorServiceProvider interface instead
+@Deprecated
+public class ExecutorServiceFactory extends DaemonThreadExecutorServiceFactory {
 
     private ExecutorServiceFactory() {
-    }
-
-    public static ExecutorService createDaemonThreadPoolExecutor(String threadGroupName, int poolSize) {
-        return Executors.newFixedThreadPool(poolSize, new DaemonThreadFactory(threadGroupName));
-    }
-
-    public static ScheduledExecutorService createDaemonThreadScheduledExecutor(String threadGroupName) {
-        return Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory(threadGroupName));
     }
 }

--- a/slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceProvider.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceProvider.java
@@ -1,0 +1,26 @@
+package com.slack.api.util.thread;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Provides ExecutorServices for asynchronous code executions
+ */
+public interface ExecutorServiceProvider {
+
+    /**
+     * Creates a new ExecutorService instance.
+     * @param threadGroupName the thread group name
+     * @param poolSize the thread pool size
+     * @return a new ExecutorService
+     */
+    ExecutorService createThreadPoolExecutor(String threadGroupName, int poolSize);
+
+    /**
+     * Creates a new ScheduledExecutorService instance.
+     * @param threadGroupName the thread group name
+     * @return a new ScheduledExecutorService
+     */
+    ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName);
+
+}


### PR DESCRIPTION
This pull request resolves #915 

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
