### PR TITLE
Upgrade gson, slf4j versions and others

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.19.0.0</http4k.version>
+        <http4k.version>4.19.3.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.version>3.3.0</micronaut.version>
+        <micronaut.version>3.3.1</micronaut.version>
         <micronaut-test-junit5.version>3.0.5</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>2.2.0</micronaut-rxjava3.version>
         <!-- Note that upgrading this library breaks other dependency resolution -->

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
         <mutiny.version>1.3.1</mutiny.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -49,15 +49,15 @@
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <okhttp.version>4.9.3</okhttp.version>
-        <gson.version>2.8.9</gson.version>
+        <gson.version>2.9.0</gson.version>
         <kotlin.version>1.6.10</kotlin.version>
-        <slf4j.version>1.7.35</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <lombok.version>1.18.22</lombok.version>
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
 
         <!-- optional / testing-only dependencies -->
-        <jakarta.jetty.version>11.0.7</jakarta.jetty.version>
+        <jakarta.jetty.version>11.0.8</jakarta.jetty.version>
         <java-jwt.version>3.18.3</java-jwt.version>
         <aws.s3.version>[1.12.62,1.13.0)</aws.s3.version>
         <junit.version>4.13.2</junit.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -21,7 +21,7 @@
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
         <java-websocket.version>1.5.2</java-websocket.version>
         <jedis.version>4.1.1</jedis.version>
-        <jedis-mock.version>1.0.0</jedis-mock.version>
+        <jedis-mock.version>1.0.1</jedis-mock.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This pull request upgrades the following dependencies in the next minor version -  v1.19

* gson from 2.8.9 to 2.9.0
* slf4j-api from 1.7.35 to 1.7.36

The rest are optional or only tests for this SDK itself.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to those rules.
