### PR TITLE
Fix #937 bolt-socket-mode establishes a connection before a SocketModeApp#start()/startAsync() method call

### DIFF
--- a/bolt-socket-mode/src/main/java/com/slack/api/bolt/socket_mode/SocketModeApp.java
+++ b/bolt-socket-mode/src/main/java/com/slack/api/bolt/socket_mode/SocketModeApp.java
@@ -130,12 +130,13 @@ public class SocketModeApp {
         if (this.client == null) {
             this.client = clientFactory.get();
         }
-        if (this.clientStopped) {
+        if (this.isClientStopped()) {
             this.client.connectToNewEndpoint();
         } else {
             this.client.connect();
         }
         this.client.setAutoReconnectEnabled(true);
+        this.clientStopped = false;
         if (blockCurrentThread) {
             Thread.sleep(Long.MAX_VALUE);
         }

--- a/bolt-socket-mode/src/main/java/com/slack/api/bolt/socket_mode/SocketModeApp.java
+++ b/bolt-socket-mode/src/main/java/com/slack/api/bolt/socket_mode/SocketModeApp.java
@@ -14,57 +14,68 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 @Slf4j
 public class SocketModeApp {
-    private boolean clientStopped = false;
-    private final SocketModeClient client;
+    private boolean clientStopped = true;
     private final App app;
+    private final Supplier<SocketModeClient> clientFactory;
+    private SocketModeClient client;
 
-    private static SocketModeClient buildSocketModeClient(
+    // -------------------------------------------
+
+    private static Supplier<SocketModeClient> buildSocketModeClientFactory(
             App app,
             String appToken,
             SocketModeClient.Backend backend
-    ) throws IOException {
-        final SocketModeClient client = app.slack().socketMode(appToken, backend);
-        final SocketModeRequestParser requestParser = new SocketModeRequestParser(app.config());
-        final Gson gson = GsonFactory.createSnakeCase(app.slack().getConfig());
-        client.addWebSocketMessageListener(message -> {
-            long startMillis = System.currentTimeMillis();
-            SocketModeRequest req = requestParser.parse(message);
-            if (req != null) {
-                try {
-                    Response boltResponse = app.run(req.getBoltRequest());
-                    if (boltResponse.getStatusCode() != 200) {
-                        log.warn("Unsuccessful Bolt app execution (status: {}, body: {})",
-                                boltResponse.getStatusCode(), boltResponse.getBody());
-                        return;
-                    }
-                    if (boltResponse.getBody() != null) {
-                        Map<String, Object> response = new HashMap<>();
-                        if (boltResponse.getContentType().startsWith("application/json")) {
-                            response.put("envelope_id", req.getEnvelope().getEnvelopeId());
-                            response.put("payload", gson.fromJson(boltResponse.getBody(), JsonElement.class));
-                        } else {
-                            response.put("envelope_id", req.getEnvelope().getEnvelopeId());
-                            Map<String, Object> payload = new HashMap<>();
-                            payload.put("text", boltResponse.getBody());
-                            response.put("payload", payload);
+    ) {
+        return () -> {
+            try {
+                final SocketModeClient client = app.slack().socketMode(appToken, backend);
+                final SocketModeRequestParser requestParser = new SocketModeRequestParser(app.config());
+                final Gson gson = GsonFactory.createSnakeCase(app.slack().getConfig());
+                client.addWebSocketMessageListener(message -> {
+                    long startMillis = System.currentTimeMillis();
+                    SocketModeRequest req = requestParser.parse(message);
+                    if (req != null) {
+                        try {
+                            Response boltResponse = app.run(req.getBoltRequest());
+                            if (boltResponse.getStatusCode() != 200) {
+                                log.warn("Unsuccessful Bolt app execution (status: {}, body: {})",
+                                        boltResponse.getStatusCode(), boltResponse.getBody());
+                                return;
+                            }
+                            if (boltResponse.getBody() != null) {
+                                Map<String, Object> response = new HashMap<>();
+                                if (boltResponse.getContentType().startsWith("application/json")) {
+                                    response.put("envelope_id", req.getEnvelope().getEnvelopeId());
+                                    response.put("payload", gson.fromJson(boltResponse.getBody(), JsonElement.class));
+                                } else {
+                                    response.put("envelope_id", req.getEnvelope().getEnvelopeId());
+                                    Map<String, Object> payload = new HashMap<>();
+                                    payload.put("text", boltResponse.getBody());
+                                    response.put("payload", payload);
+                                }
+                                client.sendSocketModeResponse(gson.toJson(response));
+                            } else {
+                                client.sendSocketModeResponse(new AckResponse(req.getEnvelope().getEnvelopeId()));
+                            }
+                            long spentMillis = System.currentTimeMillis() - startMillis;
+                            log.debug("Response time: {} milliseconds", spentMillis);
+                            return;
+                        } catch (Exception e) {
+                            log.error("Failed to handle a request: {}", e.getMessage(), e);
+                            return;
                         }
-                        client.sendSocketModeResponse(gson.toJson(response));
-                    } else {
-                        client.sendSocketModeResponse(new AckResponse(req.getEnvelope().getEnvelopeId()));
                     }
-                    long spentMillis = System.currentTimeMillis() - startMillis;
-                    log.debug("Response time: {} milliseconds", spentMillis);
-                    return;
-                } catch (Exception e) {
-                    log.error("Failed to handle a request: {}", e.getMessage(), e);
-                    return;
-                }
+                });
+                return client;
+            } catch (IOException e) {
+                log.error("Failed to start a new Socket Mode client (error: {})", e.getMessage(), e);
+                return null;
             }
-        });
-        return client;
+        };
     }
 
     public SocketModeApp(App app) throws IOException {
@@ -80,13 +91,31 @@ public class SocketModeApp {
             SocketModeClient.Backend backend,
             App app
     ) throws IOException {
-        this(buildSocketModeClient(app, appToken, backend), app);
+        this(buildSocketModeClientFactory(app, appToken, backend), app);
     }
 
-    public SocketModeApp(SocketModeClient socketModeClient, App app) {
-        this.client = socketModeClient;
+    public SocketModeApp(Supplier<SocketModeClient> clientFactory, App app) {
+        this.clientFactory = clientFactory;
         this.app = app;
     }
+
+    /**
+     * If you would like to synchronously detect the connection error as an exception when bootstrapping,
+     * use this constructor. The first line can throw an exception
+     * in the case where either the token or network settings are valid.
+     *
+     * <code>
+     * SocketModeClient client = Slack.getInstance().socketMode(appToken);
+     * SocketModeApp socketModeApp = new SocketModeApp(client, app);
+     * </code>
+     */
+    public SocketModeApp(SocketModeClient socketModeClient, App app) {
+        this.client = socketModeClient;
+        this.clientFactory = () -> socketModeClient;
+        this.app = app;
+    }
+
+    // -------------------------------------------
 
     public void start() throws Exception {
         run(true);
@@ -97,21 +126,47 @@ public class SocketModeApp {
     }
 
     public void run(boolean blockCurrentThread) throws Exception {
-        app.start();
-        if (clientStopped) {
-            client.connectToNewEndpoint();
-        } else {
-            client.connect();
+        this.app.start();
+        if (this.client == null) {
+            this.client = clientFactory.get();
         }
-        client.setAutoReconnectEnabled(true);
+        if (this.clientStopped) {
+            this.client.connectToNewEndpoint();
+        } else {
+            this.client.connect();
+        }
+        this.client.setAutoReconnectEnabled(true);
         if (blockCurrentThread) {
             Thread.sleep(Long.MAX_VALUE);
         }
     }
 
     public void stop() throws Exception {
-        client.disconnect();
-        clientStopped = true;
-        app.stop();
+        if (this.client != null && this.client.verifyConnection()) {
+            this.client.disconnect();
+        }
+        this.clientStopped = true;
+        this.app.stop();
+    }
+
+    public void close() throws Exception {
+        this.stop();
+        this.client = null;
+    }
+
+    // -------------------------------------------
+    // Accessors
+    // -------------------------------------------
+
+    public boolean isClientStopped() {
+        return clientStopped;
+    }
+
+    public SocketModeClient getClient() {
+        return client;
+    }
+
+    public App getApp() {
+        return app;
     }
 }

--- a/bolt-socket-mode/src/test/java/test_locally/SocketModeAppTest.java
+++ b/bolt-socket-mode/src/test/java/test_locally/SocketModeAppTest.java
@@ -16,7 +16,7 @@ import util.socket_mode.MockWebSocketServer;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class SocketModeAppTest {
 
@@ -75,6 +75,26 @@ public class SocketModeAppTest {
             assertTrue(eventCalled.get());
         } finally {
             socketModeApp.stop();
+        }
+    }
+
+    @Test
+    public void issue_937_it_should_not_be_connected_before_start_method_call() throws Exception {
+        App app = new App(AppConfig.builder()
+                .slack(slack)
+                .singleTeamBotToken(VALID_BOT_TOKEN)
+                .build());
+        SocketModeApp socketModeApp = new SocketModeApp(VALID_APP_TOKEN, app);
+        try {
+            assertTrue(socketModeApp.isClientStopped());
+            assertNull(socketModeApp.getClient());
+
+            // Check again to make sure if the auto-connection does not work in this scenario
+            Thread.sleep(3_000L);
+            assertTrue(socketModeApp.isClientStopped());
+            assertNull(socketModeApp.getClient());
+        } finally {
+            socketModeApp.close();
         }
     }
 


### PR DESCRIPTION
This pull request resolves #937 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
