### PR TITLE
Updates `tyrus-standalone-client` version from 1.17 to 1.19 in the documentations

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,4 +15,4 @@ compatibleMicronautVersion: 3.x
 quarkusVersion: 2.10.2.Final
 helidonVersion: 2.5.0
 javaxWebsocketApiVersion: 1.1
-tyrusStandaloneClientVersion: 1.17
+tyrusStandaloneClientVersion: 1.19

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,3 +14,5 @@ springBootVersion: 2.7.1
 compatibleMicronautVersion: 3.x
 quarkusVersion: 2.10.2.Final
 helidonVersion: 2.5.0
+javaxWebsocketApiVersion: 1.1
+tyrusStandaloneClientVersion: 1.17

--- a/docs/guides/getting-started-with-bolt-socket-mode.md
+++ b/docs/guides/getting-started-with-bolt-socket-mode.md
@@ -46,12 +46,12 @@ After you [create your Maven project](https://maven.apache.org/guides/getting-st
 <dependency>
   <groupId>javax.websocket</groupId>
   <artifactId>javax.websocket-api</artifactId>
-  <version>1.1</version>
+  <version>{{ site.javaxWebsocketApiVersion }}</version>
 </dependency>
 <dependency>
   <groupId>org.glassfish.tyrus.bundles</groupId>
   <artifactId>tyrus-standalone-client</artifactId>
-  <version>1.17</version>
+  <version>{{ site.tyrusStandaloneClientVersion }}</version>
 </dependency>
 <dependency>
   <groupId>org.slf4j</groupId>
@@ -87,8 +87,8 @@ After you [create your Gradle project](https://docs.gradle.org/current/samples/s
 ```groovy
 dependencies {
   implementation("com.slack.api:bolt-socket-mode:{{ site.sdkLatestVersion }}")
-  implementation("javax.websocket:javax.websocket-api:1.1")
-  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.17")
+  implementation("javax.websocket:javax.websocket-api:{{ site.javaxWebsocketApiVersion }}")
+  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:{{ site.tyrusStandaloneClientVersion }}")
   implementation("org.slf4j:slf4j-simple:{{ site.slf4jApiVersion }}")
 }
 ```
@@ -113,8 +113,8 @@ repositories {
 }
 dependencies {
   implementation("com.slack.api:bolt-socket-mode:{{ site.sdkLatestVersion }}")
-  implementation("javax.websocket:javax.websocket-api:1.1")
-  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.17")
+  implementation("javax.websocket:javax.websocket-api:{{ site.javaxWebsocketApiVersion }}")
+  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:{{ site.tyrusStandaloneClientVersion }}")
   implementation("org.slf4j:slf4j-simple:{{ site.slf4jApiVersion }}")
 }
 application {
@@ -249,8 +249,8 @@ dependencies {
   implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
   implementation("com.slack.api:bolt-socket-mode:{{ site.sdkLatestVersion }}")
-  implementation("javax.websocket:javax.websocket-api:1.1")
-  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.17")
+  implementation("javax.websocket:javax.websocket-api:{{ site.javaxWebsocketApiVersion }}")
+  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:{{ site.tyrusStandaloneClientVersion }}")
   implementation("org.slf4j:slf4j-simple:{{ site.slf4jApiVersion }}") // or logback-classic
 }
 application {

--- a/docs/guides/ja/getting-started-with-bolt-socket-mode.md
+++ b/docs/guides/ja/getting-started-with-bolt-socket-mode.md
@@ -46,12 +46,12 @@ lang: ja
 <dependency>
   <groupId>javax.websocket</groupId>
   <artifactId>javax.websocket-api</artifactId>
-  <version>1.1</version>
+  <version>{{ site.javaxWebsocketApiVersion }}</version>
 </dependency>
 <dependency>
   <groupId>org.glassfish.tyrus.bundles</groupId>
   <artifactId>tyrus-standalone-client</artifactId>
-  <version>1.17</version>
+  <version>{{ site.tyrusStandaloneClientVersion }}</version>
 </dependency>
 <dependency>
   <groupId>org.slf4j</groupId>
@@ -88,8 +88,8 @@ Gralde プロジェクトを作成した後 **bolt** 関連の依存ライブラ
 dependencies {
   implementation("com.slack.api:bolt:{{ site.sdkLatestVersion }}")
   implementation("com.slack.api:bolt-socket-mode:{{ site.sdkLatestVersion }}")
-  implementation("javax.websocket:javax.websocket-api:1.1")
-  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.17")
+  implementation("javax.websocket:javax.websocket-api:{{ site.javaxWebsocketApiVersion }}")
+  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:{{ site.tyrusStandaloneClientVersion }}")
   implementation("org.slf4j:slf4j-simple:{{ site.slf4jApiVersion }}")
 }
 ```
@@ -114,8 +114,8 @@ repositories {
 }
 dependencies {
   implementation("com.slack.api:bolt-socket-mode:{{ site.sdkLatestVersion }}")
-  implementation("javax.websocket:javax.websocket-api:1.1")
-  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.17")
+  implementation("javax.websocket:javax.websocket-api:{{ site.javaxWebsocketApiVersion }}")
+  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:{{ site.tyrusStandaloneClientVersion }}")
   implementation("org.slf4j:slf4j-simple:{{ site.slf4jApiVersion }}")
 }
 application {
@@ -250,8 +250,8 @@ dependencies {
   implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
   implementation("com.slack.api:bolt-socket-mode:{{ site.sdkLatestVersion }}")
-  implementation("javax.websocket:javax.websocket-api:1.1")
-  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.17")
+  implementation("javax.websocket:javax.websocket-api:{{ site.javaxWebsocketApiVersion }}")
+  implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:{{ site.tyrusStandaloneClientVersion }}")
   implementation("org.slf4j:slf4j-simple:{{ site.slf4jApiVersion }}") // または logback-classic など
 }
 application {

--- a/docs/guides/ja/rtm.md
+++ b/docs/guides/ja/rtm.md
@@ -33,12 +33,12 @@ RTM クライアントを使うためには、**slack-api-client** ライブラ�
     <dependency>
       <groupId>javax.websocket</groupId>
       <artifactId>javax.websocket-api</artifactId>
-      <version>1.1</version>
+      <version>{{ site.javaxWebsocketApiVersion }}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.tyrus.bundles</groupId>
       <artifactId>tyrus-standalone-client</artifactId>
-      <version>1.17</version>
+      <version>{{ site.tyrusStandaloneClientVersion }}</version>
     </dependency>
   </dependencies>
 </project>

--- a/docs/guides/ja/socket-mode.md
+++ b/docs/guides/ja/socket-mode.md
@@ -42,12 +42,12 @@ lang: ja
     <dependency>
       <groupId>javax.websocket</groupId>
       <artifactId>javax.websocket-api</artifactId>
-      <version>1.1</version>
+      <version>{{ site.javaxWebsocketApiVersion }}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.tyrus.bundles</groupId>
       <artifactId>tyrus-standalone-client</artifactId>
-      <version>1.17</version>
+      <version>{{ site.tyrusStandaloneClientVersion }}</version>
     </dependency>
   </dependencies>
 </project>
@@ -110,7 +110,7 @@ String appToken = System.getenv("SLACK_APP_TOKEN");
 SocketModeApp socketModeApp = new SocketModeApp(appToken, app);
 
 // #start() メソッドは WebSocket コネクションを確立して、カレントスレッドをブロックし続けます。
-// ブロックしたくない場合は #startAsync() を使ってください。     
+// ブロックしたくない場合は #startAsync() を使ってください。
 socketModeApp.start();
 ```
 
@@ -186,11 +186,11 @@ try (SocketModeClient client = Slack.getInstance().socketMode(appLevelToken)) {
   client.addWebSocketMessageListener((String message) -> {
     // TODO: WebSocket のテキストメッセージを使って何かする
   });
-  
+
   client.addWebSocketErrorListener((Throwable reason) -> {
     // TODO: 例外を処理する
   });
-  
+
   // type: events のエンベロープだけを受け取るリスナーを追加
   client.addEventsApiEnvelopeListener((EventsApiEnvelope envelope) -> {
     // TODO: Events API のペイロードを使って何ややる
@@ -199,9 +199,9 @@ try (SocketModeClient client = Slack.getInstance().socketMode(appLevelToken)) {
     SocketModeResponse ack = AckResponse.builder().envelopeId(envelope.getEnvelopeId()).build();
     client.sendSocketModeResponse(ack);
   });
-  
+
   client.connect(); // ソケットモードサーバーに接続してメッセージの受信を開始
-  
+
   client.disconnect(); // ソケットモードサーバーから切断
 
   client.connectToNewEndpoint(); // 新しい WSS URL を発行して、その URL に接続

--- a/docs/guides/rtm.md
+++ b/docs/guides/rtm.md
@@ -33,12 +33,12 @@ To use the RTM Client, in addition to the **slack-api-client** library, **javax.
     <dependency>
       <groupId>javax.websocket</groupId>
       <artifactId>javax.websocket-api</artifactId>
-      <version>1.1</version>
+      <version>{{ site.javaxWebsocketApiVersion }}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.tyrus.bundles</groupId>
       <artifactId>tyrus-standalone-client</artifactId>
-      <version>1.17</version>
+      <version>{{ site.tyrusStandaloneClientVersion }}</version>
     </dependency>
   </dependencies>
 </project>

--- a/docs/guides/socket-mode.md
+++ b/docs/guides/socket-mode.md
@@ -42,12 +42,12 @@ To manage the Socket Mode connections, in addition to the **bolt-socket-mode** l
     <dependency>
       <groupId>javax.websocket</groupId>
       <artifactId>javax.websocket-api</artifactId>
-      <version>1.1</version>
+      <version>{{ site.javaxWebsocketApiVersion }}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.tyrus.bundles</groupId>
       <artifactId>tyrus-standalone-client</artifactId>
-      <version>1.17</version>
+      <version>{{ site.tyrusStandaloneClientVersion }}</version>
     </dependency>
   </dependencies>
 </project>
@@ -106,12 +106,12 @@ import com.slack.api.bolt.socket_mode.SocketModeApp;
 // the app-level token with `connections:write` scope
 String appToken = System.getenv("SLACK_APP_TOKEN");
 
-// Initialize the adapter for Socket Mode 
+// Initialize the adapter for Socket Mode
 // with an app-level token and your Bolt app with listeners.
 SocketModeApp socketModeApp = new SocketModeApp(appToken, app);
 
 // #start() method establishes a new WebSocket connection and then blocks the current thread.
-// If you do not want to block this thread, use #startAsync() instead.        
+// If you do not want to block this thread, use #startAsync() instead.
 socketModeApp.start();
 ```
 
@@ -122,7 +122,7 @@ import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.model.event.AppMentionEvent;
 
-// As this is a distributed Socket Mode app, 
+// As this is a distributed Socket Mode app,
 // you do not need a token for a specific workspace and the signing secret here.
 AppConfig appConfig = AppConfig.builder()
   .clientId("111.222")
@@ -187,11 +187,11 @@ try (SocketModeClient client = Slack.getInstance().socketMode(appLevelToken)) {
   client.addWebSocketMessageListener((String message) -> {
     // TODO: Do something with the raw WebSocket text message
   });
-  
+
   client.addWebSocketErrorListener((Throwable reason) -> {
     // TODO: Do something with a thrown exception
   });
-  
+
   // Add a listener function that handles only type: events envelopes
   client.addEventsApiEnvelopeListener((EventsApiEnvelope envelope) -> {
     // TODO: Do something with an Events API payload
@@ -200,9 +200,9 @@ try (SocketModeClient client = Slack.getInstance().socketMode(appLevelToken)) {
     SocketModeResponse ack = AckResponse.builder().envelopeId(envelope.getEnvelopeId()).build();
     client.sendSocketModeResponse(ack);
   });
-  
+
   client.connect(); // Start receiving messages from the Socket Mode server
-  
+
   client.disconnect(); // Disconnect from the server
 
   client.connectToNewEndpoint(); // Issue a new WSS URL and connects to the URL


### PR DESCRIPTION
This PR updates `tyrus-standalone-client` version from 1.17 to 1.19 in the documentations. `tyrus-standalone-client` 1.19 is still compatible with bolt-socket-mode, but supports officially Java 17 and contains various bug fixes and improvements. See https://projects.eclipse.org/projects/ee4j.tyrus/tyrus-standalone-client.

The PR has been split in two commits so that even if the `tyrus-standalone-client` version update is not possible future version updates will be easier for both  `javax.websocket-api` and `tyrus-standalone-client` :
1. Replace `javax.websocket-api` and `tyrus-standalone-client` versions by variables in documentation. Note that a few trailing whitespaces were automatically trimmed and a few final new lines were automatically added. This is not an issue so it has not been reverted.
2. Update `tyrus-standalone-client` version in documentation.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
