### PR TITLE
Fix context.getTeamId() to return a valid ID for org-wide installations

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/BlockActionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/BlockActionRequest.java
@@ -30,8 +30,10 @@ public class BlockActionRequest extends Request<ActionContext> {
             } else if (payload.getTeam() != null) {
                 getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
             }
-            if (payload.getTeam() != null) {
+            if (payload.getTeam() != null && payload.getTeam().getId() != null) {
                 getContext().setTeamId(payload.getTeam().getId());
+            } else if (payload.getUser() != null && payload.getUser().getTeamId() != null) {
+                getContext().setTeamId(payload.getUser().getTeamId());
             }
             getContext().setRequestUserId(payload.getUser().getId());
         }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/BlockSuggestionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/BlockSuggestionRequest.java
@@ -27,8 +27,10 @@ public class BlockSuggestionRequest extends Request<BlockSuggestionContext> {
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null) {
+        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
+        } else if (payload.getUser() != null && payload.getUser().getTeamId() != null) {
+            getContext().setTeamId(payload.getUser().getTeamId());
         }
         getContext().setRequestUserId(payload.getUser().getId());
     }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogCancellationRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogCancellationRequest.java
@@ -28,8 +28,10 @@ public class DialogCancellationRequest extends Request<DialogCancellationContext
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null) {
+        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
+        } else if (payload.getUser() != null && payload.getUser().getTeamId() != null) {
+            getContext().setTeamId(payload.getUser().getTeamId());
         }
         if (payload.getChannel() != null) {
             getContext().setChannelId(payload.getChannel().getId());

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogSubmissionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogSubmissionRequest.java
@@ -28,8 +28,10 @@ public class DialogSubmissionRequest extends Request<DialogSubmissionContext> {
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null) {
+        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
+        } else if (payload.getUser() != null && payload.getUser().getTeamId() != null) {
+            getContext().setTeamId(payload.getUser().getTeamId());
         }
         if (payload.getChannel() != null) {
             getContext().setChannelId(payload.getChannel().getId());

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogSuggestionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/DialogSuggestionRequest.java
@@ -27,8 +27,10 @@ public class DialogSuggestionRequest extends Request<DialogSuggestionContext> {
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null) {
+        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
+        } else if (payload.getUser() != null && payload.getUser().getTeamId() != null) {
+            getContext().setTeamId(payload.getUser().getTeamId());
         }
         getContext().setRequestUserId(payload.getUser().getId());
     }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/GlobalShortcutRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/GlobalShortcutRequest.java
@@ -29,8 +29,10 @@ public class GlobalShortcutRequest extends Request<GlobalShortcutContext> {
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null) {
+        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
+        } else if (payload.getUser() != null && payload.getUser().getTeamId() != null) {
+            getContext().setTeamId(payload.getUser().getTeamId());
         }
         getContext().setRequestUserId(payload.getUser().getId());
     }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/MessageShortcutRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/MessageShortcutRequest.java
@@ -30,8 +30,10 @@ public class MessageShortcutRequest extends Request<MessageShortcutContext> {
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null) {
+        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
+        } else if (payload.getUser() != null && payload.getUser().getTeamId() != null) {
+            getContext().setTeamId(payload.getUser().getTeamId());
         }
         if (payload.getChannel() != null) {
             getContext().setChannelId(payload.getChannel().getId());

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewClosedRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewClosedRequest.java
@@ -28,8 +28,12 @@ public class ViewClosedRequest extends Request<DefaultContext> {
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null) {
+        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
+        } else if (payload.getView() != null && payload.getView().getTeamId() != null) {
+            getContext().setTeamId(payload.getView().getTeamId());
+        } else if (payload.getUser() != null && payload.getUser().getId() != null) {
+            getContext().setTeamId(payload.getUser().getTeamId());
         }
         getContext().setRequestUserId(payload.getUser().getId());
     }

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewSubmissionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewSubmissionRequest.java
@@ -28,8 +28,12 @@ public class ViewSubmissionRequest extends Request<ViewSubmissionContext> {
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null) {
+        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
+        } else if (payload.getView() != null && payload.getView().getTeamId() != null) {
+            getContext().setTeamId(payload.getView().getTeamId());
+        } else if (payload.getUser() != null && payload.getUser().getId() != null) {
+            getContext().setTeamId(payload.getUser().getTeamId());
         }
         getContext().setRequestUserId(payload.getUser().getId());
         getContext().setResponseUrls(payload.getResponseUrls());

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/WorkflowStepEditRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/WorkflowStepEditRequest.java
@@ -29,8 +29,10 @@ public class WorkflowStepEditRequest extends Request<WorkflowStepEditContext> {
             } else if (payload.getTeam() != null) {
                 getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
             }
-            if (payload.getTeam() != null) {
+            if (payload.getTeam() != null && payload.getTeam().getId() != null) {
                 getContext().setTeamId(payload.getTeam().getId());
+            } else if (payload.getUser() != null && payload.getUser().getTeamId() != null) {
+                getContext().setTeamId(payload.getUser().getTeamId());
             }
             getContext().setRequestUserId(payload.getUser().getId());
             getContext().setTriggerId(payload.getTriggerId());

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/WorkflowStepSaveRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/WorkflowStepSaveRequest.java
@@ -28,8 +28,10 @@ public class WorkflowStepSaveRequest extends Request<WorkflowStepSaveContext> {
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null) {
+        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
+        } else if (payload.getUser() != null && payload.getUser().getTeamId() != null) {
+            getContext().setTeamId(payload.getUser().getTeamId());
         }
         getContext().setRequestUserId(payload.getUser().getId());
         getContext().setWorkflowStepEditId(payload.getWorkflowStep().getWorkflowStepEditId());

--- a/bolt/src/test/java/test_locally/request/BlockActionRequestTest.java
+++ b/bolt/src/test/java/test_locally/request/BlockActionRequestTest.java
@@ -7,10 +7,7 @@ import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -103,5 +100,59 @@ public class BlockActionRequestTest {
         assertEquals(1, request.getHeaders().getNames().size());
         assertEquals("x-slack-signature", request.getHeaders().getNames().iterator().next());
         assertEquals(signature, request.getHeaders().getFirstValue("X-Slack-Signature"));
+    }
+
+    String orgWideInstallationPayload = "{\n" +
+            "  \"type\": \"block_actions\",\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"W111\",\n" +
+            "    \"username\": \"primary-owner\",\n" +
+            "    \"name\": \"primary-owner\",\n" +
+            "    \"team_id\": \"T_expected\"\n" +
+            "  },\n" +
+            "  \"api_app_id\": \"A111\",\n" +
+            "  \"token\": \"fixed-value\",\n" +
+            "  \"container\": {\n" +
+            "    \"type\": \"message\",\n" +
+            "    \"message_ts\": \"1643113871.000700\",\n" +
+            "    \"channel_id\": \"C111\",\n" +
+            "    \"is_ephemeral\": true\n" +
+            "  },\n" +
+            "  \"trigger_id\": \"111.222.xxx\",\n" +
+            "  \"team\": null,\n" +
+            "  \"enterprise\": {\n" +
+            "    \"id\": \"E111\",\n" +
+            "    \"name\": \"Sandbox Org\"\n" +
+            "  },\n" +
+            "  \"is_enterprise_install\": true,\n" +
+            "  \"channel\": {\n" +
+            "    \"id\": \"C111\",\n" +
+            "    \"name\": \"random\"\n" +
+            "  },\n" +
+            "  \"state\": {\n" +
+            "    \"values\": {}\n" +
+            "  },\n" +
+            "  \"response_url\": \"https://hooks.slack.com/actions/E111/111/xxx\",\n" +
+            "  \"actions\": [\n" +
+            "    {\n" +
+            "      \"action_id\": \"a\",\n" +
+            "      \"block_id\": \"b\",\n" +
+            "      \"text\": {\n" +
+            "        \"type\": \"plain_text\",\n" +
+            "        \"text\": \"Button\"\n" +
+            "      },\n" +
+            "      \"value\": \"click_me_123\",\n" +
+            "      \"type\": \"button\",\n" +
+            "      \"action_ts\": \"1643113877.645417\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}\n";
+
+    @Test
+    public void test_org_wide_installation() throws UnsupportedEncodingException {
+        String requestBody = "payload=" + URLEncoder.encode(orgWideInstallationPayload, "UTF-8");
+        RequestHeaders headers = new RequestHeaders(Collections.emptyMap());
+        BlockActionRequest request = new BlockActionRequest(requestBody, orgWideInstallationPayload, headers);
+        assertEquals("T_expected", request.getContext().getTeamId());
     }
 }

--- a/bolt/src/test/java/test_locally/request/ViewClosedRequestTest.java
+++ b/bolt/src/test/java/test_locally/request/ViewClosedRequestTest.java
@@ -1,0 +1,92 @@
+package test_locally.request;
+
+import com.slack.api.bolt.request.RequestHeaders;
+import com.slack.api.bolt.request.builtin.ViewClosedRequest;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class ViewClosedRequestTest {
+
+    String orgWideInstallationPayload = "{\n" +
+            "  \"type\": \"view_closed\",\n" +
+            "  \"team\": null,\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"W111\",\n" +
+            "    \"username\": \"primary-owner\",\n" +
+            "    \"name\": \"primary-owner\",\n" +
+            "    \"team_id\": \"T_expected\"\n" +
+            "  },\n" +
+            "  \"api_app_id\": \"A111\",\n" +
+            "  \"token\": \"fixed-value\",\n" +
+            "  \"view\": {\n" +
+            "    \"id\": \"V111\",\n" +
+            "    \"team_id\": \"T_expected\",\n" +
+            "    \"type\": \"modal\",\n" +
+            "    \"blocks\": [\n" +
+            "      {\n" +
+            "        \"type\": \"input\",\n" +
+            "        \"block_id\": \"M2r2p\",\n" +
+            "        \"label\": {\n" +
+            "          \"type\": \"plain_text\",\n" +
+            "          \"text\": \"Label\"\n" +
+            "        },\n" +
+            "        \"optional\": false,\n" +
+            "        \"dispatch_action\": false,\n" +
+            "        \"element\": {\n" +
+            "          \"type\": \"plain_text_input\",\n" +
+            "          \"dispatch_action_config\": {\n" +
+            "            \"trigger_actions_on\": [\n" +
+            "              \"on_enter_pressed\"\n" +
+            "            ]\n" +
+            "          },\n" +
+            "          \"action_id\": \"xB+\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"private_metadata\": \"\",\n" +
+            "    \"callback_id\": \"view-id\",\n" +
+            "    \"state\": {\n" +
+            "      \"values\": {}\n" +
+            "    },\n" +
+            "    \"hash\": \"1643113987.gRY6ROtt\",\n" +
+            "    \"title\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"My App\"\n" +
+            "    },\n" +
+            "    \"clear_on_close\": false,\n" +
+            "    \"notify_on_close\": true,\n" +
+            "    \"close\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"Cancel\"\n" +
+            "    },\n" +
+            "    \"submit\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"Submit\"\n" +
+            "    },\n" +
+            "    \"previous_view_id\": null,\n" +
+            "    \"root_view_id\": \"V111\",\n" +
+            "    \"app_id\": \"A111\",\n" +
+            "    \"external_id\": \"\",\n" +
+            "    \"app_installed_team_id\": \"E111\",\n" +
+            "    \"bot_id\": \"B0302M47727\"\n" +
+            "  },\n" +
+            "  \"is_cleared\": false,\n" +
+            "  \"is_enterprise_install\": true,\n" +
+            "  \"enterprise\": {\n" +
+            "    \"id\": \"E111\",\n" +
+            "    \"name\": \"Sandbox Org\"\n" +
+            "  }\n" +
+            "}";
+
+    @Test
+    public void orgWideInstallation() throws UnsupportedEncodingException {
+        RequestHeaders headers = new RequestHeaders(Collections.emptyMap());
+        ViewClosedRequest req = new ViewClosedRequest("payload=" + URLEncoder.encode(orgWideInstallationPayload, "UTF-8"), orgWideInstallationPayload, headers);
+        assertEquals("T_expected", req.getContext().getTeamId());
+    }
+}

--- a/bolt/src/test/java/test_locally/request/ViewSubmissionRequestTest.java
+++ b/bolt/src/test/java/test_locally/request/ViewSubmissionRequestTest.java
@@ -167,4 +167,92 @@ public class ViewSubmissionRequestTest {
         ViewSubmissionRequest req = new ViewSubmissionRequest("payload=" + URLEncoder.encode(payload, "UTF-8"), payload, headers);
         assertEquals("https://hooks.slack.com/app/T123/123/random", req.getResponseUrl());
     }
+
+    String orgWideInstallationPayload = "{\n" +
+            "  \"type\": \"view_submission\",\n" +
+            "  \"team\": null,\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"W111\",\n" +
+            "    \"username\": \"primary-owner\",\n" +
+            "    \"name\": \"primary-owner\",\n" +
+            "    \"team_id\": \"T_expected\"\n" +
+            "  },\n" +
+            "  \"api_app_id\": \"A111\",\n" +
+            "  \"token\": \"fixed-value\",\n" +
+            "  \"trigger_id\": \"1111.222.xxx\",\n" +
+            "  \"view\": {\n" +
+            "    \"id\": \"V111\",\n" +
+            "    \"team_id\": \"T_expected\",\n" +
+            "    \"type\": \"modal\",\n" +
+            "    \"blocks\": [\n" +
+            "      {\n" +
+            "        \"type\": \"input\",\n" +
+            "        \"block_id\": \"+5B\",\n" +
+            "        \"label\": {\n" +
+            "          \"type\": \"plain_text\",\n" +
+            "          \"text\": \"Label\",\n" +
+            "          \"emoji\": true\n" +
+            "        },\n" +
+            "        \"optional\": false,\n" +
+            "        \"dispatch_action\": false,\n" +
+            "        \"element\": {\n" +
+            "          \"type\": \"plain_text_input\",\n" +
+            "          \"dispatch_action_config\": {\n" +
+            "            \"trigger_actions_on\": [\n" +
+            "              \"on_enter_pressed\"\n" +
+            "            ]\n" +
+            "          },\n" +
+            "          \"action_id\": \"MMKH\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"private_metadata\": \"\",\n" +
+            "    \"callback_id\": \"view-id\",\n" +
+            "    \"state\": {\n" +
+            "      \"values\": {\n" +
+            "        \"+5B\": {\n" +
+            "          \"MMKH\": {\n" +
+            "            \"type\": \"plain_text_input\",\n" +
+            "            \"value\": \"test\"\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"hash\": \"111.xxx\",\n" +
+            "    \"title\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"My App\"\n" +
+            "    },\n" +
+            "    \"clear_on_close\": false,\n" +
+            "    \"notify_on_close\": false,\n" +
+            "    \"close\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"Cancel\"\n" +
+            "    },\n" +
+            "    \"submit\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"Submit\",\n" +
+            "      \"emoji\": true\n" +
+            "    },\n" +
+            "    \"previous_view_id\": null,\n" +
+            "    \"root_view_id\": \"V111\",\n" +
+            "    \"app_id\": \"A111\",\n" +
+            "    \"external_id\": \"\",\n" +
+            "    \"app_installed_team_id\": \"E111\",\n" +
+            "    \"bot_id\": \"B111\"\n" +
+            "  },\n" +
+            "  \"response_urls\": [],\n" +
+            "  \"is_enterprise_install\": true,\n" +
+            "  \"enterprise\": {\n" +
+            "    \"id\": \"E111\",\n" +
+            "    \"name\": \"Sandbox Org\"\n" +
+            "  }\n" +
+            "}";
+
+    @Test
+    public void orgWideInstallation() throws UnsupportedEncodingException {
+        RequestHeaders headers = new RequestHeaders(Collections.emptyMap());
+        ViewSubmissionRequest req = new ViewSubmissionRequest("payload=" + URLEncoder.encode(orgWideInstallationPayload, "UTF-8"), orgWideInstallationPayload, headers);
+        assertEquals("T_expected", req.getContext().getTeamId());
+    }
 }


### PR DESCRIPTION
This pull request fixes a bug where `context.getTeamId()` can be unexpectedly null for org-wide installations. This issue does not exist in bolt-js and bolt-python.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
