### PR TITLE
Upgrade optional dependency patch/minor versions

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <helidon.version>[2.4,2.5)</helidon.version>
+        <helidon.version>[2.5,2.6)</helidon.version>
         <!-- Helidon 2.x requires Java 11+ -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.25.5.1</http4k.version>
+        <http4k.version>4.25.8.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.version>3.4.0</micronaut.version>
+        <micronaut.version>3.4.1</micronaut.version>
         <micronaut-test-junit5.version>3.1.1</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>2.2.1</micronaut-rxjava3.version>
         <!-- Note that upgrading this library breaks other dependency resolution -->

--- a/bolt-servlet/pom.xml
+++ b/bolt-servlet/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <!-- TODO: Upgrade to 11.x in the next major version - v2 -->
         <jetty.version>9.4.24.v20191120</jetty.version>
-        <java-jwt.version>3.19.0</java-jwt.version>
+        <java-jwt.version>3.19.1</java-jwt.version>
     </properties>
 
     <artifactId>bolt-servlet</artifactId>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.6.4</spring-boot.version>
+        <spring-boot.version>2.6.6</spring-boot.version>
     </properties>
 
     <artifactId>bolt-spring-boot-examples</artifactId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,8 +9,8 @@ url: https://slack.dev
 sdkLatestVersion: 1.20.2
 okhttpVersion: 4.9.3
 slf4jApiVersion: 1.7.33
-kotlinVersion: 1.6.0
-springBootVersion: 2.6.4
+kotlinVersion: 1.6.20
+springBootVersion: 2.6.6
 compatibleMicronautVersion: 3.x
 quarkusVersion: 2.7.5.Final
-helidonVersion: 2.3.2
+helidonVersion: 2.5.0

--- a/pom.xml
+++ b/pom.xml
@@ -50,15 +50,15 @@
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <okhttp.version>4.9.3</okhttp.version>
         <gson.version>2.9.0</gson.version>
-        <kotlin.version>1.6.10</kotlin.version>
+        <kotlin.version>1.6.20</kotlin.version>
         <slf4j.version>1.7.36</slf4j.version>
         <lombok.version>1.18.22</lombok.version>
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
 
         <!-- optional / testing-only dependencies -->
-        <jakarta.jetty.version>11.0.8</jakarta.jetty.version>
-        <java-jwt.version>3.19.0</java-jwt.version>
+        <jakarta.jetty.version>11.0.9</jakarta.jetty.version>
+        <java-jwt.version>3.19.1</java-jwt.version>
         <aws.s3.version>[1.12.62,1.13.0)</aws.s3.version>
         <junit.version>4.13.2</junit.version>
         <logback.version>1.2.11</logback.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -20,7 +20,7 @@
          -->
         <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
         <java-websocket.version>1.5.2</java-websocket.version>
-        <jedis.version>4.1.1</jedis.version>
+        <jedis.version>4.2.1</jedis.version>
         <jedis-mock.version>1.0.1</jedis-mock.version>
     </properties>
 


### PR DESCRIPTION
As a preparation for the next minor release, this pull request upgrades optional dependency patch/minor versions.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
