### PR TITLE
Add accessibility_label to button block element

### DIFF
--- a/bolt-jakarta-servlet/src/test/java/samples/BlocksSample.java
+++ b/bolt-jakarta-servlet/src/test/java/samples/BlocksSample.java
@@ -53,7 +53,7 @@ public class BlocksSample {
                             .blockId("actions-block")
                             .elements(asElements(
                                     button(b -> b.actionId("block-button-1").text(plainText(pt -> pt.emoji(true).text("Button1"))).value("v1")),
-                                    button(b -> b.actionId("block-button-2").text(plainText(pt -> pt.emoji(true).text("Button2"))).value("v2"))
+                                    button(b -> b.actionId("block-button-2").text(plainText(pt -> pt.emoji(true).text("Button2"))).value("v2").accessibilityLabel("This label will be read out by screen readers"))
                             ))
                     ),
                     // Select Menu

--- a/json-logs/samples/api/chat.postMessage.json
+++ b/json-logs/samples/api/chat.postMessage.json
@@ -97,6 +97,7 @@
             },
             "style": ""
           },
+          "accessibility_label": "",
           "options": [
             {
               "text": {
@@ -214,6 +215,7 @@
               "emoji": false
             },
             "value": "",
+            "emoji": false,
             "verbatim": false,
             "url": "",
             "style": "",
@@ -240,6 +242,7 @@
               },
               "style": ""
             },
+            "accessibility_label": "",
             "options": [
               {
                 "text": {
@@ -383,6 +386,7 @@
               },
               "style": ""
             },
+            "accessibility_label": "",
             "options": [
               {
                 "text": {
@@ -709,6 +713,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -878,6 +883,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -1262,6 +1268,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -1431,6 +1438,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {

--- a/json-logs/samples/api/chat.scheduleMessage.json
+++ b/json-logs/samples/api/chat.scheduleMessage.json
@@ -60,6 +60,7 @@
               },
               "style": ""
             },
+            "accessibility_label": "",
             "options": [
               {
                 "text": {
@@ -238,6 +239,7 @@
             },
             "style": ""
           },
+          "accessibility_label": "",
           "options": [
             {
               "text": {

--- a/json-logs/samples/api/chat.update.json
+++ b/json-logs/samples/api/chat.update.json
@@ -68,6 +68,7 @@
             },
             "style": ""
           },
+          "accessibility_label": "",
           "options": [
             {
               "text": {
@@ -210,6 +211,7 @@
               },
               "style": ""
             },
+            "accessibility_label": "",
             "options": [
               {
                 "text": {
@@ -627,6 +629,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -796,6 +799,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -330,6 +330,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -499,6 +500,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -659,6 +661,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -767,15 +770,6 @@
               "initial_users": [
                 ""
               ]
-            },
-            {
-              "type": "",
-              "image_url": "",
-              "alt_text": "",
-              "fallback": "",
-              "image_width": 12345,
-              "image_height": 12345,
-              "image_bytes": 12345
             }
           ],
           "block_id": "",
@@ -837,6 +831,7 @@
               },
               "style": ""
             },
+            "accessibility_label": "",
             "options": [
               {
                 "text": {
@@ -1082,6 +1077,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -1190,15 +1186,6 @@
                   "initial_users": [
                     ""
                   ]
-                },
-                {
-                  "type": "",
-                  "image_url": "",
-                  "alt_text": "",
-                  "fallback": "",
-                  "image_width": 12345,
-                  "image_height": 12345,
-                  "image_bytes": 12345
                 }
               ],
               "block_id": "",
@@ -1260,6 +1247,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -1644,6 +1632,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -1813,6 +1802,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {

--- a/json-logs/samples/api/conversations.open.json
+++ b/json-logs/samples/api/conversations.open.json
@@ -17,6 +17,171 @@
       "blocks": [
         {
           "type": "",
+          "block_id": "",
+          "text": {
+            "type": "",
+            "text": "",
+            "verbatim": false,
+            "emoji": false
+          },
+          "accessory": {
+            "type": "",
+            "action_id": "",
+            "options": [
+              {
+                "text": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "0",
+                "description": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              {
+                "text": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "min_query_length": 12345,
+            "text": {
+              "type": "",
+              "text": "",
+              "emoji": false
+            },
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "accessibility_label": "",
+            "initial_options": [
+              {
+                "text": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "focus_on_load": false,
+            "initial_option": {
+              "text": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "placeholder": {
+              "type": "",
+              "text": "",
+              "emoji": false
+            },
+            "initial_channel": "",
+            "response_url_enabled": false,
+            "initial_channels": [
+              ""
+            ],
+            "max_selected_items": 12345,
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "filter": {
+              "include": [
+                ""
+              ],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            },
+            "initial_conversations": [
+              ""
+            ],
+            "initial_date": "",
+            "initial_time": "",
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 12345,
+            "image_height": 12345,
+            "image_bytes": 12345,
+            "option_groups": [
+              {
+                "label": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ]
+              }
+            ],
+            "initial_user": "",
+            "initial_users": [
+              ""
+            ]
+          },
           "elements": [
             {
               "type": "",
@@ -52,6 +217,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -171,7 +337,6 @@
               "image_bytes": 12345
             }
           ],
-          "block_id": "",
           "fallback": "",
           "image_url": "",
           "image_width": 12345,
@@ -183,11 +348,6 @@
             "text": "",
             "emoji": false
           },
-          "text": {
-            "type": "",
-            "text": "",
-            "emoji": false
-          },
           "fields": [
             {
               "type": "",
@@ -195,150 +355,7 @@
               "emoji": false,
               "verbatim": false
             }
-          ],
-          "accessory": {
-            "type": "",
-            "text": {
-              "type": "",
-              "text": "",
-              "emoji": false
-            },
-            "action_id": "",
-            "url": "",
-            "value": "",
-            "style": "",
-            "confirm": {
-              "title": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "text": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "confirm": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "deny": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "style": ""
-            },
-            "options": [
-              {
-                "text": {
-                  "type": "",
-                  "text": "",
-                  "emoji": false
-                },
-                "value": "",
-                "description": {
-                  "type": "",
-                  "text": "",
-                  "emoji": false
-                },
-                "url": ""
-              }
-            ],
-            "initial_options": [
-              {
-                "text": {
-                  "type": "",
-                  "text": "",
-                  "emoji": false
-                },
-                "value": "",
-                "description": {
-                  "type": "",
-                  "text": "",
-                  "emoji": false
-                },
-                "url": ""
-              }
-            ],
-            "focus_on_load": false,
-            "initial_option": {
-              "text": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "value": "",
-              "description": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "url": ""
-            },
-            "placeholder": {
-              "type": "",
-              "text": "",
-              "emoji": false
-            },
-            "initial_channel": "",
-            "response_url_enabled": false,
-            "initial_channels": [
-              ""
-            ],
-            "max_selected_items": 12345,
-            "initial_conversation": "",
-            "default_to_current_conversation": false,
-            "filter": {
-              "include": [
-                ""
-              ],
-              "exclude_external_shared_channels": false,
-              "exclude_bot_users": false
-            },
-            "initial_conversations": [
-              ""
-            ],
-            "initial_date": "",
-            "initial_time": "",
-            "min_query_length": 12345,
-            "image_url": "",
-            "alt_text": "",
-            "fallback": "",
-            "image_width": 12345,
-            "image_height": 12345,
-            "image_bytes": 12345,
-            "option_groups": [
-              {
-                "label": {
-                  "type": "",
-                  "text": "",
-                  "emoji": false
-                },
-                "options": [
-                  {
-                    "text": {
-                      "type": "",
-                      "text": "",
-                      "emoji": false
-                    },
-                    "value": "",
-                    "description": {
-                      "type": "",
-                      "text": "",
-                      "emoji": false
-                    },
-                    "url": ""
-                  }
-                ]
-              }
-            ],
-            "initial_user": "",
-            "initial_users": [
-              ""
-            ]
-          }
+          ]
         }
       ],
       "client_msg_id": "",

--- a/json-logs/samples/api/conversations.replies.json
+++ b/json-logs/samples/api/conversations.replies.json
@@ -68,6 +68,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -237,6 +238,7 @@
               },
               "style": ""
             },
+            "accessibility_label": "",
             "options": [
               {
                 "text": {
@@ -482,6 +484,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -651,6 +654,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -1035,6 +1039,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -1204,6 +1209,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -1610,6 +1616,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -1779,6 +1786,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {

--- a/json-logs/samples/api/files.info.json
+++ b/json-logs/samples/api/files.info.json
@@ -379,7 +379,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",
@@ -1244,7 +1245,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         }
       },
       {

--- a/json-logs/samples/api/files.list.json
+++ b/json-logs/samples/api/files.list.json
@@ -21,16 +21,43 @@
       "display_as_bot": false,
       "username": "",
       "url_private": "https://www.example.com/",
+      "url_private_download": "https://www.example.com/",
+      "permalink": "https://www.example.com/",
+      "permalink_public": "https://www.example.com/",
+      "edit_link": "https://www.example.com/",
+      "preview": "",
+      "preview_highlight": "",
+      "lines": 12345,
+      "lines_more": 12345,
+      "preview_is_truncated": false,
+      "channels": [
+        "C00000000",
+        ""
+      ],
+      "groups": [
+        ""
+      ],
+      "ims": [
+        ""
+      ],
+      "comments_count": 12345,
       "media_display_type": "",
       "thumb_64": "https://www.example.com/",
       "thumb_80": "https://www.example.com/",
       "thumb_360": "https://www.example.com/",
       "thumb_360_w": 12345,
       "thumb_360_h": 12345,
+      "thumb_160": "https://www.example.com/",
+      "original_w": 12345,
+      "original_h": 12345,
+      "thumb_tiny": "",
       "thumb_480": "https://www.example.com/",
       "thumb_480_w": 12345,
       "thumb_480_h": 12345,
-      "thumb_160": "https://www.example.com/",
+      "thumb_360_gif": "https://www.example.com/",
+      "thumb_480_gif": "https://www.example.com/",
+      "deanimate": "https://www.example.com/",
+      "deanimate_gif": "https://www.example.com/",
       "thumb_720": "https://www.example.com/",
       "thumb_720_w": 12345,
       "thumb_720_h": 12345,
@@ -43,33 +70,6 @@
       "thumb_1024": "https://www.example.com/",
       "thumb_1024_w": 12345,
       "thumb_1024_h": 12345,
-      "original_w": 12345,
-      "original_h": 12345,
-      "thumb_tiny": "",
-      "permalink": "https://www.example.com/",
-      "channels": [
-        "C00000000",
-        ""
-      ],
-      "groups": [
-        ""
-      ],
-      "ims": [
-        ""
-      ],
-      "comments_count": 12345,
-      "url_private_download": "https://www.example.com/",
-      "permalink_public": "https://www.example.com/",
-      "edit_link": "https://www.example.com/",
-      "preview": "",
-      "preview_highlight": "",
-      "lines": 12345,
-      "lines_more": 12345,
-      "preview_is_truncated": false,
-      "thumb_360_gif": "https://www.example.com/",
-      "thumb_480_gif": "https://www.example.com/",
-      "deanimate": "https://www.example.com/",
-      "deanimate_gif": "https://www.example.com/",
       "subject": "",
       "non_owner_editable": false,
       "editor": "",
@@ -265,6 +265,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -434,6 +435,7 @@
               },
               "style": ""
             },
+            "accessibility_label": "",
             "options": [
               {
                 "text": {
@@ -590,6 +592,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -759,6 +762,7 @@
               },
               "style": ""
             },
+            "accessibility_label": "",
             "options": [
               {
                 "text": {

--- a/json-logs/samples/api/files.remote.add.json
+++ b/json-logs/samples/api/files.remote.add.json
@@ -379,7 +379,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",
@@ -1244,7 +1245,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         }
       },
       {

--- a/json-logs/samples/api/files.remote.info.json
+++ b/json-logs/samples/api/files.remote.info.json
@@ -379,7 +379,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",
@@ -1244,7 +1245,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         }
       },
       {

--- a/json-logs/samples/api/files.remote.list.json
+++ b/json-logs/samples/api/files.remote.list.json
@@ -22,18 +22,6 @@
       "username": "",
       "url_private": "https://www.example.com/",
       "media_display_type": "",
-      "permalink": "https://www.example.com/",
-      "channels": [
-        "C00000000",
-        ""
-      ],
-      "groups": [
-        ""
-      ],
-      "ims": [
-        ""
-      ],
-      "comments_count": 12345,
       "thumb_64": "https://www.example.com/",
       "thumb_80": "https://www.example.com/",
       "thumb_360": "https://www.example.com/",
@@ -59,6 +47,18 @@
       "original_w": 12345,
       "original_h": 12345,
       "thumb_tiny": "",
+      "permalink": "https://www.example.com/",
+      "channels": [
+        "C00000000",
+        ""
+      ],
+      "groups": [
+        ""
+      ],
+      "ims": [
+        ""
+      ],
+      "comments_count": 12345,
       "subject": "",
       "non_owner_editable": false,
       "editor": "",
@@ -265,6 +265,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -434,6 +435,7 @@
               },
               "style": ""
             },
+            "accessibility_label": "",
             "options": [
               {
                 "text": {
@@ -590,6 +592,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -759,6 +762,7 @@
               },
               "style": ""
             },
+            "accessibility_label": "",
             "options": [
               {
                 "text": {

--- a/json-logs/samples/api/files.remote.share.json
+++ b/json-logs/samples/api/files.remote.share.json
@@ -379,7 +379,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",
@@ -1244,7 +1245,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         }
       },
       {

--- a/json-logs/samples/api/files.remote.update.json
+++ b/json-logs/samples/api/files.remote.update.json
@@ -379,7 +379,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",
@@ -1244,7 +1245,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         }
       },
       {

--- a/json-logs/samples/api/files.revokePublicURL.json
+++ b/json-logs/samples/api/files.revokePublicURL.json
@@ -379,7 +379,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",
@@ -1244,7 +1245,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         }
       },
       {

--- a/json-logs/samples/api/files.sharedPublicURL.json
+++ b/json-logs/samples/api/files.sharedPublicURL.json
@@ -379,7 +379,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",
@@ -1244,7 +1245,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         }
       },
       {

--- a/json-logs/samples/api/files.upload.json
+++ b/json-logs/samples/api/files.upload.json
@@ -379,7 +379,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",
@@ -1244,7 +1245,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         }
       },
       {

--- a/json-logs/samples/api/pins.list.json
+++ b/json-logs/samples/api/pins.list.json
@@ -384,7 +384,8 @@
                     "emoji": false
                   },
                   "style": ""
-                }
+                },
+                "accessibility_label": ""
               },
               {
                 "type": "checkboxes",
@@ -1249,7 +1250,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "accessibility_label": ""
             }
           },
           {

--- a/json-logs/samples/api/reactions.list.json
+++ b/json-logs/samples/api/reactions.list.json
@@ -280,6 +280,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -449,6 +450,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -616,6 +618,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -785,6 +788,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -1043,6 +1043,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -1212,6 +1213,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -1596,6 +1598,7 @@
                           },
                           "style": ""
                         },
+                        "accessibility_label": "",
                         "options": [
                           {
                             "text": {
@@ -1765,6 +1768,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -1935,6 +1939,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -2104,6 +2109,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -2488,6 +2494,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -2657,6 +2664,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -3087,6 +3095,7 @@
                               },
                               "style": ""
                             },
+                            "accessibility_label": "",
                             "options": [
                               {
                                 "text": {
@@ -3256,6 +3265,7 @@
                             },
                             "style": ""
                           },
+                          "accessibility_label": "",
                           "options": [
                             {
                               "text": {
@@ -3640,6 +3650,7 @@
                                   },
                                   "style": ""
                                 },
+                                "accessibility_label": "",
                                 "options": [
                                   {
                                     "text": {
@@ -3809,6 +3820,7 @@
                                 },
                                 "style": ""
                               },
+                              "accessibility_label": "",
                               "options": [
                                 {
                                   "text": {
@@ -3979,6 +3991,7 @@
                           },
                           "style": ""
                         },
+                        "accessibility_label": "",
                         "options": [
                           {
                             "text": {
@@ -4148,6 +4161,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -4532,6 +4546,7 @@
                               },
                               "style": ""
                             },
+                            "accessibility_label": "",
                             "options": [
                               {
                                 "text": {
@@ -4701,6 +4716,7 @@
                             },
                             "style": ""
                           },
+                          "accessibility_label": "",
                           "options": [
                             {
                               "text": {

--- a/json-logs/samples/api/search.all.json
+++ b/json-logs/samples/api/search.all.json
@@ -189,6 +189,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -297,15 +298,6 @@
                       "initial_users": [
                         ""
                       ]
-                    },
-                    {
-                      "type": "",
-                      "image_url": "",
-                      "alt_text": "",
-                      "fallback": "",
-                      "image_width": 12345,
-                      "image_height": 12345,
-                      "image_bytes": 12345
                     }
                   ],
                   "block_id": "",
@@ -367,6 +359,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -751,6 +744,7 @@
                             },
                             "style": ""
                           },
+                          "accessibility_label": "",
                           "options": [
                             {
                               "text": {
@@ -920,6 +914,7 @@
                           },
                           "style": ""
                         },
+                        "accessibility_label": "",
                         "options": [
                           {
                             "text": {
@@ -1090,6 +1085,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -1198,15 +1194,6 @@
                   "initial_users": [
                     ""
                   ]
-                },
-                {
-                  "type": "",
-                  "image_url": "",
-                  "alt_text": "",
-                  "fallback": "",
-                  "image_width": 12345,
-                  "image_height": 12345,
-                  "image_bytes": 12345
                 }
               ],
               "block_id": "",
@@ -1268,6 +1255,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -1522,6 +1510,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -1630,15 +1619,6 @@
                       "initial_users": [
                         ""
                       ]
-                    },
-                    {
-                      "type": "",
-                      "image_url": "",
-                      "alt_text": "",
-                      "fallback": "",
-                      "image_width": 12345,
-                      "image_height": 12345,
-                      "image_bytes": 12345
                     }
                   ],
                   "block_id": "",
@@ -1700,6 +1680,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -2084,6 +2065,7 @@
                             },
                             "style": ""
                           },
+                          "accessibility_label": "",
                           "options": [
                             {
                               "text": {
@@ -2253,6 +2235,7 @@
                           },
                           "style": ""
                         },
+                        "accessibility_label": "",
                         "options": [
                           {
                             "text": {
@@ -2423,6 +2406,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -2531,15 +2515,6 @@
                   "initial_users": [
                     ""
                   ]
-                },
-                {
-                  "type": "",
-                  "image_url": "",
-                  "alt_text": "",
-                  "fallback": "",
-                  "image_width": 12345,
-                  "image_height": 12345,
-                  "image_bytes": 12345
                 }
               ],
               "block_id": "",
@@ -2601,6 +2576,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -2751,6 +2727,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -2859,15 +2836,6 @@
                 "initial_users": [
                   ""
                 ]
-              },
-              {
-                "type": "",
-                "image_url": "",
-                "alt_text": "",
-                "fallback": "",
-                "image_width": 12345,
-                "image_height": 12345,
-                "image_bytes": 12345
               }
             ],
             "block_id": "",
@@ -2929,6 +2897,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -3174,6 +3143,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -3282,15 +3252,6 @@
                     "initial_users": [
                       ""
                     ]
-                  },
-                  {
-                    "type": "",
-                    "image_url": "",
-                    "alt_text": "",
-                    "fallback": "",
-                    "image_width": 12345,
-                    "image_height": 12345,
-                    "image_bytes": 12345
                   }
                 ],
                 "block_id": "",
@@ -3352,6 +3313,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -3736,6 +3698,7 @@
                           },
                           "style": ""
                         },
+                        "accessibility_label": "",
                         "options": [
                           {
                             "text": {
@@ -3905,6 +3868,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -4312,6 +4276,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -4481,6 +4446,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {

--- a/json-logs/samples/api/search.messages.json
+++ b/json-logs/samples/api/search.messages.json
@@ -188,6 +188,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -296,15 +297,6 @@
                       "initial_users": [
                         ""
                       ]
-                    },
-                    {
-                      "type": "",
-                      "image_url": "",
-                      "alt_text": "",
-                      "fallback": "",
-                      "image_width": 12345,
-                      "image_height": 12345,
-                      "image_bytes": 12345
                     }
                   ],
                   "block_id": "",
@@ -366,6 +358,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -750,6 +743,7 @@
                             },
                             "style": ""
                           },
+                          "accessibility_label": "",
                           "options": [
                             {
                               "text": {
@@ -919,6 +913,7 @@
                           },
                           "style": ""
                         },
+                        "accessibility_label": "",
                         "options": [
                           {
                             "text": {
@@ -1089,6 +1084,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -1197,15 +1193,6 @@
                   "initial_users": [
                     ""
                   ]
-                },
-                {
-                  "type": "",
-                  "image_url": "",
-                  "alt_text": "",
-                  "fallback": "",
-                  "image_width": 12345,
-                  "image_height": 12345,
-                  "image_bytes": 12345
                 }
               ],
               "block_id": "",
@@ -1267,6 +1254,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -1521,6 +1509,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -1629,15 +1618,6 @@
                       "initial_users": [
                         ""
                       ]
-                    },
-                    {
-                      "type": "",
-                      "image_url": "",
-                      "alt_text": "",
-                      "fallback": "",
-                      "image_width": 12345,
-                      "image_height": 12345,
-                      "image_bytes": 12345
                     }
                   ],
                   "block_id": "",
@@ -1699,6 +1679,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -2083,6 +2064,7 @@
                             },
                             "style": ""
                           },
+                          "accessibility_label": "",
                           "options": [
                             {
                               "text": {
@@ -2252,6 +2234,7 @@
                           },
                           "style": ""
                         },
+                        "accessibility_label": "",
                         "options": [
                           {
                             "text": {
@@ -2422,6 +2405,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -2530,15 +2514,6 @@
                   "initial_users": [
                     ""
                   ]
-                },
-                {
-                  "type": "",
-                  "image_url": "",
-                  "alt_text": "",
-                  "fallback": "",
-                  "image_width": 12345,
-                  "image_height": 12345,
-                  "image_bytes": 12345
                 }
               ],
               "block_id": "",
@@ -2600,6 +2575,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -2750,6 +2726,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -2858,15 +2835,6 @@
                 "initial_users": [
                   ""
                 ]
-              },
-              {
-                "type": "",
-                "image_url": "",
-                "alt_text": "",
-                "fallback": "",
-                "image_width": 12345,
-                "image_height": 12345,
-                "image_bytes": 12345
               }
             ],
             "block_id": "",
@@ -2928,6 +2896,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -3173,6 +3142,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -3281,15 +3251,6 @@
                     "initial_users": [
                       ""
                     ]
-                  },
-                  {
-                    "type": "",
-                    "image_url": "",
-                    "alt_text": "",
-                    "fallback": "",
-                    "image_width": 12345,
-                    "image_height": 12345,
-                    "image_bytes": 12345
                   }
                 ],
                 "block_id": "",
@@ -3351,6 +3312,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -3735,6 +3697,7 @@
                           },
                           "style": ""
                         },
+                        "accessibility_label": "",
                         "options": [
                           {
                             "text": {
@@ -3904,6 +3867,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -4311,6 +4275,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -4480,6 +4445,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {

--- a/json-logs/samples/api/stars.list.json
+++ b/json-logs/samples/api/stars.list.json
@@ -146,6 +146,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -315,6 +316,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -699,6 +701,7 @@
                           },
                           "style": ""
                         },
+                        "accessibility_label": "",
                         "options": [
                           {
                             "text": {
@@ -868,6 +871,7 @@
                         },
                         "style": ""
                       },
+                      "accessibility_label": "",
                       "options": [
                         {
                           "text": {
@@ -1042,6 +1046,7 @@
                   },
                   "style": ""
                 },
+                "accessibility_label": "",
                 "options": [
                   {
                     "text": {
@@ -1211,6 +1216,7 @@
                 },
                 "style": ""
               },
+              "accessibility_label": "",
               "options": [
                 {
                   "text": {
@@ -1631,6 +1637,7 @@
                       },
                       "style": ""
                     },
+                    "accessibility_label": "",
                     "options": [
                       {
                         "text": {
@@ -1800,6 +1807,7 @@
                     },
                     "style": ""
                   },
+                  "accessibility_label": "",
                   "options": [
                     {
                       "text": {
@@ -2297,7 +2305,8 @@
                     "emoji": false
                   },
                   "style": ""
-                }
+                },
+                "accessibility_label": ""
               },
               {
                 "type": "checkboxes",
@@ -3162,7 +3171,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "accessibility_label": ""
             }
           },
           {

--- a/json-logs/samples/api/views.open.json
+++ b/json-logs/samples/api/views.open.json
@@ -188,7 +188,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         },
         "dispatch_action": false,
         "hint": {
@@ -744,7 +745,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",

--- a/json-logs/samples/api/views.publish.json
+++ b/json-logs/samples/api/views.publish.json
@@ -188,7 +188,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         },
         "dispatch_action": false,
         "hint": {
@@ -744,7 +745,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",

--- a/json-logs/samples/api/views.push.json
+++ b/json-logs/samples/api/views.push.json
@@ -188,7 +188,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         },
         "dispatch_action": false,
         "hint": {
@@ -744,7 +745,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",

--- a/json-logs/samples/api/views.update.json
+++ b/json-logs/samples/api/views.update.json
@@ -188,7 +188,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         },
         "dispatch_action": false,
         "hint": {
@@ -744,7 +745,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "checkboxes",

--- a/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
@@ -77,7 +77,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "channels_select",

--- a/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
@@ -49,7 +49,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "channels_select",

--- a/json-logs/samples/events/AppMentionPayload.json
+++ b/json-logs/samples/events/AppMentionPayload.json
@@ -81,7 +81,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "channels_select",

--- a/json-logs/samples/events/MessageBotPayload.json
+++ b/json-logs/samples/events/MessageBotPayload.json
@@ -74,7 +74,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "channels_select",

--- a/json-logs/samples/events/MessageChangedPayload.json
+++ b/json-logs/samples/events/MessageChangedPayload.json
@@ -90,7 +90,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "accessibility_label": ""
             },
             {
               "type": "channels_select",
@@ -788,7 +789,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "accessibility_label": ""
             },
             {
               "type": "channels_select",

--- a/json-logs/samples/events/MessageDeletedPayload.json
+++ b/json-logs/samples/events/MessageDeletedPayload.json
@@ -77,7 +77,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "accessibility_label": ""
             },
             {
               "type": "channels_select",

--- a/json-logs/samples/events/MessageEkmAccessDeniedPayload.json
+++ b/json-logs/samples/events/MessageEkmAccessDeniedPayload.json
@@ -67,7 +67,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "channels_select",

--- a/json-logs/samples/events/MessageFileSharePayload.json
+++ b/json-logs/samples/events/MessageFileSharePayload.json
@@ -64,7 +64,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "channels_select",

--- a/json-logs/samples/events/MessagePayload.json
+++ b/json-logs/samples/events/MessagePayload.json
@@ -81,7 +81,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "channels_select",

--- a/json-logs/samples/events/MessageRepliedPayload.json
+++ b/json-logs/samples/events/MessageRepliedPayload.json
@@ -76,7 +76,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "accessibility_label": ""
             },
             {
               "type": "channels_select",

--- a/json-logs/samples/events/MessageThreadBroadcastPayload.json
+++ b/json-logs/samples/events/MessageThreadBroadcastPayload.json
@@ -110,7 +110,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           },
           {
             "type": "channels_select",

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -56,7 +56,8 @@
               "emoji": false
             },
             "style": ""
-          }
+          },
+          "accessibility_label": ""
         },
         {
           "type": "checkboxes",
@@ -921,7 +922,8 @@
             "emoji": false
           },
           "style": ""
-        }
+        },
+        "accessibility_label": ""
       }
     },
     {

--- a/json-logs/samples/rtm/PinAddedEvent.json
+++ b/json-logs/samples/rtm/PinAddedEvent.json
@@ -65,7 +65,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "accessibility_label": ""
             },
             {
               "type": "checkboxes",
@@ -930,7 +931,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           }
         },
         {

--- a/json-logs/samples/rtm/PinRemovedEvent.json
+++ b/json-logs/samples/rtm/PinRemovedEvent.json
@@ -65,7 +65,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "accessibility_label": ""
             },
             {
               "type": "checkboxes",
@@ -930,7 +931,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           }
         },
         {

--- a/json-logs/samples/rtm/StarAddedEvent.json
+++ b/json-logs/samples/rtm/StarAddedEvent.json
@@ -65,7 +65,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "accessibility_label": ""
             },
             {
               "type": "checkboxes",
@@ -930,7 +931,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           }
         },
         {

--- a/json-logs/samples/rtm/StarRemovedEvent.json
+++ b/json-logs/samples/rtm/StarRemovedEvent.json
@@ -64,7 +64,8 @@
                   "emoji": false
                 },
                 "style": ""
-              }
+              },
+              "accessibility_label": ""
             },
             {
               "type": "checkboxes",
@@ -929,7 +930,8 @@
                 "emoji": false
               },
               "style": ""
-            }
+            },
+            "accessibility_label": ""
           }
         },
         {

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/ButtonElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/ButtonElementBuilder.kt
@@ -16,6 +16,7 @@ class ButtonElementBuilder : Builder<ButtonElement> {
     private var value: String? = null
     private var style: String? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var accessibilityLabel: String? = null
 
     /**
      * An identifier for this action. You can use this when you receive an interaction payload to identify the source
@@ -91,6 +92,17 @@ class ButtonElementBuilder : Builder<ButtonElement> {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
     }
 
+    /**
+     * A label for longer descriptive text about a button element.
+     * This label will be read out by screen readers instead of the button text object.
+     * Maximum length for this field is 75 characters.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#button">Button element documentation</a>
+     */
+    fun accessibilityLabel(accessibilityLabel: String) {
+        this.accessibilityLabel = accessibilityLabel
+    }
+
     override fun build(): ButtonElement {
         return ButtonElement.builder()
                 .actionId(actionId)
@@ -99,6 +111,7 @@ class ButtonElementBuilder : Builder<ButtonElement> {
                 .text(text)
                 .style(style)
                 .confirm(confirm)
+                .accessibilityLabel(accessibilityLabel)
                 .build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/HomeTemplateTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/HomeTemplateTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertEquals
 // https://api.slack.com/tools/block-kit-builder?mode=appHome&template=1
 class HomeTemplateTest {
 
-    val gson = GsonFactory.createSnakeCase()
+    private val gson = GsonFactory.createSnakeCase()
 
     @Test
     fun projectTracker() {
@@ -32,6 +32,11 @@ class HomeTemplateTest {
                     button {
                         text(text = "Help", emoji = true)
                         value("help")
+                    }
+                    button {
+                        text(text = "Help", emoji = true)
+                        value("help")
+                        accessibilityLabel("This label will be read out by screen readers")
                     }
                 }
             }
@@ -113,6 +118,16 @@ class HomeTemplateTest {
 						"emoji": true
 					},
 					"value": "help"
+				},
+				{
+					"type": "button",
+					"text": {
+						"type": "plain_text",
+						"text": "Help",
+						"emoji": true
+					},
+					"value": "help",
+					"accessibility_label": "This label will be read out by screen readers"
 				}
 			]
 		},

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/ButtonElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/ButtonElement.java
@@ -61,4 +61,11 @@ public class ButtonElement extends BlockElement {
      * A confirm object that defines an optional confirmation dialog after the button is clicked.
      */
     private ConfirmationDialogObject confirm;
+
+    /**
+     * A label for longer descriptive text about a button element.
+     * This label will be read out by screen readers instead of the button text object.
+     * Maximum length for this field is 75 characters.
+     */
+    private String accessibilityLabel;
 }


### PR DESCRIPTION
This pull request adds "accessibility_label" to the "button" type block element.

* https://api.slack.com/reference/block-kit/block-elements#button
* https://api.slack.com/changelog

As this is a tiny addition, I'm planning to have this change in the next patch version (if we don't have other major changes that require minor version upgrade)

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
