### PR TITLE
Fix #1013 Update tyrus-standalone-client dependency from 1.18 to 1.19

### DIFF
--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -18,7 +18,7 @@
         <!-- TODO upgrade to 2.0 in the next major version
          see https://github.com/slackapi/java-slack-sdk/issues/919#issuecomment-1022822962
          -->
-        <tyrus-standalone-client.version>1.18</tyrus-standalone-client.version>
+        <tyrus-standalone-client.version>1.19</tyrus-standalone-client.version>
         <java-websocket.version>1.5.3</java-websocket.version>
         <jedis.version>4.2.3</jedis.version>
         <jedis-mock.version>1.0.3</jedis-mock.version>


### PR DESCRIPTION
This pull request resolves #1013 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
