### PR TITLE
Fix a bug where DetailedLoggingListener does not print text request body

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -3173,7 +3173,7 @@ public class MethodsClientImpl implements MethodsClient {
                 metricsDatastore.addToLastMinuteRequests(executorName, teamId, methodName, System.currentTimeMillis());
             }
             Response response = runPostMultipart(form, methodName, token);
-            T apiResponse = parseJsonResponseAndRunListeners(teamId, methodName, response, clazz);
+            T apiResponse = parseJsonResponseAndRunListeners(teamId, methodName, response, clazz, true);
             return apiResponse;
 
         } catch (IOException e) {
@@ -3221,7 +3221,18 @@ public class MethodsClientImpl implements MethodsClient {
             String teamId,
             String methodName,
             Response response,
-            Class<T> clazz) throws IOException, SlackApiException {
+            Class<T> clazz
+    ) throws IOException, SlackApiException {
+        return parseJsonResponseAndRunListeners(teamId, methodName, response, clazz, false);
+    }
+
+    <T extends SlackApiTextResponse> T parseJsonResponseAndRunListeners(
+            String teamId,
+            String methodName,
+            Response response,
+            Class<T> clazz,
+            boolean isRequestBodyBinary
+            ) throws IOException, SlackApiException {
         String body = response.body().string();
         if (response.isSuccessful()) {
             try {
@@ -3236,7 +3247,7 @@ public class MethodsClientImpl implements MethodsClient {
                 apiResponse.setHttpResponseHeaders(toLowerCasedKeyMap(response.headers()));
                 return apiResponse;
             } finally {
-                slackHttpClient.runHttpResponseListeners(response, body);
+                slackHttpClient.runHttpResponseListeners(response, body, isRequestBodyBinary);
             }
         } else {
             throw new SlackApiException(slackHttpClient.getConfig(), response, body);

--- a/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
@@ -253,7 +253,11 @@ public class SlackHttpClient implements AutoCloseable {
     }
 
     public void runHttpResponseListeners(Response response, String body) {
-        HttpResponseListener.State state = new HttpResponseListener.State(config, response, body);
+        runHttpResponseListeners(response, body, false);
+    }
+
+    public void runHttpResponseListeners(Response response, String body, boolean isRequestBodyBinary) {
+        HttpResponseListener.State state = new HttpResponseListener.State(config, response, body, isRequestBodyBinary);
         for (HttpResponseListener responseListener : config.getHttpClientResponseHandlers()) {
             responseListener.accept(state);
         }

--- a/slack-api-client/src/main/java/com/slack/api/util/http/listener/DetailedLoggingListener.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/listener/DetailedLoggingListener.java
@@ -47,14 +47,9 @@ public class DetailedLoggingListener extends HttpResponseListener {
 
             String textRequestBody = null;
             try {
-                String contentType = "";
-                if (requestBodyObj.contentType() != null
-                    && requestBodyObj.contentType().type() != null
-                ) {
-                    contentType = requestBodyObj.contentType().type().toLowerCase(Locale.ENGLISH);
-                }
-                if (contentType.equals("application/json") ||
-                        contentType.equals("text/html")) {
+                if (state.isRequestBodyBinary()) {
+                    textRequestBody = "(binary)";
+                } else {
                     textRequestBody = requestBody.buffer().readUtf8();
                     if (!state.getConfig().isLibraryMaintainerMode()) {
                         if (textRequestBody.contains("refresh_token=")) {
@@ -62,8 +57,6 @@ public class DetailedLoggingListener extends HttpResponseListener {
                                     "refresh_token=[^\\&]+", "refresh_token=(redacted)");
                         }
                     }
-                } else {
-                    textRequestBody = "(binary)";
                 }
             } catch (Exception e) {
                 log.debug("Failed to read request body because {}, error: {}", e.getMessage(), e.getClass().getCanonicalName());

--- a/slack-api-client/src/main/java/com/slack/api/util/http/listener/HttpResponseListener.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/listener/HttpResponseListener.java
@@ -18,9 +18,14 @@ public abstract class HttpResponseListener implements Consumer<HttpResponseListe
     @AllArgsConstructor
     @Data
     public static class State {
+        public State(SlackConfig config, Response response, String parsedResponseBody) {
+            this(config, response, parsedResponseBody, false);
+        }
+
         private SlackConfig config;
         private Response response;
         private String parsedResponseBody;
+        private boolean requestBodyBinary;
     }
 
 }


### PR DESCRIPTION
This pull request fixes a bug on DetailedLoggingListener behavior. If I remember correctly, the logging listener used to work properly with older versions of okhttp but not it sometimes does not work. This pull request refactors the internals to make it function again. This PR does not bring any breaking changes to existing public classes / interfaces. Thus, we can ship it in the next patch version.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
