### PR TITLE
Add external_limited to conversations.inviteShared API parameters

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -1454,6 +1454,7 @@ public class RequestFormBuilder {
         if (req.getEmails() != null) {
             setIfNotNull("emails", req.getEmails().stream().collect(joining(",")), form);
         }
+        setIfNotNull("external_limited", req.getExternalLimited(), form);
         if (req.getUserIds() != null) {
             setIfNotNull("user_ids", req.getUserIds().stream().collect(joining(",")), form);
         }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsInviteSharedRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsInviteSharedRequest.java
@@ -27,6 +27,11 @@ public class ConversationsInviteSharedRequest implements SlackApiRequest {
     private List<String> emails;
 
     /**
+     * Optional boolean on whether invite is to a external limited member. Defaults to true.
+     */
+    private Boolean externalLimited;
+
+    /**
      * Optional user_id to receive this invite. Either emails or user_ids must be provided.
      */
     private List<String> userIds;

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/conversations_connect_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/conversations_connect_Test.java
@@ -40,6 +40,7 @@ public class conversations_connect_Test {
         try {
             ConversationsInviteSharedResponse invitation = sender.conversationsInviteShared(r -> r
                     .channel(channelId)
+                    .externalLimited(false)
                     .userIds(Arrays.asList(System.getenv(Constants.SLACK_SDK_TEST_CONNECT_INVITE_RECEIVER_BOT_USER_ID)))
             );
             assertThat(invitation.getError(), is(nullValue()));
@@ -82,6 +83,7 @@ public class conversations_connect_Test {
         try {
             ConversationsInviteSharedResponse invitation = sender.conversationsInviteShared(r -> r
                     .channel(channelId)
+                    .externalLimited(false)
                     .userIds(Arrays.asList(System.getenv(Constants.SLACK_SDK_TEST_CONNECT_INVITE_RECEIVER_BOT_USER_ID)))
             );
             assertThat(invitation.getError(), is(nullValue()));


### PR DESCRIPTION
This pull request adds a missing parameter "external_limited: boolean' to https://api.slack.com/methods/conversations.inviteShared API method parameters.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
