### PR TITLE
Fix #945 Log level for rate-limited error logging

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
@@ -188,7 +188,8 @@ public class AsyncRateLimitExecutor {
     private static void logSlackApiException(String teamId, String methodName, SlackApiException e) {
         if (e.getResponse().code() == 429) {
             String retryAfterSeconds = e.getResponse().header("Retry-After");
-            log.error("Got a rate-limited response from {} API (team: {}, error: {}, retry-after: {})",
+            // As long as you use this executor, the API client automatically retries the same request for you
+            log.warn("Got a rate-limited response from {} API (team: {}, error: {}, retry-after: {})",
                     methodName,
                     teamId,
                     e.getMessage(),


### PR DESCRIPTION
This pull request resolves #945 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
