### PR TITLE
Fix #955 Add more Javadocs to slack-api-method classes and interfaces

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
@@ -193,8 +193,9 @@ import com.slack.api.methods.response.workflows.WorkflowsUpdateStepResponse;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * API Methods.
- * https://api.slack.com/methods
+ * Asnc Slack API Methods client.
+ * <p>
+ * @see <a href="https://api.slack.com/methods">Slack API Methods</a>
  */
 public interface AsyncMethodsClient {
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
@@ -1,5 +1,10 @@
 package com.slack.api.methods;
 
+/**
+ * The comprehensive list of Slack API methods.
+ *
+ * @see <a href="https://api.slack.com/methods">Slack API Methods</a>
+ */
 public class Methods {
 
     private Methods() {

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
@@ -225,7 +225,7 @@ import java.io.IOException;
 /**
  * Slack API Methods client.
  * <p>
- * c<a href="https://api.slack.com/methods">Slack API Methods</a>
+ * @see <a href="https://api.slack.com/methods">Slack API Methods</a>
  */
 public interface MethodsClient {
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsCompletionException.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsCompletionException.java
@@ -6,6 +6,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
+/**
+ * Wrapped exception holding the cause exception occurred in AsyncMethodsClient
+ */
 @Data
 @Slf4j
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
@@ -12,6 +12,11 @@ import java.util.concurrent.ConcurrentMap;
 import static com.slack.api.methods.Methods.*;
 import static com.slack.api.methods.MethodsRateLimitTier.*;
 
+/**
+ * The comprehensive list of Slack Web API rate limits.
+ *
+ * @see <a href="https://api.slack.com/docs/rate-limits">api.slack.com document</a>
+ */
 @Slf4j
 public class MethodsRateLimits {
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -121,6 +121,9 @@ import java.util.List;
 
 import static java.util.stream.Collectors.joining;
 
+/**
+ * Binds API request parameters to the form body.
+ */
 @Slf4j
 public class RequestFormBuilder {
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiBinaryResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiBinaryResponse.java
@@ -2,6 +2,9 @@ package com.slack.api.methods;
 
 import java.io.IOException;
 
+/**
+ * Some APIs such as admin.analytics.getFile return binary data when the API call is successful.
+ */
 public interface SlackApiBinaryResponse extends SlackApiResponse {
 
     byte[] asBytes() throws IOException;

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiErrorResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiErrorResponse.java
@@ -5,6 +5,10 @@ import lombok.Data;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Represents the error response from Slack Web APIs. Developers can check the "error" code.
+ * Refer to the API documents (https://api.slack.com/methods) to check the full list of each API's error codes.
+ */
 @Data
 public class SlackApiErrorResponse implements SlackApiTextResponse {
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiException.java
@@ -7,6 +7,9 @@ import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 
+/**
+ * Represents an error returned from Slack Web APIs.
+ */
 @Data
 @Slf4j
 @EqualsAndHashCode(callSuper = false)

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiRequest.java
@@ -2,6 +2,18 @@ package com.slack.api.methods;
 
 /**
  * A marker interface for Slack API request objects.
+ *
+ * Developers can instantiate a request object by either of the following ways:
+ * <code>
+ * AuthTestRequest req = AuthTestRequest.builder().token("your-token").build();
+ * AuthTestResponse response = Slack.getInstance().methods().authTest(req);
+ * </code>
+ * or
+ * <code>
+ * AuthTestResponse response = Slack.getInstance().methods().authTest(req -> req.token("your-token"));
+ * </code>
+ * <p>
+ * Refer to https://api.slack.com/methods for the API details.
  */
 public interface SlackApiRequest {
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiResponse.java
@@ -3,6 +3,11 @@ package com.slack.api.methods;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * The marker interface for Slack Web API responses.
+ * <p>
+ * Refer to https://api.slack.com/methods for the API details.
+ */
 public interface SlackApiResponse {
 
     /**

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiTextResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiTextResponse.java
@@ -1,5 +1,8 @@
 package com.slack.api.methods;
 
+/**
+ * Most of the Slack APIs return text data. This interface defines the common properties of those.
+ */
 public interface SlackApiTextResponse extends SlackApiResponse {
 
     boolean isOk();

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/api/ApiTestRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/api/ApiTestRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/api.test
+ */
 @Data
 @Builder
 public class ApiTestRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/apps/AppsUninstallRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/apps/AppsUninstallRequest.java
@@ -7,6 +7,8 @@ import lombok.Data;
 /**
  * This method uninstalls an app. Unlike auth.revoke, which revokes a single token,
  * this method revokes all tokens associated with a single installation of an app.
+ *
+ * https://api.slack.com/methods/apps.uninstall
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/AppsPermissionsInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/AppsPermissionsInfoRequest.java
@@ -4,6 +4,11 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * On August 24, 2021, legacy workspace apps were retired. Workspace apps were part of a brief developer preview we elected to not fully release. Since October 2018, existing workspace apps have remained functional but on August 24, 2021 workspace apps will be retired and no longer function.
+ * - https://api.slack.com/changelog/2021-03-workspace-apps-to-retire-in-august-2021
+ */
+@Deprecated
 @Data
 @Builder
 public class AppsPermissionsInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/AppsPermissionsRequestRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/AppsPermissionsRequestRequest.java
@@ -6,6 +6,11 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * On August 24, 2021, legacy workspace apps were retired. Workspace apps were part of a brief developer preview we elected to not fully release. Since October 2018, existing workspace apps have remained functional but on August 24, 2021 workspace apps will be retired and no longer function.
+ * - https://api.slack.com/changelog/2021-03-workspace-apps-to-retire-in-august-2021
+ */
+@Deprecated
 @Data
 @Builder
 public class AppsPermissionsRequestRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/resources/AppsPermissionsResourcesListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/resources/AppsPermissionsResourcesListRequest.java
@@ -4,6 +4,11 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * On August 24, 2021, legacy workspace apps were retired. Workspace apps were part of a brief developer preview we elected to not fully release. Since October 2018, existing workspace apps have remained functional but on August 24, 2021 workspace apps will be retired and no longer function.
+ * - https://api.slack.com/changelog/2021-03-workspace-apps-to-retire-in-august-2021
+ */
+@Deprecated
 @Data
 @Builder
 public class AppsPermissionsResourcesListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/scopes/AppsPermissionsScopesListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/scopes/AppsPermissionsScopesListRequest.java
@@ -4,6 +4,11 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * On August 24, 2021, legacy workspace apps were retired. Workspace apps were part of a brief developer preview we elected to not fully release. Since October 2018, existing workspace apps have remained functional but on August 24, 2021 workspace apps will be retired and no longer function.
+ * - https://api.slack.com/changelog/2021-03-workspace-apps-to-retire-in-august-2021
+ */
+@Deprecated
 @Data
 @Builder
 public class AppsPermissionsScopesListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/users/AppsPermissionsUsersListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/users/AppsPermissionsUsersListRequest.java
@@ -4,6 +4,11 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * On August 24, 2021, legacy workspace apps were retired. Workspace apps were part of a brief developer preview we elected to not fully release. Since October 2018, existing workspace apps have remained functional but on August 24, 2021 workspace apps will be retired and no longer function.
+ * - https://api.slack.com/changelog/2021-03-workspace-apps-to-retire-in-august-2021
+ */
+@Deprecated
 @Data
 @Builder
 public class AppsPermissionsUsersListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/users/AppsPermissionsUsersRequestRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/apps/permissions/users/AppsPermissionsUsersRequestRequest.java
@@ -6,6 +6,11 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * On August 24, 2021, legacy workspace apps were retired. Workspace apps were part of a brief developer preview we elected to not fully release. Since October 2018, existing workspace apps have remained functional but on August 24, 2021 workspace apps will be retired and no longer function.
+ * - https://api.slack.com/changelog/2021-03-workspace-apps-to-retire-in-august-2021
+ */
+@Deprecated
 @Data
 @Builder
 public class AppsPermissionsUsersRequestRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/auth/AuthRevokeRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/auth/AuthRevokeRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/auth.revoke
+ */
 @Data
 @Builder
 public class AuthRevokeRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/auth/AuthTestRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/auth/AuthTestRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/auth.test
+ */
 @Data
 @Builder
 public class AuthTestRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/auth/teams/AuthTeamsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/auth/teams/AuthTeamsListRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/auth.teams.list
+ */
 @Data
 @Builder
 public class AuthTeamsListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/bookmarks/BookmarksAddRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/bookmarks/BookmarksAddRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/bookmarks.add
+ */
 @Data
 @Builder
 public class BookmarksAddRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/bookmarks/BookmarksEditRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/bookmarks/BookmarksEditRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/bookmarks.edit
+ */
 @Data
 @Builder
 public class BookmarksEditRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/bookmarks/BookmarksListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/bookmarks/BookmarksListRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/bookmarks.list
+ */
 @Data
 @Builder
 public class BookmarksListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/bookmarks/BookmarksRemoveRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/bookmarks/BookmarksRemoveRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/bookmarks.remove
+ */
 @Data
 @Builder
 public class BookmarksRemoveRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/bots/BotsInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/bots/BotsInfoRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/bots.info
+ */
 @Data
 @Builder
 public class BotsInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/calls/CallsInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/calls/CallsInfoRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/calls.info
+ */
 @Data
 @Builder
 public class CallsInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/calls/CallsUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/calls/CallsUpdateRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/calls.update
+ */
 @Data
 @Builder
 public class CallsUpdateRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/calls/participants/CallsParticipantsAddRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/calls/participants/CallsParticipantsAddRequest.java
@@ -7,6 +7,9 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/calls.participants.add
+ */
 @Data
 @Builder
 public class CallsParticipantsAddRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/calls/participants/CallsParticipantsRemoveRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/calls/participants/CallsParticipantsRemoveRequest.java
@@ -7,6 +7,9 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/calls.participants.remove
+ */
 @Data
 @Builder
 public class CallsParticipantsRemoveRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatDeleteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatDeleteRequest.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.request.chat;
 import com.slack.api.methods.SlackApiRequest;
 import lombok.*;
 
+/**
+ * https://api.slack.com/methods/chat.delete
+ */
 @Data
 @Builder
 public class ChatDeleteRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatDeleteScheduledMessageRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatDeleteScheduledMessageRequest.java
@@ -4,7 +4,7 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.*;
 
 /**
- * https://api.slack.com/methods/chat.deleteScheduleMessage
+ * https://api.slack.com/methods/chat.deleteScheduledMessage
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatDeleteScheduledMessageRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatDeleteScheduledMessageRequest.java
@@ -3,6 +3,9 @@ package com.slack.api.methods.request.chat;
 import com.slack.api.methods.SlackApiRequest;
 import lombok.*;
 
+/**
+ * https://api.slack.com/methods/chat.deleteScheduleMessage
+ */
 @Data
 @Builder
 public class ChatDeleteScheduledMessageRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatGetPermalinkRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatGetPermalinkRequest.java
@@ -5,9 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * A request to retrieve a permalink URL for a specific extant message
- *
- * @see <a href="https://api.slack.com/methods/chat.getPermalink">Slack chat.getPermalink API</a>
+ * https://api.slack.com/methods/chat.getPermalink
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatMeMessageRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatMeMessageRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/chat.meMessage
+ */
 @Data
 @Builder
 public class ChatMeMessageRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatPostEphemeralRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatPostEphemeralRequest.java
@@ -7,6 +7,9 @@ import lombok.*;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/chat.postEphemeral
+ */
 @Data
 @Builder
 public class ChatPostEphemeralRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatScheduleMessageRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatScheduleMessageRequest.java
@@ -7,6 +7,9 @@ import lombok.*;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/chat.scheduleMessage
+ */
 @Data
 @Builder
 public class ChatScheduleMessageRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Provide custom unfurl behavior for user-posted URLs
+ * https://api.slack.com/methods/chat.unfurl
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUpdateRequest.java
@@ -7,6 +7,9 @@ import lombok.*;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/chat.update
+ */
 @Data
 @Builder
 public class ChatUpdateRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/scheduled_messages/ChatScheduledMessagesListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/scheduled_messages/ChatScheduledMessagesListRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/chat.scheduledMessages.list
+ */
 @Data
 @Builder
 public class ChatScheduledMessagesListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsAcceptSharedInviteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsAcceptSharedInviteRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.acceptSharedInvite
+ */
 @Data
 @Builder
 public class ConversationsAcceptSharedInviteRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsApproveSharedInviteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsApproveSharedInviteRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.approveSharedInvite
+ */
 @Data
 @Builder
 public class ConversationsApproveSharedInviteRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsArchiveRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsArchiveRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.archive
+ */
 @Data
 @Builder
 public class ConversationsArchiveRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsCloseRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsCloseRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.close
+ */
 @Data
 @Builder
 public class ConversationsCloseRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsCreateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsCreateRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.create
+ */
 @Data
 @Builder
 public class ConversationsCreateRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsDeclineSharedInviteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsDeclineSharedInviteRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.declineSharedInvite
+ */
 @Data
 @Builder
 public class ConversationsDeclineSharedInviteRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsHistoryRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsHistoryRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.history
+ */
 @Data
 @Builder
 public class ConversationsHistoryRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsInfoRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.info
+ */
 @Data
 @Builder
 public class ConversationsInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsInviteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsInviteRequest.java
@@ -7,6 +7,9 @@ import lombok.Data;
 import java.util.List;
 
 @Data
+/**
+ * https://api.slack.com/methods/conversations.invite
+ */
 @Builder
 public class ConversationsInviteRequest implements SlackApiRequest {
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsInviteSharedRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsInviteSharedRequest.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/conversations.inviteShared
+ */
 @Data
 @Builder
 public class ConversationsInviteSharedRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsJoinRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsJoinRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.join
+ */
 @Data
 @Builder
 public class ConversationsJoinRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsKickRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsKickRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.kick
+ */
 @Data
 @Builder
 public class ConversationsKickRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsLeaveRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsLeaveRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.leave
+ */
 @Data
 @Builder
 public class ConversationsLeaveRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsListConnectInvitesRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsListConnectInvitesRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.listConnectInvites
+ */
 @Data
 @Builder
 public class ConversationsListConnectInvitesRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsListRequest.java
@@ -7,6 +7,9 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/conversations.list
+ */
 @Data
 @Builder
 public class ConversationsListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsMarkRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsMarkRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.mark
+ */
 @Data
 @Builder
 public class ConversationsMarkRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsMembersRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsMembersRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.members
+ */
 @Data
 @Builder
 public class ConversationsMembersRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsOpenRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsOpenRequest.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/conversations.open
+ */
 @Data
 @Builder
 public class ConversationsOpenRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsRenameRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsRenameRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.rename
+ */
 @Data
 @Builder
 public class ConversationsRenameRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsRepliesRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsRepliesRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.replies
+ */
 @Data
 @Builder
 public class ConversationsRepliesRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsSetPurposeRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsSetPurposeRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.setPurpose
+ */
 @Data
 @Builder
 public class ConversationsSetPurposeRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsSetTopicRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsSetTopicRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.setTopic
+ */
 @Data
 @Builder
 public class ConversationsSetTopicRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsUnarchiveRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsUnarchiveRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/conversations.unarchive
+ */
 @Data
 @Builder
 public class ConversationsUnarchiveRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/dialog/DialogOpenRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/dialog/DialogOpenRequest.java
@@ -5,6 +5,9 @@ import com.slack.api.model.dialog.Dialog;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/dialog.open
+ */
 @Data
 @Builder
 public class DialogOpenRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/dnd/DndEndDndRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/dnd/DndEndDndRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/dnd.endDnd
+ */
 @Data
 @Builder
 public class DndEndDndRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/dnd/DndEndSnoozeRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/dnd/DndEndSnoozeRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/dnd.endSnooze
+ */
 @Data
 @Builder
 public class DndEndSnoozeRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/dnd/DndInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/dnd/DndInfoRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/dnd.info
+ */
 @Data
 @Builder
 public class DndInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/dnd/DndSetSnoozeRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/dnd/DndSetSnoozeRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/dnd.setSnooze
+ */
 @Data
 @Builder
 public class DndSetSnoozeRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/dnd/DndTeamInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/dnd/DndTeamInfoRequest.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/dnd.teamInfo
+ */
 @Data
 @Builder
 public class DndTeamInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/emoji/EmojiListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/emoji/EmojiListRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/emoji.list
+ */
 @Data
 @Builder
 public class EmojiListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesDeleteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesDeleteRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/files.delete
+ */
 @Data
 @Builder
 public class FilesDeleteRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesInfoRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/files.info
+ */
 @Data
 @Builder
 public class FilesInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesListRequest.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/files.list
+ */
 @Data
 @Builder
 public class FilesListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesRevokePublicURLRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesRevokePublicURLRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/files.revokePublicURL
+ */
 @Data
 @Builder
 public class FilesRevokePublicURLRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesSharedPublicURLRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesSharedPublicURLRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/files.sharedPublicURL
+ */
 @Data
 @Builder
 public class FilesSharedPublicURLRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadRequest.java
@@ -7,6 +7,9 @@ import lombok.Data;
 import java.io.File;
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/files.upload
+ */
 @Data
 @Builder
 public class FilesUploadRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/comments/FilesCommentsAddRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/comments/FilesCommentsAddRequest.java
@@ -4,6 +4,10 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * No longer supported - https://api.slack.com/changelog/2018-05-file-threads-soon-tread
+ */
+@Deprecated // https://api.slack.com/changelog/2018-05-file-threads-soon-tread
 @Data
 @Builder
 public class FilesCommentsAddRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/comments/FilesCommentsDeleteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/comments/FilesCommentsDeleteRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/files.comments.delete
+ */
 @Data
 @Builder
 public class FilesCommentsDeleteRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/comments/FilesCommentsEditRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/comments/FilesCommentsEditRequest.java
@@ -4,6 +4,10 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * No longer supported - https://api.slack.com/changelog/2018-05-file-threads-soon-tread
+ */
+@Deprecated // no longer supported
 @Data
 @Builder
 public class FilesCommentsEditRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/remote/FilesRemoteRemoveRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/remote/FilesRemoteRemoveRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/files.remote.remove
+ */
 @Data
 @Builder
 public class FilesRemoteRemoveRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/remote/FilesRemoteShareRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/remote/FilesRemoteShareRequest.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import java.util.List;
 
+/**
+ * https://api.slack.com/methods/files.remote.share
+ */
 @Data
 @Builder
 public class FilesRemoteShareRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/remote/FilesRemoteUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/remote/FilesRemoteUpdateRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/files.remote.update
+ */
 @Data
 @Builder
 public class FilesRemoteUpdateRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/migration/MigrationExchangeRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/migration/MigrationExchangeRequest.java
@@ -7,7 +7,9 @@ import lombok.Data;
 import java.util.List;
 
 /**
- * For Enterprise Grid workspaces, map local user IDs to global user IDs
+ * For Enterprise Grid workspaces, map local user IDs to global user IDs.
+ *
+ * https://api.slack.com/methods/migration.exchange
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/migration/MigrationExchangeRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/migration/MigrationExchangeRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 /**
  * For Enterprise Grid workspaces, map local user IDs to global user IDs.
- *
+ * <p>
  * https://api.slack.com/methods/migration.exchange
  */
 @Data

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthAccessRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthAccessRequest.java
@@ -5,7 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * https://api.slack.com/docs/oauth
+ * - https://api.slack.com/methods/oauth.access
+ * - https://api.slack.com/docs/oauth
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthTokenRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthTokenRequest.java
@@ -7,7 +7,8 @@ import lombok.Data;
 /**
  * Exchanges a temporary OAuth verifier code for a workspace token.
  * <p>
- * https://api.slack.com/docs/oauth
+ * - https://api.slack.com/methods/oauth.token
+ * - https://api.slack.com/docs/oauth
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthV2AccessRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthV2AccessRequest.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * https://api.slack.com/authentication/basics
- * https://api.slack.com/methods/oauth.v2.access
+ * - https://api.slack.com/methods/oauth.v2.access
+ * - https://api.slack.com/authentication/basics
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthV2ExchangeRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/oauth/OAuthV2ExchangeRequest.java
@@ -5,7 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * https://api.slack.com/methods/oauth.v2.exchange
+ * - https://api.slack.com/methods/oauth.v2.exchange
+ * - https://api.slack.com/authentication/rotation
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/openid/connect/OpenIDConnectTokenRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/openid/connect/OpenIDConnectTokenRequest.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * https://api.slack.com/methods/openid.connect.token
- * https://api.slack.com/authentication/sign-in-with-slack
+ * - https://api.slack.com/methods/openid.connect.token
+ * - https://api.slack.com/authentication/sign-in-with-slack
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/openid/connect/OpenIDConnectUserInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/openid/connect/OpenIDConnectUserInfoRequest.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * https://api.slack.com/methods/openid.connect.userInfo
- * https://api.slack.com/authentication/sign-in-with-slack
+ * - https://api.slack.com/methods/openid.connect.userInfo
+ * - https://api.slack.com/authentication/sign-in-with-slack
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/pins/PinsAddRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/pins/PinsAddRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/pins.add
+ */
 @Data
 @Builder
 public class PinsAddRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/pins/PinsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/pins/PinsListRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/pins.list
+ */
 @Data
 @Builder
 public class PinsListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/pins/PinsRemoveRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/pins/PinsRemoveRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/pins.remove
+ */
 @Data
 @Builder
 public class PinsRemoveRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsAddRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsAddRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/reactions.add
+ */
 @Data
 @Builder
 public class ReactionsAddRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsGetRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsGetRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/reactions.get
+ */
 @Data
 @Builder
 public class ReactionsGetRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsListRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/reactions.list
+ */
 @Data
 @Builder
 public class ReactionsListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsRemoveRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsRemoveRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/reactions.remove
+ */
 @Data
 @Builder
 public class ReactionsRemoveRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reminders/RemindersAddRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reminders/RemindersAddRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/reminders.add
+ */
 @Data
 @Builder
 public class RemindersAddRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reminders/RemindersCompleteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reminders/RemindersCompleteRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/reminders.complete
+ */
 @Data
 @Builder
 public class RemindersCompleteRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reminders/RemindersDeleteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reminders/RemindersDeleteRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/reminders.delete
+ */
 @Data
 @Builder
 public class RemindersDeleteRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reminders/RemindersInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reminders/RemindersInfoRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/reminders.info
+ */
 @Data
 @Builder
 public class RemindersInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reminders/RemindersListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reminders/RemindersListRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/reminders.list
+ */
 @Data
 @Builder
 public class RemindersListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchAllRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchAllRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/search.all
+ */
 @Data
 @Builder
 public class SearchAllRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchFilesRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchFilesRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/search.files
+ */
 @Data
 @Builder
 public class SearchFilesRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchMessagesRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/search/SearchMessagesRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/search.messages
+ */
 @Data
 @Builder
 public class SearchMessagesRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/stars/StarsAddRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/stars/StarsAddRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/stars.add
+ */
 @Data
 @Builder
 public class StarsAddRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/stars/StarsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/stars/StarsListRequest.java
@@ -4,7 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
-// https://api.slack.com/methods/stars.list
+/**
+ * https://api.slack.com/methods/stars.list
+ */
 @Data
 @Builder
 public class StarsListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/stars/StarsRemoveRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/stars/StarsRemoveRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/stars.remove
+ */
 @Data
 @Builder
 public class StarsRemoveRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamAccessLogsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamAccessLogsRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/team.accessLogs
+ */
 @Data
 @Builder
 public class TeamAccessLogsRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamBillableInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamBillableInfoRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/team.billableInfo
+ */
 @Data
 @Builder
 public class TeamBillableInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamBillingInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamBillingInfoRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/team.billingInfo
+ */
 @Data
 @Builder
 public class TeamBillingInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamInfoRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/team.info
+ */
 @Data
 @Builder
 public class TeamInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamIntegrationLogsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamIntegrationLogsRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/team.integrationLogs
+ */
 @Data
 @Builder
 public class TeamIntegrationLogsRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamPreferencesListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamPreferencesListRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/team.preferences.list
+ */
 @Data
 @Builder
 public class TeamPreferencesListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/profile/TeamProfileGetRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/profile/TeamProfileGetRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/team.profile.get
+ */
 @Data
 @Builder
 public class TeamProfileGetRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/UsergroupsCreateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/UsergroupsCreateRequest.java
@@ -6,7 +6,9 @@ import lombok.Data;
 
 import java.util.List;
 
-// https://api.slack.com/methods/usergroups.create
+/**
+ * https://api.slack.com/methods/usergroups.create
+ */
 @Data
 @Builder
 public class UsergroupsCreateRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/UsergroupsDisableRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/UsergroupsDisableRequest.java
@@ -4,7 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
-// https://api.slack.com/methods/usergroups.disable
+/**
+ * https://api.slack.com/methods/usergroups.disable
+ */
 @Data
 @Builder
 public class UsergroupsDisableRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/UsergroupsEnableRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/UsergroupsEnableRequest.java
@@ -4,7 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
-// https://api.slack.com/methods/usergroups.enable
+/**
+ * https://api.slack.com/methods/usergroups.enable
+ */
 @Data
 @Builder
 public class UsergroupsEnableRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/UsergroupsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/UsergroupsListRequest.java
@@ -4,7 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
-// https://api.slack.com/methods/usergroups.list
+/**
+ * https://api.slack.com/methods/usergroups.list
+ */
 @Data
 @Builder
 public class UsergroupsListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/UsergroupsUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/UsergroupsUpdateRequest.java
@@ -6,7 +6,9 @@ import lombok.Data;
 
 import java.util.List;
 
-// https://api.slack.com/methods/usergroups.update
+/**
+ * https://api.slack.com/methods/usergroups.update
+ */
 @Data
 @Builder
 public class UsergroupsUpdateRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/users/UsergroupsUsersListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/users/UsergroupsUsersListRequest.java
@@ -4,7 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
-// https://api.slack.com/methods/usergroups.users.list
+/**
+ * https://api.slack.com/methods/usergroups.users.list
+ */
 @Data
 @Builder
 public class UsergroupsUsersListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/users/UsergroupsUsersUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/usergroups/users/UsergroupsUsersUpdateRequest.java
@@ -6,7 +6,9 @@ import lombok.Data;
 
 import java.util.List;
 
-// https://api.slack.com/methods/usergroups.users.update
+/**
+ * https://api.slack.com/methods/usergroups.users.update
+ */
 @Data
 @Builder
 public class UsergroupsUsersUpdateRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersConversationsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersConversationsRequest.java
@@ -8,7 +8,7 @@ import lombok.Data;
 import java.util.List;
 
 /**
- * List conversations the calling user may access.
+ * https://api.slack.com/methods/users.conversations
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersDeletePhotoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersDeletePhotoRequest.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * Delete the user profile photo
+ * https://api.slack.com/methods/users.deletePhoto
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersGetPresenceRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersGetPresenceRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/users.getPresence
+ */
 @Data
 @Builder
 public class UsersGetPresenceRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersIdentityRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersIdentityRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/users.identity
+ */
 @Data
 @Builder
 public class UsersIdentityRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersInfoRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/users.info
+ */
 @Data
 @Builder
 public class UsersInfoRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersListRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/users.list
+ */
 @Data
 @Builder
 public class UsersListRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersLookupByEmailRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersLookupByEmailRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/users.lookupByEmail
+ */
 @Data
 @Builder
 public class UsersLookupByEmailRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersSetActiveRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersSetActiveRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/users.setActive
+ */
 @Data
 @Builder
 public class UsersSetActiveRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersSetPhotoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersSetPhotoRequest.java
@@ -7,7 +7,7 @@ import lombok.Data;
 import java.io.File;
 
 /**
- * Set the user profile photo
+ * https://api.slack.com/methods/users.setPhoto
  */
 @Data
 @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersSetPresenceRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/UsersSetPresenceRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/users.setPresence
+ */
 @Data
 @Builder
 public class UsersSetPresenceRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/profile/UsersProfileGetRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/profile/UsersProfileGetRequest.java
@@ -4,6 +4,9 @@ import com.slack.api.methods.SlackApiRequest;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/users.profile.get
+ */
 @Data
 @Builder
 public class UsersProfileGetRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/users/profile/UsersProfileSetRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/users/profile/UsersProfileSetRequest.java
@@ -5,6 +5,9 @@ import com.slack.api.model.User;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/users.profile.set
+ */
 @Data
 @Builder
 public class UsersProfileSetRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/views/ViewsOpenRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/views/ViewsOpenRequest.java
@@ -5,6 +5,9 @@ import com.slack.api.model.view.View;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/views.open
+ */
 @Data
 @Builder
 public class ViewsOpenRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/views/ViewsPublishRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/views/ViewsPublishRequest.java
@@ -5,6 +5,9 @@ import com.slack.api.model.view.View;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/views.publish
+ */
 @Data
 @Builder
 public class ViewsPublishRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/views/ViewsPushRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/views/ViewsPushRequest.java
@@ -5,6 +5,9 @@ import com.slack.api.model.view.View;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/views.push
+ */
 @Data
 @Builder
 public class ViewsPushRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/views/ViewsUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/views/ViewsUpdateRequest.java
@@ -5,6 +5,9 @@ import com.slack.api.model.view.View;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * https://api.slack.com/methods/views.update
+ */
 @Data
 @Builder
 public class ViewsUpdateRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/workflows/WorkflowsStepCompletedRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/workflows/WorkflowsStepCompletedRequest.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import java.util.Map;
 
+/**
+ * https://api.slack.com/methods/workflows.stepCompleted
+ */
 @Data
 @Builder
 public class WorkflowsStepCompletedRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/workflows/WorkflowsStepFailedRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/workflows/WorkflowsStepFailedRequest.java
@@ -6,6 +6,9 @@ import lombok.Data;
 
 import java.util.Map;
 
+/**
+ * https://api.slack.com/methods/workflows.stepFailed
+ */
 @Data
 @Builder
 public class WorkflowsStepFailedRequest implements SlackApiRequest {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/workflows/WorkflowsUpdateStepRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/workflows/WorkflowsUpdateStepRequest.java
@@ -9,6 +9,9 @@ import lombok.Data;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * https://api.slack.com/methods/workflows.updateStep
+ */
 @Data
 @Builder
 public class WorkflowsUpdateStepRequest implements SlackApiRequest {


### PR DESCRIPTION
This pull request resolves #955 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
