### PR TITLE
Improve #917 not to rely on #toString() method behavior

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/ThreadPools.java
@@ -1,7 +1,6 @@
 package com.slack.api.audit.impl;
 
 import com.slack.api.audit.AuditConfig;
-import com.slack.api.util.thread.ExecutorServiceProvider;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/ThreadPools.java
@@ -1,6 +1,7 @@
 package com.slack.api.audit.impl;
 
 import com.slack.api.audit.AuditConfig;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -22,7 +23,7 @@ public class ThreadPools {
     }
 
     public static ExecutorService getOrCreate(AuditConfig config, String enterpriseId) {
-        String providerInstanceId = config.getExecutorServiceProvider().toString();
+        String providerInstanceId = config.getExecutorServiceProvider().getInstanceId();
         Integer orgCustomPoolSize = enterpriseId != null ? config.getCustomThreadPoolSizes().get(enterpriseId) : null;
         if (orgCustomPoolSize != null) {
             return ENTERPRISE_CUSTOM

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java
@@ -21,7 +21,7 @@ public class ThreadPools {
     }
 
     public static ExecutorService getOrCreate(MethodsConfig config, String teamId) {
-        String providerInstanceId = config.getExecutorServiceProvider().toString();
+        String providerInstanceId = config.getExecutorServiceProvider().getInstanceId();
         Integer teamCustomPoolSize = teamId != null ? config.getCustomThreadPoolSizes().get(teamId) : null;
         if (teamCustomPoolSize != null) {
             return TEAM_CUSTOM

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/ThreadPools.java
@@ -22,7 +22,7 @@ public class ThreadPools {
     }
 
     public static ExecutorService getOrCreate(SCIMConfig config, String enterpriseId) {
-        String providerInstanceId = config.getExecutorServiceProvider().toString();
+        String providerInstanceId = config.getExecutorServiceProvider().getInstanceId();
         Integer orgCustomPoolSize = enterpriseId != null ? config.getCustomThreadPoolSizes().get(enterpriseId) : null;
         if (orgCustomPoolSize != null) {
             return ENTERPRISE_CUSTOM

--- a/slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceProvider.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/thread/ExecutorServiceProvider.java
@@ -23,4 +23,15 @@ public interface ExecutorServiceProvider {
      */
     ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName);
 
+    /**
+     * Returns the unique identifier for this instance. The value must be unique among different implementations.
+     * The default implementation is exactly the same with the default #toString() method.
+     * The reason why we have this method is to avoid unexpected side effect
+     * in the case where a developer customizes the #toString() method behavior.
+     * @return an instance ID
+     */
+    default String getInstanceId() {
+        return this.getClass().getName() + "@" + Integer.toHexString(this.hashCode());
+    }
+
 }

--- a/slack-api-model/src/test/java/test_locally/util/ExecutorServiceFactoryTest.java
+++ b/slack-api-model/src/test/java/test_locally/util/ExecutorServiceFactoryTest.java
@@ -1,6 +1,7 @@
 package test_locally.util;
 
 import com.slack.api.util.thread.ExecutorServiceFactory;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
@@ -11,6 +12,22 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.Assert.assertTrue;
 
 public class ExecutorServiceFactoryTest {
+
+    @Test
+    public void getInstanceId() throws Exception {
+        ExecutorServiceProvider provider = new ExecutorServiceProvider() {
+            @Override
+            public ExecutorService createThreadPoolExecutor(String threadGroupName, int poolSize) {
+                return null;
+            }
+
+            @Override
+            public ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName) {
+                return null;
+            }
+        };
+        assertTrue(provider.getInstanceId().matches("test_locally.util.ExecutorServiceFactoryTest\\$1\\@\\w+$"));
+    }
 
     @Test
     public void createDaemonThreadScheduledExecutor() throws InterruptedException {

--- a/slack-api-model/src/test/java/test_locally/util/ExecutorServiceFactoryTest.java
+++ b/slack-api-model/src/test/java/test_locally/util/ExecutorServiceFactoryTest.java
@@ -1,7 +1,6 @@
 package test_locally.util;
 
 import com.slack.api.util.thread.ExecutorServiceFactory;
-import com.slack.api.util.thread.ExecutorServiceProvider;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
@@ -12,22 +11,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.Assert.assertTrue;
 
 public class ExecutorServiceFactoryTest {
-
-    @Test
-    public void getInstanceId() throws Exception {
-        ExecutorServiceProvider provider = new ExecutorServiceProvider() {
-            @Override
-            public ExecutorService createThreadPoolExecutor(String threadGroupName, int poolSize) {
-                return null;
-            }
-
-            @Override
-            public ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName) {
-                return null;
-            }
-        };
-        assertTrue(provider.getInstanceId().matches("test_locally.util.ExecutorServiceFactoryTest\\$1\\@\\w+$"));
-    }
 
     @Test
     public void createDaemonThreadScheduledExecutor() throws InterruptedException {

--- a/slack-api-model/src/test/java/test_locally/util/ExecutorServiceProviderTest.java
+++ b/slack-api-model/src/test/java/test_locally/util/ExecutorServiceProviderTest.java
@@ -1,0 +1,28 @@
+package test_locally.util;
+
+import com.slack.api.util.thread.ExecutorServiceProvider;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.Assert.assertTrue;
+
+public class ExecutorServiceProviderTest {
+
+    @Test
+    public void getInstanceId() {
+        ExecutorServiceProvider provider = new ExecutorServiceProvider() {
+            @Override
+            public ExecutorService createThreadPoolExecutor(String threadGroupName, int poolSize) {
+                return null;
+            }
+
+            @Override
+            public ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName) {
+                return null;
+            }
+        };
+        assertTrue(provider.getInstanceId().matches("test_locally.util.ExecutorServiceFactoryTest\\$1\\@\\w+$"));
+    }
+}

--- a/slack-api-model/src/test/java/test_locally/util/ExecutorServiceProviderTest.java
+++ b/slack-api-model/src/test/java/test_locally/util/ExecutorServiceProviderTest.java
@@ -23,6 +23,6 @@ public class ExecutorServiceProviderTest {
                 return null;
             }
         };
-        assertTrue(provider.getInstanceId().matches("test_locally.util.ExecutorServiceFactoryTest\\$1\\@\\w+$"));
+        assertTrue(provider.getInstanceId().matches("test_locally.util.ExecutorServiceProviderTest\\$1\\@\\w+$"));
     }
 }


### PR DESCRIPTION
This pull request improves #917 code changes although it's not a bug. Refer to the code comment for learning the reason of this fix.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
