### PR TITLE
Add domain to team.info API parameters

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -2177,6 +2177,7 @@ public class RequestFormBuilder {
     public static FormBody.Builder toForm(TeamInfoRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("team", req.getTeam(), form);
+        setIfNotNull("domain", req.getDomain(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamInfoRequest.java
@@ -21,4 +21,9 @@ public class TeamInfoRequest implements SlackApiRequest {
      */
     private String team;
 
+    /**
+     * Query by domain instead of team (only when team is null). This only works for domains in the same enterprise as the querying team token. This also expects the domain to belong to a team and not the enterprise itself.
+     */
+    private String domain;
+
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/team_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/team_Test.java
@@ -1,6 +1,7 @@
 package test_with_remote_apis.methods;
 
 import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.request.team.TeamBillingInfoRequest;
 import com.slack.api.methods.response.team.*;
 import com.slack.api.methods.response.team.profile.TeamProfileGetResponse;
@@ -104,6 +105,18 @@ public class team_Test {
         TeamInfoResponse response = slack.methods().teamInfo(r -> r.token(botToken));
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.isOk(), is(true));
+    }
+
+    @Test
+    public void teamInfo_EnterpriseGrid() throws Exception {
+        MethodsClient client = slack.methods(gridWorkspaceUserToken);
+        TeamInfoResponse response = client.teamInfo(r -> r);
+        assertThat(response.getError(), is(nullValue()));
+
+        TeamInfoResponse domainResponse = client.teamInfo(r -> r
+                .domain(response.getTeam().getDomain())
+        );
+        assertThat(domainResponse.getError(), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
This pull request adds `domain` parameter to the [team.info](https://api.slack.com/methods/team.info) API method.

>The [team.info](https://api.slack.com/methods/team.info) parameter [domain](https://api.slack.com/methods/team.info#arg_domain) is now public. Query for your team's information by domain only when team is null.
>https://api.slack.com/changelog

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
