### PR TITLE
Fix #967 Attach AppConfig#getSingleTeamToken() to App#client()

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -76,7 +76,9 @@ public class App {
      * The default Web API client without any tokens.
      */
     public MethodsClient getClient() {
-        return config().getSlack().methods();
+        // This token can be null if this app is not for a single workspace
+        String token = config().getSingleTeamBotToken();
+        return config().getSlack().methods(token);
     }
 
     /**

--- a/bolt/src/test/java/test_locally/app/AppConfigTest.java
+++ b/bolt/src/test/java/test_locally/app/AppConfigTest.java
@@ -10,6 +10,7 @@ import com.slack.api.bolt.request.builtin.BlockActionRequest;
 import com.slack.api.bolt.request.builtin.EventRequest;
 import com.slack.api.bolt.request.builtin.SSLCheckRequest;
 import com.slack.api.bolt.response.Response;
+import com.slack.api.methods.response.auth.AuthTestResponse;
 import com.slack.api.model.event.ReactionAddedEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
@@ -24,6 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 @Slf4j
@@ -209,6 +213,34 @@ public class AppConfigTest {
         BlockActionRequest req = new BlockActionRequest(requestBody, blockActionsPayload, new RequestHeaders(rawHeaders));
         Response response = app.run(req);
         assertEquals(400L, response.getStatusCode().longValue());
+    }
+
+    @Test
+    public void singleTeamBotTokenClient() throws Exception {
+        App app = new App(AppConfig.builder()
+                .signingSecret(secret)
+                .singleTeamBotToken(AuthTestMockServer.ValidToken)
+                .slack(slack)
+                .build());
+
+        AuthTestResponse authTest = app.client().authTest(r -> r);
+        assertThat(authTest.getError(), is(nullValue()));
+    }
+
+    @Test
+    public void authorizeClient() throws Exception {
+        App app = new App(AppConfig.builder()
+                .signingSecret(secret)
+                .clientId("111.222")
+                .clientSecret("secret")
+                .slack(slack)
+                .build());
+
+        AuthTestResponse authTest = app.client().authTest(r -> r);
+        assertThat(authTest.getError(), is("invalid_auth_local"));
+
+        authTest = app.client().authTest(r -> r.token(AuthTestMockServer.ValidToken));
+        assertThat(authTest.getError(), is(nullValue()));
     }
 
 }

--- a/bolt/src/test/java/util/AuthTestMockServer.java
+++ b/bolt/src/test/java/util/AuthTestMockServer.java
@@ -26,7 +26,7 @@ public class AuthTestMockServer {
             "}";
     static String ng = "{\n" +
             "  \"ok\": false,\n" +
-            "  \"error\": \"invalid\"\n" +
+            "  \"error\": \"invalid_auth_local\"\n" +
             "}";
 
     @WebServlet


### PR DESCRIPTION
This pull request resolves #967 

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
