### PR TITLE
Fix #936 AdminAppsRequestsListRequest class missing enterpriseId field

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -245,6 +245,7 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("cursor", req.getCursor(), form);
         setIfNotNull("limit", req.getLimit(), form);
+        setIfNotNull("enterprise_id", req.getEnterpriseId(), form);
         setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/admin/apps/AdminAppsRequestsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/admin/apps/AdminAppsRequestsListRequest.java
@@ -27,6 +27,11 @@ public class AdminAppsRequestsListRequest implements SlackApiRequest {
     private Integer limit;
 
     /**
+     * Enterprise Grid Organization Id.
+     */
+    private String enterpriseId;
+
+    /**
      * Workspace Id.
      */
     private String teamId;


### PR DESCRIPTION
This pull request resolves #936 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
