### PR TITLE
Fix link to Slack filetype documentation on API methods site

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadRequest.java
@@ -31,7 +31,7 @@ public class FilesUploadRequest implements SlackApiRequest {
     private String content;
 
     /**
-     * A [file type](/types/file#file_types) identifier.
+     * A [file type](https://api.slack.com/types/file#file_types) identifier.
      */
     private String filetype;
 


### PR DESCRIPTION
This fixes #1036 