### PR TITLE
Fix #960 The bot refresh token is overridden with the user refresh token in OAuthV2DefaultSuccessHandler.java

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultSuccessHandler.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/default_impl/OAuthV2DefaultSuccessHandler.java
@@ -75,11 +75,13 @@ public class OAuthV2DefaultSuccessHandler implements OAuthV2SuccessHandler {
         if (o.getAuthedUser() != null) {
             // we can assume authed_user should exist but just in case
             i = i.installerUserId(o.getAuthedUser().getId())
+                    // These properties can exist only when a user token is requested
                     .installerUserAccessToken(o.getAuthedUser().getAccessToken())
-                    .botRefreshToken(o.getAuthedUser().getRefreshToken())
-                    .botTokenExpiresAt(o.getAuthedUser().getExpiresIn() == null ?
-                            null : System.currentTimeMillis() + (o.getAuthedUser().getExpiresIn() * 1000))
-                    .installerUserScope(o.getAuthedUser().getScope());
+                    .installerUserScope(o.getAuthedUser().getScope())
+                    // These token-rotation-related properties can be absent
+                    .installerUserRefreshToken(o.getAuthedUser().getRefreshToken())
+                    .installerUserTokenExpiresAt(o.getAuthedUser().getExpiresIn() == null ?
+                            null : System.currentTimeMillis() + (o.getAuthedUser().getExpiresIn() * 1000));
         }
 
         if (o.getBotUserId() != null) {


### PR DESCRIPTION
This pull request resolves #960 

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
