### PR TITLE
Fix #954 Add setToken(String) to MethodsClient request Interface

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiRequest.java
@@ -21,7 +21,7 @@ public interface SlackApiRequest {
      * Returns a token in this request object.
      * If the API endpoint does not require a token (e.g., api.test), this method can return null.
      *
-     * @return token string value
+     * @return token string value or null
      */
     String getToken();
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/SlackApiRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/SlackApiRequest.java
@@ -2,7 +2,7 @@ package com.slack.api.methods;
 
 /**
  * A marker interface for Slack API request objects.
- *
+ * <p>
  * Developers can instantiate a request object by either of the following ways:
  * <code>
  * AuthTestRequest req = AuthTestRequest.builder().token("your-token").build();
@@ -17,6 +17,25 @@ package com.slack.api.methods;
  */
 public interface SlackApiRequest {
 
+    /**
+     * Returns a token in this request object.
+     * If the API endpoint does not require a token (e.g., api.test), this method can return null.
+     *
+     * @return token string value
+     */
     String getToken();
+
+    /**
+     * Updates the token in this request object.
+     * <p>
+     * The default implementation throws {@link UnsupportedOperationException}.
+     * All the built-in implementing classes overrides this method in a proper way.
+     *
+     * @throws UnsupportedOperationException is always thrown if this method is not overridden
+     */
+    default void setToken(String token) {
+        throw new UnsupportedOperationException(
+                "SlackApiRequest#setToken(String) is not overridden in this class.");
+    }
 
 }

--- a/slack-api-client/src/test/java/test_locally/api/methods/SlackApiRequestTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/SlackApiRequestTest.java
@@ -32,6 +32,17 @@ public class SlackApiRequestTest {
         server.stop();
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void defaultSetToken() {
+        SlackApiRequest req = new SlackApiRequest() {
+            @Override
+            public String getToken() {
+                return null;
+            }
+        };
+        req.setToken("foo");
+    }
+
     @Test
     public void requestObjectCreation() {
         AuthTestRequest req = AuthTestRequest.builder().token("xoxb-old-token").build();

--- a/slack-api-client/src/test/java/test_locally/api/methods/SlackApiRequestTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/SlackApiRequestTest.java
@@ -44,7 +44,7 @@ public class SlackApiRequestTest {
     }
 
     @Test
-    public void requestObjectCreation() {
+    public void tokenReplacement() {
         AuthTestRequest req = AuthTestRequest.builder().token("xoxb-old-token").build();
         assertThat(req.getToken(), is("xoxb-old-token"));
         req.setToken("xoxb-new-token"); // no exception here

--- a/slack-api-client/src/test/java/test_locally/api/methods/SlackApiRequestTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/SlackApiRequestTest.java
@@ -1,0 +1,58 @@
+package test_locally.api.methods;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.methods.SlackApiRequest;
+import com.slack.api.methods.request.auth.AuthTestRequest;
+import com.slack.api.methods.response.auth.AuthTestResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import util.MockSlackApiServer;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static util.MockSlackApi.ExpiredToken;
+import static util.MockSlackApi.ValidToken;
+
+public class SlackApiRequestTest {
+
+    MockSlackApiServer server = new MockSlackApiServer();
+    SlackConfig config = new SlackConfig();
+    Slack slack = Slack.getInstance(config);
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+        config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void requestObjectCreation() {
+        AuthTestRequest req = AuthTestRequest.builder().token("xoxb-old-token").build();
+        assertThat(req.getToken(), is("xoxb-old-token"));
+        req.setToken("xoxb-new-token"); // no exception here
+        assertThat(req.getToken(), is("xoxb-new-token"));
+    }
+
+    @Test
+    public void setTokenUseCase() throws Exception {
+        AuthTestRequest req = AuthTestRequest.builder().token(ExpiredToken).build();
+        AuthTestResponse response1 = slack.methods().authTest(req);
+        assertThat(response1.getError(), is("token_expired"));
+
+        replaceToken(req, ValidToken);
+        AuthTestResponse response2 = slack.methods().authTest(req);
+        assertThat(response2.getError(), is(nullValue()));
+    }
+
+    private static void replaceToken(SlackApiRequest req, String newToken) {
+        req.setToken(newToken);
+    }
+
+}

--- a/slack-api-client/src/test/java/util/MockSlackApi.java
+++ b/slack-api-client/src/test/java/util/MockSlackApi.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 public class MockSlackApi extends HttpServlet {
 
     public static final String ValidToken = "xoxb-this-is-valid";
+    public static final String ExpiredToken = "xoxb-this-is-expired";
     public static final String InvalidToken = "xoxb-this-is-INVALID";
 
     private final FileReader reader = new FileReader("../json-logs/samples/api/");
@@ -44,7 +45,11 @@ public class MockSlackApi extends HttpServlet {
                 return;
             } else if (!authorizationHeader.equals("Bearer " + ValidToken)) {
                 resp.setStatus(200);
-                resp.getWriter().write("{\"ok\":false,\"error\":\"invalid_auth\"}");
+                if (authorizationHeader.equals("Bearer " + ExpiredToken)) {
+                    resp.getWriter().write("{\"ok\":false,\"error\":\"token_expired\"}");
+                } else {
+                    resp.getWriter().write("{\"ok\":false,\"error\":\"invalid_auth\"}");
+                }
                 resp.setContentType("application/json");
                 return;
             }
@@ -62,8 +67,7 @@ public class MockSlackApi extends HttpServlet {
                     "  \"team_id\": \"T1234567\",\n" +
                     "  \"user_id\": \"U1234567\",\n" +
                     "  \"bot_id\": \"B12345678\",\n" +
-                    "  \"enterprise_id\": \"E12345678\",\n" +
-                    "  \"error\": \"\"\n" +
+                    "  \"enterprise_id\": \"E12345678\"\n" +
                     "}";
         }
         if (body == null || body.trim().isEmpty()) {


### PR DESCRIPTION
This pull request fixes #954 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
