### PR TITLE
Fix #992 Automatically resolve the proxy URL by HTTP_PROXY env variable

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
@@ -172,7 +172,7 @@ public class SlackConfig {
     private String proxyUrl = initProxyUrl();
 
     // This method runs only once when instantiating this object.
-    // If you want to reflect dynamically updated system properties,
+    // If you want to reflect dynamically updated system properties or env variables,
     // create a new instance by invoking the default constructor.
     private static String initProxyUrl() {
         String host = System.getProperty("http.proxyHost");
@@ -193,6 +193,14 @@ public class SlackConfig {
             } else {
                 return "http://" + host;
             }
+        }
+        String httpsEnvProxyUrl = System.getenv("HTTPS_PROXY");
+        if (httpsEnvProxyUrl != null && !httpsEnvProxyUrl.trim().isEmpty()) {
+            return httpsEnvProxyUrl;
+        }
+        String httpEnvProxyUrl = System.getenv("HTTP_PROXY");
+        if (httpEnvProxyUrl != null && !httpEnvProxyUrl.trim().isEmpty()) {
+            return httpEnvProxyUrl;
         }
         return null;
     }


### PR DESCRIPTION
This pull request resolves #992 by adding HTTP_PROXY / HTTPS_PROXY env variable supports to all the API clients in slack-api-client artifact. These env variables are widely accepted in the industry, so that I believe adding this to the initialization process should be a great addition.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
