### PR TITLE
Null validation for workflow update request

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -2472,9 +2472,9 @@ public class RequestFormBuilder {
         setIfNotNull("workflow_step_edit_id", req.getWorkflowStepEditId(), form);
         setIfNotNull("step_image_url", req.getStepImageUrl(), form);
         setIfNotNull("step_name", req.getStepName(), form);
-        if (req.getOutputsAsString() != null) {
+        if (req.getInputsAsString() != null) {
             setIfNotNull("inputs", req.getInputsAsString(), form);
-        } else if (req.getOutputs() != null) {
+        } else if (req.getInputs() != null) {
             setIfNotNull("inputs", GSON.toJson(req.getInputs()), form);
         }
         if (req.getOutputsAsString() != null) {


### PR DESCRIPTION
Seems like there was a typo that validated the wrong variable for NULL values.

Need confirmation on this

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
