### PR TITLE
Add missing parameters in chat.update API method

### DIFF
--- a/json-logs/samples/api/chat.update.json
+++ b/json-logs/samples/api/chat.update.json
@@ -1340,5 +1340,10 @@
   },
   "error": "",
   "needed": "",
-  "provided": ""
+  "provided": "",
+  "response_metadata": {
+    "messages": [
+      ""
+    ]
+  }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -1251,6 +1251,9 @@ public class RequestFormBuilder {
         setIfNotNull("text", req.getText(), form);
         setIfNotNull("parse", req.getParse(), form);
         setIfNotNull("link_names", req.isLinkNames(), form);
+        if (req.getFileIds() != null) {
+            setIfNotNull("file_ids", req.getFileIds().stream().collect(joining(",")), form);
+        }
 
         if (req.getBlocksAsString() != null) {
             form.add("blocks", req.getBlocksAsString());
@@ -1269,6 +1272,7 @@ public class RequestFormBuilder {
             form.add("attachments", json);
         }
         setIfNotNull("as_user", req.isAsUser(), form);
+        setIfNotNull("reply_broadcast", req.isReplyBroadcast(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUpdateRequest.java
@@ -39,10 +39,25 @@ public class ChatUpdateRequest implements SlackApiRequest {
     private String user;
 
     /**
+     * Broadcast an existing thread reply to make it visible to everyone in the channel or conversation.
+     */
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private Boolean replyBroadcast;
+
+    // NOTE: The default value is intentionally null
+    public Boolean isReplyBroadcast() {
+        return this.replyBroadcast;
+    }
+
+    // NOTE: The default value is intentionally null
+    public void setReplyBroadcast(Boolean replyBroadcast) {
+        this.replyBroadcast = replyBroadcast;
+    }
+
+    /**
      * Pass true to post the message as the authed user, instead of as a bot.
      * Defaults to false. See [authorship](#authorship) below.
-     * <p>
-     * NOTE: The default value is intentionally null to support workplace apps.
      */
     @Getter(AccessLevel.NONE)
     @Setter(AccessLevel.NONE)
@@ -77,6 +92,11 @@ public class ChatUpdateRequest implements SlackApiRequest {
      * A JSON-based array of structured attachments, presented as a URL-encoded string.
      */
     private String attachmentsAsString;
+
+    /**
+     * Array of new file ids that will be sent with this message.
+     */
+    private List<String> fileIds;
 
     /**
      * Find and link channel names and usernames.

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatUpdateResponse.java
@@ -1,6 +1,7 @@
 package com.slack.api.methods.response.chat;
 
 import com.slack.api.methods.SlackApiTextResponse;
+import com.slack.api.model.ErrorResponseMetadata;
 import com.slack.api.model.Message;
 import lombok.Data;
 
@@ -18,6 +19,7 @@ public class ChatUpdateResponse implements SlackApiTextResponse {
     private transient Map<String, List<String>> httpResponseHeaders;
 
     private String deprecatedArgument;
+    private ErrorResponseMetadata responseMetadata;
 
     private String channel;
     private String ts;


### PR DESCRIPTION
This pull request adds two missing parameters in chat.update API method calls:
* file_ids
* reply_broadcast

Refer to https://api.slack.com/methods/chat.update for more details.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
