### PR TITLE
Add preivew param to chat.unfurl API parameters

### DIFF
--- a/json-logs/samples/api/chat.postMessage.json
+++ b/json-logs/samples/api/chat.postMessage.json
@@ -495,15 +495,6 @@
             "initial_users": [
               ""
             ]
-          },
-          {
-            "type": "",
-            "image_url": "",
-            "alt_text": "",
-            "fallback": "",
-            "image_width": 12345,
-            "image_height": 12345,
-            "image_bytes": 12345
           }
         ],
         "call_id": "R00000000",
@@ -771,6 +762,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 12345,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -1378,6 +1370,21 @@
             "optional": false
           }
         ],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "files": [
           {
             "id": "",

--- a/json-logs/samples/api/chat.scheduleMessage.json
+++ b/json-logs/samples/api/chat.scheduleMessage.json
@@ -169,15 +169,6 @@
             "initial_users": [
               ""
             ]
-          },
-          {
-            "type": "",
-            "image_url": "",
-            "alt_text": "",
-            "fallback": "",
-            "image_width": 12345,
-            "image_height": 12345,
-            "image_bytes": 12345
           }
         ],
         "block_id": "",

--- a/json-logs/samples/api/chat.update.json
+++ b/json-logs/samples/api/chat.update.json
@@ -320,15 +320,6 @@
             "initial_users": [
               ""
             ]
-          },
-          {
-            "type": "",
-            "image_url": "",
-            "alt_text": "",
-            "fallback": "",
-            "image_width": 12345,
-            "image_height": 12345,
-            "image_bytes": 12345
           }
         ],
         "call_id": "",

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -1397,6 +1397,7 @@
           "channel_id": "",
           "channel_name": "",
           "id": 12345,
+          "app_id": "",
           "bot_id": "",
           "indent": false,
           "is_msg_unfurl": false,
@@ -2004,6 +2005,21 @@
               "optional": false
             }
           ],
+          "preview": {
+            "type": "",
+            "can_remove": false,
+            "title": {
+              "type": "",
+              "text": "",
+              "emoji": false
+            },
+            "subtitle": {
+              "type": "",
+              "text": "",
+              "emoji": false
+            },
+            "icon_url": ""
+          },
           "files": [
             {
               "id": "",
@@ -2826,5 +2842,6 @@
   },
   "error": "",
   "needed": "",
-  "provided": ""
+  "provided": "",
+  "oldest": "0000000000.000000"
 }

--- a/json-logs/samples/api/conversations.open.json
+++ b/json-logs/samples/api/conversations.open.json
@@ -162,15 +162,6 @@
               "initial_users": [
                 ""
               ]
-            },
-            {
-              "type": "",
-              "image_url": "",
-              "alt_text": "",
-              "fallback": "",
-              "image_width": 12345,
-              "image_height": 12345,
-              "image_bytes": 12345
             }
           ],
           "text": {

--- a/json-logs/samples/api/conversations.replies.json
+++ b/json-logs/samples/api/conversations.replies.json
@@ -581,6 +581,7 @@
           "channel_id": "",
           "channel_name": "",
           "id": 12345,
+          "app_id": "",
           "bot_id": "",
           "indent": false,
           "is_msg_unfurl": false,
@@ -1188,6 +1189,21 @@
               "optional": false
             }
           ],
+          "preview": {
+            "type": "",
+            "can_remove": false,
+            "title": {
+              "type": "",
+              "text": "",
+              "emoji": false
+            },
+            "subtitle": {
+              "type": "",
+              "text": "",
+              "emoji": false
+            },
+            "icon_url": ""
+          },
           "files": [
             {
               "id": "",

--- a/json-logs/samples/api/files.info.json
+++ b/json-logs/samples/api/files.info.json
@@ -257,6 +257,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -334,6 +335,21 @@
           }
         ],
         "blocks": [],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "files": [],
         "filename": "",
         "size": 123,

--- a/json-logs/samples/api/files.remote.add.json
+++ b/json-logs/samples/api/files.remote.add.json
@@ -257,6 +257,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -334,6 +335,21 @@
           }
         ],
         "blocks": [],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "files": [],
         "filename": "",
         "size": 123,

--- a/json-logs/samples/api/files.remote.info.json
+++ b/json-logs/samples/api/files.remote.info.json
@@ -257,6 +257,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -334,6 +335,21 @@
           }
         ],
         "blocks": [],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "files": [],
         "filename": "",
         "size": 123,

--- a/json-logs/samples/api/files.remote.share.json
+++ b/json-logs/samples/api/files.remote.share.json
@@ -257,6 +257,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -334,6 +335,21 @@
           }
         ],
         "blocks": [],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "files": [],
         "filename": "",
         "size": 123,

--- a/json-logs/samples/api/files.remote.update.json
+++ b/json-logs/samples/api/files.remote.update.json
@@ -257,6 +257,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -334,6 +335,21 @@
           }
         ],
         "blocks": [],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "files": [],
         "filename": "",
         "size": 123,

--- a/json-logs/samples/api/files.revokePublicURL.json
+++ b/json-logs/samples/api/files.revokePublicURL.json
@@ -257,6 +257,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -334,6 +335,21 @@
           }
         ],
         "blocks": [],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "files": [],
         "filename": "",
         "size": 123,

--- a/json-logs/samples/api/files.sharedPublicURL.json
+++ b/json-logs/samples/api/files.sharedPublicURL.json
@@ -257,6 +257,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -334,6 +335,21 @@
           }
         ],
         "blocks": [],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "files": [],
         "filename": "",
         "size": 123,

--- a/json-logs/samples/api/files.upload.json
+++ b/json-logs/samples/api/files.upload.json
@@ -257,6 +257,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -334,6 +335,21 @@
           }
         ],
         "blocks": [],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "files": [],
         "filename": "",
         "size": 123,

--- a/json-logs/samples/api/pins.list.json
+++ b/json-logs/samples/api/pins.list.json
@@ -262,6 +262,7 @@
             "channel_id": "",
             "channel_name": "",
             "id": 123,
+            "app_id": "",
             "bot_id": "",
             "indent": false,
             "is_msg_unfurl": false,
@@ -339,6 +340,21 @@
               }
             ],
             "blocks": [],
+            "preview": {
+              "type": "",
+              "can_remove": false,
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "subtitle": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "icon_url": ""
+            },
             "files": [],
             "filename": "",
             "size": 123,

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -948,6 +948,7 @@
             "channel_id": "",
             "channel_name": "",
             "id": 12345,
+            "app_id": "",
             "bot_id": "",
             "indent": false,
             "is_msg_unfurl": false,
@@ -1555,6 +1556,21 @@
                 "optional": false
               }
             ],
+            "preview": {
+              "type": "",
+              "can_remove": false,
+              "title": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "subtitle": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "icon_url": ""
+            },
             "files": [
               {
                 "id": "",
@@ -3868,6 +3884,7 @@
                     "channel_id": "",
                     "channel_name": "",
                     "id": 12345,
+                    "app_id": "",
                     "bot_id": "",
                     "indent": false,
                     "is_msg_unfurl": false,
@@ -4475,6 +4492,21 @@
                         "optional": false
                       }
                     ],
+                    "preview": {
+                      "type": "",
+                      "can_remove": false,
+                      "title": {
+                        "type": "",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "subtitle": {
+                        "type": "",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "icon_url": ""
+                    },
                     "files": [
                       {
                         "id": "",

--- a/json-logs/samples/api/search.all.json
+++ b/json-logs/samples/api/search.all.json
@@ -75,6 +75,7 @@
               "channel_id": "",
               "channel_name": "",
               "id": 12345,
+              "app_id": "",
               "bot_id": "",
               "indent": false,
               "is_msg_unfurl": false,
@@ -298,15 +299,6 @@
                       "initial_users": [
                         ""
                       ]
-                    },
-                    {
-                      "type": "",
-                      "image_url": "",
-                      "alt_text": "",
-                      "fallback": "",
-                      "image_width": 12345,
-                      "image_height": 12345,
-                      "image_bytes": 12345
                     }
                   ],
                   "block_id": "",
@@ -691,6 +683,21 @@
                   "optional": false
                 }
               ],
+              "preview": {
+                "type": "",
+                "can_remove": false,
+                "title": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "subtitle": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "icon_url": ""
+              },
               "files": [
                 {
                   "id": "",
@@ -1637,15 +1644,6 @@
                   "initial_users": [
                     ""
                   ]
-                },
-                {
-                  "type": "",
-                  "image_url": "",
-                  "alt_text": "",
-                  "fallback": "",
-                  "image_width": 12345,
-                  "image_height": 12345,
-                  "image_bytes": 12345
                 }
               ],
               "block_id": "",
@@ -2059,6 +2057,7 @@
               "channel_id": "",
               "channel_name": "",
               "id": 12345,
+              "app_id": "",
               "bot_id": "",
               "indent": false,
               "is_msg_unfurl": false,
@@ -2282,15 +2281,6 @@
                       "initial_users": [
                         ""
                       ]
-                    },
-                    {
-                      "type": "",
-                      "image_url": "",
-                      "alt_text": "",
-                      "fallback": "",
-                      "image_width": 12345,
-                      "image_height": 12345,
-                      "image_bytes": 12345
                     }
                   ],
                   "block_id": "",
@@ -2675,6 +2665,21 @@
                   "optional": false
                 }
               ],
+              "preview": {
+                "type": "",
+                "can_remove": false,
+                "title": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "subtitle": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "icon_url": ""
+              },
               "files": [
                 {
                   "id": "",
@@ -3621,15 +3626,6 @@
                   "initial_users": [
                     ""
                   ]
-                },
-                {
-                  "type": "",
-                  "image_url": "",
-                  "alt_text": "",
-                  "fallback": "",
-                  "image_width": 12345,
-                  "image_height": 12345,
-                  "image_bytes": 12345
                 }
               ],
               "block_id": "",
@@ -4162,15 +4158,6 @@
                 "initial_users": [
                   ""
                 ]
-              },
-              {
-                "type": "",
-                "image_url": "",
-                "alt_text": "",
-                "fallback": "",
-                "image_width": 12345,
-                "image_height": 12345,
-                "image_bytes": 12345
               }
             ],
             "block_id": "",
@@ -4575,6 +4562,7 @@
             "channel_id": "",
             "channel_name": "",
             "id": 12345,
+            "app_id": "",
             "bot_id": "",
             "indent": false,
             "is_msg_unfurl": false,
@@ -4798,15 +4786,6 @@
                     "initial_users": [
                       ""
                     ]
-                  },
-                  {
-                    "type": "",
-                    "image_url": "",
-                    "alt_text": "",
-                    "fallback": "",
-                    "image_width": 12345,
-                    "image_height": 12345,
-                    "image_bytes": 12345
                   }
                 ],
                 "block_id": "",
@@ -5191,6 +5170,21 @@
                 "optional": false
               }
             ],
+            "preview": {
+              "type": "",
+              "can_remove": false,
+              "title": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "subtitle": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "icon_url": ""
+            },
             "files": [
               {
                 "id": "",

--- a/json-logs/samples/api/search.messages.json
+++ b/json-logs/samples/api/search.messages.json
@@ -74,6 +74,7 @@
               "channel_id": "",
               "channel_name": "",
               "id": 12345,
+              "app_id": "",
               "bot_id": "",
               "indent": false,
               "is_msg_unfurl": false,
@@ -297,15 +298,6 @@
                       "initial_users": [
                         ""
                       ]
-                    },
-                    {
-                      "type": "",
-                      "image_url": "",
-                      "alt_text": "",
-                      "fallback": "",
-                      "image_width": 12345,
-                      "image_height": 12345,
-                      "image_bytes": 12345
                     }
                   ],
                   "block_id": "",
@@ -690,6 +682,21 @@
                   "optional": false
                 }
               ],
+              "preview": {
+                "type": "",
+                "can_remove": false,
+                "title": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "subtitle": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "icon_url": ""
+              },
               "files": [
                 {
                   "id": "",
@@ -1636,15 +1643,6 @@
                   "initial_users": [
                     ""
                   ]
-                },
-                {
-                  "type": "",
-                  "image_url": "",
-                  "alt_text": "",
-                  "fallback": "",
-                  "image_width": 12345,
-                  "image_height": 12345,
-                  "image_bytes": 12345
                 }
               ],
               "block_id": "",
@@ -2058,6 +2056,7 @@
               "channel_id": "",
               "channel_name": "",
               "id": 12345,
+              "app_id": "",
               "bot_id": "",
               "indent": false,
               "is_msg_unfurl": false,
@@ -2281,15 +2280,6 @@
                       "initial_users": [
                         ""
                       ]
-                    },
-                    {
-                      "type": "",
-                      "image_url": "",
-                      "alt_text": "",
-                      "fallback": "",
-                      "image_width": 12345,
-                      "image_height": 12345,
-                      "image_bytes": 12345
                     }
                   ],
                   "block_id": "",
@@ -2674,6 +2664,21 @@
                   "optional": false
                 }
               ],
+              "preview": {
+                "type": "",
+                "can_remove": false,
+                "title": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "subtitle": {
+                  "type": "",
+                  "text": "",
+                  "emoji": false
+                },
+                "icon_url": ""
+              },
               "files": [
                 {
                   "id": "",
@@ -3620,15 +3625,6 @@
                   "initial_users": [
                     ""
                   ]
-                },
-                {
-                  "type": "",
-                  "image_url": "",
-                  "alt_text": "",
-                  "fallback": "",
-                  "image_width": 12345,
-                  "image_height": 12345,
-                  "image_bytes": 12345
                 }
               ],
               "block_id": "",
@@ -4161,15 +4157,6 @@
                 "initial_users": [
                   ""
                 ]
-              },
-              {
-                "type": "",
-                "image_url": "",
-                "alt_text": "",
-                "fallback": "",
-                "image_width": 12345,
-                "image_height": 12345,
-                "image_bytes": 12345
               }
             ],
             "block_id": "",
@@ -4574,6 +4561,7 @@
             "channel_id": "",
             "channel_name": "",
             "id": 12345,
+            "app_id": "",
             "bot_id": "",
             "indent": false,
             "is_msg_unfurl": false,
@@ -4797,15 +4785,6 @@
                     "initial_users": [
                       ""
                     ]
-                  },
-                  {
-                    "type": "",
-                    "image_url": "",
-                    "alt_text": "",
-                    "fallback": "",
-                    "image_width": 12345,
-                    "image_height": 12345,
-                    "image_bytes": 12345
                   }
                 ],
                 "block_id": "",
@@ -5190,6 +5169,21 @@
                 "optional": false
               }
             ],
+            "preview": {
+              "type": "",
+              "can_remove": false,
+              "title": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "subtitle": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "icon_url": ""
+            },
             "files": [
               {
                 "id": "",

--- a/json-logs/samples/api/stars.list.json
+++ b/json-logs/samples/api/stars.list.json
@@ -32,6 +32,7 @@
             "channel_id": "",
             "channel_name": "",
             "id": 12345,
+            "app_id": "",
             "bot_id": "",
             "indent": false,
             "is_msg_unfurl": false,
@@ -639,6 +640,21 @@
                 "optional": false
               }
             ],
+            "preview": {
+              "type": "",
+              "can_remove": false,
+              "title": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "subtitle": {
+                "type": "",
+                "text": "",
+                "emoji": false
+              },
+              "icon_url": ""
+            },
             "files": [
               {
                 "id": "",
@@ -3051,6 +3067,7 @@
             "channel_id": "",
             "channel_name": "",
             "id": 123,
+            "app_id": "",
             "bot_id": "",
             "indent": false,
             "is_msg_unfurl": false,
@@ -3128,6 +3145,21 @@
               }
             ],
             "blocks": [],
+            "preview": {
+              "type": "",
+              "can_remove": false,
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "subtitle": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "icon_url": ""
+            },
             "files": [],
             "filename": "",
             "size": 123,

--- a/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
@@ -624,6 +624,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -679,6 +680,21 @@
             "url": ""
           }
         ],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "filename": "",
         "size": 123,
         "mimetype": "",

--- a/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
@@ -596,6 +596,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -651,6 +652,21 @@
             "url": ""
           }
         ],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "filename": "",
         "size": 123,
         "mimetype": "",

--- a/json-logs/samples/events/MessageBotPayload.json
+++ b/json-logs/samples/events/MessageBotPayload.json
@@ -621,6 +621,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -676,6 +677,21 @@
             "url": ""
           }
         ],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "filename": "",
         "size": 123,
         "mimetype": "",

--- a/json-logs/samples/events/MessageChangedPayload.json
+++ b/json-logs/samples/events/MessageChangedPayload.json
@@ -637,6 +637,7 @@
           "channel_id": "",
           "channel_name": "",
           "id": 123,
+          "app_id": "",
           "bot_id": "",
           "indent": false,
           "is_msg_unfurl": false,
@@ -692,6 +693,21 @@
               "url": ""
             }
           ],
+          "preview": {
+            "type": "",
+            "can_remove": false,
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "subtitle": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "icon_url": ""
+          },
           "filename": "",
           "size": 123,
           "mimetype": "",
@@ -1336,6 +1352,7 @@
           "channel_id": "",
           "channel_name": "",
           "id": 123,
+          "app_id": "",
           "bot_id": "",
           "indent": false,
           "is_msg_unfurl": false,
@@ -1391,6 +1408,21 @@
               "url": ""
             }
           ],
+          "preview": {
+            "type": "",
+            "can_remove": false,
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "subtitle": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "icon_url": ""
+          },
           "filename": "",
           "size": 123,
           "mimetype": "",

--- a/json-logs/samples/events/MessageDeletedPayload.json
+++ b/json-logs/samples/events/MessageDeletedPayload.json
@@ -624,6 +624,7 @@
           "channel_id": "",
           "channel_name": "",
           "id": 123,
+          "app_id": "",
           "bot_id": "",
           "indent": false,
           "is_msg_unfurl": false,
@@ -679,6 +680,21 @@
               "url": ""
             }
           ],
+          "preview": {
+            "type": "",
+            "can_remove": false,
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "subtitle": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "icon_url": ""
+          },
           "filename": "",
           "size": 123,
           "mimetype": "",

--- a/json-logs/samples/events/MessageEkmAccessDeniedPayload.json
+++ b/json-logs/samples/events/MessageEkmAccessDeniedPayload.json
@@ -614,6 +614,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -669,6 +670,21 @@
             "url": ""
           }
         ],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "filename": "",
         "size": 123,
         "mimetype": "",

--- a/json-logs/samples/events/MessageFileSharePayload.json
+++ b/json-logs/samples/events/MessageFileSharePayload.json
@@ -611,6 +611,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -666,6 +667,21 @@
             "url": ""
           }
         ],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "filename": "",
         "size": 123,
         "mimetype": "",

--- a/json-logs/samples/events/MessagePayload.json
+++ b/json-logs/samples/events/MessagePayload.json
@@ -628,6 +628,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -683,6 +684,21 @@
             "url": ""
           }
         ],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "filename": "",
         "size": 123,
         "mimetype": "",

--- a/json-logs/samples/events/MessageRepliedPayload.json
+++ b/json-logs/samples/events/MessageRepliedPayload.json
@@ -623,6 +623,7 @@
           "channel_id": "",
           "channel_name": "",
           "id": 123,
+          "app_id": "",
           "bot_id": "",
           "indent": false,
           "is_msg_unfurl": false,
@@ -678,6 +679,21 @@
               "url": ""
             }
           ],
+          "preview": {
+            "type": "",
+            "can_remove": false,
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "subtitle": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "icon_url": ""
+          },
           "filename": "",
           "size": 123,
           "mimetype": "",

--- a/json-logs/samples/events/MessageThreadBroadcastPayload.json
+++ b/json-logs/samples/events/MessageThreadBroadcastPayload.json
@@ -657,6 +657,7 @@
         "channel_id": "",
         "channel_name": "",
         "id": 123,
+        "app_id": "",
         "bot_id": "",
         "indent": false,
         "is_msg_unfurl": false,
@@ -712,6 +713,21 @@
             "url": ""
           }
         ],
+        "preview": {
+          "type": "",
+          "can_remove": false,
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "subtitle": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "icon_url": ""
+        },
         "filename": "",
         "size": 123,
         "mimetype": "",

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -2026,6 +2026,7 @@
       "channel_id": "",
       "channel_name": "",
       "id": 123,
+      "app_id": "",
       "bot_id": "",
       "indent": false,
       "is_msg_unfurl": false,
@@ -2103,6 +2104,21 @@
         }
       ],
       "blocks": [],
+      "preview": {
+        "type": "",
+        "can_remove": false,
+        "title": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "subtitle": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "icon_url": ""
+      },
       "files": [],
       "filename": "",
       "size": 123,

--- a/json-logs/samples/rtm/PinAddedEvent.json
+++ b/json-logs/samples/rtm/PinAddedEvent.json
@@ -2035,6 +2035,7 @@
           "channel_id": "",
           "channel_name": "",
           "id": 123,
+          "app_id": "",
           "bot_id": "",
           "indent": false,
           "is_msg_unfurl": false,
@@ -2112,6 +2113,21 @@
             }
           ],
           "blocks": [],
+          "preview": {
+            "type": "",
+            "can_remove": false,
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "subtitle": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "icon_url": ""
+          },
           "files": [],
           "filename": "",
           "size": 123,

--- a/json-logs/samples/rtm/PinRemovedEvent.json
+++ b/json-logs/samples/rtm/PinRemovedEvent.json
@@ -2035,6 +2035,7 @@
           "channel_id": "",
           "channel_name": "",
           "id": 123,
+          "app_id": "",
           "bot_id": "",
           "indent": false,
           "is_msg_unfurl": false,
@@ -2112,6 +2113,21 @@
             }
           ],
           "blocks": [],
+          "preview": {
+            "type": "",
+            "can_remove": false,
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "subtitle": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "icon_url": ""
+          },
           "files": [],
           "filename": "",
           "size": 123,

--- a/json-logs/samples/rtm/StarAddedEvent.json
+++ b/json-logs/samples/rtm/StarAddedEvent.json
@@ -2035,6 +2035,7 @@
           "channel_id": "",
           "channel_name": "",
           "id": 123,
+          "app_id": "",
           "bot_id": "",
           "indent": false,
           "is_msg_unfurl": false,
@@ -2112,6 +2113,21 @@
             }
           ],
           "blocks": [],
+          "preview": {
+            "type": "",
+            "can_remove": false,
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "subtitle": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "icon_url": ""
+          },
           "files": [],
           "filename": "",
           "size": 123,

--- a/json-logs/samples/rtm/StarRemovedEvent.json
+++ b/json-logs/samples/rtm/StarRemovedEvent.json
@@ -2034,6 +2034,7 @@
           "channel_id": "",
           "channel_name": "",
           "id": 123,
+          "app_id": "",
           "bot_id": "",
           "indent": false,
           "is_msg_unfurl": false,
@@ -2111,6 +2112,21 @@
             }
           ],
           "blocks": [],
+          "preview": {
+            "type": "",
+            "can_remove": false,
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "subtitle": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "icon_url": ""
+          },
           "files": [],
           "filename": "",
           "size": 123,

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUnfurlRequest.java
@@ -4,8 +4,11 @@ import com.slack.api.methods.SlackApiRequest;
 import com.slack.api.model.Action;
 import com.slack.api.model.Field;
 import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.PlainTextObject;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
@@ -15,6 +18,8 @@ import java.util.Map;
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ChatUnfurlRequest implements SlackApiRequest {
 
     /**
@@ -72,6 +77,9 @@ public class ChatUnfurlRequest implements SlackApiRequest {
 
     // https://api.slack.com/docs/message-link-unfurling#unfurls_parameter
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class UnfurlDetail {
 
         private String text;
@@ -93,5 +101,17 @@ public class ChatUnfurlRequest implements SlackApiRequest {
 
         // blocks: https://api.slack.com/reference/block-kit/blocks
         private List<LayoutBlock> blocks;
+        // preview: https://api.slack.com/methods/chat.unfurl#markdown
+        private UnfurlDetailPreview preview;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UnfurlDetailPreview {
+        private PlainTextObject title;
+        private PlainTextObject subtitle;
+        private String iconUrl;
     }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsHistoryResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/conversations/ConversationsHistoryResponse.java
@@ -19,6 +19,7 @@ public class ConversationsHistoryResponse implements SlackApiTextResponse {
     private transient Map<String, List<String>> httpResponseHeaders;
 
     private String latest;
+    private String oldest;
     private List<Message> messages;
     private boolean hasMore;
     private Integer pinCount;

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
@@ -399,7 +399,7 @@ public class chat_Test {
                 .token(botToken)
                 .channel(randomChannelId)
                 .ts(ts)
-                .rawUnfurls(GsonFactory.createSnakeCase().toJson(unfurls))
+                .unfurls(unfurls)
                 .build());
         assertThat(unfurlResponse.getError(), is(nullValue()));
     }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
@@ -402,6 +402,14 @@ public class chat_Test {
                 .unfurls(unfurls)
                 .build());
         assertThat(unfurlResponse.getError(), is(nullValue()));
+
+        // verify if the message can be parsed by the JSON parser
+        ConversationsHistoryResponse history = slack.methods(botToken).conversationsHistory(r -> r
+                .channel(randomChannelId)
+                .oldest(ts)
+                .inclusive(true)
+        );
+        assertThat(history.getError(), is(nullValue()));
     }
 
     // NOTE: You need to add "youtube.com" at

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
@@ -29,8 +29,7 @@ import java.util.concurrent.ExecutionException;
 
 import static com.slack.api.model.Attachments.asAttachments;
 import static com.slack.api.model.Attachments.attachment;
-import static com.slack.api.model.block.Blocks.asBlocks;
-import static com.slack.api.model.block.Blocks.section;
+import static com.slack.api.model.block.Blocks.*;
 import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
 import static com.slack.api.model.block.composition.BlockCompositions.plainText;
 import static com.slack.api.model.block.element.BlockElements.timePicker;
@@ -276,8 +275,8 @@ public class chat_Test {
     @Test
     public void chat_getPermalink_bot_async() throws ExecutionException, InterruptedException {
         ConversationsListResponse channels = slack.methodsAsync().conversationsList(req -> req
-                .token(botToken)
-                .excludeArchived(true))
+                        .token(botToken)
+                        .excludeArchived(true))
                 .get();
         assertThat(channels.getError(), is(nullValue()));
         assertThat(channels.isOk(), is(true));
@@ -285,10 +284,10 @@ public class chat_Test {
         String channelId = channels.getChannels().get(0).getId();
 
         ChatPostMessageResponse postResponse = slack.methodsAsync().chatPostMessage(req -> req
-                .channel(channelId)
-                .token(botToken)
-                .text("Hi, this is a test message from Java Slack SDK's unit tests")
-                .linkNames(true))
+                        .channel(channelId)
+                        .token(botToken)
+                        .text("Hi, this is a test message from Java Slack SDK's unit tests")
+                        .linkNames(true))
                 .get();
         assertThat(postResponse.getError(), is(nullValue()));
         assertThat(postResponse.isOk(), is(true));
@@ -299,9 +298,9 @@ public class chat_Test {
         assertThat(scopes, is(notNullValue()));
 
         ChatGetPermalinkResponse permalink = slack.methodsAsync().chatGetPermalink(req -> req
-                .token(botToken)
-                .channel(channelId)
-                .messageTs(postResponse.getTs()))
+                        .token(botToken)
+                        .channel(channelId)
+                        .messageTs(postResponse.getTs()))
                 .get();
         assertThat(permalink.getError(), is(nullValue()));
         assertThat(permalink.isOk(), is(true));
@@ -356,6 +355,44 @@ public class chat_Test {
         Map<String, ChatUnfurlRequest.UnfurlDetail> unfurls = new HashMap<>();
         ChatUnfurlRequest.UnfurlDetail detail = new ChatUnfurlRequest.UnfurlDetail();
         detail.setText("Every day is the test.");
+        unfurls.put(url, detail);
+
+        ChatUnfurlResponse unfurlResponse = slack.methods().chatUnfurl(ChatUnfurlRequest.builder()
+                .token(botToken)
+                .channel(randomChannelId)
+                .ts(ts)
+                .rawUnfurls(GsonFactory.createSnakeCase().toJson(unfurls))
+                .build());
+        assertThat(unfurlResponse.getError(), is(nullValue()));
+    }
+
+    // NOTE: You need to add "youtube.com" at
+    // Features > Event Subscriptions > App Unfurl Domains
+    @Test
+    public void unfurl_with_preview() throws Exception {
+        loadRandomChannelId();
+
+        String url = "https://www.youtube.com/watch?v=wq1R93UMqlk";
+        ChatPostMessageResponse postResponse = slack.methods().chatPostMessage(ChatPostMessageRequest.builder()
+                .token(userToken)
+                .channel(randomChannelId)
+                .text(url)
+                .unfurlLinks(false)
+                .unfurlMedia(false)
+                .build());
+        assertThat(postResponse.getError(), is(nullValue()));
+        assertThat(postResponse.getMessage().getText(), is("<" + url + ">"));
+
+        String ts = postResponse.getTs();
+        Map<String, ChatUnfurlRequest.UnfurlDetail> unfurls = new HashMap<>();
+        ChatUnfurlRequest.UnfurlDetail detail = new ChatUnfurlRequest.UnfurlDetail();
+        detail.setTitle("The top-level title (set by chat.unfurl)");
+        detail.setPreview(ChatUnfurlRequest.UnfurlDetailPreview.builder()
+                .title(plainText("The title in the preview set (set by chat.unfurl)"))
+                .subtitle(plainText("The subtitle in the preview (set by chat.unfurl)"))
+                .iconUrl("https://assets.brandfolder.com/pmix53-32t4so-a6439g/original/slackbot.png")
+                .build()
+        );
         unfurls.put(url, detail);
 
         ChatUnfurlResponse unfurlResponse = slack.methods().chatUnfurl(ChatUnfurlRequest.builder()
@@ -799,10 +836,10 @@ public class chat_Test {
 
         ChatPostMessageResponse response = slack.methods(botToken).chatPostMessage(r -> r.channel(randomChannelId)
                 .blocks(Arrays.asList(section(s -> s.text(plainText("test")).blockId("b").accessory(
-                        timePicker(t -> t
-                                .actionId("a")
-                                .initialTime("09:10")
-                                .placeholder(plainText("It's time to start!")))
+                                timePicker(t -> t
+                                        .actionId("a")
+                                        .initialTime("09:10")
+                                        .placeholder(plainText("It's time to start!")))
                         ))
                 ))
         );

--- a/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
@@ -119,6 +119,12 @@ public class SampleObjects {
                                     .build(),
                             true
                     )))
+                    .preview(initProperties(Attachment.Preview.builder()
+                            .title(initProperties(PlainTextObject.builder().build()))
+                            .subtitle(initProperties(PlainTextObject.builder().build()))
+                            .build())
+                    )
+                    .metadata(initProperties(new Attachment.AttachmentMetadata()))
                     .mrkdwnIn(Arrays.asList(""))
                     .build())
     );

--- a/slack-api-model/src/main/java/com/slack/api/model/Attachment.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/Attachment.java
@@ -2,6 +2,7 @@ package com.slack.api.model;
 
 import com.google.gson.annotations.SerializedName;
 import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.PlainTextObject;
 import lombok.*;
 
 import java.util.List;
@@ -86,6 +87,7 @@ public class Attachment {
     //"id": 1,
     private Integer id;
 
+    private String appId;
     private String botId;
 
     @Getter(AccessLevel.NONE)
@@ -274,6 +276,20 @@ public class Attachment {
     private List<Action> actions;
 
     private List<LayoutBlock> blocks;
+
+    private Preview preview;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Preview {
+        private String type; // "app"
+        private boolean canRemove;
+        private PlainTextObject title;
+        private PlainTextObject subtitle;
+        private String iconUrl;
+    }
 
     // --------------------------
     // Files


### PR DESCRIPTION
This pull request adds a missing parameter `unfurls[].preview` to the chat.unfurl API method parameters. 

If a developer would like to change an attachment's title (like https://github.com/slackapi/java-slack-sdk/issues/963), setting the top-level title seems to be the way to go. That being said, since the `preview` parameter is mentioned in [the API document](https://api.slack.com/methods/chat.unfurl), we should resolve the lack of the available parameter anyways.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
