### PR TITLE
Fix #1015 Lambda handler class doesn't account for base64 encoded body

### DIFF
--- a/bolt-aws-lambda/src/main/java/com/slack/api/bolt/aws_lambda/SlackApiLambdaHandler.java
+++ b/bolt-aws-lambda/src/main/java/com/slack/api/bolt/aws_lambda/SlackApiLambdaHandler.java
@@ -74,11 +74,12 @@ public abstract class SlackApiLambdaHandler implements RequestHandler<ApiGateway
             log.debug("AWS API Gateway Request: {}", awsReq);
         }
         RequestContext context = awsReq.getRequestContext();
+        String body = (awsReq.isBase64Encoded()) ? new String(Base64.getDecoder().decode(awsReq.getBody())) : awsReq.getBody();
         SlackRequestParser.HttpRequest rawRequest = SlackRequestParser.HttpRequest.builder()
                 .requestUri(awsReq.getPath())
                 .queryString(toStringToStringListMap(awsReq.getQueryStringParameters()))
                 .headers(new RequestHeaders(toStringToStringListMap(awsReq.getHeaders())))
-                .requestBody(awsReq.getBody())
+                .requestBody(body)
                 .remoteAddress(context != null && context.getIdentity() != null ? context.getIdentity().getSourceIp() : null)
                 .build();
         return requestParser.parse(rawRequest);


### PR DESCRIPTION
This pull request fixes #1015 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you are agreeing to the those rules.
