### PR TITLE
Add missing properties to ChannelDeletedEvent

### DIFF
--- a/json-logs/samples/events/ChannelDeletedPayload.json
+++ b/json-logs/samples/events/ChannelDeletedPayload.json
@@ -25,6 +25,8 @@
   "event_context": "",
   "event": {
     "type": "channel_deleted",
-    "channel": ""
+    "channel": "",
+    "actor_id": "",
+    "event_ts": ""
   }
 }

--- a/json-logs/samples/rtm/ChannelDeletedEvent.json
+++ b/json-logs/samples/rtm/ChannelDeletedEvent.json
@@ -1,4 +1,6 @@
 {
   "type": "channel_deleted",
-  "channel": ""
+  "channel": "",
+  "actor_id": "",
+  "event_ts": ""
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/event/ChannelDeletedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/ChannelDeletedEvent.java
@@ -15,4 +15,6 @@ public class ChannelDeletedEvent implements Event {
 
     private final String type = TYPE_NAME;
     private String channel;
+    private String actorId;
+    private String eventTs;
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/event/ChannelCreatedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/ChannelCreatedEventTest.java
@@ -22,7 +22,12 @@ public class ChannelCreatedEventTest {
                 "    \"type\": \"channel_created\",\n" +
                 "    \"channel\": {\n" +
                 "        \"id\": \"C024BE91L\",\n" +
+                "        \"is_channel\": true,\n" +
+                "        \"is_org_shared\": false,\n" +
+                "        \"is_shared\": false,\n" +
                 "        \"name\": \"fun\",\n" +
+                "        \"name\": \"fun\",\n" +
+                "        \"name_normalized\": \"fun\",\n" +
                 "        \"created\": 1360782804,\n" +
                 "        \"creator\": \"U024BE7LH\"\n" +
                 "    }\n" +

--- a/slack-api-model/src/test/java/test_locally/api/model/event/ChannelDeletedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/ChannelDeletedEventTest.java
@@ -18,8 +18,10 @@ public class ChannelDeletedEventTest {
     @Test
     public void deserialize() {
         String json = "{\n" +
-                "    \"type\": \"channel_deleted\",\n" +
-                "    \"channel\": \"C024BE91L\"\n" +
+                "  \"channel\": \"C024BE91L\",\n" +
+                "  \"actor_id\": \"U03E94MK0\",\n" +
+                "  \"type\": \"channel_deleted\",\n" +
+                "  \"event_ts\": \"1654751431.047500\"\n" +
                 "}";
         ChannelDeletedEvent event = GsonFactory.createSnakeCase().fromJson(json, ChannelDeletedEvent.class);
         assertThat(event.getType(), is("channel_deleted"));

--- a/slack-api-model/src/test/java/test_locally/api/model/event/ChannelRenameEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/ChannelRenameEventTest.java
@@ -19,18 +19,22 @@ public class ChannelRenameEventTest {
     @Test
     public void deserialize() {
         String json = "{\n" +
-                "    \"type\": \"channel_rename\",\n" +
-                "    \"channel\": {\n" +
-                "        \"id\":\"C02ELGNBH\",\n" +
-                "        \"name\":\"new_name\",\n" +
-                "        \"created\":1360782804\n" +
-                "    }\n" +
+                "  \"type\": \"channel_rename\",\n" +
+                "  \"channel\": {\n" +
+                "    \"id\": \"C02ELGNBH\",\n" +
+                "    \"is_channel\": true,\n" +
+                "    \"is_mpim\": false,\n" +
+                "    \"name\": \"channel-renamed\",\n" +
+                "    \"name_normalized\": \"channel-renamed\",\n" +
+                "    \"created\": 1360782804\n" +
+                "  },\n" +
+                "  \"event_ts\": \"1654751422.047200\"\n" +
                 "}";
         ChannelRenameEvent event = GsonFactory.createSnakeCase().fromJson(json, ChannelRenameEvent.class);
         assertThat(event.getType(), is("channel_rename"));
         assertThat(event.getChannel(), is(notNullValue()));
         assertThat(event.getChannel().getId(), is("C02ELGNBH"));
-        assertThat(event.getChannel().getName(), is("new_name"));
+        assertThat(event.getChannel().getName(), is("channel-renamed"));
         assertThat(event.getChannel().getCreated(), is(1360782804));
     }
 

--- a/slack-api-model/src/test/java/test_locally/api/model/event/GroupDeletedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/GroupDeletedEventTest.java
@@ -18,9 +18,12 @@ public class GroupDeletedEventTest {
     @Test
     public void deserialize() {
         String json = "{\n" +
-                "    \"type\": \"group_deleted\",\n" +
-                "    \"channel\": \"G0QN9RGTT\"\n" +
-                "}\n";
+                "  \"channel\": \"G0QN9RGTT\",\n" +
+                "  \"date_deleted\": 1654752053,\n" +
+                "  \"actor_id\": \"U03E94MK0\",\n" +
+                "  \"type\": \"group_deleted\",\n" +
+                "  \"event_ts\": \"1654752053.000400\"\n" +
+                "}";
         GroupDeletedEvent event = GsonFactory.createSnakeCase().fromJson(json, GroupDeletedEvent.class);
         assertThat(event.getType(), is("group_deleted"));
         assertThat(event.getChannel(), is("G0QN9RGTT"));

--- a/slack-api-model/src/test/java/test_locally/api/model/event/GroupRenameEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/GroupRenameEventTest.java
@@ -18,12 +18,16 @@ public class GroupRenameEventTest {
     @Test
     public void deserialize() {
         String json = "{\n" +
-                "    \"type\": \"group_rename\",\n" +
-                "    \"channel\": {\n" +
-                "        \"id\":\"G02ELGNBH\",\n" +
-                "        \"name\":\"new_name\",\n" +
-                "        \"created\":1360782804\n" +
-                "    }\n" +
+                "  \"type\": \"group_rename\",\n" +
+                "  \"channel\": {\n" +
+                "    \"id\": \"G02ELGNBH\",\n" +
+                "    \"is_channel\": true,\n" +
+                "    \"is_mpim\": false,\n" +
+                "    \"name\": \"new_name\",\n" +
+                "    \"name_normalized\": \"new_name\",\n" +
+                "    \"created\": 1360782804\n" +
+                "  },\n" +
+                "  \"event_ts\": \"1654751965.000300\"\n" +
                 "}";
         GroupRenameEvent event = GsonFactory.createSnakeCase().fromJson(json, GroupRenameEvent.class);
         assertThat(event.getType(), is("group_rename"));


### PR DESCRIPTION
This pull request fixes the incomplete ChannelDeletedEvent data class definition.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
