### PR TITLE
Add unfurling capabilities to Webhook payload

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/webhook/Payload.java
+++ b/slack-api-model/src/main/java/com/slack/api/webhook/Payload.java
@@ -77,4 +77,14 @@ public class Payload {
      * An array of legacy secondary attachments. We recommend you use {@link #blocks} instead.
      */
     private List<Attachment> attachments;
+    
+     /**
+     * Pass true to enable unfurling of primarily text-based content.
+     */
+    private boolean unfurlLinks;
+
+    /**
+     * Pass false to disable unfurling of media content.
+     */
+    private boolean unfurlMedia;
 }

--- a/slack-api-model/src/main/java/com/slack/api/webhook/Payload.java
+++ b/slack-api-model/src/main/java/com/slack/api/webhook/Payload.java
@@ -81,10 +81,10 @@ public class Payload {
      /**
      * Pass true to enable unfurling of primarily text-based content.
      */
-    private boolean unfurlLinks;
+    private Boolean unfurlLinks;
 
     /**
      * Pass false to disable unfurling of media content.
      */
-    private boolean unfurlMedia;
+    private Boolean unfurlMedia;
 }


### PR DESCRIPTION
Sending a chat message with `ChatScheduleMessageRequest` has both `unfurlLinks` and `unfurlMedia`, but `com.slack.api.webhook.Payload` does not. Testing the API manually, it looks that Slack does abide the `unfurl_links` and `unfurl_media` in the hooks URL

### Misc
PR # 1000 🎉 

### Category

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.