### PR TITLE
Arraylist<LayoutBlock> GSON anonymous inner class initialization bug

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -2496,6 +2496,8 @@ public class RequestFormBuilder {
     private static final String FALLBACK_WARN_MESSAGE_TEMPLATE =
             "Additionally, the attachment-level `fallback` argument is missing in the request payload for a {} call - To avoid this warning, it is recommended to always provide a top-level `text` argument when posting a message. Alternatively, you can provide an attachment-level `fallback` argument, though this is now considered a legacy field (see https://api.slack.com/reference/messaging/attachments#legacy_fields for more details).";
 
+    private static final String GSON_ANONYM_INNER_CLASS_INIT_OUTPUT = "null";
+
     private static void warnIfAttachmentWithoutFallbackDetected(String endpointName, List<Attachment> attachments) {
         boolean fallbackMissing = false;
         for (Attachment a : attachments) {
@@ -2556,7 +2558,7 @@ public class RequestFormBuilder {
 
     private static String getJsonWithGsonAnonymInnerClassHandling(List<LayoutBlock> blocks){
         String json = GSON.toJson(blocks);
-        if ("null".equals(json)){
+        if (GSON_ANONYM_INNER_CLASS_INIT_OUTPUT.equals(json)){
             return GSON.toJson(new ArrayList<>(blocks));
         }
         return json;

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -108,6 +108,7 @@ import com.slack.api.methods.request.workflows.WorkflowsStepFailedRequest;
 import com.slack.api.methods.request.workflows.WorkflowsUpdateStepRequest;
 import com.slack.api.model.Attachment;
 import com.slack.api.model.ConversationType;
+import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.util.json.GsonFactory;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.FormBody;
@@ -1134,7 +1135,7 @@ public class RequestFormBuilder {
         if (req.getBlocksAsString() != null) {
             form.add("blocks", req.getBlocksAsString());
         } else if (req.getBlocks() != null) {
-            String json = GSON.toJson(req.getBlocks());
+            String json = getJsonWithGsonAnonymInnerClassHandling(req.getBlocks());
             form.add("blocks", json);
         }
         if (req.getBlocksAsString() != null && req.getBlocks() != null) {
@@ -1183,7 +1184,7 @@ public class RequestFormBuilder {
         if (req.getBlocksAsString() != null) {
             form.add("blocks", req.getBlocksAsString());
         } else if (req.getBlocks() != null) {
-            String json = GSON.toJson(req.getBlocks());
+            String json = getJsonWithGsonAnonymInnerClassHandling(req.getBlocks());
             form.add("blocks", json);
         }
         if (req.getBlocksAsString() != null && req.getBlocks() != null) {
@@ -1229,7 +1230,7 @@ public class RequestFormBuilder {
         if (req.getBlocksAsString() != null) {
             form.add("blocks", req.getBlocksAsString());
         } else if (req.getBlocks() != null) {
-            String json = GSON.toJson(req.getBlocks());
+            String json = getJsonWithGsonAnonymInnerClassHandling(req.getBlocks());
             form.add("blocks", json);
         }
         if (req.getBlocksAsString() != null && req.getBlocks() != null) {
@@ -1279,7 +1280,7 @@ public class RequestFormBuilder {
         if (req.getBlocksAsString() != null) {
             form.add("blocks", req.getBlocksAsString());
         } else if (req.getBlocks() != null) {
-            String json = GSON.toJson(req.getBlocks());
+            String json = getJsonWithGsonAnonymInnerClassHandling(req.getBlocks());
             form.add("blocks", json);
         }
         if (req.getBlocksAsString() != null && req.getBlocks() != null) {
@@ -2551,6 +2552,14 @@ public class RequestFormBuilder {
                 form.addFormDataPart(name, String.valueOf(value));
             }
         }
+    }
+
+    private static String getJsonWithGsonAnonymInnerClassHandling(List<LayoutBlock> blocks){
+        String json = GSON.toJson(blocks);
+        if ("null".equals(json)){
+            return GSON.toJson(new ArrayList<>(blocks));
+        }
+        return json;
     }
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -116,9 +116,7 @@ import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 import static java.util.stream.Collectors.joining;
 
@@ -923,7 +921,7 @@ public class RequestFormBuilder {
         setIfNotNull("external_display_id", req.getExternalDisplayId(), form);
         setIfNotNull("title", req.getTitle(), form);
         if (req.getUsers() != null && req.getUsers().size() > 0) {
-            String usersJson = GSON.toJson(req.getUsers());
+            String usersJson = getJsonWithGsonAnonymInnerClassHandling(req.getUsers());
             setIfNotNull("users", usersJson, form);
         }
         return form;
@@ -955,7 +953,7 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("id", req.getId(), form);
         if (req.getUsers() != null && req.getUsers().size() > 0) {
-            String usersJson = GSON.toJson(req.getUsers());
+            String usersJson = getJsonWithGsonAnonymInnerClassHandling(req.getUsers());
             setIfNotNull("users", usersJson, form);
         }
         return form;
@@ -965,7 +963,7 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("id", req.getId(), form);
         if (req.getUsers() != null && req.getUsers().size() > 0) {
-            String usersJson = GSON.toJson(req.getUsers());
+            String usersJson = getJsonWithGsonAnonymInnerClassHandling(req.getUsers());
             setIfNotNull("users", usersJson, form);
         }
         return form;
@@ -1145,7 +1143,7 @@ public class RequestFormBuilder {
         if (req.getAttachmentsAsString() != null) {
             form.add("attachments", req.getAttachmentsAsString());
         } else if (req.getAttachments() != null) {
-            String json = GSON.toJson(req.getAttachments());
+            String json = getJsonWithGsonAnonymInnerClassHandling(req.getAttachments());
             form.add("attachments", json);
         }
         setIfNotNull("link_names", req.isLinkNames(), form);
@@ -1194,7 +1192,7 @@ public class RequestFormBuilder {
         if (req.getAttachmentsAsString() != null) {
             form.add("attachments", req.getAttachmentsAsString());
         } else if (req.getAttachments() != null) {
-            String json = GSON.toJson(req.getAttachments());
+            String json = getJsonWithGsonAnonymInnerClassHandling(req.getAttachments());
             form.add("attachments", json);
         }
         setIfNotNull("thread_ts", req.getThreadTs(), form);
@@ -1240,7 +1238,7 @@ public class RequestFormBuilder {
         if (req.getAttachmentsAsString() != null) {
             form.add("attachments", req.getAttachmentsAsString());
         } else if (req.getAttachments() != null) {
-            String json = GSON.toJson(req.getAttachments());
+            String json = getJsonWithGsonAnonymInnerClassHandling(req.getAttachments());
             form.add("attachments", json);
         }
         setIfNotNull("unfurl_links", req.isUnfurlLinks(), form);
@@ -1290,7 +1288,7 @@ public class RequestFormBuilder {
         if (req.getAttachmentsAsString() != null) {
             form.add("attachments", req.getAttachmentsAsString());
         } else if (req.getAttachments() != null) {
-            String json = GSON.toJson(req.getAttachments());
+            String json = getJsonWithGsonAnonymInnerClassHandling(req.getAttachments());
             form.add("attachments", json);
         }
         setIfNotNull("as_user", req.isAsUser(), form);
@@ -1304,8 +1302,8 @@ public class RequestFormBuilder {
         setIfNotNull("channel", req.getChannel(), form);
         if (req.getRawUnfurls() != null) {
             setIfNotNull("unfurls", req.getRawUnfurls(), form);
-        } else {
-            String json = GSON.toJson(req.getUnfurls());
+        } else if (req.getUnfurls() != null) {
+            String json = getJsonWithGsonAnonymInnerClassHandling(req.getUnfurls());
             setIfNotNull("unfurls", json, form);
         }
         setIfNotNull("user_auth_required", req.isUserAuthRequired(), form);
@@ -1313,7 +1311,7 @@ public class RequestFormBuilder {
         if (req.getRawUserAuthBlocks() != null) {
             setIfNotNull("user_auth_blocks", req.getRawUserAuthBlocks(), form);
         } else if (req.getUserAuthBlocks() != null) {
-            String json = GSON.toJson(req.getUserAuthBlocks());
+            String json = getJsonWithGsonAnonymInnerClassHandling(req.getUserAuthBlocks());
             setIfNotNull("user_auth_blocks", json, form);
         }
         setIfNotNull("user_auth_url", req.getUserAuthUrl(), form);
@@ -2456,7 +2454,9 @@ public class RequestFormBuilder {
         if (req.getOutputsAsString() != null) {
             setIfNotNull("outputs", req.getOutputsAsString(), form);
         } else if (req.getOutputs() != null) {
-            setIfNotNull("outputs", GSON.toJson(req.getOutputs()), form);
+            setIfNotNull("outputs",
+                    getJsonWithGsonAnonymInnerClassHandling(req.getOutputs()),
+                    form);
         }
         return form;
     }
@@ -2464,7 +2464,9 @@ public class RequestFormBuilder {
     public static FormBody.Builder toForm(WorkflowsStepFailedRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("workflow_step_execute_id", req.getWorkflowStepExecuteId(), form);
-        setIfNotNull("error", GSON.toJson(req.getError()), form);
+        setIfNotNull("error",
+                getJsonWithGsonAnonymInnerClassHandling(req.getError()),
+                form);
         return form;
     }
 
@@ -2476,12 +2478,16 @@ public class RequestFormBuilder {
         if (req.getOutputsAsString() != null) {
             setIfNotNull("inputs", req.getInputsAsString(), form);
         } else if (req.getOutputs() != null) {
-            setIfNotNull("inputs", GSON.toJson(req.getInputs()), form);
+            setIfNotNull("inputs",
+                    getJsonWithGsonAnonymInnerClassHandling(req.getInputs()),
+                    form);
         }
         if (req.getOutputsAsString() != null) {
             setIfNotNull("outputs", req.getOutputsAsString(), form);
         } else if (req.getOutputs() != null) {
-            setIfNotNull("outputs", GSON.toJson(req.getOutputs()), form);
+            setIfNotNull("outputs",
+                    getJsonWithGsonAnonymInnerClassHandling(req.getOutputs()),
+                    form);
         }
         return form;
     }
@@ -2556,12 +2562,16 @@ public class RequestFormBuilder {
         }
     }
 
-    private static String getJsonWithGsonAnonymInnerClassHandling(List<LayoutBlock> blocks){
-        String json = GSON.toJson(blocks);
-        if (GSON_ANONYM_INNER_CLASS_INIT_OUTPUT.equals(json)){
-            return GSON.toJson(new ArrayList<>(blocks));
-        }
-        return json;
+    // Workarounds to solve GSON not handling anonymous inner class object initialization
+    // https://github.com/google/gson/issues/2023
+    private static <T> String getJsonWithGsonAnonymInnerClassHandling(Map<String, T> stringTMap){
+        String json = GSON.toJson(stringTMap);
+        return GSON_ANONYM_INNER_CLASS_INIT_OUTPUT.equals(json) ? GSON.toJson(new HashMap<>(stringTMap)) : json;
+    }
+
+    private static <T> String getJsonWithGsonAnonymInnerClassHandling(List<T> tList){
+        String json = GSON.toJson(tList);
+        return GSON_ANONYM_INNER_CLASS_INIT_OUTPUT.equals(json) ? GSON.toJson(new ArrayList<>(tList)) : json;
     }
 
 }

--- a/slack-api-client/src/test/java/test_locally/api/methods/RequestFormBuilderTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/RequestFormBuilderTest.java
@@ -1,23 +1,170 @@
 package test_locally.api.methods;
 
 import com.slack.api.methods.RequestFormBuilder;
+import com.slack.api.methods.request.calls.CallsAddRequest;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.request.chat.ChatUnfurlRequest;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.CallParticipant;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.FormBody;
 import org.junit.Test;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RequestFormBuilderTest {
 
+
+    @Test
+    public void testBlocksJsonSerialization() {
+        // GIVEN
+        List<LayoutBlock> blocks = new ArrayList<>();
+        blocks.add(MyTestBlock.builder().build());
+
+        ChatPostMessageRequest chatPostMessageRequest = ChatPostMessageRequest.builder().build();
+        chatPostMessageRequest.setBlocks(blocks);
+
+        // WHEN
+        FormBody form = RequestFormBuilder.toForm(chatPostMessageRequest).build();
+
+        // THEN
+        final int blocksIndexInForm = 2;
+        assertThat(form.name(blocksIndexInForm), is("blocks"));
+        assertThat(form.value(blocksIndexInForm), is("[{\"type\":\"myTestBlock\"}]"));
+    }
+
+    @Test
+    public void testEmptyListJsonSerialization() {
+        // GIVEN
+        List<LayoutBlock> blocks = new ArrayList<>();
+
+        ChatPostMessageRequest chatPostMessageRequest = ChatPostMessageRequest.builder().build();
+        chatPostMessageRequest.setBlocks(blocks);
+
+        // WHEN
+        FormBody form = RequestFormBuilder.toForm(chatPostMessageRequest).build();
+
+        // THEN
+        final int blocksIndexInForm = 2;
+        assertThat(form.name(blocksIndexInForm), is("blocks"));
+        assertThat(form.value(blocksIndexInForm), is("[]"));
+    }
+
+    @Test
+    public void testBlocksJsonSerializationWithInnerClassInit() {
+        // GIVEN
+        ChatPostMessageRequest chatPostMessageRequest = ChatPostMessageRequest.builder().build();
+        chatPostMessageRequest.setBlocks(new ArrayList<LayoutBlock>() {{
+            add(MyTestBlock.builder().build());
+        }});
+
+        // WHEN
+        FormBody form = RequestFormBuilder.toForm(chatPostMessageRequest).build();
+
+        // THEN
+        final int blocksIndexInForm = 2;
+        assertThat(form.name(blocksIndexInForm), is("blocks"));
+        assertThat(form.value(blocksIndexInForm), is("[{\"type\":\"myTestBlock\"}]"));
+    }
+
+    @Test
+    public void testAttachmentsJsonSerializationWithInnerClassInit() {
+        // GIVEN
+        ChatPostMessageRequest chatPostMessageRequest = ChatPostMessageRequest.builder().build();
+        chatPostMessageRequest.setAttachments(new ArrayList<Attachment>() {{
+            add(Attachment.builder().build());
+        }});
+
+        // WHEN
+        FormBody form = RequestFormBuilder.toForm(chatPostMessageRequest).build();
+
+        // THEN
+        final int attachmentIndexInForm = 2;
+        assertThat(form.name(attachmentIndexInForm), is("attachments"));
+        assertThat(form.value(attachmentIndexInForm), is("[{}]"));
+    }
+
+    @Test
+    public void testUserAuthBlocksJsonSerializationWithInnerClassInit() {
+        // GIVEN
+        ChatUnfurlRequest chatUnfurlRequest = ChatUnfurlRequest.builder().build();
+        chatUnfurlRequest.setUserAuthBlocks(new ArrayList<LayoutBlock>() {{
+            add(MyTestBlock.builder().build());
+        }});
+
+        // WHEN
+        FormBody form = RequestFormBuilder.toForm(chatUnfurlRequest).build();
+
+        // THEN
+        final int userAuthBlocksIndexInFrom = 1;
+        assertThat(form.name(userAuthBlocksIndexInFrom), is("user_auth_blocks"));
+        assertThat(form.value(userAuthBlocksIndexInFrom), is("[{\"type\":\"myTestBlock\"}]"));
+    }
+
+    @Test
+    public void testUsersJsonSerializationWithInnerClassInit() {
+        // GIVEN
+        CallParticipant participant = CallParticipant.builder().build();
+        participant.setDisplayName("Bill");
+
+        CallsAddRequest callsAddRequest = CallsAddRequest.builder().build();
+        callsAddRequest.setUsers(new ArrayList<CallParticipant>() {{
+            add(participant);
+        }});
+
+        // WHEN
+        FormBody form = RequestFormBuilder.toForm(callsAddRequest).build();
+
+        // THEN
+        final int usersIndexInFrom = 0;
+        assertThat(form.name(usersIndexInFrom), is("users"));
+        assertThat(form.value(usersIndexInFrom), is("[{\"display_name\":\"Bill\"}]"));
+    }
+
+    @Test
+    public void testUnfurlsJsonSerializationWithInnerClassInit() {
+        // GIVEN
+        ChatUnfurlRequest chatUnfurlRequest = ChatUnfurlRequest.builder().build();
+        chatUnfurlRequest.setUnfurls(new HashMap<String, ChatUnfurlRequest.UnfurlDetail>() {{
+            put("key", ChatUnfurlRequest.UnfurlDetail.builder().build());
+        }});
+
+        // WHEN
+        FormBody form = RequestFormBuilder.toForm(chatUnfurlRequest).build();
+
+        // THEN
+        final int userAuthBlocksIndexInFrom = 0;
+        assertThat(form.name(userAuthBlocksIndexInFrom), is("unfurls"));
+        assertThat(form.value(userAuthBlocksIndexInFrom), is("{\"key\":{}}"));
+    }
+
+    @Test
+    public void testUnfurlsJsonSerialization() {
+        // GIVEN
+        Map<String, ChatUnfurlRequest.UnfurlDetail> unfurls = new HashMap<>();
+        unfurls.put("key", ChatUnfurlRequest.UnfurlDetail.builder().build());
+
+        ChatUnfurlRequest chatUnfurlRequest = ChatUnfurlRequest.builder().build();
+        chatUnfurlRequest.setUnfurls(unfurls);
+
+        // WHEN
+        FormBody form = RequestFormBuilder.toForm(chatUnfurlRequest).build();
+
+        // THEN
+        final int userAuthBlocksIndexInFrom = 0;
+        assertThat(form.name(userAuthBlocksIndexInFrom), is("unfurls"));
+        assertThat(form.value(userAuthBlocksIndexInFrom), is("{\"key\":{}}"));
+    }
 
     @Data
     @Builder
@@ -27,55 +174,5 @@ public class RequestFormBuilderTest {
         public static final String TYPE = "myTestBlock";
         private final String type = TYPE;
         private String blockId;
-    }
-
-    @Test
-    public void testGetJsonWithGsonAnonymInnerClassHandling() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        // SETUP
-        Method method = RequestFormBuilder.class.getDeclaredMethod("getJsonWithGsonAnonymInnerClassHandling", List.class);
-        method.setAccessible(true);
-
-        List<LayoutBlock> blocks = new ArrayList<LayoutBlock>(){{
-            add(MyTestBlock.builder().build());
-            add(MyTestBlock.builder().build());
-        }};
-
-        // EXECUTE
-        String json = (String) method.invoke(null, blocks);
-
-        // VALIDATE
-        assertThat(json, is("[{\"type\":\"myTestBlock\"},{\"type\":\"myTestBlock\"}]"));
-    }
-
-    @Test
-    public void testTraditionalGetJsonWithGsonAnonymInnerClassHandling() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        // SETUP
-        Method method = RequestFormBuilder.class.getDeclaredMethod("getJsonWithGsonAnonymInnerClassHandling", List.class);
-        method.setAccessible(true);
-
-        List<LayoutBlock> blocks = new ArrayList<LayoutBlock>();
-        blocks.add(MyTestBlock.builder().build());
-        blocks.add(MyTestBlock.builder().build());
-
-        // EXECUTE
-        String json = (String) method.invoke(null, blocks);
-
-        // VALIDATE
-        assertThat(json, is("[{\"type\":\"myTestBlock\"},{\"type\":\"myTestBlock\"}]"));
-    }
-
-    @Test
-    public void testEmptyGetJsonWithGsonAnonymInnerClassHandling() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        // SETUP
-        Method method = RequestFormBuilder.class.getDeclaredMethod("getJsonWithGsonAnonymInnerClassHandling", List.class);
-        method.setAccessible(true);
-
-        List<LayoutBlock> blocks = new ArrayList<>();
-
-        // EXECUTE
-        String json = (String) method.invoke(null, blocks);
-
-        // VALIDATE
-        assertThat(json, is("[]"));
     }
 }

--- a/slack-api-client/src/test/java/test_locally/api/methods/RequestFormBuilderTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/RequestFormBuilderTest.java
@@ -1,0 +1,67 @@
+package test_locally.api.methods;
+
+import com.slack.api.methods.RequestFormBuilder;
+import com.slack.api.model.block.LayoutBlock;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.slack.api.model.block.Blocks.divider;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RequestFormBuilderTest {
+
+    @Test
+    public void testGetJsonWithGsonAnonymInnerClassHandling() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        // SETUP
+        Method method = RequestFormBuilder.class.getDeclaredMethod("getJsonWithGsonAnonymInnerClassHandling", List.class);
+        method.setAccessible(true);
+
+        List<LayoutBlock> blocks = new ArrayList<LayoutBlock>(){{
+            add(divider());
+            add(divider());
+        }};
+
+        // EXECUTE
+        String json = (String) method.invoke(null, blocks);
+
+        // VALIDATE
+        assertThat(json, is("[{\"type\":\"divider\"},{\"type\":\"divider\"}]"));
+    }
+
+    @Test
+    public void testTraditionalGetJsonWithGsonAnonymInnerClassHandling() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        // SETUP
+        Method method = RequestFormBuilder.class.getDeclaredMethod("getJsonWithGsonAnonymInnerClassHandling", List.class);
+        method.setAccessible(true);
+
+        List<LayoutBlock> blocks = new ArrayList<LayoutBlock>();
+        blocks.add(divider());
+        blocks.add(divider());
+
+        // EXECUTE
+        String json = (String) method.invoke(null, blocks);
+
+        // VALIDATE
+        assertThat(json, is("[{\"type\":\"divider\"},{\"type\":\"divider\"}]"));
+    }
+
+    @Test
+    public void testEmptyGetJsonWithGsonAnonymInnerClassHandling() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        // SETUP
+        Method method = RequestFormBuilder.class.getDeclaredMethod("getJsonWithGsonAnonymInnerClassHandling", List.class);
+        method.setAccessible(true);
+
+        List<LayoutBlock> blocks = new ArrayList<>();
+
+        // EXECUTE
+        String json = (String) method.invoke(null, blocks);
+
+        // VALIDATE
+        assertThat(json, is("[]"));
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/methods/RequestFormBuilderTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/RequestFormBuilderTest.java
@@ -2,6 +2,10 @@ package test_locally.api.methods;
 
 import com.slack.api.methods.RequestFormBuilder;
 import com.slack.api.model.block.LayoutBlock;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -9,11 +13,21 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.slack.api.model.block.Blocks.divider;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RequestFormBuilderTest {
+
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class MyTestBlock implements LayoutBlock {
+        public static final String TYPE = "myTestBlock";
+        private final String type = TYPE;
+        private String blockId;
+    }
 
     @Test
     public void testGetJsonWithGsonAnonymInnerClassHandling() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
@@ -22,15 +36,15 @@ public class RequestFormBuilderTest {
         method.setAccessible(true);
 
         List<LayoutBlock> blocks = new ArrayList<LayoutBlock>(){{
-            add(divider());
-            add(divider());
+            add(MyTestBlock.builder().build());
+            add(MyTestBlock.builder().build());
         }};
 
         // EXECUTE
         String json = (String) method.invoke(null, blocks);
 
         // VALIDATE
-        assertThat(json, is("[{\"type\":\"divider\"},{\"type\":\"divider\"}]"));
+        assertThat(json, is("[{\"type\":\"myTestBlock\"},{\"type\":\"myTestBlock\"}]"));
     }
 
     @Test
@@ -40,14 +54,14 @@ public class RequestFormBuilderTest {
         method.setAccessible(true);
 
         List<LayoutBlock> blocks = new ArrayList<LayoutBlock>();
-        blocks.add(divider());
-        blocks.add(divider());
+        blocks.add(MyTestBlock.builder().build());
+        blocks.add(MyTestBlock.builder().build());
 
         // EXECUTE
         String json = (String) method.invoke(null, blocks);
 
         // VALIDATE
-        assertThat(json, is("[{\"type\":\"divider\"},{\"type\":\"divider\"}]"));
+        assertThat(json, is("[{\"type\":\"myTestBlock\"},{\"type\":\"myTestBlock\"}]"));
     }
 
     @Test


### PR DESCRIPTION
GSON has a [known issue](https://github.com/google/gson/issues/2023#issuecomment-974230703) where null is returned if it tries to serialize an object that was initialized using an anonymous inner class.

Example:
```java
import com.google.gson.Gson;
import com.google.gson.GsonBuilder;

import java.util.ArrayList;
import java.util.List;

List<String> strings = new ArrayList<>() {{
            add("hello");
            add("world");
        }};

GsonBuilder builder = new GsonBuilder();
Gson gson = builder.create();

String json = gson.toJson(strings);

assertEquals("{\"hello\", \"world\"}", json); // this should be true but json = "null"
```

The above assertion should be true but the json string generated by the GSON lib actually returns a string of value "null". This can lead to some head scratching for the users of this library.

These changes try to reinitialize & reserialize the list of blocks if this "null" output is obtained from the GSON library.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
