### PR TITLE
Fix #933 by adjusting the internals of smart rate limiter

### DIFF
--- a/bolt-servlet/src/test/java/samples/EventsSample_WatchingYou.java
+++ b/bolt-servlet/src/test/java/samples/EventsSample_WatchingYou.java
@@ -2,7 +2,6 @@ package samples;
 
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
-import com.slack.api.methods.response.reactions.ReactionsAddResponse;
 import com.slack.api.model.event.MessageEvent;
 import com.slack.api.model.event.ReactionAddedEvent;
 import util.ResourceLoader;
@@ -14,11 +13,13 @@ public class EventsSample_WatchingYou {
         AppConfig config = ResourceLoader.loadAppConfig();
         App app = new App(config);
 
+        // config.getSlack().getConfig().setRateLimiterBackgroundJobIntervalMillis(3_000L);
+        // config.getSlack().getConfig().setLibraryMaintainerMode(true);
+
         app.event(MessageEvent.class, (req, ctx) -> {
             String channel = req.getEvent().getChannel();
             String ts = req.getEvent().getTs();
-            ReactionsAddResponse res = ctx.client().reactionsAdd(r -> r.channel(channel).timestamp(ts).name("eyes"));
-            ctx.logger.info("reactions.add - {}", res);
+            ctx.asyncClient().reactionsAdd(r -> r.channel(channel).timestamp(ts).name("eyes"));
             return ctx.ack();
         });
 

--- a/bolt-servlet/src/test/java/samples/EventsSample_WatchingYou.java
+++ b/bolt-servlet/src/test/java/samples/EventsSample_WatchingYou.java
@@ -13,8 +13,9 @@ public class EventsSample_WatchingYou {
         AppConfig config = ResourceLoader.loadAppConfig();
         App app = new App(config);
 
-        // config.getSlack().getConfig().setRateLimiterBackgroundJobIntervalMillis(3_000L);
         // config.getSlack().getConfig().setLibraryMaintainerMode(true);
+        // config.getSlack().getConfig().setStatsEnabled(false);
+        // config.getSlack().getConfig().setRateLimiterBackgroundJobIntervalMillis(3_000L);
 
         app.event(MessageEvent.class, (req, ctx) -> {
             String channel = req.getEvent().getChannel();

--- a/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
@@ -234,17 +234,28 @@ public class SlackConfig {
         if (!methodsConfig.equals(MethodsConfig.DEFAULT_SINGLETON)
                 && !methodsConfig.getExecutorServiceProvider().equals(executorServiceProvider)) {
             methodsConfig.setExecutorServiceProvider(executorServiceProvider);
-            methodsConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
+            if (methodsConfig.isStatsEnabled()) {
+                methodsConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
+            }
         }
         if (!auditConfig.equals(AuditConfig.DEFAULT_SINGLETON)
                 && !auditConfig.getExecutorServiceProvider().equals(executorServiceProvider)) {
             auditConfig.setExecutorServiceProvider(executorServiceProvider);
-            auditConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
+            if (auditConfig.isStatsEnabled()) {
+                auditConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
+            }
         }
         if (!sCIMConfig.equals(SCIMConfig.DEFAULT_SINGLETON)
                 && !sCIMConfig.getExecutorServiceProvider().equals(executorServiceProvider)) {
             sCIMConfig.setExecutorServiceProvider(executorServiceProvider);
-            sCIMConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
+            if (sCIMConfig.isStatsEnabled()) {
+                sCIMConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
+            }
+        }
+        if (this.isLibraryMaintainerMode()) {
+            methodsConfig.getMetricsDatastore().setTraceMode(true);
+            auditConfig.getMetricsDatastore().setTraceMode(true);
+            sCIMConfig.getMetricsDatastore().setTraceMode(true);
         }
     }
 }

--- a/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
@@ -4,6 +4,7 @@ import com.slack.api.audit.AuditClient;
 import com.slack.api.audit.AuditConfig;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.MethodsConfig;
+import com.slack.api.rate_limits.RateLimiter;
 import com.slack.api.scim.SCIMClient;
 import com.slack.api.scim.SCIMConfig;
 import com.slack.api.status.v1.LegacyStatusClient;
@@ -129,6 +130,11 @@ public class SlackConfig {
         public void setExecutorServiceProvider(ExecutorServiceProvider executorServiceProvider) {
             throwException();
         }
+
+        @Override
+        public void setRateLimiterBackgroundJobIntervalMillis(Long rateLimiterBackgroundJobIntervalMillis) {
+            throwException();
+        }
     };
 
     public SlackConfig() {
@@ -150,8 +156,7 @@ public class SlackConfig {
 
     /**
      * The underlying HTTP client's call timeout (in milliseconds).
-     * By default there is no timeout for complete calls,
-     * but there is for the connect, write, and read actions within a call.
+     * By default, there is no timeout for complete calls while there is for connect/write/read actions within a call.
      * https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/call-timeout-millis/
      */
     private Integer httpClientCallTimeoutMillis;
@@ -199,6 +204,11 @@ public class SlackConfig {
      */
     private boolean libraryMaintainerMode = false;
 
+    public void setLibraryMaintainerMode(boolean libraryMaintainerMode) {
+        this.libraryMaintainerMode = libraryMaintainerMode;
+        this.synchronizeLibraryMaintainerMode();
+    }
+
     /**
      * If you would like to detect unknown properties by throwing exceptions, set this flag as true.
      */
@@ -224,11 +234,49 @@ public class SlackConfig {
     @Builder.Default
     private ExecutorServiceProvider executorServiceProvider = DaemonThreadExecutorServiceProvider.getInstance();
 
+    @Builder.Default
+    private Long rateLimiterBackgroundJobIntervalMillis = RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS;
+
+    public void setRateLimiterBackgroundJobIntervalMillis(Long rateLimiterBackgroundJobIntervalMillis) {
+        if (rateLimiterBackgroundJobIntervalMillis == 0) {
+            throw new IllegalArgumentException(
+                    "0 millisecond is not a valid value for rateLimiterBackgroundJobIntervalMillis");
+        }
+        this.rateLimiterBackgroundJobIntervalMillis = rateLimiterBackgroundJobIntervalMillis;
+        this.synchronizeMetricsDatabases();
+    }
+
     private MethodsConfig methodsConfig = new MethodsConfig();
 
     private AuditConfig auditConfig = new AuditConfig();
 
     private SCIMConfig sCIMConfig = new SCIMConfig();
+
+    public void synchronizeMetricsDatabases() {
+        this.synchronizeExecutorServiceProviders();
+
+        if (!methodsConfig.equals(MethodsConfig.DEFAULT_SINGLETON)
+                && methodsConfig.isStatsEnabled()
+                && methodsConfig.getMetricsDatastore().getRateLimiterBackgroundJobIntervalMillis()
+                != this.getRateLimiterBackgroundJobIntervalMillis()) {
+            methodsConfig.getMetricsDatastore().setRateLimiterBackgroundJobIntervalMillis(
+                    this.getRateLimiterBackgroundJobIntervalMillis());
+        }
+        if (!auditConfig.equals(AuditConfig.DEFAULT_SINGLETON)
+                && auditConfig.isStatsEnabled()
+                && auditConfig.getMetricsDatastore().getRateLimiterBackgroundJobIntervalMillis()
+                != this.getRateLimiterBackgroundJobIntervalMillis()) {
+            auditConfig.getMetricsDatastore().setRateLimiterBackgroundJobIntervalMillis(
+                    this.getRateLimiterBackgroundJobIntervalMillis());
+        }
+        if (!sCIMConfig.equals(SCIMConfig.DEFAULT_SINGLETON)
+                && sCIMConfig.isStatsEnabled()
+                && sCIMConfig.getMetricsDatastore().getRateLimiterBackgroundJobIntervalMillis()
+                != this.getRateLimiterBackgroundJobIntervalMillis()) {
+            sCIMConfig.getMetricsDatastore().setRateLimiterBackgroundJobIntervalMillis(
+                    this.getRateLimiterBackgroundJobIntervalMillis());
+        }
+    }
 
     public void synchronizeExecutorServiceProviders() {
         if (!methodsConfig.equals(MethodsConfig.DEFAULT_SINGLETON)
@@ -252,10 +300,13 @@ public class SlackConfig {
                 sCIMConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
             }
         }
-        if (this.isLibraryMaintainerMode()) {
-            methodsConfig.getMetricsDatastore().setTraceMode(true);
-            auditConfig.getMetricsDatastore().setTraceMode(true);
-            sCIMConfig.getMetricsDatastore().setTraceMode(true);
-        }
+        this.synchronizeLibraryMaintainerMode();
     }
+
+    public void synchronizeLibraryMaintainerMode() {
+        methodsConfig.getMetricsDatastore().setTraceMode(this.isLibraryMaintainerMode());
+        auditConfig.getMetricsDatastore().setTraceMode(this.isLibraryMaintainerMode());
+        sCIMConfig.getMetricsDatastore().setTraceMode(this.isLibraryMaintainerMode());
+    }
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
@@ -87,6 +87,11 @@ public class SlackConfig {
         }
 
         @Override
+        public void setStatsEnabled(boolean statsEnabled) {
+            throwException();
+        }
+
+        @Override
         public void setMethodsConfig(MethodsConfig methodsConfig) {
             throwException();
         }
@@ -246,6 +251,17 @@ public class SlackConfig {
         this.synchronizeMetricsDatabases();
     }
 
+    @Builder.Default
+    private boolean statsEnabled = true;
+
+    public void setStatsEnabled(boolean statsEnabled) {
+        this.statsEnabled = statsEnabled;
+        this.getMethodsConfig().setStatsEnabled(this.isStatsEnabled());
+        this.getSCIMConfig().setStatsEnabled(this.isStatsEnabled());
+        this.getAuditConfig().setStatsEnabled(this.isStatsEnabled());
+        this.synchronizeMetricsDatabases();
+    }
+
     private MethodsConfig methodsConfig = new MethodsConfig();
 
     private AuditConfig auditConfig = new AuditConfig();
@@ -255,50 +271,59 @@ public class SlackConfig {
     public void synchronizeMetricsDatabases() {
         this.synchronizeExecutorServiceProviders();
 
-        if (!methodsConfig.equals(MethodsConfig.DEFAULT_SINGLETON)
-                && methodsConfig.isStatsEnabled()
-                && methodsConfig.getMetricsDatastore().getRateLimiterBackgroundJobIntervalMillis()
-                != this.getRateLimiterBackgroundJobIntervalMillis()) {
-            methodsConfig.getMetricsDatastore().setRateLimiterBackgroundJobIntervalMillis(
-                    this.getRateLimiterBackgroundJobIntervalMillis());
+        if (!methodsConfig.equals(MethodsConfig.DEFAULT_SINGLETON)) {
+            if (methodsConfig.isStatsEnabled()) {
+                if (methodsConfig.getMetricsDatastore().getRateLimiterBackgroundJobIntervalMillis()
+                        != this.getRateLimiterBackgroundJobIntervalMillis()) {
+                    methodsConfig.getMetricsDatastore().setRateLimiterBackgroundJobIntervalMillis(
+                            this.getRateLimiterBackgroundJobIntervalMillis());
+                }
+            } else {
+                methodsConfig.getMetricsDatastore().setStatsEnabled(false);
+            }
         }
-        if (!auditConfig.equals(AuditConfig.DEFAULT_SINGLETON)
-                && auditConfig.isStatsEnabled()
-                && auditConfig.getMetricsDatastore().getRateLimiterBackgroundJobIntervalMillis()
-                != this.getRateLimiterBackgroundJobIntervalMillis()) {
-            auditConfig.getMetricsDatastore().setRateLimiterBackgroundJobIntervalMillis(
-                    this.getRateLimiterBackgroundJobIntervalMillis());
+        if (!auditConfig.equals(auditConfig.DEFAULT_SINGLETON)) {
+            if (auditConfig.isStatsEnabled()) {
+                if (auditConfig.getMetricsDatastore().getRateLimiterBackgroundJobIntervalMillis()
+                        != this.getRateLimiterBackgroundJobIntervalMillis()) {
+                    auditConfig.getMetricsDatastore().setRateLimiterBackgroundJobIntervalMillis(
+                            this.getRateLimiterBackgroundJobIntervalMillis());
+                }
+            } else {
+                auditConfig.getMetricsDatastore().setStatsEnabled(false);
+            }
         }
-        if (!sCIMConfig.equals(SCIMConfig.DEFAULT_SINGLETON)
-                && sCIMConfig.isStatsEnabled()
-                && sCIMConfig.getMetricsDatastore().getRateLimiterBackgroundJobIntervalMillis()
-                != this.getRateLimiterBackgroundJobIntervalMillis()) {
-            sCIMConfig.getMetricsDatastore().setRateLimiterBackgroundJobIntervalMillis(
-                    this.getRateLimiterBackgroundJobIntervalMillis());
+        if (!sCIMConfig.equals(sCIMConfig.DEFAULT_SINGLETON)) {
+            if (sCIMConfig.isStatsEnabled()) {
+                if (sCIMConfig.getMetricsDatastore().getRateLimiterBackgroundJobIntervalMillis()
+                        != this.getRateLimiterBackgroundJobIntervalMillis()) {
+                    sCIMConfig.getMetricsDatastore().setRateLimiterBackgroundJobIntervalMillis(
+                            this.getRateLimiterBackgroundJobIntervalMillis());
+                }
+            } else {
+                sCIMConfig.getMetricsDatastore().setStatsEnabled(false);
+            }
         }
     }
 
     public void synchronizeExecutorServiceProviders() {
         if (!methodsConfig.equals(MethodsConfig.DEFAULT_SINGLETON)
+                && methodsConfig.isStatsEnabled()
                 && !methodsConfig.getExecutorServiceProvider().equals(executorServiceProvider)) {
             methodsConfig.setExecutorServiceProvider(executorServiceProvider);
-            if (methodsConfig.isStatsEnabled()) {
-                methodsConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
-            }
+            methodsConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
         }
         if (!auditConfig.equals(AuditConfig.DEFAULT_SINGLETON)
+                && auditConfig.isStatsEnabled()
                 && !auditConfig.getExecutorServiceProvider().equals(executorServiceProvider)) {
             auditConfig.setExecutorServiceProvider(executorServiceProvider);
-            if (auditConfig.isStatsEnabled()) {
-                auditConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
-            }
+            auditConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
         }
         if (!sCIMConfig.equals(SCIMConfig.DEFAULT_SINGLETON)
+                && sCIMConfig.isStatsEnabled()
                 && !sCIMConfig.getExecutorServiceProvider().equals(executorServiceProvider)) {
             sCIMConfig.setExecutorServiceProvider(executorServiceProvider);
-            if (sCIMConfig.isStatsEnabled()) {
-                sCIMConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
-            }
+            sCIMConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
         }
         this.synchronizeLibraryMaintainerMode();
     }

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
@@ -17,26 +17,26 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean cleanerEnabled
+            boolean backgroundJobEnabled
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
             ExecutorServiceProvider executorServiceProvider,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(numberOfNodes, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
@@ -17,26 +17,26 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean backgroundJobEnabled
+            boolean statsEnabled
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), statsEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
             ExecutorServiceProvider executorServiceProvider,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(numberOfNodes, executorServiceProvider, statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
@@ -3,6 +3,7 @@ package com.slack.api.audit.metrics;
 import com.slack.api.audit.AuditApiResponse;
 import com.slack.api.audit.impl.AsyncExecutionSupplier;
 import com.slack.api.audit.impl.AsyncRateLimitQueue;
+import com.slack.api.rate_limits.RateLimiter;
 import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
 import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import com.slack.api.util.thread.ExecutorServiceProvider;
@@ -18,7 +19,7 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
             int numberOfNodes,
             boolean cleanerEnabled
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, DEFAULT_CLEANER_EXECUTION_INTERVAL_MILLISECONDS);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
     }
 
     public MemoryMetricsDatastore(

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
@@ -4,12 +4,38 @@ import com.slack.api.audit.AuditApiResponse;
 import com.slack.api.audit.impl.AsyncExecutionSupplier;
 import com.slack.api.audit.impl.AsyncRateLimitQueue;
 import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 
 public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
         AsyncExecutionSupplier<? extends AuditApiResponse>, AsyncRateLimitQueue.AuditMessage> {
 
     public MemoryMetricsDatastore(int numberOfNodes) {
         super(numberOfNodes);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            boolean cleanerEnabled
+    ) {
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, DEFAULT_CLEANER_EXECUTION_INTERVAL_MILLISECONDS);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            ExecutorServiceProvider executorServiceProvider,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(numberOfNodes, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/MemoryMetricsDatastore.java
@@ -25,18 +25,18 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
     public MemoryMetricsDatastore(
             int numberOfNodes,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
             ExecutorServiceProvider executorServiceProvider,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/RedisMetricsDatastore.java
@@ -17,20 +17,20 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(appName, jedisPool, statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
             ExecutorServiceProvider executorServiceProvider,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(appName, jedisPool, executorServiceProvider, statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/RedisMetricsDatastore.java
@@ -18,9 +18,9 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
             String appName,
             JedisPool jedisPool,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public RedisMetricsDatastore(
@@ -28,9 +28,9 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
             JedisPool jedisPool,
             ExecutorServiceProvider executorServiceProvider,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/RedisMetricsDatastore.java
@@ -17,20 +17,20 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(appName, jedisPool, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
             ExecutorServiceProvider executorServiceProvider,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(appName, jedisPool, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/audit/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/metrics/RedisMetricsDatastore.java
@@ -4,6 +4,7 @@ import com.slack.api.audit.AuditApiResponse;
 import com.slack.api.audit.impl.AsyncExecutionSupplier;
 import com.slack.api.audit.impl.AsyncRateLimitQueue;
 import com.slack.api.rate_limits.metrics.impl.BaseRedisMetricsDatastore;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import redis.clients.jedis.JedisPool;
 
 public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
@@ -13,9 +14,33 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
         super(appName, jedisPool);
     }
 
+    public RedisMetricsDatastore(
+            String appName,
+            JedisPool jedisPool,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(appName, jedisPool, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+    }
+
+    public RedisMetricsDatastore(
+            String appName,
+            JedisPool jedisPool,
+            ExecutorServiceProvider executorServiceProvider,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(appName, jedisPool, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+    }
+
     @Override
     public AsyncRateLimitQueue getRateLimitQueue(String executorName, String teamId) {
         return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+
+    @Override
+    protected String getMetricsType() {
+        return "AUDIT_LOGS";
     }
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
@@ -16,26 +16,26 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<AsyncExec
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean cleanerEnabled
+            boolean backgroundJobEnabled
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
             ExecutorServiceProvider executorServiceProvider,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(numberOfNodes, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(int numberOfNodes) {

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
@@ -24,18 +24,18 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<AsyncExec
     public MemoryMetricsDatastore(
             int numberOfNodes,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
             ExecutorServiceProvider executorServiceProvider,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(int numberOfNodes) {

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
@@ -3,6 +3,7 @@ package com.slack.api.methods.metrics;
 import com.slack.api.methods.SlackApiResponse;
 import com.slack.api.methods.impl.AsyncExecutionSupplier;
 import com.slack.api.methods.impl.AsyncRateLimitQueue;
+import com.slack.api.rate_limits.RateLimiter;
 import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
 import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import com.slack.api.util.thread.ExecutorServiceProvider;
@@ -17,7 +18,7 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<AsyncExec
             int numberOfNodes,
             boolean cleanerEnabled
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, DEFAULT_CLEANER_EXECUTION_INTERVAL_MILLISECONDS);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
     }
 
     public MemoryMetricsDatastore(
@@ -50,5 +51,4 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<AsyncExec
     public AsyncRateLimitQueue getRateLimitQueue(String executorName, String teamId) {
         return AsyncRateLimitQueue.get(executorName, teamId);
     }
-
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
@@ -16,26 +16,26 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<AsyncExec
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean backgroundJobEnabled
+            boolean statsEnabled
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), statsEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
             ExecutorServiceProvider executorServiceProvider,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(numberOfNodes, executorServiceProvider, statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(int numberOfNodes) {

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/MemoryMetricsDatastore.java
@@ -4,12 +4,37 @@ import com.slack.api.methods.SlackApiResponse;
 import com.slack.api.methods.impl.AsyncExecutionSupplier;
 import com.slack.api.methods.impl.AsyncRateLimitQueue;
 import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import com.slack.api.util.thread.ExecutorServiceProvider;
 
 public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<AsyncExecutionSupplier<? extends SlackApiResponse>, AsyncRateLimitQueue.Message> {
 
     public MemoryMetricsDatastore(int numberOfNodes, ExecutorServiceProvider executorServiceProvider) {
         super(numberOfNodes, executorServiceProvider);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            boolean cleanerEnabled
+    ) {
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, DEFAULT_CLEANER_EXECUTION_INTERVAL_MILLISECONDS);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            ExecutorServiceProvider executorServiceProvider,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(numberOfNodes, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(int numberOfNodes) {

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/RedisMetricsDatastore.java
@@ -17,20 +17,20 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<AsyncExecut
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(appName, jedisPool, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
             ExecutorServiceProvider executorServiceProvider,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(appName, jedisPool, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/RedisMetricsDatastore.java
@@ -5,6 +5,7 @@ import com.slack.api.methods.impl.AsyncExecutionSupplier;
 import com.slack.api.methods.impl.AsyncRateLimitQueue;
 import com.slack.api.rate_limits.metrics.impl.BaseRedisMetricsDatastore;
 import com.slack.api.rate_limits.queue.RateLimitQueue;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 import redis.clients.jedis.JedisPool;
 
 public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<AsyncExecutionSupplier<? extends SlackApiResponse>, AsyncRateLimitQueue.Message> {
@@ -13,8 +14,32 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<AsyncExecut
         super(appName, jedisPool);
     }
 
+    public RedisMetricsDatastore(
+            String appName,
+            JedisPool jedisPool,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(appName, jedisPool, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+    }
+
+    public RedisMetricsDatastore(
+            String appName,
+            JedisPool jedisPool,
+            ExecutorServiceProvider executorServiceProvider,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(appName, jedisPool, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+    }
+
     @Override
     public RateLimitQueue<AsyncExecutionSupplier<? extends SlackApiResponse>, AsyncRateLimitQueue.Message> getRateLimitQueue(String executorName, String teamId) {
         return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+
+    @Override
+    protected String getMetricsType() {
+        return "METHODS";
     }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/RedisMetricsDatastore.java
@@ -17,20 +17,20 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<AsyncExecut
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(appName, jedisPool, statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
             ExecutorServiceProvider executorServiceProvider,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(appName, jedisPool, executorServiceProvider, statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/methods/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/metrics/RedisMetricsDatastore.java
@@ -18,9 +18,9 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<AsyncExecut
             String appName,
             JedisPool jedisPool,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public RedisMetricsDatastore(
@@ -28,9 +28,9 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<AsyncExecut
             JedisPool jedisPool,
             ExecutorServiceProvider executorServiceProvider,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/RateLimiter.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/RateLimiter.java
@@ -6,4 +6,6 @@ public interface RateLimiter {
 
     WaitTime acquireWaitTimeForChatPostMessage(String teamId, String channel);
 
+    long DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS = 1_000L;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/LiveRequestStats.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/LiveRequestStats.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 @Data
 public class LiveRequestStats {
+    private Long lastRequestTimestampMillis;
     private final ConcurrentMap<String, AtomicLong> allCompletedCalls = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, AtomicLong> successfulCalls = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, AtomicLong> unsuccessfulCalls = new ConcurrentHashMap<>();

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
@@ -54,4 +54,8 @@ public interface MetricsDatastore {
 
     void setExecutorServiceProvider(ExecutorServiceProvider executorServiceProvider);
 
+    boolean isTraceMode();
+
+    void setTraceMode(boolean isTraceMode);
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
@@ -58,4 +58,8 @@ public interface MetricsDatastore {
 
     void setTraceMode(boolean isTraceMode);
 
+    long getRateLimiterBackgroundJobIntervalMillis();
+
+    void setRateLimiterBackgroundJobIntervalMillis(long rateLimiterBackgroundJobIntervalMillis);
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
@@ -56,7 +56,7 @@ public interface MetricsDatastore {
 
     boolean isTraceMode();
 
-    void setTraceMode(boolean isTraceMode);
+    void setTraceMode(boolean traceMode);
 
     boolean isStatsEnabled();
 

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
@@ -58,6 +58,10 @@ public interface MetricsDatastore {
 
     void setTraceMode(boolean isTraceMode);
 
+    boolean isStatsEnabled();
+
+    void setStatsEnabled(boolean statsEnabled);
+
     long getRateLimiterBackgroundJobIntervalMillis();
 
     void setRateLimiterBackgroundJobIntervalMillis(long rateLimiterBackgroundJobIntervalMillis);

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/RequestStats.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/RequestStats.java
@@ -15,6 +15,12 @@ import java.util.Map;
 public class RequestStats {
 
     /**
+     * The last request timestamp in milliseconds
+     */
+    @Builder.Default
+    private Long lastRequestTimestampMillis = 0L;
+
+    /**
      * Method name -> # of calls
      */
     @Builder.Default

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseMemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseMemoryMetricsDatastore.java
@@ -380,7 +380,8 @@ public abstract class BaseMemoryMetricsDatastore<SUPPLIER, MSG extends QueueMess
                     if (stats == null) {
                         continue;
                     }
-                    if (stats.getLastRequestTimestampMillis() <= this.lastExecutionTimestampMillis) {
+                    if (stats.getLastRequestTimestampMillis() != null
+                            && stats.getLastRequestTimestampMillis() <= this.lastExecutionTimestampMillis) {
                         if (this.store.isTraceMode()) {
                             log.debug("No request for team: {} since the last maintenance", teamId);
                         }

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseMemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseMemoryMetricsDatastore.java
@@ -291,7 +291,7 @@ public abstract class BaseMemoryMetricsDatastore<SUPPLIER, MSG extends QueueMess
     private LiveRequestStats getOrCreateTeamLiveStats(String executorName, String teamId) {
         ConcurrentMap<String, LiveRequestStats> executor = getOrCreateExecutorLiveStats(executorName);
         if (teamId == null) {
-            teamId = "";
+            teamId = "-";
         }
         if (executor.get(teamId) == null) {
             executor.putIfAbsent(teamId, new LiveRequestStats());

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseMemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseMemoryMetricsDatastore.java
@@ -142,8 +142,8 @@ public abstract class BaseMemoryMetricsDatastore<SUPPLIER, MSG extends QueueMess
     }
 
     @Override
-    public void setTraceMode(boolean isTraceMode) {
-        this.traceMode = isTraceMode;
+    public void setTraceMode(boolean traceMode) {
+        this.traceMode = traceMode;
     }
 
     @Override
@@ -154,7 +154,7 @@ public abstract class BaseMemoryMetricsDatastore<SUPPLIER, MSG extends QueueMess
     @Override
     public void setStatsEnabled(boolean statsEnabled) {
         this.statsEnabled = statsEnabled;
-        if (this.rateLimiterBackgroundJob != null) {
+        if (!this.statsEnabled && this.rateLimiterBackgroundJob != null) {
             this.rateLimiterBackgroundJob.shutdown();
             this.rateLimiterBackgroundJob = null;
         }

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseMemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseMemoryMetricsDatastore.java
@@ -108,6 +108,7 @@ public abstract class BaseMemoryMetricsDatastore<SUPPLIER, MSG extends QueueMess
         for (Map.Entry<String, ConcurrentMap<String, LiveRequestStats>> executor : ALL_LIVE_STATS.entrySet()) {
             Map<String, RequestStats> allTeams = new HashMap<>();
             for (Map.Entry<String, LiveRequestStats> team : executor.getValue().entrySet()) {
+                // Can be improved: A bit costly way to build a deep copy here
                 RequestStats stats = GSON.fromJson(GSON.toJson(team.getValue()), RequestStats.class);
                 allTeams.put(team.getKey(), stats);
             }
@@ -119,6 +120,7 @@ public abstract class BaseMemoryMetricsDatastore<SUPPLIER, MSG extends QueueMess
     @Override
     public RequestStats getStats(String executorName, String teamId) {
         LiveRequestStats internal = getOrCreateTeamLiveStats(executorName, teamId);
+        // Can be improved: A bit costly way to build a deep copy here
         RequestStats stats = GSON.fromJson(GSON.toJson(internal), RequestStats.class);
         return stats;
     }

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseRedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseRedisMetricsDatastore.java
@@ -417,7 +417,14 @@ public abstract class BaseRedisMetricsDatastore<SUPPLIER, MSG extends QueueMessa
                 for (Map.Entry<String, RequestStats> team : executor.getValue().entrySet()) {
                     String teamId = team.getKey();
                     RequestStats stats = team.getValue();
-                    if (stats.getLastRequestTimestampMillis() <= this.lastExecutionTimestampMillis) {
+                    if (stats == null) {
+                        continue;
+                    }
+                    if (stats.getLastRequestTimestampMillis() != null
+                            && stats.getLastRequestTimestampMillis() <= this.lastExecutionTimestampMillis) {
+                        if (this.store.isTraceMode()) {
+                            log.debug("No request for team: {} since the last maintenance", teamId);
+                        }
                         continue;
                     }
                     if (this.store.isTraceMode()) {

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseRedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseRedisMetricsDatastore.java
@@ -160,8 +160,8 @@ public abstract class BaseRedisMetricsDatastore<SUPPLIER, MSG extends QueueMessa
     }
 
     @Override
-    public void setTraceMode(boolean isTraceMode) {
-        this.traceMode = isTraceMode;
+    public void setTraceMode(boolean traceMode) {
+        this.traceMode = traceMode;
     }
 
     @Override
@@ -172,7 +172,7 @@ public abstract class BaseRedisMetricsDatastore<SUPPLIER, MSG extends QueueMessa
     @Override
     public void setStatsEnabled(boolean statsEnabled) {
         this.statsEnabled = statsEnabled;
-        if (this.rateLimiterBackgroundJob != null) {
+        if (!this.statsEnabled && this.rateLimiterBackgroundJob != null) {
             this.rateLimiterBackgroundJob.shutdown();
             this.rateLimiterBackgroundJob = null;
         }

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
@@ -17,26 +17,26 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean cleanerEnabled
+            boolean backgroundJobEnabled
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
             ExecutorServiceProvider executorServiceProvider,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(numberOfNodes, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
@@ -4,12 +4,38 @@ import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.impl.AsyncExecutionSupplier;
 import com.slack.api.scim.impl.AsyncRateLimitQueue;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
 
 public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
         AsyncExecutionSupplier<? extends SCIMApiResponse>, AsyncRateLimitQueue.SCIMMessage> {
 
     public MemoryMetricsDatastore(int numberOfNodes) {
         super(numberOfNodes);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            boolean cleanerEnabled
+    ) {
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, DEFAULT_CLEANER_EXECUTION_INTERVAL_MILLISECONDS);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            ExecutorServiceProvider executorServiceProvider,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(numberOfNodes, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
@@ -1,5 +1,6 @@
 package com.slack.api.scim.metrics;
 
+import com.slack.api.rate_limits.RateLimiter;
 import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.impl.AsyncExecutionSupplier;
@@ -18,7 +19,7 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
             int numberOfNodes,
             boolean cleanerEnabled
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, DEFAULT_CLEANER_EXECUTION_INTERVAL_MILLISECONDS);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), cleanerEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
     }
 
     public MemoryMetricsDatastore(

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
@@ -17,26 +17,26 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean backgroundJobEnabled
+            boolean statsEnabled
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), statsEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
             ExecutorServiceProvider executorServiceProvider,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(numberOfNodes, executorServiceProvider, statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/MemoryMetricsDatastore.java
@@ -25,18 +25,18 @@ public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
     public MemoryMetricsDatastore(
             int numberOfNodes,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public MemoryMetricsDatastore(
             int numberOfNodes,
             ExecutorServiceProvider executorServiceProvider,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(numberOfNodes, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
@@ -17,20 +17,20 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(appName, jedisPool, statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
             ExecutorServiceProvider executorServiceProvider,
-            boolean backgroundJobEnabled,
+            boolean statsEnabled,
             long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
+        super(appName, jedisPool, executorServiceProvider, statsEnabled, backgroundJobIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
@@ -10,6 +10,10 @@ import redis.clients.jedis.JedisPool;
 public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
         AsyncExecutionSupplier<? extends SCIMApiResponse>, AsyncRateLimitQueue.SCIMMessage> {
 
+    public RedisMetricsDatastore(String appName, JedisPool jedisPool) {
+        super(appName, jedisPool);
+    }
+
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
@@ -18,9 +18,9 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
             String appName,
             JedisPool jedisPool,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     public RedisMetricsDatastore(
@@ -28,9 +28,9 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
             JedisPool jedisPool,
             ExecutorServiceProvider executorServiceProvider,
             boolean backgroundJobEnabled,
-            long cleanerExecutionIntervalMilliseconds
+            long backgroundJobIntervalMilliseconds
     ) {
-        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, backgroundJobIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
@@ -4,27 +4,39 @@ import com.slack.api.rate_limits.metrics.impl.BaseRedisMetricsDatastore;
 import com.slack.api.scim.SCIMApiResponse;
 import com.slack.api.scim.impl.AsyncExecutionSupplier;
 import com.slack.api.scim.impl.AsyncRateLimitQueue;
-import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import com.slack.api.util.thread.ExecutorServiceProvider;
 import redis.clients.jedis.JedisPool;
 
 public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
         AsyncExecutionSupplier<? extends SCIMApiResponse>, AsyncRateLimitQueue.SCIMMessage> {
 
-    public RedisMetricsDatastore(String appName, JedisPool jedisPool) {
-        super(appName, jedisPool, DaemonThreadExecutorServiceProvider.getInstance());
+    public RedisMetricsDatastore(
+            String appName,
+            JedisPool jedisPool,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(appName, jedisPool, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
-            ExecutorServiceProvider executorServiceProvider) {
-        super(appName, jedisPool, executorServiceProvider);
+            ExecutorServiceProvider executorServiceProvider,
+            boolean cleanerEnabled,
+            long cleanerExecutionIntervalMilliseconds
+    ) {
+        super(appName, jedisPool, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     @Override
     public AsyncRateLimitQueue getRateLimitQueue(String executorName, String teamId) {
         return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+
+    @Override
+    protected String getMetricsType() {
+        return "SCIM";
     }
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/metrics/RedisMetricsDatastore.java
@@ -17,20 +17,20 @@ public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(appName, jedisPool, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     public RedisMetricsDatastore(
             String appName,
             JedisPool jedisPool,
             ExecutorServiceProvider executorServiceProvider,
-            boolean cleanerEnabled,
+            boolean backgroundJobEnabled,
             long cleanerExecutionIntervalMilliseconds
     ) {
-        super(appName, jedisPool, executorServiceProvider, cleanerEnabled, cleanerExecutionIntervalMilliseconds);
+        super(appName, jedisPool, executorServiceProvider, backgroundJobEnabled, cleanerExecutionIntervalMilliseconds);
     }
 
     @Override

--- a/slack-api-client/src/test/java/test_locally/api/methods/metrics/MemoryMetricsDatastoreTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/metrics/MemoryMetricsDatastoreTest.java
@@ -1,6 +1,7 @@
 package test_locally.api.methods.metrics;
 
 import com.slack.api.methods.metrics.MemoryMetricsDatastore;
+import com.slack.api.rate_limits.RateLimiter;
 import com.slack.api.rate_limits.metrics.RequestStats;
 import org.junit.Test;
 
@@ -15,6 +16,8 @@ public class MemoryMetricsDatastoreTest {
     public void getNumberOfNodes() {
         MemoryMetricsDatastore datastore = new MemoryMetricsDatastore(3);
         assertEquals(3, datastore.getNumberOfNodes());
+        assertEquals(RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS,
+                datastore.getRateLimiterBackgroundJobIntervalMillis());
     }
 
     @Test

--- a/slack-api-client/src/test/java/test_locally/api/methods/metrics/MemoryMetricsDatastoreTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/metrics/MemoryMetricsDatastoreTest.java
@@ -2,14 +2,9 @@ package test_locally.api.methods.metrics;
 
 import com.slack.api.methods.metrics.MemoryMetricsDatastore;
 import com.slack.api.rate_limits.metrics.RequestStats;
-import com.slack.api.util.json.GsonFactory;
-import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static com.slack.api.methods.MethodsConfig.DEFAULT_SINGLETON_EXECUTOR_NAME;
 import static org.junit.Assert.*;
@@ -63,23 +58,4 @@ public class MemoryMetricsDatastoreTest {
         assertNotEquals(datastore1.getThreadGroupName(), datastore2.getThreadGroupName());
     }
 
-    private static final String[] methodNames = "admin.analytics.getFile,admin.apps.approve,admin.apps.clearResolution,admin.apps.restrict,admin.apps.uninstall,admin.apps.approved.list,admin.apps.requests.cancel,admin.apps.requests.list,admin.apps.restricted.list,admin.auth.policy.assignEntities,admin.auth.policy.getEntities,admin.auth.policy.removeEntities,admin.barriers.create,admin.barriers.delete,admin.barriers.list,admin.barriers.update,admin.conversations.archive,admin.conversations.convertToPrivate,admin.conversations.create,admin.conversations.delete,admin.conversations.disconnectShared,admin.conversations.getConversationPrefs,admin.conversations.getCustomRetention,admin.conversations.getTeams,admin.conversations.invite,admin.conversations.removeCustomRetention,admin.conversations.rename,admin.conversations.search,admin.conversations.setConversationPrefs,admin.conversations.setCustomRetention,admin.conversations.setTeams,admin.conversations.unarchive,admin.conversations.ekm.listOriginalConnectedChannelInfo,admin.conversations.restrictAccess.addGroup,admin.conversations.restrictAccess.listGroups,admin.conversations.restrictAccess.removeGroup,admin.emoji.add,admin.emoji.addAlias,admin.emoji.list,admin.emoji.remove,admin.emoji.rename,admin.inviteRequests.approve,admin.inviteRequests.deny,admin.inviteRequests.list,admin.inviteRequests.approved.list,admin.inviteRequests.denied.list,admin.teams.admins.list,admin.teams.create,admin.teams.list,admin.teams.owners.list,admin.teams.settings.info,admin.teams.settings.setDefaultChannels,admin.teams.settings.setDescription,admin.teams.settings.setDiscoverability,admin.teams.settings.setIcon,admin.teams.settings.setName,admin.usergroups.addChannels,admin.usergroups.addTeams,admin.usergroups.listChannels,admin.usergroups.removeChannels,admin.users.assign,admin.users.invite,admin.users.list,admin.users.remove,admin.users.setAdmin,admin.users.setExpiration,admin.users.setOwner,admin.users.setRegular,admin.users.session.clearSettings,admin.users.session.getSettings,admin.users.session.invalidate,admin.users.session.list,admin.users.session.reset,admin.users.session.resetBulk,admin.users.session.setSettings,admin.users.unsupportedVersions.export,api.test,apps.connections.open,apps.event.authorizations.list,apps.manifest.create,apps.manifest.delete,apps.manifest.export,apps.manifest.update,apps.manifest.validate,apps.uninstall,auth.revoke,auth.test,auth.teams.list,bookmarks.add,bookmarks.edit,bookmarks.list,bookmarks.remove,bots.info,calls.add,calls.end,calls.info,calls.update,calls.participants.add,calls.participants.remove,chat.delete,chat.deleteScheduledMessage,chat.getPermalink,chat.meMessage,chat.postEphemeral,chat.postMessage,chat.scheduleMessage,chat.unfurl,chat.update,chat.scheduledMessages.list,conversations.acceptSharedInvite,conversations.approveSharedInvite,conversations.archive,conversations.close,conversations.create,conversations.declineSharedInvite,conversations.history,conversations.info,conversations.invite,conversations.inviteShared,conversations.join,conversations.kick,conversations.leave,conversations.list,conversations.listConnectInvites,conversations.mark,conversations.members,conversations.open,conversations.rename,conversations.replies,conversations.setPurpose,conversations.setTopic,conversations.unarchive,dialog.open,dnd.endDnd,dnd.endSnooze,dnd.info,dnd.setSnooze,dnd.teamInfo,emoji.list,files.comments.delete,files.delete,files.info,files.list,files.revokePublicURL,files.sharedPublicURL,files.upload,files.remote.add,files.remote.info,files.remote.list,files.remote.remove,files.remote.share,files.remote.update,migration.exchange,oauth.access,oauth.v2.access,oauth.v2.exchange,openid.connect.token,openid.connect.userInfo,pins.add,pins.list,pins.remove,reactions.add,reactions.get,reactions.list,reactions.remove,reminders.add,reminders.complete,reminders.delete,reminders.info,reminders.list,rtm.connect,rtm.start,search.all,search.files,search.messages,stars.add,stars.list,stars.remove,team.accessLogs,team.billableInfo,team.info,team.integrationLogs,team.billing.info,team.preferences.list,team.profile.get,tooling.tokens.rotate,usergroups.create,usergroups.disable,usergroups.enable,usergroups.list,usergroups.update,usergroups.users.list,usergroups.users.update,users.conversations,users.deletePhoto,users.getPresence,users.identity,users.info,users.list,users.lookupByEmail,users.setActive,users.setPhoto,users.setPresence,users.profile.get,users.profile.set,views.open,views.publish,views.push,views.update,workflows.stepCompleted,workflows.stepFailed,workflows.updateStep,channels.create,channels.info,channels.invite,channels.mark,groups.create,groups.info,groups.invite,groups.mark,groups.open,im.list,im.mark,im.open,mpim.list,mpim.mark,mpim.open".split(",");
-
-    // TODO
-    @Ignore
-    @Test
-    public void issue_933_MetricsMaintenanceJobLoad() throws Exception {
-        MemoryMetricsDatastore datastore = new MemoryMetricsDatastore(1);
-        List<String> methodsForTests = Arrays.stream(methodNames).limit(30).collect(Collectors.toList());
-        for (int i = 0; i < 600; i++) {
-            String teamId = "T" + i;
-            for (String methodName : methodsForTests) {
-                datastore.incrementAllCompletedCalls(DEFAULT_SINGLETON_EXECUTOR_NAME, teamId, methodName);
-            }
-        }
-        while (true) {
-            System.out.println(GsonFactory.createSnakeCase().toJson(datastore.getAllStats()));
-            Thread.sleep(5_000L);
-        }
-    }
 }

--- a/slack-api-client/src/test/java/test_locally/api/methods/metrics/MemoryMetricsDatastoreTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/metrics/MemoryMetricsDatastoreTest.java
@@ -2,9 +2,14 @@ package test_locally.api.methods.metrics;
 
 import com.slack.api.methods.metrics.MemoryMetricsDatastore;
 import com.slack.api.rate_limits.metrics.RequestStats;
+import com.slack.api.util.json.GsonFactory;
+import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.slack.api.methods.MethodsConfig.DEFAULT_SINGLETON_EXECUTOR_NAME;
 import static org.junit.Assert.*;
@@ -56,5 +61,25 @@ public class MemoryMetricsDatastoreTest {
         MemoryMetricsDatastore datastore1 = new MemoryMetricsDatastore(1);
         MemoryMetricsDatastore datastore2 = new MemoryMetricsDatastore(1);
         assertNotEquals(datastore1.getThreadGroupName(), datastore2.getThreadGroupName());
+    }
+
+    private static final String[] methodNames = "admin.analytics.getFile,admin.apps.approve,admin.apps.clearResolution,admin.apps.restrict,admin.apps.uninstall,admin.apps.approved.list,admin.apps.requests.cancel,admin.apps.requests.list,admin.apps.restricted.list,admin.auth.policy.assignEntities,admin.auth.policy.getEntities,admin.auth.policy.removeEntities,admin.barriers.create,admin.barriers.delete,admin.barriers.list,admin.barriers.update,admin.conversations.archive,admin.conversations.convertToPrivate,admin.conversations.create,admin.conversations.delete,admin.conversations.disconnectShared,admin.conversations.getConversationPrefs,admin.conversations.getCustomRetention,admin.conversations.getTeams,admin.conversations.invite,admin.conversations.removeCustomRetention,admin.conversations.rename,admin.conversations.search,admin.conversations.setConversationPrefs,admin.conversations.setCustomRetention,admin.conversations.setTeams,admin.conversations.unarchive,admin.conversations.ekm.listOriginalConnectedChannelInfo,admin.conversations.restrictAccess.addGroup,admin.conversations.restrictAccess.listGroups,admin.conversations.restrictAccess.removeGroup,admin.emoji.add,admin.emoji.addAlias,admin.emoji.list,admin.emoji.remove,admin.emoji.rename,admin.inviteRequests.approve,admin.inviteRequests.deny,admin.inviteRequests.list,admin.inviteRequests.approved.list,admin.inviteRequests.denied.list,admin.teams.admins.list,admin.teams.create,admin.teams.list,admin.teams.owners.list,admin.teams.settings.info,admin.teams.settings.setDefaultChannels,admin.teams.settings.setDescription,admin.teams.settings.setDiscoverability,admin.teams.settings.setIcon,admin.teams.settings.setName,admin.usergroups.addChannels,admin.usergroups.addTeams,admin.usergroups.listChannels,admin.usergroups.removeChannels,admin.users.assign,admin.users.invite,admin.users.list,admin.users.remove,admin.users.setAdmin,admin.users.setExpiration,admin.users.setOwner,admin.users.setRegular,admin.users.session.clearSettings,admin.users.session.getSettings,admin.users.session.invalidate,admin.users.session.list,admin.users.session.reset,admin.users.session.resetBulk,admin.users.session.setSettings,admin.users.unsupportedVersions.export,api.test,apps.connections.open,apps.event.authorizations.list,apps.manifest.create,apps.manifest.delete,apps.manifest.export,apps.manifest.update,apps.manifest.validate,apps.uninstall,auth.revoke,auth.test,auth.teams.list,bookmarks.add,bookmarks.edit,bookmarks.list,bookmarks.remove,bots.info,calls.add,calls.end,calls.info,calls.update,calls.participants.add,calls.participants.remove,chat.delete,chat.deleteScheduledMessage,chat.getPermalink,chat.meMessage,chat.postEphemeral,chat.postMessage,chat.scheduleMessage,chat.unfurl,chat.update,chat.scheduledMessages.list,conversations.acceptSharedInvite,conversations.approveSharedInvite,conversations.archive,conversations.close,conversations.create,conversations.declineSharedInvite,conversations.history,conversations.info,conversations.invite,conversations.inviteShared,conversations.join,conversations.kick,conversations.leave,conversations.list,conversations.listConnectInvites,conversations.mark,conversations.members,conversations.open,conversations.rename,conversations.replies,conversations.setPurpose,conversations.setTopic,conversations.unarchive,dialog.open,dnd.endDnd,dnd.endSnooze,dnd.info,dnd.setSnooze,dnd.teamInfo,emoji.list,files.comments.delete,files.delete,files.info,files.list,files.revokePublicURL,files.sharedPublicURL,files.upload,files.remote.add,files.remote.info,files.remote.list,files.remote.remove,files.remote.share,files.remote.update,migration.exchange,oauth.access,oauth.v2.access,oauth.v2.exchange,openid.connect.token,openid.connect.userInfo,pins.add,pins.list,pins.remove,reactions.add,reactions.get,reactions.list,reactions.remove,reminders.add,reminders.complete,reminders.delete,reminders.info,reminders.list,rtm.connect,rtm.start,search.all,search.files,search.messages,stars.add,stars.list,stars.remove,team.accessLogs,team.billableInfo,team.info,team.integrationLogs,team.billing.info,team.preferences.list,team.profile.get,tooling.tokens.rotate,usergroups.create,usergroups.disable,usergroups.enable,usergroups.list,usergroups.update,usergroups.users.list,usergroups.users.update,users.conversations,users.deletePhoto,users.getPresence,users.identity,users.info,users.list,users.lookupByEmail,users.setActive,users.setPhoto,users.setPresence,users.profile.get,users.profile.set,views.open,views.publish,views.push,views.update,workflows.stepCompleted,workflows.stepFailed,workflows.updateStep,channels.create,channels.info,channels.invite,channels.mark,groups.create,groups.info,groups.invite,groups.mark,groups.open,im.list,im.mark,im.open,mpim.list,mpim.mark,mpim.open".split(",");
+
+    // TODO
+    @Ignore
+    @Test
+    public void issue_933_MetricsMaintenanceJobLoad() throws Exception {
+        MemoryMetricsDatastore datastore = new MemoryMetricsDatastore(1);
+        List<String> methodsForTests = Arrays.stream(methodNames).limit(30).collect(Collectors.toList());
+        for (int i = 0; i < 600; i++) {
+            String teamId = "T" + i;
+            for (String methodName : methodsForTests) {
+                datastore.incrementAllCompletedCalls(DEFAULT_SINGLETON_EXECUTOR_NAME, teamId, methodName);
+            }
+        }
+        while (true) {
+            System.out.println(GsonFactory.createSnakeCase().toJson(datastore.getAllStats()));
+            Thread.sleep(5_000L);
+        }
     }
 }

--- a/slack-api-client/src/test/java/test_locally/api/methods/metrics/RedisMetricsDatastoreTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/metrics/RedisMetricsDatastoreTest.java
@@ -106,8 +106,8 @@ public class RedisMetricsDatastoreTest {
     public void threadGroupName() {
         RedisMetricsDatastore datastore1 = new RedisMetricsDatastore("app1", jedisPool);
         RedisMetricsDatastore datastore2 = new RedisMetricsDatastore("app2", jedisPool);
-        assertEquals("slack-methods-metrics-redis:app1", datastore1.getThreadGroupName());
-        assertEquals("slack-methods-metrics-redis:app2", datastore2.getThreadGroupName());
+        assertEquals("slack-api-metrics:app1", datastore1.getThreadGroupName());
+        assertEquals("slack-api-metrics:app2", datastore2.getThreadGroupName());
         assertNotEquals(datastore1.getThreadGroupName(), datastore2.getThreadGroupName());
     }
 }

--- a/slack-api-client/src/test/java/test_locally/api/rate_limits/MemoryMaintenanceJobTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/rate_limits/MemoryMaintenanceJobTest.java
@@ -1,0 +1,69 @@
+package test_locally.api.rate_limits;
+
+import com.slack.api.methods.metrics.MemoryMetricsDatastore;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceFactory;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+@Slf4j
+public class MemoryMaintenanceJobTest {
+
+    @Test
+    public void verifyPerformance() {
+        ExecutorService executor = DaemonThreadExecutorServiceFactory.createDaemonThreadPoolExecutor(
+                "test", 1);
+
+        try {
+            MemoryMetricsDatastore store = new MemoryMetricsDatastore(
+                    1, DaemonThreadExecutorServiceProvider.getInstance(), false, 0L);
+            store.setTraceMode(false); // Enabling this affects the performance
+
+            for (int testNum = 0; testNum < 5; testNum++) {
+                // Data preparation
+                for (int i = 0; i < 8000; i++) {
+                    String teamId = "T" + i;
+                    for (int methodNum = 0; methodNum < 50; methodNum++) {
+                        String method = "chat." + methodNum;
+                        for (int requestNum = 0; requestNum < 30; requestNum++) {
+                            store.incrementAllCompletedCalls(MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME, teamId, method);
+                            store.incrementSuccessfulCalls(MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME, teamId, method);
+                            store.incrementUnsuccessfulCalls(MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME, teamId, method);
+                            store.incrementFailedCalls(MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME, teamId, method);
+                        }
+                    }
+                }
+                BaseMemoryMetricsDatastore.MaintenanceJob job = new BaseMemoryMetricsDatastore.MaintenanceJob(store);
+                Long firstSpentTime;
+                {
+                    long before = System.currentTimeMillis();
+                    job.run();
+                    firstSpentTime = System.currentTimeMillis() - before;
+                    log.info("First execution: {} ms", firstSpentTime);
+                    assertThat(firstSpentTime, is(lessThan(store.isTraceMode() ? 300L : 50L)));
+                }
+
+                // All the teams are marked as done
+                {
+                    long before = System.currentTimeMillis();
+                    job.run();
+                    long spentMillis = System.currentTimeMillis() - before;
+                    log.info("Second execution: {} ms", spentMillis);
+                    assertThat(spentMillis, is(lessThan(store.isTraceMode() ? 150L : 30L)));
+                    assertThat(spentMillis, is(lessThanOrEqualTo(firstSpentTime)));
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/rate_limits/MemoryMaintenanceJobTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/rate_limits/MemoryMaintenanceJobTest.java
@@ -1,16 +1,14 @@
 package test_locally.api.rate_limits;
 
 import com.slack.api.methods.metrics.MemoryMetricsDatastore;
-import com.slack.api.rate_limits.metrics.MetricsDatastore;
 import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
 import com.slack.api.util.thread.DaemonThreadExecutorServiceFactory;
-import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -19,14 +17,55 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public class MemoryMaintenanceJobTest {
 
     @Test
-    public void verifyPerformance() {
+    public void disablingStats() {
         ExecutorService executor = DaemonThreadExecutorServiceFactory.createDaemonThreadPoolExecutor(
                 "test", 1);
+        String executorName = "MemoryMaintenanceJobTest_disablingStats";
 
         try {
-            MemoryMetricsDatastore store = new MemoryMetricsDatastore(
-                    1, DaemonThreadExecutorServiceProvider.getInstance(), false, 0L);
+            MemoryMetricsDatastore store = new MemoryMetricsDatastore(1, false);
             store.setTraceMode(false); // Enabling this affects the performance
+
+            for (int testNum = 0; testNum < 3; testNum++) {
+                // Data preparation
+                for (int i = 0; i < 10; i++) {
+                    String teamId = "T" + i;
+                    for (int methodNum = 0; methodNum < 10; methodNum++) {
+                        String method = "chat." + methodNum;
+                        for (int requestNum = 0; requestNum < 5; requestNum++) {
+                            store.incrementAllCompletedCalls(executorName, teamId, method);
+                            store.incrementSuccessfulCalls(executorName, teamId, method);
+                            store.incrementUnsuccessfulCalls(executorName, teamId, method);
+                            store.incrementFailedCalls(executorName, teamId, method);
+                        }
+                    }
+                }
+            }
+            BaseMemoryMetricsDatastore.MaintenanceJob job = new BaseMemoryMetricsDatastore.MaintenanceJob(store);
+            assertThat(store.getAllStats().toString(), store.getAllStats().get("METHODS/" + executorName), is(nullValue()));
+
+            long before = System.currentTimeMillis();
+            job.run();
+            long spentTime = System.currentTimeMillis() - before;
+            log.info("Execution time: {} ms", spentTime);
+            assertThat(spentTime, is(lessThan(10L)));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void maintenanceJobPerformance() throws Exception {
+        ExecutorService executor = DaemonThreadExecutorServiceFactory.createDaemonThreadPoolExecutor(
+                "test", 1);
+        String executorName = "MemoryMaintenanceJobTest_maintenanceJobPerformance";
+
+        try {
+            MemoryMetricsDatastore store = new MemoryMetricsDatastore(1, true, 60_000L);
+            store.setTraceMode(false); // Enabling this affects the performance
+
+            // Wait for the initial maintenance
+            Thread.sleep(1500L);
 
             for (int testNum = 0; testNum < 5; testNum++) {
                 // Data preparation
@@ -35,13 +74,15 @@ public class MemoryMaintenanceJobTest {
                     for (int methodNum = 0; methodNum < 50; methodNum++) {
                         String method = "chat." + methodNum;
                         for (int requestNum = 0; requestNum < 30; requestNum++) {
-                            store.incrementAllCompletedCalls(MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME, teamId, method);
-                            store.incrementSuccessfulCalls(MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME, teamId, method);
-                            store.incrementUnsuccessfulCalls(MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME, teamId, method);
-                            store.incrementFailedCalls(MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME, teamId, method);
+                            store.incrementAllCompletedCalls(executorName, teamId, method);
+                            store.incrementSuccessfulCalls(executorName, teamId, method);
+                            store.incrementUnsuccessfulCalls(executorName, teamId, method);
+                            store.incrementFailedCalls(executorName, teamId, method);
                         }
                     }
                 }
+                assertThat(store.getAllStats().toString(), store.getAllStats().get("METHODS/" + executorName), is(notNullValue()));
+
                 BaseMemoryMetricsDatastore.MaintenanceJob job = new BaseMemoryMetricsDatastore.MaintenanceJob(store);
                 Long firstSpentTime;
                 {

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/rate_limiter/RateLimiterTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/rate_limiter/RateLimiterTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 /**
- * Note: These tests are usually ignored but they're useful for verifying the behavior of RateLimiter
+ * Note: These tests are usually ignored, but they're useful for verifying the behavior of RateLimiter
  */
 @Slf4j
 public class RateLimiterTest {
@@ -39,22 +39,24 @@ public class RateLimiterTest {
 
     String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
 
-    @Ignore // These tests are usually ignored but they're useful for verifying the behavior of RateLimiter
+    @Ignore // These tests are usually ignored, but they're useful for verifying the behavior of RateLimiter
     @Test
     public void sequentialRequests() throws Exception {
         assertThat(botToken, is(notNullValue()));
-        for (int i = 0; i < 3; i++) {
+        Long requestNum = 3L;
+        for (int i = 0; i < requestNum; i++) {
             CompletableFuture<ConversationsListResponse> response = slack.methodsAsync(botToken).conversationsList(r -> r.limit(1));
             response.get();
         }
 
         String teamId = slack.methods().teamInfo(r -> r.token(botToken)).getTeam().getId();
         RequestStats stats = testConfig.getMethodsMetricsDatastore().getStats(teamId);
-        assertThat(stats.getSuccessfulCalls().get(Methods.CONVERSATIONS_LIST), is(greaterThanOrEqualTo(3L)));
-        assertThat(stats.getLastMinuteRequests().get(Methods.CONVERSATIONS_LIST), is(greaterThanOrEqualTo(3)));
+        assertThat(stats.getSuccessfulCalls().get(Methods.CONVERSATIONS_LIST), is(greaterThanOrEqualTo(requestNum)));
+        assertThat(stats.getLastMinuteRequests().get(Methods.CONVERSATIONS_LIST),
+                is(greaterThanOrEqualTo(requestNum.intValue())));
     }
 
-    @Ignore // These tests are usually ignored but they're useful for verifying the behavior of RateLimiter
+    @Ignore // These tests are usually ignored, but they're useful for verifying the behavior of RateLimiter
     @Test
     public void controlRequestsAndCleanupData() throws Exception {
         assertThat(botToken, is(notNullValue()));
@@ -115,7 +117,7 @@ public class RateLimiterTest {
         return totalCalls;
     }
 
-    @Ignore // These tests are usually ignored but they're useful for verifying the behavior of RateLimiter
+    @Ignore // These tests are usually ignored, but they're useful for verifying the behavior of RateLimiter
     @Test
     public void chat_postMessage() throws Exception {
         long start = System.currentTimeMillis();


### PR DESCRIPTION
This pull request resolves #933 by improving the internals of API clients' smart rate limiter. The key changes are:

* Changed the interval of the background job from 50 milliseconds to 1,000 milliseconds (verified that there is almost zero downsize by changing this)
* Enabled the maintenance job to skip updating metrics data if a team_id does not have any updates since the previous maintenance
* Changed to disable the background thread If the `statsEnabled` is false
* Added traceMode to the background job for easier debugging on the SDK maintainer side (disabled by default)

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
