### PR TITLE
Add headers to WebhookResponse class

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/Slack.java
+++ b/slack-api-client/src/main/java/com/slack/api/Slack.java
@@ -128,6 +128,7 @@ public class Slack implements AutoCloseable {
         return WebhookResponse.builder()
                 .code(httpResponse.code())
                 .message(httpResponse.message())
+                .headers(httpResponse.headers().toMultimap())
                 .body(body)
                 .build();
     }
@@ -144,6 +145,7 @@ public class Slack implements AutoCloseable {
         return WebhookResponse.builder()
                 .code(httpResponse.code())
                 .message(httpResponse.message())
+                .headers(httpResponse.headers().toMultimap())
                 .body(body)
                 .build();
     }

--- a/slack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 
 @Slf4j
 public class IncomingWebhooksTest {
@@ -290,5 +291,13 @@ public class IncomingWebhooksTest {
         WebhookResponse response = slack.send(url, payload);
         assertThat(response.getBody(), is("invalid_blocks"));
         assertThat(response.getCode(), is(400));
+    }
+
+    @Test
+    public void headers() throws IOException {
+        WebhookResponse response = slack.send(url, Payload.builder().text("Hello world!").build());
+        assertThat(response.getBody(), is("ok"));
+        assertThat(response.getCode(), is(200));
+        assertThat(response.getHeaders().size(),is(greaterThan(0)));
     }
 }

--- a/slack-api-model/src/main/java/com/slack/api/webhook/WebhookResponse.java
+++ b/slack-api-model/src/main/java/com/slack/api/webhook/WebhookResponse.java
@@ -3,10 +3,14 @@ package com.slack.api.webhook;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
 @Builder
 public class WebhookResponse {
     private Integer code;
     private String message;
+    private Map<String, List<String>> headers;
     private String body;
 }


### PR DESCRIPTION
This pull request enhances WebhookResponse class to include more information about the webhook API call response.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
