### PR TITLE
Fix #1038 BlockActionPayload is missing app_unfurl information

### DIFF
--- a/bolt-socket-mode/src/test/java/samples/UnfurlingApp.java
+++ b/bolt-socket-mode/src/test/java/samples/UnfurlingApp.java
@@ -4,19 +4,35 @@ import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.socket_mode.SocketModeApp;
 import com.slack.api.methods.request.chat.ChatUnfurlRequest;
+import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.model.event.LinkSharedEvent;
+import com.slack.api.model.event.MessageChangedEvent;
+import com.slack.api.model.event.MessageEvent;
+import com.slack.api.util.json.GsonFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static com.slack.api.model.block.Blocks.actions;
+import static com.slack.api.model.block.Blocks.asBlocks;
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static com.slack.api.model.block.element.BlockElements.asElements;
+import static com.slack.api.model.block.element.BlockElements.button;
 
 public class UnfurlingApp {
 
     public static void main(String[] args) throws Exception {
-        App app = new App(AppConfig.builder().singleTeamBotToken(System.getenv("SLACK_BOT_TOKEN")).build());
+        String appToken = System.getenv("SLACK_APP_TOKEN");
+        String botToken = System.getenv("SLACK_BOT_TOKEN");
+        App app = new App(AppConfig.builder().singleTeamBotToken(botToken).build());
         app.use((req, resp, chain) -> {
             req.getContext().logger.info(req.getRequestBodyAsString());
             return chain.next(req);
         });
+
+        app.event(MessageEvent.class, (payload, ctx) -> ctx.ack());
+        app.event(MessageChangedEvent.class, (payload, ctx) -> ctx.ack());
 
         app.event(LinkSharedEvent.class, (payload, ctx) -> {
             app.executorService().submit(() -> {
@@ -24,8 +40,13 @@ public class UnfurlingApp {
                     Map<String, ChatUnfurlRequest.UnfurlDetail> unfurls = new HashMap<>();
                     for (LinkSharedEvent.Link link : payload.getEvent().getLinks()) {
                         ChatUnfurlRequest.UnfurlDetail unfurl = new ChatUnfurlRequest.UnfurlDetail();
-                        unfurl.setTitle("Collaborate & Create Amazing Graphic Design for Free");
-                        unfurl.setText("text text text");
+                        // unfurl.setTitle("Collaborate & Create Amazing Graphic Design for Free");
+                        // unfurl.setText("text text text");
+                        List<LayoutBlock> blocks = asBlocks(actions(a -> a.blockId("b").elements(asElements(
+                                button(b -> b.actionId("a").value("clicked").text(plainText("Click this!")))
+                        ))));
+                        unfurl.setBlocks(blocks);
+                        ctx.logger.info(GsonFactory.createSnakeCase().toJson(unfurl));
                         unfurls.put(link.getUrl(), unfurl);
                     }
                     ctx.client().chatUnfurl(r -> r
@@ -41,7 +62,11 @@ public class UnfurlingApp {
             return ctx.ack();
         });
 
-        String appToken = System.getenv("SLACK_APP_TOKEN");
+        app.blockAction("a", (req, ctx) -> {
+            ctx.logger.info(req.getRequestBodyAsString());
+            return ctx.ack();
+        });
+
         SocketModeApp socketModeApp = new SocketModeApp(appToken, app);
         socketModeApp.start();
     }

--- a/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
@@ -23,9 +23,11 @@
     "message_ts": "",
     "attachment_id": 123,
     "channel_id": "",
+    "view_id": "",
     "text": "",
     "is_ephemeral": false,
-    "is_app_unfurl": false
+    "is_app_unfurl": false,
+    "app_unfurl_url": ""
   },
   "trigger_id": "",
   "channel": {
@@ -1322,6 +1324,14 @@
     "bot_id": ""
   },
   "state": {},
+  "app_unfurl": {
+    "id": 123,
+    "fallback": "",
+    "bot_id": "",
+    "app_unfurl_url": "",
+    "is_app_unfurl": false,
+    "app_id": ""
+  },
   "actions": [
     {
       "action_id": "",
@@ -1333,6 +1343,7 @@
       },
       "value": "",
       "type": "",
+      "style": "",
       "action_ts": "",
       "placeholder": {
         "type": "plain_text",

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/payload/BlockActionPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/payload/BlockActionPayload.java
@@ -2,6 +2,7 @@ package com.slack.api.app_backend.interactive_components.payload;
 
 import com.google.gson.annotations.SerializedName;
 import com.slack.api.model.Message;
+import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.OptionObject;
 import com.slack.api.model.block.composition.PlainTextObject;
@@ -38,11 +39,9 @@ public class BlockActionPayload {
     private String responseUrl;
     private View view;
     private ViewState state; // for actions in a message
+    private AppUnfurl appUnfurl;
     private List<Action> actions;
     private boolean isEnterpriseInstall;
-
-    // TODO: app_unfurl
-    // https://github.com/slackapi/bolt/blob/8f9245f9b9dce0771bb615b42192e7adb6228444/src/types/actions/block-action.ts#L154-L155
 
     @Data
     public static class Enterprise {
@@ -72,11 +71,13 @@ public class BlockActionPayload {
         private String messageTs;
         private Integer attachmentId;
         private String channelId;
+        private String viewId;
         private String text;
         @SerializedName("is_ephemeral")
         private boolean ephemeral;
         @SerializedName("is_app_unfurl")
-        private boolean app_unfurl;
+        private boolean appUnfurl;
+        private String appUnfurlUrl;
     }
 
     @Data
@@ -86,12 +87,25 @@ public class BlockActionPayload {
     }
 
     @Data
+    public static class AppUnfurl {
+        private Integer id;
+        private List<LayoutBlock> blocks;
+        private String fallback;
+        private String botId;
+        private String appUnfurlUrl;
+        @SerializedName("is_app_unfurl")
+        private boolean appUnfurl;
+        private String appId;
+    }
+
+    @Data
     public static class Action {
         private String actionId;
         private String blockId;
         private Text text;
         private String value;
         private String type;
+        private String style;
         private String actionTs;
 
         // common fields

--- a/slack-app-backend/src/test/java/test_locally/app_backend/interactive_components/payload/BlockActionPayloadTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/interactive_components/payload/BlockActionPayloadTest.java
@@ -1,5 +1,7 @@
 package test_locally.app_backend.interactive_components.payload;
 
+import com.google.gson.Gson;
+import com.slack.api.SlackConfig;
 import com.slack.api.app_backend.interactive_components.payload.BlockActionPayload;
 import com.slack.api.util.json.GsonFactory;
 import org.junit.Test;
@@ -9,6 +11,12 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BlockActionPayloadTest {
+
+    static final SlackConfig TEST_CONFIG = new SlackConfig();
+    static {
+        TEST_CONFIG.setFailOnUnknownProperties(true);
+    }
+    static final Gson GSON = GsonFactory.createSnakeCase(TEST_CONFIG);
 
     // https://api.slack.com/messaging/interactivity/enabling
     String json = "{\n" +
@@ -63,7 +71,7 @@ public class BlockActionPayloadTest {
 
     @Test
     public void deserialize() {
-        BlockActionPayload payload = GsonFactory.createSnakeCase().fromJson(json, BlockActionPayload.class);
+        BlockActionPayload payload = GSON.fromJson(json, BlockActionPayload.class);
         assertThat(payload.getType(), is("block_actions"));
         assertThat(payload.getToken(), is("9s8d9as89d8as9d8as989"));
         assertThat(payload.getUser(), is(notNullValue()));
@@ -150,7 +158,7 @@ public class BlockActionPayloadTest {
 
     @Test
     public void deserialize_confirm() {
-        BlockActionPayload payload = GsonFactory.createSnakeCase().fromJson(jsonWithConfirm, BlockActionPayload.class);
+        BlockActionPayload payload = GSON.fromJson(jsonWithConfirm, BlockActionPayload.class);
         assertThat(payload.getType(), is("block_actions"));
         assertThat(payload.getActions().size(), is(1));
 
@@ -221,7 +229,7 @@ public class BlockActionPayloadTest {
 
     @Test
     public void state_in_messages() {
-        BlockActionPayload payload = GsonFactory.createSnakeCase().fromJson(jsonWithState, BlockActionPayload.class);
+        BlockActionPayload payload = GSON.fromJson(jsonWithState, BlockActionPayload.class);
         assertThat(payload.getType(), is("block_actions"));
         assertThat(payload.getActions().size(), is(1));
 
@@ -231,5 +239,87 @@ public class BlockActionPayloadTest {
                         .getSelectedOption().getValue(),
                 is("schedule"));
     }
+
+    @Test
+    public void deserialize_app_unfurl() {
+        String jsonData = "{\n" +
+                "  \"type\": \"block_actions\",\n" +
+                "  \"user\": {\n" +
+                "    \"id\": \"U111\",\n" +
+                "    \"username\": \"seratch\",\n" +
+                "    \"name\": \"seratch\",\n" +
+                "    \"team_id\": \"T111\"\n" +
+                "  },\n" +
+                "  \"api_app_id\": \"A111\",\n" +
+                "  \"token\": \"xxx\",\n" +
+                "  \"container\": {\n" +
+                "    \"type\": \"message_attachment\",\n" +
+                "    \"message_ts\": \"1661488735.191299\",\n" +
+                "    \"attachment_id\": 1,\n" +
+                "    \"channel_id\": \"C111\",\n" +
+                "    \"is_ephemeral\": false,\n" +
+                "    \"is_app_unfurl\": true,\n" +
+                "    \"app_unfurl_url\": \"https://example.com/foo\"\n" +
+                "  },\n" +
+                "  \"trigger_id\": \"111.222.xxx\",\n" +
+                "  \"team\": {\n" +
+                "    \"id\": \"T111\",\n" +
+                "    \"domain\": \"seratch\"\n" +
+                "  },\n" +
+                "  \"is_enterprise_install\": false,\n" +
+                "  \"channel\": {\n" +
+                "    \"id\": \"C111\",\n" +
+                "    \"name\": \"general\"\n" +
+                "  },\n" +
+                "  \"app_unfurl\": {\n" +
+                "    \"id\": 1,\n" +
+                "    \"blocks\": [\n" +
+                "      {\n" +
+                "        \"type\": \"actions\",\n" +
+                "        \"block_id\": \"b\",\n" +
+                "        \"elements\": [\n" +
+                "          {\n" +
+                "            \"type\": \"button\",\n" +
+                "            \"action_id\": \"a\",\n" +
+                "            \"text\": {\n" +
+                "              \"type\": \"plain_text\",\n" +
+                "              \"text\": \"Click this!\",\n" +
+                "              \"emoji\": true\n" +
+                "            },\n" +
+                "            \"value\": \"clicked\"\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"fallback\": \"[no preview available]\",\n" +
+                "    \"bot_id\": \"B01K9P888EL\",\n" +
+                "    \"app_unfurl_url\": \"https://example.com/foo\",\n" +
+                "    \"is_app_unfurl\": true,\n" +
+                "    \"app_id\": \"A111\"\n" +
+                "  },\n" +
+                "  \"state\": {\n" +
+                "    \"values\": {}\n" +
+                "  },\n" +
+                "  \"response_url\": \"https://hooks.slack.com/actions/T111/111/222\",\n" +
+                "  \"actions\": [\n" +
+                "    {\n" +
+                "      \"action_id\": \"a\",\n" +
+                "      \"block_id\": \"b\",\n" +
+                "      \"text\": {\n" +
+                "        \"type\": \"plain_text\",\n" +
+                "        \"text\": \"Click this!\",\n" +
+                "        \"emoji\": true\n" +
+                "      },\n" +
+                "      \"value\": \"clicked\",\n" +
+                "      \"type\": \"button\",\n" +
+                "      \"action_ts\": \"1661488741.407859\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+        BlockActionPayload payload = GSON.fromJson(jsonData, BlockActionPayload.class);
+        assertThat(payload.getType(), is("block_actions"));
+        assertThat(payload.getActions().size(), is(1));
+    }
+
 
 }


### PR DESCRIPTION
This pull request resolves #1038 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
