### PR TITLE
Add cursor parameter to reactions.list API method

### DIFF
--- a/json-logs/samples/api/reactions.list.json
+++ b/json-logs/samples/api/reactions.list.json
@@ -1061,8 +1061,7 @@
         "reply_users_count": 12345,
         "latest_reply": "0000000000.000000",
         "reply_users": [
-          "B00000000",
-          "U00000000"
+          "B00000000"
         ],
         "subscribed": false,
         "subtype": "",
@@ -1082,5 +1081,8 @@
   },
   "error": "",
   "needed": "",
-  "provided": ""
+  "provided": "",
+  "response_metadata": {
+    "next_cursor": ""
+  }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -2043,6 +2043,7 @@ public class RequestFormBuilder {
         setIfNotNull("count", req.getCount(), form);
         setIfNotNull("page", req.getPage(), form);
         setIfNotNull("limit", req.getLimit(), form);
+        setIfNotNull("cursor", req.getCursor(), form);
         setIfNotNull("team_id", req.getTeamId(), form);
         return form;
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/reactions/ReactionsListRequest.java
@@ -32,6 +32,8 @@ public class ReactionsListRequest implements SlackApiRequest {
 
     private Integer limit;
 
+    private String cursor;
+
     /**
      * Required for org-wide apps.
      */

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsListResponse.java
@@ -20,7 +20,8 @@ public class ReactionsListResponse implements SlackApiTextResponse {
     private transient Map<String, List<String>> httpResponseHeaders;
 
     private List<Item> items;
-    private Paging paging;
+    private Paging paging; // for "count" and "page"
+    private ResponseMetadata responseMetadata; // only when "limit" parameter is given
 
     @Data
     public static class Item {

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/reactions_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/reactions_Test.java
@@ -196,4 +196,28 @@ public class reactions_Test {
         assertThat(response.getItems(), is(notNullValue()));
     }
 
+    @Test
+    public void paginationWithLimitAndCursor() throws IOException, SlackApiException {
+        String user = slack.methods().usersList(r -> r.token(botToken))
+                .getMembers().get(0).getId();
+
+        ReactionsListResponse pageOne = slack.methods().reactionsList(r -> r
+                .token(botToken)
+                .user(user)
+                .limit(1)
+        );
+        assertThat(pageOne.getError(), is(nullValue()));
+        assertThat(pageOne.getResponseMetadata().getNextCursor(), is(notNullValue()));
+
+        ReactionsListResponse pageTwo = slack.methods().reactionsList(r -> r
+                .token(botToken)
+                .user(user)
+                .cursor(pageOne.getResponseMetadata().getNextCursor())
+                .limit(1)
+        );
+        assertThat(pageTwo.getError(), is(nullValue()));
+        assertThat(pageTwo.getResponseMetadata().getNextCursor(),
+                is(not(pageOne.getResponseMetadata().getNextCursor())));
+    }
+
 }


### PR DESCRIPTION
This pull request fixes a long-lived bug in reactions.list API support. While an API caller passes count / page, the paging data can be returned, response_metadata.next_cursor can be returned when passing limit parameter instead. This pull request adds response_metadata to the response data class plus add the missing cursor parameter to the request data class.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
