### PR TITLE
Upgrade gson patch version and other optional ones

### DIFF
--- a/bolt-helidon/pom.xml
+++ b/bolt-helidon/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <properties>
+        <!-- TODO: Upgrade to Helidon v3 (requires a new minor release) -->
         <helidon.version>[2.5,2.6)</helidon.version>
         <!-- Helidon 2.x requires Java 11+ -->
         <maven.compiler.source>11</maven.compiler.source>

--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.27.1.0</http4k.version>
+        <http4k.version>4.27.4.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,9 +10,9 @@
     </parent>
 
     <properties>
-        <micronaut.version>3.5.3</micronaut.version>
-        <micronaut-test-junit5.version>3.4.0</micronaut-test-junit5.version>
-        <micronaut-rxjava3.version>2.2.1</micronaut-rxjava3.version>
+        <micronaut.version>3.6.0</micronaut.version>
+        <micronaut-test-junit5.version>3.5.0</micronaut-test-junit5.version>
+        <micronaut-rxjava3.version>2.3.0</micronaut-rxjava3.version>
         <!-- Note that upgrading this library breaks other dependency resolution -->
         <mockito-all.version>1.10.19</mockito-all.version>
         <jakarta.inject.version>2.0.1.MR</jakarta.inject.version>

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.10.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.11.2.Final</quarkus.platform.version>
         <mutiny.version>1.6.0</mutiny.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
     </properties>

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.7.1</spring-boot.version>
+        <spring-boot.version>2.7.2</spring-boot.version>
     </properties>
 
     <artifactId>bolt-spring-boot-examples</artifactId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,9 +10,9 @@ sdkLatestVersion: 1.24.0
 okhttpVersion: 4.10.0
 slf4jApiVersion: 1.7.36
 kotlinVersion: 1.7.10
-springBootVersion: 2.7.1
+springBootVersion: 2.7.2
 compatibleMicronautVersion: 3.x
-quarkusVersion: 2.10.2.Final
+quarkusVersion: 2.11.2.Final
 helidonVersion: 2.5.0
 javaxWebsocketApiVersion: 1.1
 tyrusStandaloneClientVersion: 1.19

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <!-- We don't change the versions of servlet API interface to keep the backward compatibility with older versions of them -->
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <okhttp.version>4.10.0</okhttp.version>
-        <gson.version>2.9.0</gson.version>
+        <gson.version>2.9.1</gson.version>
         <kotlin.version>1.7.10</kotlin.version>
         <slf4j.version>1.7.36</slf4j.version>
         <lombok.version>1.18.24</lombok.version>


### PR DESCRIPTION
This pull request upgrades a few external dependences. The only impactful thing is the patch version bump of gson library but it looks safe enough to me.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
