### PR TITLE
Ugprade tyrus 1.x to 1.18, lombok patch version, and optional ones

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.25.8.0</http4k.version>
+        <http4k.version>4.25.9.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.version>3.4.1</micronaut.version>
+        <micronaut.version>3.4.2</micronaut.version>
         <micronaut-test-junit5.version>3.1.1</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>2.2.1</micronaut-rxjava3.version>
         <!-- Note that upgrading this library breaks other dependency resolution -->

--- a/bolt-socket-mode/pom.xml
+++ b/bolt-socket-mode/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <javax.websocket-api.version>1.1</javax.websocket-api.version>
         <!-- TODO upgrade to 2.0 in the next major version -->
-        <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
+        <tyrus-standalone-client.version>1.18</tyrus-standalone-client.version>
         <java-websocket.version>1.5.3</java-websocket.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <gson.version>2.9.0</gson.version>
         <kotlin.version>1.6.20</kotlin.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <lombok.version>1.18.22</lombok.version>
+        <lombok.version>1.18.24</lombok.version>
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
         <delombok.output>target/generated-sources-for-javadocs</delombok.output>
 

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -18,7 +18,7 @@
         <!-- TODO upgrade to 2.0 in the next major version
          see https://github.com/slackapi/java-slack-sdk/issues/919#issuecomment-1022822962
          -->
-        <tyrus-standalone-client.version>1.17</tyrus-standalone-client.version>
+        <tyrus-standalone-client.version>1.18</tyrus-standalone-client.version>
         <java-websocket.version>1.5.3</java-websocket.version>
         <jedis.version>4.2.2</jedis.version>
         <jedis-mock.version>1.0.1</jedis-mock.version>


### PR DESCRIPTION
This pull request upgrades the following dependencies:

* tyrus websocket client (the default one) from 1.17 to 1.18
* lombok patch version upgrade (1.18.22 to 1.18.24)
* optional bolt dependencies - http4k, micronaut

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
