### PR TITLE
Add timezone property to timepicker block element

### DIFF
--- a/json-logs/samples/api/views.open.json
+++ b/json-logs/samples/api/views.open.json
@@ -374,6 +374,7 @@
             "emoji": false
           },
           "initial_time": "",
+          "timezone": "",
           "confirm": {
             "title": {
               "type": "plain_text",
@@ -1065,6 +1066,7 @@
               "emoji": false
             },
             "initial_time": "",
+            "timezone": "",
             "confirm": {
               "title": {
                 "type": "plain_text",

--- a/json-logs/samples/api/views.publish.json
+++ b/json-logs/samples/api/views.publish.json
@@ -374,6 +374,7 @@
             "emoji": false
           },
           "initial_time": "",
+          "timezone": "",
           "confirm": {
             "title": {
               "type": "plain_text",
@@ -1065,6 +1066,7 @@
               "emoji": false
             },
             "initial_time": "",
+            "timezone": "",
             "confirm": {
               "title": {
                 "type": "plain_text",

--- a/json-logs/samples/api/views.push.json
+++ b/json-logs/samples/api/views.push.json
@@ -374,6 +374,7 @@
             "emoji": false
           },
           "initial_time": "",
+          "timezone": "",
           "confirm": {
             "title": {
               "type": "plain_text",
@@ -1065,6 +1066,7 @@
               "emoji": false
             },
             "initial_time": "",
+            "timezone": "",
             "confirm": {
               "title": {
                 "type": "plain_text",

--- a/json-logs/samples/api/views.update.json
+++ b/json-logs/samples/api/views.update.json
@@ -374,6 +374,7 @@
             "emoji": false
           },
           "initial_time": "",
+          "timezone": "",
           "confirm": {
             "title": {
               "type": "plain_text",
@@ -1065,6 +1066,7 @@
               "emoji": false
             },
             "initial_time": "",
+            "timezone": "",
             "confirm": {
               "title": {
                 "type": "plain_text",

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -376,6 +376,7 @@
             "emoji": false
           },
           "initial_time": "",
+          "timezone": "",
           "confirm": {
             "title": {
               "type": "plain_text",
@@ -2790,6 +2791,7 @@
           "emoji": false
         },
         "initial_time": "",
+        "timezone": "",
         "confirm": {
           "title": {
             "type": "plain_text",
@@ -3840,6 +3842,7 @@
                 "emoji": false
               },
               "initial_time": "",
+              "timezone": "",
               "confirm": {
                 "title": {
                   "type": "plain_text",
@@ -6254,6 +6257,7 @@
               "emoji": false
             },
             "initial_time": "",
+            "timezone": "",
             "confirm": {
               "title": {
                 "type": "plain_text",

--- a/json-logs/samples/rtm/PinAddedEvent.json
+++ b/json-logs/samples/rtm/PinAddedEvent.json
@@ -385,6 +385,7 @@
                 "emoji": false
               },
               "initial_time": "",
+              "timezone": "",
               "confirm": {
                 "title": {
                   "type": "plain_text",
@@ -2799,6 +2800,7 @@
               "emoji": false
             },
             "initial_time": "",
+            "timezone": "",
             "confirm": {
               "title": {
                 "type": "plain_text",
@@ -3849,6 +3851,7 @@
                     "emoji": false
                   },
                   "initial_time": "",
+                  "timezone": "",
                   "confirm": {
                     "title": {
                       "type": "plain_text",
@@ -6263,6 +6266,7 @@
                   "emoji": false
                 },
                 "initial_time": "",
+                "timezone": "",
                 "confirm": {
                   "title": {
                     "type": "plain_text",

--- a/json-logs/samples/rtm/PinRemovedEvent.json
+++ b/json-logs/samples/rtm/PinRemovedEvent.json
@@ -385,6 +385,7 @@
                 "emoji": false
               },
               "initial_time": "",
+              "timezone": "",
               "confirm": {
                 "title": {
                   "type": "plain_text",
@@ -2799,6 +2800,7 @@
               "emoji": false
             },
             "initial_time": "",
+            "timezone": "",
             "confirm": {
               "title": {
                 "type": "plain_text",
@@ -3849,6 +3851,7 @@
                     "emoji": false
                   },
                   "initial_time": "",
+                  "timezone": "",
                   "confirm": {
                     "title": {
                       "type": "plain_text",
@@ -6263,6 +6266,7 @@
                   "emoji": false
                 },
                 "initial_time": "",
+                "timezone": "",
                 "confirm": {
                   "title": {
                     "type": "plain_text",

--- a/json-logs/samples/rtm/StarAddedEvent.json
+++ b/json-logs/samples/rtm/StarAddedEvent.json
@@ -385,6 +385,7 @@
                 "emoji": false
               },
               "initial_time": "",
+              "timezone": "",
               "confirm": {
                 "title": {
                   "type": "plain_text",
@@ -2799,6 +2800,7 @@
               "emoji": false
             },
             "initial_time": "",
+            "timezone": "",
             "confirm": {
               "title": {
                 "type": "plain_text",
@@ -3849,6 +3851,7 @@
                     "emoji": false
                   },
                   "initial_time": "",
+                  "timezone": "",
                   "confirm": {
                     "title": {
                       "type": "plain_text",
@@ -6263,6 +6266,7 @@
                   "emoji": false
                 },
                 "initial_time": "",
+                "timezone": "",
                 "confirm": {
                   "title": {
                     "type": "plain_text",

--- a/json-logs/samples/rtm/StarRemovedEvent.json
+++ b/json-logs/samples/rtm/StarRemovedEvent.json
@@ -384,6 +384,7 @@
                 "emoji": false
               },
               "initial_time": "",
+              "timezone": "",
               "confirm": {
                 "title": {
                   "type": "plain_text",
@@ -2798,6 +2799,7 @@
               "emoji": false
             },
             "initial_time": "",
+            "timezone": "",
             "confirm": {
               "title": {
                 "type": "plain_text",
@@ -3848,6 +3850,7 @@
                     "emoji": false
                   },
                   "initial_time": "",
+                  "timezone": "",
                   "confirm": {
                     "title": {
                       "type": "plain_text",
@@ -6262,6 +6265,7 @@
                   "emoji": false
                 },
                 "initial_time": "",
+                "timezone": "",
                 "confirm": {
                   "title": {
                     "type": "plain_text",

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/TimePickerElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/TimePickerElementBuilder.kt
@@ -13,6 +13,7 @@ class TimePickerElementBuilder : Builder<TimePickerElement> {
     private var actionId: String? = null
     private var initialTime: String? = null
     private var confirm: ConfirmationDialogObject? = null
+    private var _timezone: String? = null
     private var _focusOnLoad: Boolean? = null
 
     /**
@@ -54,6 +55,15 @@ class TimePickerElementBuilder : Builder<TimePickerElement> {
      */
     fun confirm(builder: ConfirmationDialogObjectBuilder.() -> Unit) {
         confirm = ConfirmationDialogObjectBuilder().apply(builder).build()
+    }
+
+    /**
+     * The timezone to consider for this input value.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#timepicker">Time picker element documentation</a>
+     */
+    fun timezone(timezone: String) {
+        _timezone = timezone
     }
 
     /**

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/TimePickerElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/TimePickerElement.java
@@ -38,6 +38,11 @@ public class TimePickerElement extends BlockElement {
     private String initialTime;
 
     /**
+     * The timezone to consider for this input value.
+     */
+    private String timezone;
+
+    /**
      * A confirm object that defines an optional confirmation dialog that appears after a date is selected.
      */
     private ConfirmationDialogObject confirm;

--- a/slack-api-model/src/main/java/com/slack/api/model/view/ViewState.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/view/ViewState.java
@@ -33,6 +33,7 @@ public class ViewState {
         private List<String> selectedChannels;
         private List<String> selectedUsers;
         private List<SelectedOption> selectedOptions;
+        private String timezone; // for timepicker
     }
 
     @Data

--- a/slack-app-backend/src/test/java/test_locally/app_backend/views/ViewSubmissionPayloadTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/views/ViewSubmissionPayloadTest.java
@@ -2,6 +2,10 @@ package test_locally.app_backend.views;
 
 import com.google.gson.Gson;
 import com.slack.api.app_backend.views.payload.ViewSubmissionPayload;
+import com.slack.api.model.block.InputBlock;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.element.TimePickerElement;
+import com.slack.api.model.view.ViewState;
 import com.slack.api.util.json.GsonFactory;
 import org.junit.Test;
 
@@ -218,6 +222,37 @@ public class ViewSubmissionPayloadTest {
             "            ]\n" +
             "          }\n" +
             "        }\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"type\": \"input\",\n" +
+            "        \"block_id\": \"date-block\",\n" +
+            "        \"label\": {\n" +
+            "          \"type\": \"plain_text\",\n" +
+            "          \"text\": \"Date\",\n" +
+            "          \"emoji\": true\n" +
+            "        },\n" +
+            "        \"optional\": false,\n" +
+            "        \"dispatch_action\": false,\n" +
+            "        \"element\": {\n" +
+            "          \"type\": \"datepicker\",\n" +
+            "          \"action_id\": \"date-action\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"type\": \"input\",\n" +
+            "        \"block_id\": \"time-block\",\n" +
+            "        \"label\": {\n" +
+            "          \"type\": \"plain_text\",\n" +
+            "          \"text\": \"Time\",\n" +
+            "          \"emoji\": true\n" +
+            "        },\n" +
+            "        \"optional\": false,\n" +
+            "        \"dispatch_action\": false,\n" +
+            "        \"element\": {\n" +
+            "          \"type\": \"timepicker\",\n" +
+            "          \"action_id\": \"time-action\",\n" +
+            "          \"timezone\": \"America/Los_Angeles\"\n" +
+            "        }\n" +
             "      }\n" +
             "    ],\n" +
             "    \"private_metadata\": \"\",\n" +
@@ -228,6 +263,19 @@ public class ViewSubmissionPayloadTest {
             "          \"agenda-action\": {\n" +
             "            \"type\": \"plain_text_input\",\n" +
             "            \"value\": \"test\"\n" +
+            "          }\n" +
+            "        }," +
+            "        \"date-block\": {\n" +
+            "          \"date-action\": {\n" +
+            "            \"type\": \"datepicker\",\n" +
+            "            \"selected_date\": \"2022-06-22\"\n" +
+            "          }\n" +
+            "        },\n" +
+            "        \"time-block\": {\n" +
+            "          \"time-action\": {\n" +
+            "            \"type\": \"timepicker\",\n" +
+            "            \"selected_time\": \"03:00\",\n" +
+            "            \"timezone\": \"America/Los_Angeles\"\n" +
             "          }\n" +
             "        }\n" +
             "      }\n" +
@@ -271,5 +319,20 @@ public class ViewSubmissionPayloadTest {
         assertThat(payload.getEnterprise().getId(), is("E111"));
         assertThat(payload.getTeam(), is(nullValue()));
         assertThat(payload.isEnterpriseInstall(), is(true));
+
+        TimePickerElement timepickerBlockElement = null;
+        for (LayoutBlock block : payload.getView().getBlocks()) {
+            if (block.getType().equals(InputBlock.TYPE)) {
+                if (((InputBlock) block).getElement() instanceof TimePickerElement) {
+                    timepickerBlockElement = (TimePickerElement) ((InputBlock) block).getElement();
+                }
+            }
+        }
+        assertThat(timepickerBlockElement.getTimezone(), is("America/Los_Angeles"));
+
+        ViewState.Value timeStateValue = payload.getView().getState().getValues()
+                .get("time-block").get("time-action");
+        assertThat(timeStateValue.getSelectedTime(), is("03:00"));
+        assertThat(timeStateValue.getTimezone(), is("America/Los_Angeles"));
     }
 }


### PR DESCRIPTION
This pull request adds timezone property to timepicker block element. see also: https://github.com/slackapi/node-slack-sdk/issues/1502

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
