### PR TITLE
Add share_shortcut block support

### DIFF
--- a/json-logs/samples/api/chat.postMessage.json
+++ b/json-logs/samples/api/chat.postMessage.json
@@ -54,201 +54,7 @@
     "blocks": [
       {
         "type": "",
-        "block_id": "",
         "elements": [
-          {
-            "type": "",
-            "elements": [
-              {
-                "type": "",
-                "text": ""
-              },
-              {
-                "type": "",
-                "text": "",
-                "url": "https://www.example.com/"
-              },
-              {
-                "type": "",
-                "url": "https://www.example.com/"
-              },
-              {
-                "type": "",
-                "elements": [
-                  {
-                    "type": "",
-                    "range": "",
-                    "text": "",
-                    "style": {
-                      "bold": false,
-                      "italic": false,
-                      "strike": false,
-                      "code": false
-                    },
-                    "channel_id": "",
-                    "value": "",
-                    "timestamp": "",
-                    "url": "",
-                    "team_id": "",
-                    "user_id": "",
-                    "usergroup_id": "",
-                    "name": "",
-                    "skin_tone": 12345,
-                    "unicode": ""
-                  }
-                ],
-                "style": "",
-                "indent": 12345,
-                "offset": 12345,
-                "border": 12345
-              }
-            ],
-            "text": {
-              "type": "",
-              "text": "",
-              "emoji": false
-            },
-            "action_id": "",
-            "url": "",
-            "value": "",
-            "style": "",
-            "confirm": {
-              "title": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "text": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "confirm": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "deny": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "style": ""
-            },
-            "accessibility_label": "",
-            "options": [
-              {
-                "text": {
-                  "type": "",
-                  "text": "",
-                  "emoji": false
-                },
-                "value": "",
-                "description": {
-                  "type": "",
-                  "text": "",
-                  "emoji": false
-                },
-                "url": ""
-              }
-            ],
-            "initial_options": [
-              {
-                "text": {
-                  "type": "",
-                  "text": "",
-                  "emoji": false
-                },
-                "value": "",
-                "description": {
-                  "type": "",
-                  "text": "",
-                  "emoji": false
-                },
-                "url": ""
-              }
-            ],
-            "focus_on_load": false,
-            "initial_option": {
-              "text": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "value": "",
-              "description": {
-                "type": "",
-                "text": "",
-                "emoji": false
-              },
-              "url": ""
-            },
-            "placeholder": {
-              "type": "",
-              "text": "",
-              "emoji": false
-            },
-            "initial_channel": "",
-            "response_url_enabled": false,
-            "initial_channels": [
-              ""
-            ],
-            "max_selected_items": 12345,
-            "initial_conversation": "",
-            "default_to_current_conversation": false,
-            "filter": {
-              "include": [
-                ""
-              ],
-              "exclude_external_shared_channels": false,
-              "exclude_bot_users": false
-            },
-            "initial_conversations": [
-              ""
-            ],
-            "initial_date": "",
-            "initial_time": "",
-            "timezone": "",
-            "min_query_length": 12345,
-            "image_url": "",
-            "alt_text": "",
-            "fallback": "",
-            "image_width": 12345,
-            "image_height": 12345,
-            "image_bytes": 12345,
-            "option_groups": [
-              {
-                "label": {
-                  "type": "",
-                  "text": "",
-                  "emoji": false
-                },
-                "options": [
-                  {
-                    "text": {
-                      "type": "",
-                      "text": "",
-                      "emoji": false
-                    },
-                    "value": "",
-                    "description": {
-                      "type": "",
-                      "text": "",
-                      "emoji": false
-                    },
-                    "url": ""
-                  }
-                ]
-              }
-            ],
-            "initial_user": "",
-            "initial_users": [
-              ""
-            ],
-            "indent": 12345,
-            "offset": 12345,
-            "border": 12345
-          },
           {
             "type": "",
             "text": {
@@ -478,11 +284,7 @@
             "border": 12345
           }
         ],
-        "text": {
-          "type": "",
-          "text": "",
-          "emoji": false
-        },
+        "block_id": "",
         "call_id": "",
         "api_decoration_available": false,
         "call": {
@@ -540,6 +342,477 @@
         "source": "",
         "file_id": "",
         "file": {
+          "timestamp": 123,
+          "name": "",
+          "title": "",
+          "subject": "",
+          "mimetype": "",
+          "filetype": "",
+          "pretty_type": "",
+          "user": "",
+          "user_team": "",
+          "mode": "",
+          "editable": false,
+          "non_owner_editable": false,
+          "editor": "",
+          "last_editor": "",
+          "updated": 123,
+          "file_access": "",
+          "subtype": "",
+          "transcription": {
+            "status": "",
+            "locale": ""
+          },
+          "mp4": "",
+          "vtt": "",
+          "hls": "",
+          "hls_embed": "",
+          "duration_ms": 123,
+          "thumb_video_w": 123,
+          "thumb_video_h": 123,
+          "original_attachment_count": 123,
+          "is_external": false,
+          "external_type": "",
+          "external_id": "",
+          "external_url": "",
+          "username": "",
+          "size": 123,
+          "url_private": "",
+          "url_private_download": "",
+          "app_id": "",
+          "app_name": "",
+          "thumb_64": "",
+          "thumb_64_gif": "",
+          "thumb_64_w": "",
+          "thumb_64_h": "",
+          "thumb_80": "",
+          "thumb_80_gif": "",
+          "thumb_80_w": "",
+          "thumb_80_h": "",
+          "thumb_160": "",
+          "thumb_160_gif": "",
+          "thumb_160_w": "",
+          "thumb_160_h": "",
+          "thumb_360": "",
+          "thumb_360_gif": "",
+          "thumb_360_w": "",
+          "thumb_360_h": "",
+          "thumb_480": "",
+          "thumb_480_gif": "",
+          "thumb_480_w": "",
+          "thumb_480_h": "",
+          "thumb_720": "",
+          "thumb_720_gif": "",
+          "thumb_720_w": "",
+          "thumb_720_h": "",
+          "thumb_800": "",
+          "thumb_800_gif": "",
+          "thumb_800_w": "",
+          "thumb_800_h": "",
+          "thumb_960": "",
+          "thumb_960_gif": "",
+          "thumb_960_w": "",
+          "thumb_960_h": "",
+          "thumb_1024": "",
+          "thumb_1024_gif": "",
+          "thumb_1024_w": "",
+          "thumb_1024_h": "",
+          "thumb_video": "",
+          "thumb_gif": "",
+          "thumb_pdf": "",
+          "thumb_pdf_w": "",
+          "thumb_pdf_h": "",
+          "thumb_tiny": "",
+          "converted_pdf": "",
+          "image_exif_rotation": 123,
+          "original_w": "",
+          "original_h": "",
+          "deanimate": "",
+          "deanimate_gif": "",
+          "pjpeg": "",
+          "permalink": "",
+          "permalink_public": "",
+          "edit_link": "",
+          "has_rich_preview": false,
+          "media_display_type": "",
+          "preview_is_truncated": false,
+          "preview": "",
+          "preview_highlight": "",
+          "plain_text": "",
+          "preview_plain_text": "",
+          "has_more": false,
+          "sent_to_self": false,
+          "lines": 123,
+          "lines_more": 123,
+          "is_public": false,
+          "public_url_shared": false,
+          "display_as_bot": false,
+          "channels": [
+            ""
+          ],
+          "groups": [
+            ""
+          ],
+          "ims": [
+            ""
+          ],
+          "shares": {
+            "public": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            },
+            "private": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "from": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "cc": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "channel_actions_ts": "",
+          "channel_actions_count": 123,
+          "headers": {
+            "date": "",
+            "in_reply_to": "",
+            "reply_to": "",
+            "message_id": ""
+          },
+          "simplified_html": "",
+          "bot_id": "",
+          "initial_comment": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "user": "",
+            "comment": "",
+            "channel": "",
+            "is_intro": false
+          },
+          "num_stars": 123,
+          "is_starred": false,
+          "pinned_to": [
+            ""
+          ],
+          "reactions": [
+            {
+              "name": "",
+              "count": 123,
+              "users": [
+                ""
+              ],
+              "url": ""
+            }
+          ],
+          "comments_count": 123,
+          "id": "",
+          "created": 123,
+          "subject": "",
+          "mimetype": "",
+          "filetype": "",
+          "pretty_type": "",
+          "user": "",
+          "user_team": "",
+          "mode": "",
+          "editable": false,
+          "non_owner_editable": false,
+          "editor": "",
+          "last_editor": "",
+          "updated": 123,
+          "file_access": "",
+          "subtype": "",
+          "transcription": {
+            "status": "",
+            "locale": ""
+          },
+          "mp4": "",
+          "vtt": "",
+          "hls": "",
+          "hls_embed": "",
+          "duration_ms": 123,
+          "thumb_video_w": 123,
+          "thumb_video_h": 123,
+          "original_attachment_count": 123,
+          "is_external": false,
+          "external_type": "",
+          "external_id": "",
+          "external_url": "",
+          "username": "",
+          "size": 123,
+          "url_private": "",
+          "url_private_download": "",
+          "app_id": "",
+          "app_name": "",
+          "thumb_64": "",
+          "thumb_64_gif": "",
+          "thumb_64_w": "",
+          "thumb_64_h": "",
+          "thumb_80": "",
+          "thumb_80_gif": "",
+          "thumb_80_w": "",
+          "thumb_80_h": "",
+          "thumb_160": "",
+          "thumb_160_gif": "",
+          "thumb_160_w": "",
+          "thumb_160_h": "",
+          "thumb_360": "",
+          "thumb_360_gif": "",
+          "thumb_360_w": "",
+          "thumb_360_h": "",
+          "thumb_480": "",
+          "thumb_480_gif": "",
+          "thumb_480_w": "",
+          "thumb_480_h": "",
+          "thumb_720": "",
+          "thumb_720_gif": "",
+          "thumb_720_w": "",
+          "thumb_720_h": "",
+          "thumb_800": "",
+          "thumb_800_gif": "",
+          "thumb_800_w": "",
+          "thumb_800_h": "",
+          "thumb_960": "",
+          "thumb_960_gif": "",
+          "thumb_960_w": "",
+          "thumb_960_h": "",
+          "thumb_1024": "",
+          "thumb_1024_gif": "",
+          "thumb_1024_w": "",
+          "thumb_1024_h": "",
+          "thumb_video": "",
+          "thumb_gif": "",
+          "thumb_pdf": "",
+          "thumb_pdf_w": "",
+          "thumb_pdf_h": "",
+          "thumb_tiny": "",
+          "converted_pdf": "",
+          "image_exif_rotation": 123,
+          "original_w": "",
+          "original_h": "",
+          "deanimate": "",
+          "deanimate_gif": "",
+          "pjpeg": "",
+          "permalink": "",
+          "permalink_public": "",
+          "edit_link": "",
+          "has_rich_preview": false,
+          "media_display_type": "",
+          "preview_is_truncated": false,
+          "preview": "",
+          "preview_highlight": "",
+          "plain_text": "",
+          "preview_plain_text": "",
+          "has_more": false,
+          "sent_to_self": false,
+          "lines": 123,
+          "lines_more": 123,
+          "is_public": false,
+          "public_url_shared": false,
+          "display_as_bot": false,
+          "channels": [
+            ""
+          ],
+          "groups": [
+            ""
+          ],
+          "ims": [
+            ""
+          ],
+          "shares": {
+            "public": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            },
+            "private": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "from": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "cc": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "channel_actions_ts": "",
+          "channel_actions_count": 123,
+          "headers": {
+            "date": "",
+            "in_reply_to": "",
+            "reply_to": "",
+            "message_id": ""
+          },
+          "simplified_html": "",
+          "bot_id": "",
+          "initial_comment": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "user": "",
+            "comment": "",
+            "channel": "",
+            "is_intro": false
+          },
+          "num_stars": 123,
+          "is_starred": false,
+          "pinned_to": [
+            ""
+          ],
+          "reactions": [
+            {
+              "name": "",
+              "count": 123,
+              "users": [
+                ""
+              ],
+              "url": ""
+            }
+          ],
+          "comments_count": 123,
           "id": "",
           "created": 123,
           "timestamp": 123,
@@ -779,6 +1052,11 @@
           ],
           "comments_count": 123
         },
+        "text": {
+          "type": "",
+          "text": "",
+          "emoji": false
+        },
         "fallback": "",
         "image_url": "",
         "image_width": 12345,
@@ -801,6 +1079,15 @@
         "author_name": "",
         "provider_name": "",
         "provider_icon_url": "",
+        "function_trigger_id": "",
+        "app_id": "",
+        "is_workflow_app": false,
+        "app_collaborators": [
+          ""
+        ],
+        "button_label": "",
+        "bot_user_id": "",
+        "url": "",
         "fields": [
           {
             "type": "",
@@ -1501,6 +1788,477 @@
             "source": "",
             "file_id": "",
             "file": {
+              "timestamp": 123,
+              "name": "",
+              "title": "",
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
+              "id": "",
+              "created": 123,
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
               "id": "",
               "created": 123,
               "timestamp": 123,
@@ -1767,6 +2525,15 @@
             "author_name": "",
             "provider_name": "",
             "provider_icon_url": "",
+            "function_trigger_id": "",
+            "app_id": "",
+            "is_workflow_app": false,
+            "app_collaborators": [
+              ""
+            ],
+            "button_label": "",
+            "bot_user_id": "",
+            "url": "",
             "fields": [
               {
                 "type": "",

--- a/json-logs/samples/api/chat.scheduleMessage.json
+++ b/json-logs/samples/api/chat.scheduleMessage.json
@@ -313,6 +313,477 @@
         "source": "",
         "file_id": "",
         "file": {
+          "timestamp": 123,
+          "name": "",
+          "title": "",
+          "subject": "",
+          "mimetype": "",
+          "filetype": "",
+          "pretty_type": "",
+          "user": "",
+          "user_team": "",
+          "mode": "",
+          "editable": false,
+          "non_owner_editable": false,
+          "editor": "",
+          "last_editor": "",
+          "updated": 123,
+          "file_access": "",
+          "subtype": "",
+          "transcription": {
+            "status": "",
+            "locale": ""
+          },
+          "mp4": "",
+          "vtt": "",
+          "hls": "",
+          "hls_embed": "",
+          "duration_ms": 123,
+          "thumb_video_w": 123,
+          "thumb_video_h": 123,
+          "original_attachment_count": 123,
+          "is_external": false,
+          "external_type": "",
+          "external_id": "",
+          "external_url": "",
+          "username": "",
+          "size": 123,
+          "url_private": "",
+          "url_private_download": "",
+          "app_id": "",
+          "app_name": "",
+          "thumb_64": "",
+          "thumb_64_gif": "",
+          "thumb_64_w": "",
+          "thumb_64_h": "",
+          "thumb_80": "",
+          "thumb_80_gif": "",
+          "thumb_80_w": "",
+          "thumb_80_h": "",
+          "thumb_160": "",
+          "thumb_160_gif": "",
+          "thumb_160_w": "",
+          "thumb_160_h": "",
+          "thumb_360": "",
+          "thumb_360_gif": "",
+          "thumb_360_w": "",
+          "thumb_360_h": "",
+          "thumb_480": "",
+          "thumb_480_gif": "",
+          "thumb_480_w": "",
+          "thumb_480_h": "",
+          "thumb_720": "",
+          "thumb_720_gif": "",
+          "thumb_720_w": "",
+          "thumb_720_h": "",
+          "thumb_800": "",
+          "thumb_800_gif": "",
+          "thumb_800_w": "",
+          "thumb_800_h": "",
+          "thumb_960": "",
+          "thumb_960_gif": "",
+          "thumb_960_w": "",
+          "thumb_960_h": "",
+          "thumb_1024": "",
+          "thumb_1024_gif": "",
+          "thumb_1024_w": "",
+          "thumb_1024_h": "",
+          "thumb_video": "",
+          "thumb_gif": "",
+          "thumb_pdf": "",
+          "thumb_pdf_w": "",
+          "thumb_pdf_h": "",
+          "thumb_tiny": "",
+          "converted_pdf": "",
+          "image_exif_rotation": 123,
+          "original_w": "",
+          "original_h": "",
+          "deanimate": "",
+          "deanimate_gif": "",
+          "pjpeg": "",
+          "permalink": "",
+          "permalink_public": "",
+          "edit_link": "",
+          "has_rich_preview": false,
+          "media_display_type": "",
+          "preview_is_truncated": false,
+          "preview": "",
+          "preview_highlight": "",
+          "plain_text": "",
+          "preview_plain_text": "",
+          "has_more": false,
+          "sent_to_self": false,
+          "lines": 123,
+          "lines_more": 123,
+          "is_public": false,
+          "public_url_shared": false,
+          "display_as_bot": false,
+          "channels": [
+            ""
+          ],
+          "groups": [
+            ""
+          ],
+          "ims": [
+            ""
+          ],
+          "shares": {
+            "public": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            },
+            "private": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "from": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "cc": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "channel_actions_ts": "",
+          "channel_actions_count": 123,
+          "headers": {
+            "date": "",
+            "in_reply_to": "",
+            "reply_to": "",
+            "message_id": ""
+          },
+          "simplified_html": "",
+          "bot_id": "",
+          "initial_comment": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "user": "",
+            "comment": "",
+            "channel": "",
+            "is_intro": false
+          },
+          "num_stars": 123,
+          "is_starred": false,
+          "pinned_to": [
+            ""
+          ],
+          "reactions": [
+            {
+              "name": "",
+              "count": 123,
+              "users": [
+                ""
+              ],
+              "url": ""
+            }
+          ],
+          "comments_count": 123,
+          "id": "",
+          "created": 123,
+          "subject": "",
+          "mimetype": "",
+          "filetype": "",
+          "pretty_type": "",
+          "user": "",
+          "user_team": "",
+          "mode": "",
+          "editable": false,
+          "non_owner_editable": false,
+          "editor": "",
+          "last_editor": "",
+          "updated": 123,
+          "file_access": "",
+          "subtype": "",
+          "transcription": {
+            "status": "",
+            "locale": ""
+          },
+          "mp4": "",
+          "vtt": "",
+          "hls": "",
+          "hls_embed": "",
+          "duration_ms": 123,
+          "thumb_video_w": 123,
+          "thumb_video_h": 123,
+          "original_attachment_count": 123,
+          "is_external": false,
+          "external_type": "",
+          "external_id": "",
+          "external_url": "",
+          "username": "",
+          "size": 123,
+          "url_private": "",
+          "url_private_download": "",
+          "app_id": "",
+          "app_name": "",
+          "thumb_64": "",
+          "thumb_64_gif": "",
+          "thumb_64_w": "",
+          "thumb_64_h": "",
+          "thumb_80": "",
+          "thumb_80_gif": "",
+          "thumb_80_w": "",
+          "thumb_80_h": "",
+          "thumb_160": "",
+          "thumb_160_gif": "",
+          "thumb_160_w": "",
+          "thumb_160_h": "",
+          "thumb_360": "",
+          "thumb_360_gif": "",
+          "thumb_360_w": "",
+          "thumb_360_h": "",
+          "thumb_480": "",
+          "thumb_480_gif": "",
+          "thumb_480_w": "",
+          "thumb_480_h": "",
+          "thumb_720": "",
+          "thumb_720_gif": "",
+          "thumb_720_w": "",
+          "thumb_720_h": "",
+          "thumb_800": "",
+          "thumb_800_gif": "",
+          "thumb_800_w": "",
+          "thumb_800_h": "",
+          "thumb_960": "",
+          "thumb_960_gif": "",
+          "thumb_960_w": "",
+          "thumb_960_h": "",
+          "thumb_1024": "",
+          "thumb_1024_gif": "",
+          "thumb_1024_w": "",
+          "thumb_1024_h": "",
+          "thumb_video": "",
+          "thumb_gif": "",
+          "thumb_pdf": "",
+          "thumb_pdf_w": "",
+          "thumb_pdf_h": "",
+          "thumb_tiny": "",
+          "converted_pdf": "",
+          "image_exif_rotation": 123,
+          "original_w": "",
+          "original_h": "",
+          "deanimate": "",
+          "deanimate_gif": "",
+          "pjpeg": "",
+          "permalink": "",
+          "permalink_public": "",
+          "edit_link": "",
+          "has_rich_preview": false,
+          "media_display_type": "",
+          "preview_is_truncated": false,
+          "preview": "",
+          "preview_highlight": "",
+          "plain_text": "",
+          "preview_plain_text": "",
+          "has_more": false,
+          "sent_to_self": false,
+          "lines": 123,
+          "lines_more": 123,
+          "is_public": false,
+          "public_url_shared": false,
+          "display_as_bot": false,
+          "channels": [
+            ""
+          ],
+          "groups": [
+            ""
+          ],
+          "ims": [
+            ""
+          ],
+          "shares": {
+            "public": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            },
+            "private": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "from": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "cc": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "channel_actions_ts": "",
+          "channel_actions_count": 123,
+          "headers": {
+            "date": "",
+            "in_reply_to": "",
+            "reply_to": "",
+            "message_id": ""
+          },
+          "simplified_html": "",
+          "bot_id": "",
+          "initial_comment": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "user": "",
+            "comment": "",
+            "channel": "",
+            "is_intro": false
+          },
+          "num_stars": 123,
+          "is_starred": false,
+          "pinned_to": [
+            ""
+          ],
+          "reactions": [
+            {
+              "name": "",
+              "count": 123,
+              "users": [
+                ""
+              ],
+              "url": ""
+            }
+          ],
+          "comments_count": 123,
           "id": "",
           "created": 123,
           "timestamp": 123,
@@ -323,6 +794,7 @@
           "filetype": "",
           "pretty_type": "",
           "user": "",
+          "user_team": "",
           "mode": "",
           "editable": false,
           "non_owner_editable": false,
@@ -578,6 +1050,15 @@
         "author_name": "",
         "provider_name": "",
         "provider_icon_url": "",
+        "function_trigger_id": "",
+        "app_id": "",
+        "is_workflow_app": false,
+        "app_collaborators": [
+          ""
+        ],
+        "button_label": "",
+        "bot_user_id": "",
+        "url": "",
         "fields": [
           {
             "type": "",

--- a/json-logs/samples/api/chat.update.json
+++ b/json-logs/samples/api/chat.update.json
@@ -313,6 +313,477 @@
         "source": "",
         "file_id": "",
         "file": {
+          "timestamp": 123,
+          "name": "",
+          "title": "",
+          "subject": "",
+          "mimetype": "",
+          "filetype": "",
+          "pretty_type": "",
+          "user": "",
+          "user_team": "",
+          "mode": "",
+          "editable": false,
+          "non_owner_editable": false,
+          "editor": "",
+          "last_editor": "",
+          "updated": 123,
+          "file_access": "",
+          "subtype": "",
+          "transcription": {
+            "status": "",
+            "locale": ""
+          },
+          "mp4": "",
+          "vtt": "",
+          "hls": "",
+          "hls_embed": "",
+          "duration_ms": 123,
+          "thumb_video_w": 123,
+          "thumb_video_h": 123,
+          "original_attachment_count": 123,
+          "is_external": false,
+          "external_type": "",
+          "external_id": "",
+          "external_url": "",
+          "username": "",
+          "size": 123,
+          "url_private": "",
+          "url_private_download": "",
+          "app_id": "",
+          "app_name": "",
+          "thumb_64": "",
+          "thumb_64_gif": "",
+          "thumb_64_w": "",
+          "thumb_64_h": "",
+          "thumb_80": "",
+          "thumb_80_gif": "",
+          "thumb_80_w": "",
+          "thumb_80_h": "",
+          "thumb_160": "",
+          "thumb_160_gif": "",
+          "thumb_160_w": "",
+          "thumb_160_h": "",
+          "thumb_360": "",
+          "thumb_360_gif": "",
+          "thumb_360_w": "",
+          "thumb_360_h": "",
+          "thumb_480": "",
+          "thumb_480_gif": "",
+          "thumb_480_w": "",
+          "thumb_480_h": "",
+          "thumb_720": "",
+          "thumb_720_gif": "",
+          "thumb_720_w": "",
+          "thumb_720_h": "",
+          "thumb_800": "",
+          "thumb_800_gif": "",
+          "thumb_800_w": "",
+          "thumb_800_h": "",
+          "thumb_960": "",
+          "thumb_960_gif": "",
+          "thumb_960_w": "",
+          "thumb_960_h": "",
+          "thumb_1024": "",
+          "thumb_1024_gif": "",
+          "thumb_1024_w": "",
+          "thumb_1024_h": "",
+          "thumb_video": "",
+          "thumb_gif": "",
+          "thumb_pdf": "",
+          "thumb_pdf_w": "",
+          "thumb_pdf_h": "",
+          "thumb_tiny": "",
+          "converted_pdf": "",
+          "image_exif_rotation": 123,
+          "original_w": "",
+          "original_h": "",
+          "deanimate": "",
+          "deanimate_gif": "",
+          "pjpeg": "",
+          "permalink": "",
+          "permalink_public": "",
+          "edit_link": "",
+          "has_rich_preview": false,
+          "media_display_type": "",
+          "preview_is_truncated": false,
+          "preview": "",
+          "preview_highlight": "",
+          "plain_text": "",
+          "preview_plain_text": "",
+          "has_more": false,
+          "sent_to_self": false,
+          "lines": 123,
+          "lines_more": 123,
+          "is_public": false,
+          "public_url_shared": false,
+          "display_as_bot": false,
+          "channels": [
+            ""
+          ],
+          "groups": [
+            ""
+          ],
+          "ims": [
+            ""
+          ],
+          "shares": {
+            "public": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            },
+            "private": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "from": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "cc": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "channel_actions_ts": "",
+          "channel_actions_count": 123,
+          "headers": {
+            "date": "",
+            "in_reply_to": "",
+            "reply_to": "",
+            "message_id": ""
+          },
+          "simplified_html": "",
+          "bot_id": "",
+          "initial_comment": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "user": "",
+            "comment": "",
+            "channel": "",
+            "is_intro": false
+          },
+          "num_stars": 123,
+          "is_starred": false,
+          "pinned_to": [
+            ""
+          ],
+          "reactions": [
+            {
+              "name": "",
+              "count": 123,
+              "users": [
+                ""
+              ],
+              "url": ""
+            }
+          ],
+          "comments_count": 123,
+          "id": "",
+          "created": 123,
+          "subject": "",
+          "mimetype": "",
+          "filetype": "",
+          "pretty_type": "",
+          "user": "",
+          "user_team": "",
+          "mode": "",
+          "editable": false,
+          "non_owner_editable": false,
+          "editor": "",
+          "last_editor": "",
+          "updated": 123,
+          "file_access": "",
+          "subtype": "",
+          "transcription": {
+            "status": "",
+            "locale": ""
+          },
+          "mp4": "",
+          "vtt": "",
+          "hls": "",
+          "hls_embed": "",
+          "duration_ms": 123,
+          "thumb_video_w": 123,
+          "thumb_video_h": 123,
+          "original_attachment_count": 123,
+          "is_external": false,
+          "external_type": "",
+          "external_id": "",
+          "external_url": "",
+          "username": "",
+          "size": 123,
+          "url_private": "",
+          "url_private_download": "",
+          "app_id": "",
+          "app_name": "",
+          "thumb_64": "",
+          "thumb_64_gif": "",
+          "thumb_64_w": "",
+          "thumb_64_h": "",
+          "thumb_80": "",
+          "thumb_80_gif": "",
+          "thumb_80_w": "",
+          "thumb_80_h": "",
+          "thumb_160": "",
+          "thumb_160_gif": "",
+          "thumb_160_w": "",
+          "thumb_160_h": "",
+          "thumb_360": "",
+          "thumb_360_gif": "",
+          "thumb_360_w": "",
+          "thumb_360_h": "",
+          "thumb_480": "",
+          "thumb_480_gif": "",
+          "thumb_480_w": "",
+          "thumb_480_h": "",
+          "thumb_720": "",
+          "thumb_720_gif": "",
+          "thumb_720_w": "",
+          "thumb_720_h": "",
+          "thumb_800": "",
+          "thumb_800_gif": "",
+          "thumb_800_w": "",
+          "thumb_800_h": "",
+          "thumb_960": "",
+          "thumb_960_gif": "",
+          "thumb_960_w": "",
+          "thumb_960_h": "",
+          "thumb_1024": "",
+          "thumb_1024_gif": "",
+          "thumb_1024_w": "",
+          "thumb_1024_h": "",
+          "thumb_video": "",
+          "thumb_gif": "",
+          "thumb_pdf": "",
+          "thumb_pdf_w": "",
+          "thumb_pdf_h": "",
+          "thumb_tiny": "",
+          "converted_pdf": "",
+          "image_exif_rotation": 123,
+          "original_w": "",
+          "original_h": "",
+          "deanimate": "",
+          "deanimate_gif": "",
+          "pjpeg": "",
+          "permalink": "",
+          "permalink_public": "",
+          "edit_link": "",
+          "has_rich_preview": false,
+          "media_display_type": "",
+          "preview_is_truncated": false,
+          "preview": "",
+          "preview_highlight": "",
+          "plain_text": "",
+          "preview_plain_text": "",
+          "has_more": false,
+          "sent_to_self": false,
+          "lines": 123,
+          "lines_more": 123,
+          "is_public": false,
+          "public_url_shared": false,
+          "display_as_bot": false,
+          "channels": [
+            ""
+          ],
+          "groups": [
+            ""
+          ],
+          "ims": [
+            ""
+          ],
+          "shares": {
+            "public": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            },
+            "private": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "from": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "cc": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "channel_actions_ts": "",
+          "channel_actions_count": 123,
+          "headers": {
+            "date": "",
+            "in_reply_to": "",
+            "reply_to": "",
+            "message_id": ""
+          },
+          "simplified_html": "",
+          "bot_id": "",
+          "initial_comment": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "user": "",
+            "comment": "",
+            "channel": "",
+            "is_intro": false
+          },
+          "num_stars": 123,
+          "is_starred": false,
+          "pinned_to": [
+            ""
+          ],
+          "reactions": [
+            {
+              "name": "",
+              "count": 123,
+              "users": [
+                ""
+              ],
+              "url": ""
+            }
+          ],
+          "comments_count": 123,
           "id": "",
           "created": 123,
           "timestamp": 123,
@@ -579,6 +1050,15 @@
         "author_name": "",
         "provider_name": "",
         "provider_icon_url": "",
+        "function_trigger_id": "",
+        "app_id": "",
+        "is_workflow_app": false,
+        "app_collaborators": [
+          ""
+        ],
+        "button_label": "",
+        "bot_user_id": "",
+        "url": "",
         "fields": [
           {
             "type": "",

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -32,7 +32,10 @@
       "username": "",
       "icons": {
         "emoji": "",
-        "image_64": "https://www.example.com/"
+        "image_64": "https://www.example.com/",
+        "image_36": "https://www.example.com/",
+        "image_48": "https://www.example.com/",
+        "image_72": "https://www.example.com/"
       },
       "parent_user_id": "U00000000",
       "reply_count": 12345,
@@ -599,6 +602,477 @@
           "source": "",
           "file_id": "",
           "file": {
+            "timestamp": 123,
+            "name": "",
+            "title": "",
+            "subject": "",
+            "mimetype": "",
+            "filetype": "",
+            "pretty_type": "",
+            "user": "",
+            "user_team": "",
+            "mode": "",
+            "editable": false,
+            "non_owner_editable": false,
+            "editor": "",
+            "last_editor": "",
+            "updated": 123,
+            "file_access": "",
+            "subtype": "",
+            "transcription": {
+              "status": "",
+              "locale": ""
+            },
+            "mp4": "",
+            "vtt": "",
+            "hls": "",
+            "hls_embed": "",
+            "duration_ms": 123,
+            "thumb_video_w": 123,
+            "thumb_video_h": 123,
+            "original_attachment_count": 123,
+            "is_external": false,
+            "external_type": "",
+            "external_id": "",
+            "external_url": "",
+            "username": "",
+            "size": 123,
+            "url_private": "",
+            "url_private_download": "",
+            "app_id": "",
+            "app_name": "",
+            "thumb_64": "",
+            "thumb_64_gif": "",
+            "thumb_64_w": "",
+            "thumb_64_h": "",
+            "thumb_80": "",
+            "thumb_80_gif": "",
+            "thumb_80_w": "",
+            "thumb_80_h": "",
+            "thumb_160": "",
+            "thumb_160_gif": "",
+            "thumb_160_w": "",
+            "thumb_160_h": "",
+            "thumb_360": "",
+            "thumb_360_gif": "",
+            "thumb_360_w": "",
+            "thumb_360_h": "",
+            "thumb_480": "",
+            "thumb_480_gif": "",
+            "thumb_480_w": "",
+            "thumb_480_h": "",
+            "thumb_720": "",
+            "thumb_720_gif": "",
+            "thumb_720_w": "",
+            "thumb_720_h": "",
+            "thumb_800": "",
+            "thumb_800_gif": "",
+            "thumb_800_w": "",
+            "thumb_800_h": "",
+            "thumb_960": "",
+            "thumb_960_gif": "",
+            "thumb_960_w": "",
+            "thumb_960_h": "",
+            "thumb_1024": "",
+            "thumb_1024_gif": "",
+            "thumb_1024_w": "",
+            "thumb_1024_h": "",
+            "thumb_video": "",
+            "thumb_gif": "",
+            "thumb_pdf": "",
+            "thumb_pdf_w": "",
+            "thumb_pdf_h": "",
+            "thumb_tiny": "",
+            "converted_pdf": "",
+            "image_exif_rotation": 123,
+            "original_w": "",
+            "original_h": "",
+            "deanimate": "",
+            "deanimate_gif": "",
+            "pjpeg": "",
+            "permalink": "",
+            "permalink_public": "",
+            "edit_link": "",
+            "has_rich_preview": false,
+            "media_display_type": "",
+            "preview_is_truncated": false,
+            "preview": "",
+            "preview_highlight": "",
+            "plain_text": "",
+            "preview_plain_text": "",
+            "has_more": false,
+            "sent_to_self": false,
+            "lines": 123,
+            "lines_more": 123,
+            "is_public": false,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "channels": [
+              ""
+            ],
+            "groups": [
+              ""
+            ],
+            "ims": [
+              ""
+            ],
+            "shares": {
+              "public": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              },
+              "private": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              }
+            },
+            "to": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "from": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "cc": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "channel_actions_ts": "",
+            "channel_actions_count": 123,
+            "headers": {
+              "date": "",
+              "in_reply_to": "",
+              "reply_to": "",
+              "message_id": ""
+            },
+            "simplified_html": "",
+            "bot_id": "",
+            "initial_comment": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "user": "",
+              "comment": "",
+              "channel": "",
+              "is_intro": false
+            },
+            "num_stars": 123,
+            "is_starred": false,
+            "pinned_to": [
+              ""
+            ],
+            "reactions": [
+              {
+                "name": "",
+                "count": 123,
+                "users": [
+                  ""
+                ],
+                "url": ""
+              }
+            ],
+            "comments_count": 123,
+            "id": "",
+            "created": 123,
+            "subject": "",
+            "mimetype": "",
+            "filetype": "",
+            "pretty_type": "",
+            "user": "",
+            "user_team": "",
+            "mode": "",
+            "editable": false,
+            "non_owner_editable": false,
+            "editor": "",
+            "last_editor": "",
+            "updated": 123,
+            "file_access": "",
+            "subtype": "",
+            "transcription": {
+              "status": "",
+              "locale": ""
+            },
+            "mp4": "",
+            "vtt": "",
+            "hls": "",
+            "hls_embed": "",
+            "duration_ms": 123,
+            "thumb_video_w": 123,
+            "thumb_video_h": 123,
+            "original_attachment_count": 123,
+            "is_external": false,
+            "external_type": "",
+            "external_id": "",
+            "external_url": "",
+            "username": "",
+            "size": 123,
+            "url_private": "",
+            "url_private_download": "",
+            "app_id": "",
+            "app_name": "",
+            "thumb_64": "",
+            "thumb_64_gif": "",
+            "thumb_64_w": "",
+            "thumb_64_h": "",
+            "thumb_80": "",
+            "thumb_80_gif": "",
+            "thumb_80_w": "",
+            "thumb_80_h": "",
+            "thumb_160": "",
+            "thumb_160_gif": "",
+            "thumb_160_w": "",
+            "thumb_160_h": "",
+            "thumb_360": "",
+            "thumb_360_gif": "",
+            "thumb_360_w": "",
+            "thumb_360_h": "",
+            "thumb_480": "",
+            "thumb_480_gif": "",
+            "thumb_480_w": "",
+            "thumb_480_h": "",
+            "thumb_720": "",
+            "thumb_720_gif": "",
+            "thumb_720_w": "",
+            "thumb_720_h": "",
+            "thumb_800": "",
+            "thumb_800_gif": "",
+            "thumb_800_w": "",
+            "thumb_800_h": "",
+            "thumb_960": "",
+            "thumb_960_gif": "",
+            "thumb_960_w": "",
+            "thumb_960_h": "",
+            "thumb_1024": "",
+            "thumb_1024_gif": "",
+            "thumb_1024_w": "",
+            "thumb_1024_h": "",
+            "thumb_video": "",
+            "thumb_gif": "",
+            "thumb_pdf": "",
+            "thumb_pdf_w": "",
+            "thumb_pdf_h": "",
+            "thumb_tiny": "",
+            "converted_pdf": "",
+            "image_exif_rotation": 123,
+            "original_w": "",
+            "original_h": "",
+            "deanimate": "",
+            "deanimate_gif": "",
+            "pjpeg": "",
+            "permalink": "",
+            "permalink_public": "",
+            "edit_link": "",
+            "has_rich_preview": false,
+            "media_display_type": "",
+            "preview_is_truncated": false,
+            "preview": "",
+            "preview_highlight": "",
+            "plain_text": "",
+            "preview_plain_text": "",
+            "has_more": false,
+            "sent_to_self": false,
+            "lines": 123,
+            "lines_more": 123,
+            "is_public": false,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "channels": [
+              ""
+            ],
+            "groups": [
+              ""
+            ],
+            "ims": [
+              ""
+            ],
+            "shares": {
+              "public": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              },
+              "private": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              }
+            },
+            "to": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "from": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "cc": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "channel_actions_ts": "",
+            "channel_actions_count": 123,
+            "headers": {
+              "date": "",
+              "in_reply_to": "",
+              "reply_to": "",
+              "message_id": ""
+            },
+            "simplified_html": "",
+            "bot_id": "",
+            "initial_comment": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "user": "",
+              "comment": "",
+              "channel": "",
+              "is_intro": false
+            },
+            "num_stars": 123,
+            "is_starred": false,
+            "pinned_to": [
+              ""
+            ],
+            "reactions": [
+              {
+                "name": "",
+                "count": 123,
+                "users": [
+                  ""
+                ],
+                "url": ""
+              }
+            ],
+            "comments_count": 123,
             "id": "",
             "created": 123,
             "timestamp": 123,
@@ -865,6 +1339,15 @@
           "author_name": "",
           "provider_name": "",
           "provider_icon_url": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "bot_user_id": "",
+          "url": "",
           "fields": [
             {
               "type": "",
@@ -1565,6 +2048,477 @@
               "source": "",
               "file_id": "",
               "file": {
+                "timestamp": 123,
+                "name": "",
+                "title": "",
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
+                "id": "",
+                "created": 123,
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
                 "id": "",
                 "created": 123,
                 "timestamp": 123,
@@ -1831,6 +2785,15 @@
               "author_name": "",
               "provider_name": "",
               "provider_icon_url": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "bot_user_id": "",
+              "url": "",
               "fields": [
                 {
                   "type": "",
@@ -2435,7 +3398,9 @@
       "metadata": {
         "event_payload": {},
         "event_type": ""
-      }
+      },
+      "inviter": "U00000000",
+      "is_locked": false
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/conversations.open.json
+++ b/json-logs/samples/api/conversations.open.json
@@ -470,6 +470,477 @@
           "source": "",
           "file_id": "",
           "file": {
+            "timestamp": 123,
+            "name": "",
+            "title": "",
+            "subject": "",
+            "mimetype": "",
+            "filetype": "",
+            "pretty_type": "",
+            "user": "",
+            "user_team": "",
+            "mode": "",
+            "editable": false,
+            "non_owner_editable": false,
+            "editor": "",
+            "last_editor": "",
+            "updated": 123,
+            "file_access": "",
+            "subtype": "",
+            "transcription": {
+              "status": "",
+              "locale": ""
+            },
+            "mp4": "",
+            "vtt": "",
+            "hls": "",
+            "hls_embed": "",
+            "duration_ms": 123,
+            "thumb_video_w": 123,
+            "thumb_video_h": 123,
+            "original_attachment_count": 123,
+            "is_external": false,
+            "external_type": "",
+            "external_id": "",
+            "external_url": "",
+            "username": "",
+            "size": 123,
+            "url_private": "",
+            "url_private_download": "",
+            "app_id": "",
+            "app_name": "",
+            "thumb_64": "",
+            "thumb_64_gif": "",
+            "thumb_64_w": "",
+            "thumb_64_h": "",
+            "thumb_80": "",
+            "thumb_80_gif": "",
+            "thumb_80_w": "",
+            "thumb_80_h": "",
+            "thumb_160": "",
+            "thumb_160_gif": "",
+            "thumb_160_w": "",
+            "thumb_160_h": "",
+            "thumb_360": "",
+            "thumb_360_gif": "",
+            "thumb_360_w": "",
+            "thumb_360_h": "",
+            "thumb_480": "",
+            "thumb_480_gif": "",
+            "thumb_480_w": "",
+            "thumb_480_h": "",
+            "thumb_720": "",
+            "thumb_720_gif": "",
+            "thumb_720_w": "",
+            "thumb_720_h": "",
+            "thumb_800": "",
+            "thumb_800_gif": "",
+            "thumb_800_w": "",
+            "thumb_800_h": "",
+            "thumb_960": "",
+            "thumb_960_gif": "",
+            "thumb_960_w": "",
+            "thumb_960_h": "",
+            "thumb_1024": "",
+            "thumb_1024_gif": "",
+            "thumb_1024_w": "",
+            "thumb_1024_h": "",
+            "thumb_video": "",
+            "thumb_gif": "",
+            "thumb_pdf": "",
+            "thumb_pdf_w": "",
+            "thumb_pdf_h": "",
+            "thumb_tiny": "",
+            "converted_pdf": "",
+            "image_exif_rotation": 123,
+            "original_w": "",
+            "original_h": "",
+            "deanimate": "",
+            "deanimate_gif": "",
+            "pjpeg": "",
+            "permalink": "",
+            "permalink_public": "",
+            "edit_link": "",
+            "has_rich_preview": false,
+            "media_display_type": "",
+            "preview_is_truncated": false,
+            "preview": "",
+            "preview_highlight": "",
+            "plain_text": "",
+            "preview_plain_text": "",
+            "has_more": false,
+            "sent_to_self": false,
+            "lines": 123,
+            "lines_more": 123,
+            "is_public": false,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "channels": [
+              ""
+            ],
+            "groups": [
+              ""
+            ],
+            "ims": [
+              ""
+            ],
+            "shares": {
+              "public": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              },
+              "private": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              }
+            },
+            "to": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "from": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "cc": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "channel_actions_ts": "",
+            "channel_actions_count": 123,
+            "headers": {
+              "date": "",
+              "in_reply_to": "",
+              "reply_to": "",
+              "message_id": ""
+            },
+            "simplified_html": "",
+            "bot_id": "",
+            "initial_comment": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "user": "",
+              "comment": "",
+              "channel": "",
+              "is_intro": false
+            },
+            "num_stars": 123,
+            "is_starred": false,
+            "pinned_to": [
+              ""
+            ],
+            "reactions": [
+              {
+                "name": "",
+                "count": 123,
+                "users": [
+                  ""
+                ],
+                "url": ""
+              }
+            ],
+            "comments_count": 123,
+            "id": "",
+            "created": 123,
+            "subject": "",
+            "mimetype": "",
+            "filetype": "",
+            "pretty_type": "",
+            "user": "",
+            "user_team": "",
+            "mode": "",
+            "editable": false,
+            "non_owner_editable": false,
+            "editor": "",
+            "last_editor": "",
+            "updated": 123,
+            "file_access": "",
+            "subtype": "",
+            "transcription": {
+              "status": "",
+              "locale": ""
+            },
+            "mp4": "",
+            "vtt": "",
+            "hls": "",
+            "hls_embed": "",
+            "duration_ms": 123,
+            "thumb_video_w": 123,
+            "thumb_video_h": 123,
+            "original_attachment_count": 123,
+            "is_external": false,
+            "external_type": "",
+            "external_id": "",
+            "external_url": "",
+            "username": "",
+            "size": 123,
+            "url_private": "",
+            "url_private_download": "",
+            "app_id": "",
+            "app_name": "",
+            "thumb_64": "",
+            "thumb_64_gif": "",
+            "thumb_64_w": "",
+            "thumb_64_h": "",
+            "thumb_80": "",
+            "thumb_80_gif": "",
+            "thumb_80_w": "",
+            "thumb_80_h": "",
+            "thumb_160": "",
+            "thumb_160_gif": "",
+            "thumb_160_w": "",
+            "thumb_160_h": "",
+            "thumb_360": "",
+            "thumb_360_gif": "",
+            "thumb_360_w": "",
+            "thumb_360_h": "",
+            "thumb_480": "",
+            "thumb_480_gif": "",
+            "thumb_480_w": "",
+            "thumb_480_h": "",
+            "thumb_720": "",
+            "thumb_720_gif": "",
+            "thumb_720_w": "",
+            "thumb_720_h": "",
+            "thumb_800": "",
+            "thumb_800_gif": "",
+            "thumb_800_w": "",
+            "thumb_800_h": "",
+            "thumb_960": "",
+            "thumb_960_gif": "",
+            "thumb_960_w": "",
+            "thumb_960_h": "",
+            "thumb_1024": "",
+            "thumb_1024_gif": "",
+            "thumb_1024_w": "",
+            "thumb_1024_h": "",
+            "thumb_video": "",
+            "thumb_gif": "",
+            "thumb_pdf": "",
+            "thumb_pdf_w": "",
+            "thumb_pdf_h": "",
+            "thumb_tiny": "",
+            "converted_pdf": "",
+            "image_exif_rotation": 123,
+            "original_w": "",
+            "original_h": "",
+            "deanimate": "",
+            "deanimate_gif": "",
+            "pjpeg": "",
+            "permalink": "",
+            "permalink_public": "",
+            "edit_link": "",
+            "has_rich_preview": false,
+            "media_display_type": "",
+            "preview_is_truncated": false,
+            "preview": "",
+            "preview_highlight": "",
+            "plain_text": "",
+            "preview_plain_text": "",
+            "has_more": false,
+            "sent_to_self": false,
+            "lines": 123,
+            "lines_more": 123,
+            "is_public": false,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "channels": [
+              ""
+            ],
+            "groups": [
+              ""
+            ],
+            "ims": [
+              ""
+            ],
+            "shares": {
+              "public": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              },
+              "private": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              }
+            },
+            "to": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "from": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "cc": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "channel_actions_ts": "",
+            "channel_actions_count": 123,
+            "headers": {
+              "date": "",
+              "in_reply_to": "",
+              "reply_to": "",
+              "message_id": ""
+            },
+            "simplified_html": "",
+            "bot_id": "",
+            "initial_comment": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "user": "",
+              "comment": "",
+              "channel": "",
+              "is_intro": false
+            },
+            "num_stars": 123,
+            "is_starred": false,
+            "pinned_to": [
+              ""
+            ],
+            "reactions": [
+              {
+                "name": "",
+                "count": 123,
+                "users": [
+                  ""
+                ],
+                "url": ""
+              }
+            ],
+            "comments_count": 123,
             "id": "",
             "created": 123,
             "timestamp": 123,
@@ -480,6 +951,7 @@
             "filetype": "",
             "pretty_type": "",
             "user": "",
+            "user_team": "",
             "mode": "",
             "editable": false,
             "non_owner_editable": false,
@@ -730,6 +1202,15 @@
           "author_name": "",
           "provider_name": "",
           "provider_icon_url": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "bot_user_id": "",
+          "url": "",
           "fields": [
             {
               "type": "",

--- a/json-logs/samples/api/conversations.replies.json
+++ b/json-logs/samples/api/conversations.replies.json
@@ -321,6 +321,477 @@
           "source": "",
           "file_id": "",
           "file": {
+            "timestamp": 123,
+            "name": "",
+            "title": "",
+            "subject": "",
+            "mimetype": "",
+            "filetype": "",
+            "pretty_type": "",
+            "user": "",
+            "user_team": "",
+            "mode": "",
+            "editable": false,
+            "non_owner_editable": false,
+            "editor": "",
+            "last_editor": "",
+            "updated": 123,
+            "file_access": "",
+            "subtype": "",
+            "transcription": {
+              "status": "",
+              "locale": ""
+            },
+            "mp4": "",
+            "vtt": "",
+            "hls": "",
+            "hls_embed": "",
+            "duration_ms": 123,
+            "thumb_video_w": 123,
+            "thumb_video_h": 123,
+            "original_attachment_count": 123,
+            "is_external": false,
+            "external_type": "",
+            "external_id": "",
+            "external_url": "",
+            "username": "",
+            "size": 123,
+            "url_private": "",
+            "url_private_download": "",
+            "app_id": "",
+            "app_name": "",
+            "thumb_64": "",
+            "thumb_64_gif": "",
+            "thumb_64_w": "",
+            "thumb_64_h": "",
+            "thumb_80": "",
+            "thumb_80_gif": "",
+            "thumb_80_w": "",
+            "thumb_80_h": "",
+            "thumb_160": "",
+            "thumb_160_gif": "",
+            "thumb_160_w": "",
+            "thumb_160_h": "",
+            "thumb_360": "",
+            "thumb_360_gif": "",
+            "thumb_360_w": "",
+            "thumb_360_h": "",
+            "thumb_480": "",
+            "thumb_480_gif": "",
+            "thumb_480_w": "",
+            "thumb_480_h": "",
+            "thumb_720": "",
+            "thumb_720_gif": "",
+            "thumb_720_w": "",
+            "thumb_720_h": "",
+            "thumb_800": "",
+            "thumb_800_gif": "",
+            "thumb_800_w": "",
+            "thumb_800_h": "",
+            "thumb_960": "",
+            "thumb_960_gif": "",
+            "thumb_960_w": "",
+            "thumb_960_h": "",
+            "thumb_1024": "",
+            "thumb_1024_gif": "",
+            "thumb_1024_w": "",
+            "thumb_1024_h": "",
+            "thumb_video": "",
+            "thumb_gif": "",
+            "thumb_pdf": "",
+            "thumb_pdf_w": "",
+            "thumb_pdf_h": "",
+            "thumb_tiny": "",
+            "converted_pdf": "",
+            "image_exif_rotation": 123,
+            "original_w": "",
+            "original_h": "",
+            "deanimate": "",
+            "deanimate_gif": "",
+            "pjpeg": "",
+            "permalink": "",
+            "permalink_public": "",
+            "edit_link": "",
+            "has_rich_preview": false,
+            "media_display_type": "",
+            "preview_is_truncated": false,
+            "preview": "",
+            "preview_highlight": "",
+            "plain_text": "",
+            "preview_plain_text": "",
+            "has_more": false,
+            "sent_to_self": false,
+            "lines": 123,
+            "lines_more": 123,
+            "is_public": false,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "channels": [
+              ""
+            ],
+            "groups": [
+              ""
+            ],
+            "ims": [
+              ""
+            ],
+            "shares": {
+              "public": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              },
+              "private": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              }
+            },
+            "to": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "from": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "cc": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "channel_actions_ts": "",
+            "channel_actions_count": 123,
+            "headers": {
+              "date": "",
+              "in_reply_to": "",
+              "reply_to": "",
+              "message_id": ""
+            },
+            "simplified_html": "",
+            "bot_id": "",
+            "initial_comment": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "user": "",
+              "comment": "",
+              "channel": "",
+              "is_intro": false
+            },
+            "num_stars": 123,
+            "is_starred": false,
+            "pinned_to": [
+              ""
+            ],
+            "reactions": [
+              {
+                "name": "",
+                "count": 123,
+                "users": [
+                  ""
+                ],
+                "url": ""
+              }
+            ],
+            "comments_count": 123,
+            "id": "",
+            "created": 123,
+            "subject": "",
+            "mimetype": "",
+            "filetype": "",
+            "pretty_type": "",
+            "user": "",
+            "user_team": "",
+            "mode": "",
+            "editable": false,
+            "non_owner_editable": false,
+            "editor": "",
+            "last_editor": "",
+            "updated": 123,
+            "file_access": "",
+            "subtype": "",
+            "transcription": {
+              "status": "",
+              "locale": ""
+            },
+            "mp4": "",
+            "vtt": "",
+            "hls": "",
+            "hls_embed": "",
+            "duration_ms": 123,
+            "thumb_video_w": 123,
+            "thumb_video_h": 123,
+            "original_attachment_count": 123,
+            "is_external": false,
+            "external_type": "",
+            "external_id": "",
+            "external_url": "",
+            "username": "",
+            "size": 123,
+            "url_private": "",
+            "url_private_download": "",
+            "app_id": "",
+            "app_name": "",
+            "thumb_64": "",
+            "thumb_64_gif": "",
+            "thumb_64_w": "",
+            "thumb_64_h": "",
+            "thumb_80": "",
+            "thumb_80_gif": "",
+            "thumb_80_w": "",
+            "thumb_80_h": "",
+            "thumb_160": "",
+            "thumb_160_gif": "",
+            "thumb_160_w": "",
+            "thumb_160_h": "",
+            "thumb_360": "",
+            "thumb_360_gif": "",
+            "thumb_360_w": "",
+            "thumb_360_h": "",
+            "thumb_480": "",
+            "thumb_480_gif": "",
+            "thumb_480_w": "",
+            "thumb_480_h": "",
+            "thumb_720": "",
+            "thumb_720_gif": "",
+            "thumb_720_w": "",
+            "thumb_720_h": "",
+            "thumb_800": "",
+            "thumb_800_gif": "",
+            "thumb_800_w": "",
+            "thumb_800_h": "",
+            "thumb_960": "",
+            "thumb_960_gif": "",
+            "thumb_960_w": "",
+            "thumb_960_h": "",
+            "thumb_1024": "",
+            "thumb_1024_gif": "",
+            "thumb_1024_w": "",
+            "thumb_1024_h": "",
+            "thumb_video": "",
+            "thumb_gif": "",
+            "thumb_pdf": "",
+            "thumb_pdf_w": "",
+            "thumb_pdf_h": "",
+            "thumb_tiny": "",
+            "converted_pdf": "",
+            "image_exif_rotation": 123,
+            "original_w": "",
+            "original_h": "",
+            "deanimate": "",
+            "deanimate_gif": "",
+            "pjpeg": "",
+            "permalink": "",
+            "permalink_public": "",
+            "edit_link": "",
+            "has_rich_preview": false,
+            "media_display_type": "",
+            "preview_is_truncated": false,
+            "preview": "",
+            "preview_highlight": "",
+            "plain_text": "",
+            "preview_plain_text": "",
+            "has_more": false,
+            "sent_to_self": false,
+            "lines": 123,
+            "lines_more": 123,
+            "is_public": false,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "channels": [
+              ""
+            ],
+            "groups": [
+              ""
+            ],
+            "ims": [
+              ""
+            ],
+            "shares": {
+              "public": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              },
+              "private": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": ""
+                  }
+                ]
+              }
+            },
+            "to": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "from": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "cc": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "channel_actions_ts": "",
+            "channel_actions_count": 123,
+            "headers": {
+              "date": "",
+              "in_reply_to": "",
+              "reply_to": "",
+              "message_id": ""
+            },
+            "simplified_html": "",
+            "bot_id": "",
+            "initial_comment": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "user": "",
+              "comment": "",
+              "channel": "",
+              "is_intro": false
+            },
+            "num_stars": 123,
+            "is_starred": false,
+            "pinned_to": [
+              ""
+            ],
+            "reactions": [
+              {
+                "name": "",
+                "count": 123,
+                "users": [
+                  ""
+                ],
+                "url": ""
+              }
+            ],
+            "comments_count": 123,
             "id": "",
             "created": 123,
             "timestamp": 123,
@@ -587,6 +1058,15 @@
           "author_name": "",
           "provider_name": "",
           "provider_icon_url": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "bot_user_id": "",
+          "url": "",
           "fields": [
             {
               "type": "",
@@ -1287,6 +1767,477 @@
               "source": "",
               "file_id": "",
               "file": {
+                "timestamp": 123,
+                "name": "",
+                "title": "",
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
+                "id": "",
+                "created": 123,
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
                 "id": "",
                 "created": 123,
                 "timestamp": 123,
@@ -1553,6 +2504,15 @@
               "author_name": "",
               "provider_name": "",
               "provider_icon_url": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "bot_user_id": "",
+              "url": "",
               "fields": [
                 {
                   "type": "",

--- a/json-logs/samples/api/reactions.get.json
+++ b/json-logs/samples/api/reactions.get.json
@@ -508,6 +508,477 @@
         "source": "",
         "file_id": "",
         "file": {
+          "timestamp": 123,
+          "name": "",
+          "title": "",
+          "subject": "",
+          "mimetype": "",
+          "filetype": "",
+          "pretty_type": "",
+          "user": "",
+          "user_team": "",
+          "mode": "",
+          "editable": false,
+          "non_owner_editable": false,
+          "editor": "",
+          "last_editor": "",
+          "updated": 123,
+          "file_access": "",
+          "subtype": "",
+          "transcription": {
+            "status": "",
+            "locale": ""
+          },
+          "mp4": "",
+          "vtt": "",
+          "hls": "",
+          "hls_embed": "",
+          "duration_ms": 123,
+          "thumb_video_w": 123,
+          "thumb_video_h": 123,
+          "original_attachment_count": 123,
+          "is_external": false,
+          "external_type": "",
+          "external_id": "",
+          "external_url": "",
+          "username": "",
+          "size": 123,
+          "url_private": "",
+          "url_private_download": "",
+          "app_id": "",
+          "app_name": "",
+          "thumb_64": "",
+          "thumb_64_gif": "",
+          "thumb_64_w": "",
+          "thumb_64_h": "",
+          "thumb_80": "",
+          "thumb_80_gif": "",
+          "thumb_80_w": "",
+          "thumb_80_h": "",
+          "thumb_160": "",
+          "thumb_160_gif": "",
+          "thumb_160_w": "",
+          "thumb_160_h": "",
+          "thumb_360": "",
+          "thumb_360_gif": "",
+          "thumb_360_w": "",
+          "thumb_360_h": "",
+          "thumb_480": "",
+          "thumb_480_gif": "",
+          "thumb_480_w": "",
+          "thumb_480_h": "",
+          "thumb_720": "",
+          "thumb_720_gif": "",
+          "thumb_720_w": "",
+          "thumb_720_h": "",
+          "thumb_800": "",
+          "thumb_800_gif": "",
+          "thumb_800_w": "",
+          "thumb_800_h": "",
+          "thumb_960": "",
+          "thumb_960_gif": "",
+          "thumb_960_w": "",
+          "thumb_960_h": "",
+          "thumb_1024": "",
+          "thumb_1024_gif": "",
+          "thumb_1024_w": "",
+          "thumb_1024_h": "",
+          "thumb_video": "",
+          "thumb_gif": "",
+          "thumb_pdf": "",
+          "thumb_pdf_w": "",
+          "thumb_pdf_h": "",
+          "thumb_tiny": "",
+          "converted_pdf": "",
+          "image_exif_rotation": 123,
+          "original_w": "",
+          "original_h": "",
+          "deanimate": "",
+          "deanimate_gif": "",
+          "pjpeg": "",
+          "permalink": "",
+          "permalink_public": "",
+          "edit_link": "",
+          "has_rich_preview": false,
+          "media_display_type": "",
+          "preview_is_truncated": false,
+          "preview": "",
+          "preview_highlight": "",
+          "plain_text": "",
+          "preview_plain_text": "",
+          "has_more": false,
+          "sent_to_self": false,
+          "lines": 123,
+          "lines_more": 123,
+          "is_public": false,
+          "public_url_shared": false,
+          "display_as_bot": false,
+          "channels": [
+            ""
+          ],
+          "groups": [
+            ""
+          ],
+          "ims": [
+            ""
+          ],
+          "shares": {
+            "public": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            },
+            "private": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "from": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "cc": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "channel_actions_ts": "",
+          "channel_actions_count": 123,
+          "headers": {
+            "date": "",
+            "in_reply_to": "",
+            "reply_to": "",
+            "message_id": ""
+          },
+          "simplified_html": "",
+          "bot_id": "",
+          "initial_comment": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "user": "",
+            "comment": "",
+            "channel": "",
+            "is_intro": false
+          },
+          "num_stars": 123,
+          "is_starred": false,
+          "pinned_to": [
+            ""
+          ],
+          "reactions": [
+            {
+              "name": "",
+              "count": 123,
+              "users": [
+                ""
+              ],
+              "url": ""
+            }
+          ],
+          "comments_count": 123,
+          "id": "",
+          "created": 123,
+          "subject": "",
+          "mimetype": "",
+          "filetype": "",
+          "pretty_type": "",
+          "user": "",
+          "user_team": "",
+          "mode": "",
+          "editable": false,
+          "non_owner_editable": false,
+          "editor": "",
+          "last_editor": "",
+          "updated": 123,
+          "file_access": "",
+          "subtype": "",
+          "transcription": {
+            "status": "",
+            "locale": ""
+          },
+          "mp4": "",
+          "vtt": "",
+          "hls": "",
+          "hls_embed": "",
+          "duration_ms": 123,
+          "thumb_video_w": 123,
+          "thumb_video_h": 123,
+          "original_attachment_count": 123,
+          "is_external": false,
+          "external_type": "",
+          "external_id": "",
+          "external_url": "",
+          "username": "",
+          "size": 123,
+          "url_private": "",
+          "url_private_download": "",
+          "app_id": "",
+          "app_name": "",
+          "thumb_64": "",
+          "thumb_64_gif": "",
+          "thumb_64_w": "",
+          "thumb_64_h": "",
+          "thumb_80": "",
+          "thumb_80_gif": "",
+          "thumb_80_w": "",
+          "thumb_80_h": "",
+          "thumb_160": "",
+          "thumb_160_gif": "",
+          "thumb_160_w": "",
+          "thumb_160_h": "",
+          "thumb_360": "",
+          "thumb_360_gif": "",
+          "thumb_360_w": "",
+          "thumb_360_h": "",
+          "thumb_480": "",
+          "thumb_480_gif": "",
+          "thumb_480_w": "",
+          "thumb_480_h": "",
+          "thumb_720": "",
+          "thumb_720_gif": "",
+          "thumb_720_w": "",
+          "thumb_720_h": "",
+          "thumb_800": "",
+          "thumb_800_gif": "",
+          "thumb_800_w": "",
+          "thumb_800_h": "",
+          "thumb_960": "",
+          "thumb_960_gif": "",
+          "thumb_960_w": "",
+          "thumb_960_h": "",
+          "thumb_1024": "",
+          "thumb_1024_gif": "",
+          "thumb_1024_w": "",
+          "thumb_1024_h": "",
+          "thumb_video": "",
+          "thumb_gif": "",
+          "thumb_pdf": "",
+          "thumb_pdf_w": "",
+          "thumb_pdf_h": "",
+          "thumb_tiny": "",
+          "converted_pdf": "",
+          "image_exif_rotation": 123,
+          "original_w": "",
+          "original_h": "",
+          "deanimate": "",
+          "deanimate_gif": "",
+          "pjpeg": "",
+          "permalink": "",
+          "permalink_public": "",
+          "edit_link": "",
+          "has_rich_preview": false,
+          "media_display_type": "",
+          "preview_is_truncated": false,
+          "preview": "",
+          "preview_highlight": "",
+          "plain_text": "",
+          "preview_plain_text": "",
+          "has_more": false,
+          "sent_to_self": false,
+          "lines": 123,
+          "lines_more": 123,
+          "is_public": false,
+          "public_url_shared": false,
+          "display_as_bot": false,
+          "channels": [
+            ""
+          ],
+          "groups": [
+            ""
+          ],
+          "ims": [
+            ""
+          ],
+          "shares": {
+            "public": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            },
+            "private": {
+              "C03E94MKU": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ],
+              "C03E94MKU_": [
+                {
+                  "share_user_id": "",
+                  "reply_users": [
+                    ""
+                  ],
+                  "reply_users_count": 123,
+                  "reply_count": 123,
+                  "ts": "",
+                  "thread_ts": "",
+                  "latest_reply": "",
+                  "channel_name": "",
+                  "team_id": ""
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "from": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "cc": [
+            {
+              "address": "",
+              "name": "",
+              "original": ""
+            }
+          ],
+          "channel_actions_ts": "",
+          "channel_actions_count": 123,
+          "headers": {
+            "date": "",
+            "in_reply_to": "",
+            "reply_to": "",
+            "message_id": ""
+          },
+          "simplified_html": "",
+          "bot_id": "",
+          "initial_comment": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "user": "",
+            "comment": "",
+            "channel": "",
+            "is_intro": false
+          },
+          "num_stars": 123,
+          "is_starred": false,
+          "pinned_to": [
+            ""
+          ],
+          "reactions": [
+            {
+              "name": "",
+              "count": 123,
+              "users": [
+                ""
+              ],
+              "url": ""
+            }
+          ],
+          "comments_count": 123,
           "id": "",
           "created": 123,
           "timestamp": 123,
@@ -518,6 +989,7 @@
           "filetype": "",
           "pretty_type": "",
           "user": "",
+          "user_team": "",
           "mode": "",
           "editable": false,
           "non_owner_editable": false,
@@ -773,6 +1245,15 @@
         "author_name": "",
         "provider_name": "",
         "provider_icon_url": "",
+        "function_trigger_id": "",
+        "app_id": "",
+        "is_workflow_app": false,
+        "app_collaborators": [
+          ""
+        ],
+        "button_label": "",
+        "bot_user_id": "",
+        "url": "",
         "fields": [
           {
             "type": "",

--- a/json-logs/samples/api/reactions.list.json
+++ b/json-logs/samples/api/reactions.list.json
@@ -556,6 +556,477 @@
             "source": "",
             "file_id": "",
             "file": {
+              "timestamp": 123,
+              "name": "",
+              "title": "",
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
+              "id": "",
+              "created": 123,
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
               "id": "",
               "created": 123,
               "timestamp": 123,
@@ -822,6 +1293,15 @@
             "author_name": "",
             "provider_name": "",
             "provider_icon_url": "",
+            "function_trigger_id": "",
+            "app_id": "",
+            "is_workflow_app": false,
+            "app_collaborators": [
+              ""
+            ],
+            "button_label": "",
+            "bot_user_id": "",
+            "url": "",
             "fields": [
               {
                 "type": "",

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -810,6 +810,12 @@
       "who_can_use_hermes": {
         "type": [
           ""
+        ],
+        "user": [
+          ""
+        ],
+        "subteam": [
+          ""
         ]
       },
       "who_can_create_channel_email_addresses": {
@@ -1354,6 +1360,477 @@
                 "source": "",
                 "file_id": "",
                 "file": {
+                  "timestamp": 123,
+                  "name": "",
+                  "title": "",
+                  "subject": "",
+                  "mimetype": "",
+                  "filetype": "",
+                  "pretty_type": "",
+                  "user": "",
+                  "user_team": "",
+                  "mode": "",
+                  "editable": false,
+                  "non_owner_editable": false,
+                  "editor": "",
+                  "last_editor": "",
+                  "updated": 123,
+                  "file_access": "",
+                  "subtype": "",
+                  "transcription": {
+                    "status": "",
+                    "locale": ""
+                  },
+                  "mp4": "",
+                  "vtt": "",
+                  "hls": "",
+                  "hls_embed": "",
+                  "duration_ms": 123,
+                  "thumb_video_w": 123,
+                  "thumb_video_h": 123,
+                  "original_attachment_count": 123,
+                  "is_external": false,
+                  "external_type": "",
+                  "external_id": "",
+                  "external_url": "",
+                  "username": "",
+                  "size": 123,
+                  "url_private": "",
+                  "url_private_download": "",
+                  "app_id": "",
+                  "app_name": "",
+                  "thumb_64": "",
+                  "thumb_64_gif": "",
+                  "thumb_64_w": "",
+                  "thumb_64_h": "",
+                  "thumb_80": "",
+                  "thumb_80_gif": "",
+                  "thumb_80_w": "",
+                  "thumb_80_h": "",
+                  "thumb_160": "",
+                  "thumb_160_gif": "",
+                  "thumb_160_w": "",
+                  "thumb_160_h": "",
+                  "thumb_360": "",
+                  "thumb_360_gif": "",
+                  "thumb_360_w": "",
+                  "thumb_360_h": "",
+                  "thumb_480": "",
+                  "thumb_480_gif": "",
+                  "thumb_480_w": "",
+                  "thumb_480_h": "",
+                  "thumb_720": "",
+                  "thumb_720_gif": "",
+                  "thumb_720_w": "",
+                  "thumb_720_h": "",
+                  "thumb_800": "",
+                  "thumb_800_gif": "",
+                  "thumb_800_w": "",
+                  "thumb_800_h": "",
+                  "thumb_960": "",
+                  "thumb_960_gif": "",
+                  "thumb_960_w": "",
+                  "thumb_960_h": "",
+                  "thumb_1024": "",
+                  "thumb_1024_gif": "",
+                  "thumb_1024_w": "",
+                  "thumb_1024_h": "",
+                  "thumb_video": "",
+                  "thumb_gif": "",
+                  "thumb_pdf": "",
+                  "thumb_pdf_w": "",
+                  "thumb_pdf_h": "",
+                  "thumb_tiny": "",
+                  "converted_pdf": "",
+                  "image_exif_rotation": 123,
+                  "original_w": "",
+                  "original_h": "",
+                  "deanimate": "",
+                  "deanimate_gif": "",
+                  "pjpeg": "",
+                  "permalink": "",
+                  "permalink_public": "",
+                  "edit_link": "",
+                  "has_rich_preview": false,
+                  "media_display_type": "",
+                  "preview_is_truncated": false,
+                  "preview": "",
+                  "preview_highlight": "",
+                  "plain_text": "",
+                  "preview_plain_text": "",
+                  "has_more": false,
+                  "sent_to_self": false,
+                  "lines": 123,
+                  "lines_more": 123,
+                  "is_public": false,
+                  "public_url_shared": false,
+                  "display_as_bot": false,
+                  "channels": [
+                    ""
+                  ],
+                  "groups": [
+                    ""
+                  ],
+                  "ims": [
+                    ""
+                  ],
+                  "shares": {
+                    "public": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    },
+                    "private": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    }
+                  },
+                  "to": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "from": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "cc": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "channel_actions_ts": "",
+                  "channel_actions_count": 123,
+                  "headers": {
+                    "date": "",
+                    "in_reply_to": "",
+                    "reply_to": "",
+                    "message_id": ""
+                  },
+                  "simplified_html": "",
+                  "bot_id": "",
+                  "initial_comment": {
+                    "id": "",
+                    "created": 123,
+                    "timestamp": 123,
+                    "user": "",
+                    "comment": "",
+                    "channel": "",
+                    "is_intro": false
+                  },
+                  "num_stars": 123,
+                  "is_starred": false,
+                  "pinned_to": [
+                    ""
+                  ],
+                  "reactions": [
+                    {
+                      "name": "",
+                      "count": 123,
+                      "users": [
+                        ""
+                      ],
+                      "url": ""
+                    }
+                  ],
+                  "comments_count": 123,
+                  "id": "",
+                  "created": 123,
+                  "subject": "",
+                  "mimetype": "",
+                  "filetype": "",
+                  "pretty_type": "",
+                  "user": "",
+                  "user_team": "",
+                  "mode": "",
+                  "editable": false,
+                  "non_owner_editable": false,
+                  "editor": "",
+                  "last_editor": "",
+                  "updated": 123,
+                  "file_access": "",
+                  "subtype": "",
+                  "transcription": {
+                    "status": "",
+                    "locale": ""
+                  },
+                  "mp4": "",
+                  "vtt": "",
+                  "hls": "",
+                  "hls_embed": "",
+                  "duration_ms": 123,
+                  "thumb_video_w": 123,
+                  "thumb_video_h": 123,
+                  "original_attachment_count": 123,
+                  "is_external": false,
+                  "external_type": "",
+                  "external_id": "",
+                  "external_url": "",
+                  "username": "",
+                  "size": 123,
+                  "url_private": "",
+                  "url_private_download": "",
+                  "app_id": "",
+                  "app_name": "",
+                  "thumb_64": "",
+                  "thumb_64_gif": "",
+                  "thumb_64_w": "",
+                  "thumb_64_h": "",
+                  "thumb_80": "",
+                  "thumb_80_gif": "",
+                  "thumb_80_w": "",
+                  "thumb_80_h": "",
+                  "thumb_160": "",
+                  "thumb_160_gif": "",
+                  "thumb_160_w": "",
+                  "thumb_160_h": "",
+                  "thumb_360": "",
+                  "thumb_360_gif": "",
+                  "thumb_360_w": "",
+                  "thumb_360_h": "",
+                  "thumb_480": "",
+                  "thumb_480_gif": "",
+                  "thumb_480_w": "",
+                  "thumb_480_h": "",
+                  "thumb_720": "",
+                  "thumb_720_gif": "",
+                  "thumb_720_w": "",
+                  "thumb_720_h": "",
+                  "thumb_800": "",
+                  "thumb_800_gif": "",
+                  "thumb_800_w": "",
+                  "thumb_800_h": "",
+                  "thumb_960": "",
+                  "thumb_960_gif": "",
+                  "thumb_960_w": "",
+                  "thumb_960_h": "",
+                  "thumb_1024": "",
+                  "thumb_1024_gif": "",
+                  "thumb_1024_w": "",
+                  "thumb_1024_h": "",
+                  "thumb_video": "",
+                  "thumb_gif": "",
+                  "thumb_pdf": "",
+                  "thumb_pdf_w": "",
+                  "thumb_pdf_h": "",
+                  "thumb_tiny": "",
+                  "converted_pdf": "",
+                  "image_exif_rotation": 123,
+                  "original_w": "",
+                  "original_h": "",
+                  "deanimate": "",
+                  "deanimate_gif": "",
+                  "pjpeg": "",
+                  "permalink": "",
+                  "permalink_public": "",
+                  "edit_link": "",
+                  "has_rich_preview": false,
+                  "media_display_type": "",
+                  "preview_is_truncated": false,
+                  "preview": "",
+                  "preview_highlight": "",
+                  "plain_text": "",
+                  "preview_plain_text": "",
+                  "has_more": false,
+                  "sent_to_self": false,
+                  "lines": 123,
+                  "lines_more": 123,
+                  "is_public": false,
+                  "public_url_shared": false,
+                  "display_as_bot": false,
+                  "channels": [
+                    ""
+                  ],
+                  "groups": [
+                    ""
+                  ],
+                  "ims": [
+                    ""
+                  ],
+                  "shares": {
+                    "public": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    },
+                    "private": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    }
+                  },
+                  "to": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "from": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "cc": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "channel_actions_ts": "",
+                  "channel_actions_count": 123,
+                  "headers": {
+                    "date": "",
+                    "in_reply_to": "",
+                    "reply_to": "",
+                    "message_id": ""
+                  },
+                  "simplified_html": "",
+                  "bot_id": "",
+                  "initial_comment": {
+                    "id": "",
+                    "created": 123,
+                    "timestamp": 123,
+                    "user": "",
+                    "comment": "",
+                    "channel": "",
+                    "is_intro": false
+                  },
+                  "num_stars": 123,
+                  "is_starred": false,
+                  "pinned_to": [
+                    ""
+                  ],
+                  "reactions": [
+                    {
+                      "name": "",
+                      "count": 123,
+                      "users": [
+                        ""
+                      ],
+                      "url": ""
+                    }
+                  ],
+                  "comments_count": 123,
                   "id": "",
                   "created": 123,
                   "timestamp": 123,
@@ -1364,6 +1841,7 @@
                   "filetype": "",
                   "pretty_type": "",
                   "user": "",
+                  "user_team": "",
                   "mode": "",
                   "editable": false,
                   "non_owner_editable": false,
@@ -1619,6 +2097,15 @@
                 "author_name": "",
                 "provider_name": "",
                 "provider_icon_url": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "bot_user_id": "",
+                "url": "",
                 "fields": [
                   {
                     "type": "",
@@ -1958,6 +2445,7 @@
                 "filetype": "",
                 "pretty_type": "",
                 "user": "",
+                "user_team": "",
                 "mode": "",
                 "editable": false,
                 "non_owner_editable": false,
@@ -2497,6 +2985,477 @@
             "source": "",
             "file_id": "",
             "file": {
+              "timestamp": 123,
+              "name": "",
+              "title": "",
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
+              "id": "",
+              "created": 123,
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
               "id": "",
               "created": 123,
               "timestamp": 123,
@@ -2507,6 +3466,7 @@
               "filetype": "",
               "pretty_type": "",
               "user": "",
+              "user_team": "",
               "mode": "",
               "editable": false,
               "non_owner_editable": false,
@@ -2762,6 +3722,15 @@
             "author_name": "",
             "provider_name": "",
             "provider_icon_url": "",
+            "function_trigger_id": "",
+            "app_id": "",
+            "is_workflow_app": false,
+            "app_collaborators": [
+              ""
+            ],
+            "button_label": "",
+            "bot_user_id": "",
+            "url": "",
             "fields": [
               {
                 "type": "",
@@ -3086,6 +4055,7 @@
             "filetype": "",
             "pretty_type": "",
             "user": "",
+            "user_team": "",
             "mode": "",
             "editable": false,
             "non_owner_editable": false,
@@ -3887,6 +4857,477 @@
                         "source": "",
                         "file_id": "",
                         "file": {
+                          "timestamp": 123,
+                          "name": "",
+                          "title": "",
+                          "subject": "",
+                          "mimetype": "",
+                          "filetype": "",
+                          "pretty_type": "",
+                          "user": "",
+                          "user_team": "",
+                          "mode": "",
+                          "editable": false,
+                          "non_owner_editable": false,
+                          "editor": "",
+                          "last_editor": "",
+                          "updated": 123,
+                          "file_access": "",
+                          "subtype": "",
+                          "transcription": {
+                            "status": "",
+                            "locale": ""
+                          },
+                          "mp4": "",
+                          "vtt": "",
+                          "hls": "",
+                          "hls_embed": "",
+                          "duration_ms": 123,
+                          "thumb_video_w": 123,
+                          "thumb_video_h": 123,
+                          "original_attachment_count": 123,
+                          "is_external": false,
+                          "external_type": "",
+                          "external_id": "",
+                          "external_url": "",
+                          "username": "",
+                          "size": 123,
+                          "url_private": "",
+                          "url_private_download": "",
+                          "app_id": "",
+                          "app_name": "",
+                          "thumb_64": "",
+                          "thumb_64_gif": "",
+                          "thumb_64_w": "",
+                          "thumb_64_h": "",
+                          "thumb_80": "",
+                          "thumb_80_gif": "",
+                          "thumb_80_w": "",
+                          "thumb_80_h": "",
+                          "thumb_160": "",
+                          "thumb_160_gif": "",
+                          "thumb_160_w": "",
+                          "thumb_160_h": "",
+                          "thumb_360": "",
+                          "thumb_360_gif": "",
+                          "thumb_360_w": "",
+                          "thumb_360_h": "",
+                          "thumb_480": "",
+                          "thumb_480_gif": "",
+                          "thumb_480_w": "",
+                          "thumb_480_h": "",
+                          "thumb_720": "",
+                          "thumb_720_gif": "",
+                          "thumb_720_w": "",
+                          "thumb_720_h": "",
+                          "thumb_800": "",
+                          "thumb_800_gif": "",
+                          "thumb_800_w": "",
+                          "thumb_800_h": "",
+                          "thumb_960": "",
+                          "thumb_960_gif": "",
+                          "thumb_960_w": "",
+                          "thumb_960_h": "",
+                          "thumb_1024": "",
+                          "thumb_1024_gif": "",
+                          "thumb_1024_w": "",
+                          "thumb_1024_h": "",
+                          "thumb_video": "",
+                          "thumb_gif": "",
+                          "thumb_pdf": "",
+                          "thumb_pdf_w": "",
+                          "thumb_pdf_h": "",
+                          "thumb_tiny": "",
+                          "converted_pdf": "",
+                          "image_exif_rotation": 123,
+                          "original_w": "",
+                          "original_h": "",
+                          "deanimate": "",
+                          "deanimate_gif": "",
+                          "pjpeg": "",
+                          "permalink": "",
+                          "permalink_public": "",
+                          "edit_link": "",
+                          "has_rich_preview": false,
+                          "media_display_type": "",
+                          "preview_is_truncated": false,
+                          "preview": "",
+                          "preview_highlight": "",
+                          "plain_text": "",
+                          "preview_plain_text": "",
+                          "has_more": false,
+                          "sent_to_self": false,
+                          "lines": 123,
+                          "lines_more": 123,
+                          "is_public": false,
+                          "public_url_shared": false,
+                          "display_as_bot": false,
+                          "channels": [
+                            ""
+                          ],
+                          "groups": [
+                            ""
+                          ],
+                          "ims": [
+                            ""
+                          ],
+                          "shares": {
+                            "public": {
+                              "C03E94MKU": [
+                                {
+                                  "share_user_id": "",
+                                  "reply_users": [
+                                    ""
+                                  ],
+                                  "reply_users_count": 123,
+                                  "reply_count": 123,
+                                  "ts": "",
+                                  "thread_ts": "",
+                                  "latest_reply": "",
+                                  "channel_name": "",
+                                  "team_id": ""
+                                }
+                              ],
+                              "C03E94MKU_": [
+                                {
+                                  "share_user_id": "",
+                                  "reply_users": [
+                                    ""
+                                  ],
+                                  "reply_users_count": 123,
+                                  "reply_count": 123,
+                                  "ts": "",
+                                  "thread_ts": "",
+                                  "latest_reply": "",
+                                  "channel_name": "",
+                                  "team_id": ""
+                                }
+                              ]
+                            },
+                            "private": {
+                              "C03E94MKU": [
+                                {
+                                  "share_user_id": "",
+                                  "reply_users": [
+                                    ""
+                                  ],
+                                  "reply_users_count": 123,
+                                  "reply_count": 123,
+                                  "ts": "",
+                                  "thread_ts": "",
+                                  "latest_reply": "",
+                                  "channel_name": "",
+                                  "team_id": ""
+                                }
+                              ],
+                              "C03E94MKU_": [
+                                {
+                                  "share_user_id": "",
+                                  "reply_users": [
+                                    ""
+                                  ],
+                                  "reply_users_count": 123,
+                                  "reply_count": 123,
+                                  "ts": "",
+                                  "thread_ts": "",
+                                  "latest_reply": "",
+                                  "channel_name": "",
+                                  "team_id": ""
+                                }
+                              ]
+                            }
+                          },
+                          "to": [
+                            {
+                              "address": "",
+                              "name": "",
+                              "original": ""
+                            }
+                          ],
+                          "from": [
+                            {
+                              "address": "",
+                              "name": "",
+                              "original": ""
+                            }
+                          ],
+                          "cc": [
+                            {
+                              "address": "",
+                              "name": "",
+                              "original": ""
+                            }
+                          ],
+                          "channel_actions_ts": "",
+                          "channel_actions_count": 123,
+                          "headers": {
+                            "date": "",
+                            "in_reply_to": "",
+                            "reply_to": "",
+                            "message_id": ""
+                          },
+                          "simplified_html": "",
+                          "bot_id": "",
+                          "initial_comment": {
+                            "id": "",
+                            "created": 123,
+                            "timestamp": 123,
+                            "user": "",
+                            "comment": "",
+                            "channel": "",
+                            "is_intro": false
+                          },
+                          "num_stars": 123,
+                          "is_starred": false,
+                          "pinned_to": [
+                            ""
+                          ],
+                          "reactions": [
+                            {
+                              "name": "",
+                              "count": 123,
+                              "users": [
+                                ""
+                              ],
+                              "url": ""
+                            }
+                          ],
+                          "comments_count": 123,
+                          "id": "",
+                          "created": 123,
+                          "subject": "",
+                          "mimetype": "",
+                          "filetype": "",
+                          "pretty_type": "",
+                          "user": "",
+                          "user_team": "",
+                          "mode": "",
+                          "editable": false,
+                          "non_owner_editable": false,
+                          "editor": "",
+                          "last_editor": "",
+                          "updated": 123,
+                          "file_access": "",
+                          "subtype": "",
+                          "transcription": {
+                            "status": "",
+                            "locale": ""
+                          },
+                          "mp4": "",
+                          "vtt": "",
+                          "hls": "",
+                          "hls_embed": "",
+                          "duration_ms": 123,
+                          "thumb_video_w": 123,
+                          "thumb_video_h": 123,
+                          "original_attachment_count": 123,
+                          "is_external": false,
+                          "external_type": "",
+                          "external_id": "",
+                          "external_url": "",
+                          "username": "",
+                          "size": 123,
+                          "url_private": "",
+                          "url_private_download": "",
+                          "app_id": "",
+                          "app_name": "",
+                          "thumb_64": "",
+                          "thumb_64_gif": "",
+                          "thumb_64_w": "",
+                          "thumb_64_h": "",
+                          "thumb_80": "",
+                          "thumb_80_gif": "",
+                          "thumb_80_w": "",
+                          "thumb_80_h": "",
+                          "thumb_160": "",
+                          "thumb_160_gif": "",
+                          "thumb_160_w": "",
+                          "thumb_160_h": "",
+                          "thumb_360": "",
+                          "thumb_360_gif": "",
+                          "thumb_360_w": "",
+                          "thumb_360_h": "",
+                          "thumb_480": "",
+                          "thumb_480_gif": "",
+                          "thumb_480_w": "",
+                          "thumb_480_h": "",
+                          "thumb_720": "",
+                          "thumb_720_gif": "",
+                          "thumb_720_w": "",
+                          "thumb_720_h": "",
+                          "thumb_800": "",
+                          "thumb_800_gif": "",
+                          "thumb_800_w": "",
+                          "thumb_800_h": "",
+                          "thumb_960": "",
+                          "thumb_960_gif": "",
+                          "thumb_960_w": "",
+                          "thumb_960_h": "",
+                          "thumb_1024": "",
+                          "thumb_1024_gif": "",
+                          "thumb_1024_w": "",
+                          "thumb_1024_h": "",
+                          "thumb_video": "",
+                          "thumb_gif": "",
+                          "thumb_pdf": "",
+                          "thumb_pdf_w": "",
+                          "thumb_pdf_h": "",
+                          "thumb_tiny": "",
+                          "converted_pdf": "",
+                          "image_exif_rotation": 123,
+                          "original_w": "",
+                          "original_h": "",
+                          "deanimate": "",
+                          "deanimate_gif": "",
+                          "pjpeg": "",
+                          "permalink": "",
+                          "permalink_public": "",
+                          "edit_link": "",
+                          "has_rich_preview": false,
+                          "media_display_type": "",
+                          "preview_is_truncated": false,
+                          "preview": "",
+                          "preview_highlight": "",
+                          "plain_text": "",
+                          "preview_plain_text": "",
+                          "has_more": false,
+                          "sent_to_self": false,
+                          "lines": 123,
+                          "lines_more": 123,
+                          "is_public": false,
+                          "public_url_shared": false,
+                          "display_as_bot": false,
+                          "channels": [
+                            ""
+                          ],
+                          "groups": [
+                            ""
+                          ],
+                          "ims": [
+                            ""
+                          ],
+                          "shares": {
+                            "public": {
+                              "C03E94MKU": [
+                                {
+                                  "share_user_id": "",
+                                  "reply_users": [
+                                    ""
+                                  ],
+                                  "reply_users_count": 123,
+                                  "reply_count": 123,
+                                  "ts": "",
+                                  "thread_ts": "",
+                                  "latest_reply": "",
+                                  "channel_name": "",
+                                  "team_id": ""
+                                }
+                              ],
+                              "C03E94MKU_": [
+                                {
+                                  "share_user_id": "",
+                                  "reply_users": [
+                                    ""
+                                  ],
+                                  "reply_users_count": 123,
+                                  "reply_count": 123,
+                                  "ts": "",
+                                  "thread_ts": "",
+                                  "latest_reply": "",
+                                  "channel_name": "",
+                                  "team_id": ""
+                                }
+                              ]
+                            },
+                            "private": {
+                              "C03E94MKU": [
+                                {
+                                  "share_user_id": "",
+                                  "reply_users": [
+                                    ""
+                                  ],
+                                  "reply_users_count": 123,
+                                  "reply_count": 123,
+                                  "ts": "",
+                                  "thread_ts": "",
+                                  "latest_reply": "",
+                                  "channel_name": "",
+                                  "team_id": ""
+                                }
+                              ],
+                              "C03E94MKU_": [
+                                {
+                                  "share_user_id": "",
+                                  "reply_users": [
+                                    ""
+                                  ],
+                                  "reply_users_count": 123,
+                                  "reply_count": 123,
+                                  "ts": "",
+                                  "thread_ts": "",
+                                  "latest_reply": "",
+                                  "channel_name": "",
+                                  "team_id": ""
+                                }
+                              ]
+                            }
+                          },
+                          "to": [
+                            {
+                              "address": "",
+                              "name": "",
+                              "original": ""
+                            }
+                          ],
+                          "from": [
+                            {
+                              "address": "",
+                              "name": "",
+                              "original": ""
+                            }
+                          ],
+                          "cc": [
+                            {
+                              "address": "",
+                              "name": "",
+                              "original": ""
+                            }
+                          ],
+                          "channel_actions_ts": "",
+                          "channel_actions_count": 123,
+                          "headers": {
+                            "date": "",
+                            "in_reply_to": "",
+                            "reply_to": "",
+                            "message_id": ""
+                          },
+                          "simplified_html": "",
+                          "bot_id": "",
+                          "initial_comment": {
+                            "id": "",
+                            "created": 123,
+                            "timestamp": 123,
+                            "user": "",
+                            "comment": "",
+                            "channel": "",
+                            "is_intro": false
+                          },
+                          "num_stars": 123,
+                          "is_starred": false,
+                          "pinned_to": [
+                            ""
+                          ],
+                          "reactions": [
+                            {
+                              "name": "",
+                              "count": 123,
+                              "users": [
+                                ""
+                              ],
+                              "url": ""
+                            }
+                          ],
+                          "comments_count": 123,
                           "id": "",
                           "created": 123,
                           "timestamp": 123,
@@ -3897,6 +5338,7 @@
                           "filetype": "",
                           "pretty_type": "",
                           "user": "",
+                          "user_team": "",
                           "mode": "",
                           "editable": false,
                           "non_owner_editable": false,
@@ -4152,6 +5594,15 @@
                         "author_name": "",
                         "provider_name": "",
                         "provider_icon_url": "",
+                        "function_trigger_id": "",
+                        "app_id": "",
+                        "is_workflow_app": false,
+                        "app_collaborators": [
+                          ""
+                        ],
+                        "button_label": "",
+                        "bot_user_id": "",
+                        "url": "",
                         "fields": [
                           {
                             "type": "",
@@ -4491,6 +5942,7 @@
                         "filetype": "",
                         "pretty_type": "",
                         "user": "",
+                        "user_team": "",
                         "mode": "",
                         "editable": false,
                         "non_owner_editable": false,
@@ -5030,6 +6482,477 @@
                     "source": "",
                     "file_id": "",
                     "file": {
+                      "timestamp": 123,
+                      "name": "",
+                      "title": "",
+                      "subject": "",
+                      "mimetype": "",
+                      "filetype": "",
+                      "pretty_type": "",
+                      "user": "",
+                      "user_team": "",
+                      "mode": "",
+                      "editable": false,
+                      "non_owner_editable": false,
+                      "editor": "",
+                      "last_editor": "",
+                      "updated": 123,
+                      "file_access": "",
+                      "subtype": "",
+                      "transcription": {
+                        "status": "",
+                        "locale": ""
+                      },
+                      "mp4": "",
+                      "vtt": "",
+                      "hls": "",
+                      "hls_embed": "",
+                      "duration_ms": 123,
+                      "thumb_video_w": 123,
+                      "thumb_video_h": 123,
+                      "original_attachment_count": 123,
+                      "is_external": false,
+                      "external_type": "",
+                      "external_id": "",
+                      "external_url": "",
+                      "username": "",
+                      "size": 123,
+                      "url_private": "",
+                      "url_private_download": "",
+                      "app_id": "",
+                      "app_name": "",
+                      "thumb_64": "",
+                      "thumb_64_gif": "",
+                      "thumb_64_w": "",
+                      "thumb_64_h": "",
+                      "thumb_80": "",
+                      "thumb_80_gif": "",
+                      "thumb_80_w": "",
+                      "thumb_80_h": "",
+                      "thumb_160": "",
+                      "thumb_160_gif": "",
+                      "thumb_160_w": "",
+                      "thumb_160_h": "",
+                      "thumb_360": "",
+                      "thumb_360_gif": "",
+                      "thumb_360_w": "",
+                      "thumb_360_h": "",
+                      "thumb_480": "",
+                      "thumb_480_gif": "",
+                      "thumb_480_w": "",
+                      "thumb_480_h": "",
+                      "thumb_720": "",
+                      "thumb_720_gif": "",
+                      "thumb_720_w": "",
+                      "thumb_720_h": "",
+                      "thumb_800": "",
+                      "thumb_800_gif": "",
+                      "thumb_800_w": "",
+                      "thumb_800_h": "",
+                      "thumb_960": "",
+                      "thumb_960_gif": "",
+                      "thumb_960_w": "",
+                      "thumb_960_h": "",
+                      "thumb_1024": "",
+                      "thumb_1024_gif": "",
+                      "thumb_1024_w": "",
+                      "thumb_1024_h": "",
+                      "thumb_video": "",
+                      "thumb_gif": "",
+                      "thumb_pdf": "",
+                      "thumb_pdf_w": "",
+                      "thumb_pdf_h": "",
+                      "thumb_tiny": "",
+                      "converted_pdf": "",
+                      "image_exif_rotation": 123,
+                      "original_w": "",
+                      "original_h": "",
+                      "deanimate": "",
+                      "deanimate_gif": "",
+                      "pjpeg": "",
+                      "permalink": "",
+                      "permalink_public": "",
+                      "edit_link": "",
+                      "has_rich_preview": false,
+                      "media_display_type": "",
+                      "preview_is_truncated": false,
+                      "preview": "",
+                      "preview_highlight": "",
+                      "plain_text": "",
+                      "preview_plain_text": "",
+                      "has_more": false,
+                      "sent_to_self": false,
+                      "lines": 123,
+                      "lines_more": 123,
+                      "is_public": false,
+                      "public_url_shared": false,
+                      "display_as_bot": false,
+                      "channels": [
+                        ""
+                      ],
+                      "groups": [
+                        ""
+                      ],
+                      "ims": [
+                        ""
+                      ],
+                      "shares": {
+                        "public": {
+                          "C03E94MKU": [
+                            {
+                              "share_user_id": "",
+                              "reply_users": [
+                                ""
+                              ],
+                              "reply_users_count": 123,
+                              "reply_count": 123,
+                              "ts": "",
+                              "thread_ts": "",
+                              "latest_reply": "",
+                              "channel_name": "",
+                              "team_id": ""
+                            }
+                          ],
+                          "C03E94MKU_": [
+                            {
+                              "share_user_id": "",
+                              "reply_users": [
+                                ""
+                              ],
+                              "reply_users_count": 123,
+                              "reply_count": 123,
+                              "ts": "",
+                              "thread_ts": "",
+                              "latest_reply": "",
+                              "channel_name": "",
+                              "team_id": ""
+                            }
+                          ]
+                        },
+                        "private": {
+                          "C03E94MKU": [
+                            {
+                              "share_user_id": "",
+                              "reply_users": [
+                                ""
+                              ],
+                              "reply_users_count": 123,
+                              "reply_count": 123,
+                              "ts": "",
+                              "thread_ts": "",
+                              "latest_reply": "",
+                              "channel_name": "",
+                              "team_id": ""
+                            }
+                          ],
+                          "C03E94MKU_": [
+                            {
+                              "share_user_id": "",
+                              "reply_users": [
+                                ""
+                              ],
+                              "reply_users_count": 123,
+                              "reply_count": 123,
+                              "ts": "",
+                              "thread_ts": "",
+                              "latest_reply": "",
+                              "channel_name": "",
+                              "team_id": ""
+                            }
+                          ]
+                        }
+                      },
+                      "to": [
+                        {
+                          "address": "",
+                          "name": "",
+                          "original": ""
+                        }
+                      ],
+                      "from": [
+                        {
+                          "address": "",
+                          "name": "",
+                          "original": ""
+                        }
+                      ],
+                      "cc": [
+                        {
+                          "address": "",
+                          "name": "",
+                          "original": ""
+                        }
+                      ],
+                      "channel_actions_ts": "",
+                      "channel_actions_count": 123,
+                      "headers": {
+                        "date": "",
+                        "in_reply_to": "",
+                        "reply_to": "",
+                        "message_id": ""
+                      },
+                      "simplified_html": "",
+                      "bot_id": "",
+                      "initial_comment": {
+                        "id": "",
+                        "created": 123,
+                        "timestamp": 123,
+                        "user": "",
+                        "comment": "",
+                        "channel": "",
+                        "is_intro": false
+                      },
+                      "num_stars": 123,
+                      "is_starred": false,
+                      "pinned_to": [
+                        ""
+                      ],
+                      "reactions": [
+                        {
+                          "name": "",
+                          "count": 123,
+                          "users": [
+                            ""
+                          ],
+                          "url": ""
+                        }
+                      ],
+                      "comments_count": 123,
+                      "id": "",
+                      "created": 123,
+                      "subject": "",
+                      "mimetype": "",
+                      "filetype": "",
+                      "pretty_type": "",
+                      "user": "",
+                      "user_team": "",
+                      "mode": "",
+                      "editable": false,
+                      "non_owner_editable": false,
+                      "editor": "",
+                      "last_editor": "",
+                      "updated": 123,
+                      "file_access": "",
+                      "subtype": "",
+                      "transcription": {
+                        "status": "",
+                        "locale": ""
+                      },
+                      "mp4": "",
+                      "vtt": "",
+                      "hls": "",
+                      "hls_embed": "",
+                      "duration_ms": 123,
+                      "thumb_video_w": 123,
+                      "thumb_video_h": 123,
+                      "original_attachment_count": 123,
+                      "is_external": false,
+                      "external_type": "",
+                      "external_id": "",
+                      "external_url": "",
+                      "username": "",
+                      "size": 123,
+                      "url_private": "",
+                      "url_private_download": "",
+                      "app_id": "",
+                      "app_name": "",
+                      "thumb_64": "",
+                      "thumb_64_gif": "",
+                      "thumb_64_w": "",
+                      "thumb_64_h": "",
+                      "thumb_80": "",
+                      "thumb_80_gif": "",
+                      "thumb_80_w": "",
+                      "thumb_80_h": "",
+                      "thumb_160": "",
+                      "thumb_160_gif": "",
+                      "thumb_160_w": "",
+                      "thumb_160_h": "",
+                      "thumb_360": "",
+                      "thumb_360_gif": "",
+                      "thumb_360_w": "",
+                      "thumb_360_h": "",
+                      "thumb_480": "",
+                      "thumb_480_gif": "",
+                      "thumb_480_w": "",
+                      "thumb_480_h": "",
+                      "thumb_720": "",
+                      "thumb_720_gif": "",
+                      "thumb_720_w": "",
+                      "thumb_720_h": "",
+                      "thumb_800": "",
+                      "thumb_800_gif": "",
+                      "thumb_800_w": "",
+                      "thumb_800_h": "",
+                      "thumb_960": "",
+                      "thumb_960_gif": "",
+                      "thumb_960_w": "",
+                      "thumb_960_h": "",
+                      "thumb_1024": "",
+                      "thumb_1024_gif": "",
+                      "thumb_1024_w": "",
+                      "thumb_1024_h": "",
+                      "thumb_video": "",
+                      "thumb_gif": "",
+                      "thumb_pdf": "",
+                      "thumb_pdf_w": "",
+                      "thumb_pdf_h": "",
+                      "thumb_tiny": "",
+                      "converted_pdf": "",
+                      "image_exif_rotation": 123,
+                      "original_w": "",
+                      "original_h": "",
+                      "deanimate": "",
+                      "deanimate_gif": "",
+                      "pjpeg": "",
+                      "permalink": "",
+                      "permalink_public": "",
+                      "edit_link": "",
+                      "has_rich_preview": false,
+                      "media_display_type": "",
+                      "preview_is_truncated": false,
+                      "preview": "",
+                      "preview_highlight": "",
+                      "plain_text": "",
+                      "preview_plain_text": "",
+                      "has_more": false,
+                      "sent_to_self": false,
+                      "lines": 123,
+                      "lines_more": 123,
+                      "is_public": false,
+                      "public_url_shared": false,
+                      "display_as_bot": false,
+                      "channels": [
+                        ""
+                      ],
+                      "groups": [
+                        ""
+                      ],
+                      "ims": [
+                        ""
+                      ],
+                      "shares": {
+                        "public": {
+                          "C03E94MKU": [
+                            {
+                              "share_user_id": "",
+                              "reply_users": [
+                                ""
+                              ],
+                              "reply_users_count": 123,
+                              "reply_count": 123,
+                              "ts": "",
+                              "thread_ts": "",
+                              "latest_reply": "",
+                              "channel_name": "",
+                              "team_id": ""
+                            }
+                          ],
+                          "C03E94MKU_": [
+                            {
+                              "share_user_id": "",
+                              "reply_users": [
+                                ""
+                              ],
+                              "reply_users_count": 123,
+                              "reply_count": 123,
+                              "ts": "",
+                              "thread_ts": "",
+                              "latest_reply": "",
+                              "channel_name": "",
+                              "team_id": ""
+                            }
+                          ]
+                        },
+                        "private": {
+                          "C03E94MKU": [
+                            {
+                              "share_user_id": "",
+                              "reply_users": [
+                                ""
+                              ],
+                              "reply_users_count": 123,
+                              "reply_count": 123,
+                              "ts": "",
+                              "thread_ts": "",
+                              "latest_reply": "",
+                              "channel_name": "",
+                              "team_id": ""
+                            }
+                          ],
+                          "C03E94MKU_": [
+                            {
+                              "share_user_id": "",
+                              "reply_users": [
+                                ""
+                              ],
+                              "reply_users_count": 123,
+                              "reply_count": 123,
+                              "ts": "",
+                              "thread_ts": "",
+                              "latest_reply": "",
+                              "channel_name": "",
+                              "team_id": ""
+                            }
+                          ]
+                        }
+                      },
+                      "to": [
+                        {
+                          "address": "",
+                          "name": "",
+                          "original": ""
+                        }
+                      ],
+                      "from": [
+                        {
+                          "address": "",
+                          "name": "",
+                          "original": ""
+                        }
+                      ],
+                      "cc": [
+                        {
+                          "address": "",
+                          "name": "",
+                          "original": ""
+                        }
+                      ],
+                      "channel_actions_ts": "",
+                      "channel_actions_count": 123,
+                      "headers": {
+                        "date": "",
+                        "in_reply_to": "",
+                        "reply_to": "",
+                        "message_id": ""
+                      },
+                      "simplified_html": "",
+                      "bot_id": "",
+                      "initial_comment": {
+                        "id": "",
+                        "created": 123,
+                        "timestamp": 123,
+                        "user": "",
+                        "comment": "",
+                        "channel": "",
+                        "is_intro": false
+                      },
+                      "num_stars": 123,
+                      "is_starred": false,
+                      "pinned_to": [
+                        ""
+                      ],
+                      "reactions": [
+                        {
+                          "name": "",
+                          "count": 123,
+                          "users": [
+                            ""
+                          ],
+                          "url": ""
+                        }
+                      ],
+                      "comments_count": 123,
                       "id": "",
                       "created": 123,
                       "timestamp": 123,
@@ -5040,6 +6963,7 @@
                       "filetype": "",
                       "pretty_type": "",
                       "user": "",
+                      "user_team": "",
                       "mode": "",
                       "editable": false,
                       "non_owner_editable": false,
@@ -5295,6 +7219,15 @@
                     "author_name": "",
                     "provider_name": "",
                     "provider_icon_url": "",
+                    "function_trigger_id": "",
+                    "app_id": "",
+                    "is_workflow_app": false,
+                    "app_collaborators": [
+                      ""
+                    ],
+                    "button_label": "",
+                    "bot_user_id": "",
+                    "url": "",
                     "fields": [
                       {
                         "type": "",
@@ -5619,6 +7552,7 @@
                     "filetype": "",
                     "pretty_type": "",
                     "user": "",
+                    "user_team": "",
                     "mode": "",
                     "editable": false,
                     "non_owner_editable": false,

--- a/json-logs/samples/api/search.all.json
+++ b/json-logs/samples/api/search.all.json
@@ -443,6 +443,477 @@
                   "source": "",
                   "file_id": "",
                   "file": {
+                    "timestamp": 123,
+                    "name": "",
+                    "title": "",
+                    "subject": "",
+                    "mimetype": "",
+                    "filetype": "",
+                    "pretty_type": "",
+                    "user": "",
+                    "user_team": "",
+                    "mode": "",
+                    "editable": false,
+                    "non_owner_editable": false,
+                    "editor": "",
+                    "last_editor": "",
+                    "updated": 123,
+                    "file_access": "",
+                    "subtype": "",
+                    "transcription": {
+                      "status": "",
+                      "locale": ""
+                    },
+                    "mp4": "",
+                    "vtt": "",
+                    "hls": "",
+                    "hls_embed": "",
+                    "duration_ms": 123,
+                    "thumb_video_w": 123,
+                    "thumb_video_h": 123,
+                    "original_attachment_count": 123,
+                    "is_external": false,
+                    "external_type": "",
+                    "external_id": "",
+                    "external_url": "",
+                    "username": "",
+                    "size": 123,
+                    "url_private": "",
+                    "url_private_download": "",
+                    "app_id": "",
+                    "app_name": "",
+                    "thumb_64": "",
+                    "thumb_64_gif": "",
+                    "thumb_64_w": "",
+                    "thumb_64_h": "",
+                    "thumb_80": "",
+                    "thumb_80_gif": "",
+                    "thumb_80_w": "",
+                    "thumb_80_h": "",
+                    "thumb_160": "",
+                    "thumb_160_gif": "",
+                    "thumb_160_w": "",
+                    "thumb_160_h": "",
+                    "thumb_360": "",
+                    "thumb_360_gif": "",
+                    "thumb_360_w": "",
+                    "thumb_360_h": "",
+                    "thumb_480": "",
+                    "thumb_480_gif": "",
+                    "thumb_480_w": "",
+                    "thumb_480_h": "",
+                    "thumb_720": "",
+                    "thumb_720_gif": "",
+                    "thumb_720_w": "",
+                    "thumb_720_h": "",
+                    "thumb_800": "",
+                    "thumb_800_gif": "",
+                    "thumb_800_w": "",
+                    "thumb_800_h": "",
+                    "thumb_960": "",
+                    "thumb_960_gif": "",
+                    "thumb_960_w": "",
+                    "thumb_960_h": "",
+                    "thumb_1024": "",
+                    "thumb_1024_gif": "",
+                    "thumb_1024_w": "",
+                    "thumb_1024_h": "",
+                    "thumb_video": "",
+                    "thumb_gif": "",
+                    "thumb_pdf": "",
+                    "thumb_pdf_w": "",
+                    "thumb_pdf_h": "",
+                    "thumb_tiny": "",
+                    "converted_pdf": "",
+                    "image_exif_rotation": 123,
+                    "original_w": "",
+                    "original_h": "",
+                    "deanimate": "",
+                    "deanimate_gif": "",
+                    "pjpeg": "",
+                    "permalink": "",
+                    "permalink_public": "",
+                    "edit_link": "",
+                    "has_rich_preview": false,
+                    "media_display_type": "",
+                    "preview_is_truncated": false,
+                    "preview": "",
+                    "preview_highlight": "",
+                    "plain_text": "",
+                    "preview_plain_text": "",
+                    "has_more": false,
+                    "sent_to_self": false,
+                    "lines": 123,
+                    "lines_more": 123,
+                    "is_public": false,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "channels": [
+                      ""
+                    ],
+                    "groups": [
+                      ""
+                    ],
+                    "ims": [
+                      ""
+                    ],
+                    "shares": {
+                      "public": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      },
+                      "private": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      }
+                    },
+                    "to": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "from": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "cc": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "channel_actions_ts": "",
+                    "channel_actions_count": 123,
+                    "headers": {
+                      "date": "",
+                      "in_reply_to": "",
+                      "reply_to": "",
+                      "message_id": ""
+                    },
+                    "simplified_html": "",
+                    "bot_id": "",
+                    "initial_comment": {
+                      "id": "",
+                      "created": 123,
+                      "timestamp": 123,
+                      "user": "",
+                      "comment": "",
+                      "channel": "",
+                      "is_intro": false
+                    },
+                    "num_stars": 123,
+                    "is_starred": false,
+                    "pinned_to": [
+                      ""
+                    ],
+                    "reactions": [
+                      {
+                        "name": "",
+                        "count": 123,
+                        "users": [
+                          ""
+                        ],
+                        "url": ""
+                      }
+                    ],
+                    "comments_count": 123,
+                    "id": "",
+                    "created": 123,
+                    "subject": "",
+                    "mimetype": "",
+                    "filetype": "",
+                    "pretty_type": "",
+                    "user": "",
+                    "user_team": "",
+                    "mode": "",
+                    "editable": false,
+                    "non_owner_editable": false,
+                    "editor": "",
+                    "last_editor": "",
+                    "updated": 123,
+                    "file_access": "",
+                    "subtype": "",
+                    "transcription": {
+                      "status": "",
+                      "locale": ""
+                    },
+                    "mp4": "",
+                    "vtt": "",
+                    "hls": "",
+                    "hls_embed": "",
+                    "duration_ms": 123,
+                    "thumb_video_w": 123,
+                    "thumb_video_h": 123,
+                    "original_attachment_count": 123,
+                    "is_external": false,
+                    "external_type": "",
+                    "external_id": "",
+                    "external_url": "",
+                    "username": "",
+                    "size": 123,
+                    "url_private": "",
+                    "url_private_download": "",
+                    "app_id": "",
+                    "app_name": "",
+                    "thumb_64": "",
+                    "thumb_64_gif": "",
+                    "thumb_64_w": "",
+                    "thumb_64_h": "",
+                    "thumb_80": "",
+                    "thumb_80_gif": "",
+                    "thumb_80_w": "",
+                    "thumb_80_h": "",
+                    "thumb_160": "",
+                    "thumb_160_gif": "",
+                    "thumb_160_w": "",
+                    "thumb_160_h": "",
+                    "thumb_360": "",
+                    "thumb_360_gif": "",
+                    "thumb_360_w": "",
+                    "thumb_360_h": "",
+                    "thumb_480": "",
+                    "thumb_480_gif": "",
+                    "thumb_480_w": "",
+                    "thumb_480_h": "",
+                    "thumb_720": "",
+                    "thumb_720_gif": "",
+                    "thumb_720_w": "",
+                    "thumb_720_h": "",
+                    "thumb_800": "",
+                    "thumb_800_gif": "",
+                    "thumb_800_w": "",
+                    "thumb_800_h": "",
+                    "thumb_960": "",
+                    "thumb_960_gif": "",
+                    "thumb_960_w": "",
+                    "thumb_960_h": "",
+                    "thumb_1024": "",
+                    "thumb_1024_gif": "",
+                    "thumb_1024_w": "",
+                    "thumb_1024_h": "",
+                    "thumb_video": "",
+                    "thumb_gif": "",
+                    "thumb_pdf": "",
+                    "thumb_pdf_w": "",
+                    "thumb_pdf_h": "",
+                    "thumb_tiny": "",
+                    "converted_pdf": "",
+                    "image_exif_rotation": 123,
+                    "original_w": "",
+                    "original_h": "",
+                    "deanimate": "",
+                    "deanimate_gif": "",
+                    "pjpeg": "",
+                    "permalink": "",
+                    "permalink_public": "",
+                    "edit_link": "",
+                    "has_rich_preview": false,
+                    "media_display_type": "",
+                    "preview_is_truncated": false,
+                    "preview": "",
+                    "preview_highlight": "",
+                    "plain_text": "",
+                    "preview_plain_text": "",
+                    "has_more": false,
+                    "sent_to_self": false,
+                    "lines": 123,
+                    "lines_more": 123,
+                    "is_public": false,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "channels": [
+                      ""
+                    ],
+                    "groups": [
+                      ""
+                    ],
+                    "ims": [
+                      ""
+                    ],
+                    "shares": {
+                      "public": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      },
+                      "private": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      }
+                    },
+                    "to": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "from": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "cc": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "channel_actions_ts": "",
+                    "channel_actions_count": 123,
+                    "headers": {
+                      "date": "",
+                      "in_reply_to": "",
+                      "reply_to": "",
+                      "message_id": ""
+                    },
+                    "simplified_html": "",
+                    "bot_id": "",
+                    "initial_comment": {
+                      "id": "",
+                      "created": 123,
+                      "timestamp": 123,
+                      "user": "",
+                      "comment": "",
+                      "channel": "",
+                      "is_intro": false
+                    },
+                    "num_stars": 123,
+                    "is_starred": false,
+                    "pinned_to": [
+                      ""
+                    ],
+                    "reactions": [
+                      {
+                        "name": "",
+                        "count": 123,
+                        "users": [
+                          ""
+                        ],
+                        "url": ""
+                      }
+                    ],
+                    "comments_count": 123,
                     "id": "",
                     "created": 123,
                     "timestamp": 123,
@@ -709,6 +1180,15 @@
                   "author_name": "",
                   "provider_name": "",
                   "provider_icon_url": "",
+                  "function_trigger_id": "",
+                  "app_id": "",
+                  "is_workflow_app": false,
+                  "app_collaborators": [
+                    ""
+                  ],
+                  "button_label": "",
+                  "bot_user_id": "",
+                  "url": "",
                   "fields": [
                     {
                       "type": "",
@@ -1588,6 +2068,477 @@
               "source": "",
               "file_id": "",
               "file": {
+                "timestamp": 123,
+                "name": "",
+                "title": "",
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
+                "id": "",
+                "created": 123,
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
                 "id": "",
                 "created": 123,
                 "timestamp": 123,
@@ -1854,6 +2805,15 @@
               "author_name": "",
               "provider_name": "",
               "provider_icon_url": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "bot_user_id": "",
+              "url": "",
               "fields": [
                 {
                   "type": "",
@@ -2563,6 +3523,477 @@
                   "source": "",
                   "file_id": "",
                   "file": {
+                    "timestamp": 123,
+                    "name": "",
+                    "title": "",
+                    "subject": "",
+                    "mimetype": "",
+                    "filetype": "",
+                    "pretty_type": "",
+                    "user": "",
+                    "user_team": "",
+                    "mode": "",
+                    "editable": false,
+                    "non_owner_editable": false,
+                    "editor": "",
+                    "last_editor": "",
+                    "updated": 123,
+                    "file_access": "",
+                    "subtype": "",
+                    "transcription": {
+                      "status": "",
+                      "locale": ""
+                    },
+                    "mp4": "",
+                    "vtt": "",
+                    "hls": "",
+                    "hls_embed": "",
+                    "duration_ms": 123,
+                    "thumb_video_w": 123,
+                    "thumb_video_h": 123,
+                    "original_attachment_count": 123,
+                    "is_external": false,
+                    "external_type": "",
+                    "external_id": "",
+                    "external_url": "",
+                    "username": "",
+                    "size": 123,
+                    "url_private": "",
+                    "url_private_download": "",
+                    "app_id": "",
+                    "app_name": "",
+                    "thumb_64": "",
+                    "thumb_64_gif": "",
+                    "thumb_64_w": "",
+                    "thumb_64_h": "",
+                    "thumb_80": "",
+                    "thumb_80_gif": "",
+                    "thumb_80_w": "",
+                    "thumb_80_h": "",
+                    "thumb_160": "",
+                    "thumb_160_gif": "",
+                    "thumb_160_w": "",
+                    "thumb_160_h": "",
+                    "thumb_360": "",
+                    "thumb_360_gif": "",
+                    "thumb_360_w": "",
+                    "thumb_360_h": "",
+                    "thumb_480": "",
+                    "thumb_480_gif": "",
+                    "thumb_480_w": "",
+                    "thumb_480_h": "",
+                    "thumb_720": "",
+                    "thumb_720_gif": "",
+                    "thumb_720_w": "",
+                    "thumb_720_h": "",
+                    "thumb_800": "",
+                    "thumb_800_gif": "",
+                    "thumb_800_w": "",
+                    "thumb_800_h": "",
+                    "thumb_960": "",
+                    "thumb_960_gif": "",
+                    "thumb_960_w": "",
+                    "thumb_960_h": "",
+                    "thumb_1024": "",
+                    "thumb_1024_gif": "",
+                    "thumb_1024_w": "",
+                    "thumb_1024_h": "",
+                    "thumb_video": "",
+                    "thumb_gif": "",
+                    "thumb_pdf": "",
+                    "thumb_pdf_w": "",
+                    "thumb_pdf_h": "",
+                    "thumb_tiny": "",
+                    "converted_pdf": "",
+                    "image_exif_rotation": 123,
+                    "original_w": "",
+                    "original_h": "",
+                    "deanimate": "",
+                    "deanimate_gif": "",
+                    "pjpeg": "",
+                    "permalink": "",
+                    "permalink_public": "",
+                    "edit_link": "",
+                    "has_rich_preview": false,
+                    "media_display_type": "",
+                    "preview_is_truncated": false,
+                    "preview": "",
+                    "preview_highlight": "",
+                    "plain_text": "",
+                    "preview_plain_text": "",
+                    "has_more": false,
+                    "sent_to_self": false,
+                    "lines": 123,
+                    "lines_more": 123,
+                    "is_public": false,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "channels": [
+                      ""
+                    ],
+                    "groups": [
+                      ""
+                    ],
+                    "ims": [
+                      ""
+                    ],
+                    "shares": {
+                      "public": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      },
+                      "private": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      }
+                    },
+                    "to": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "from": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "cc": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "channel_actions_ts": "",
+                    "channel_actions_count": 123,
+                    "headers": {
+                      "date": "",
+                      "in_reply_to": "",
+                      "reply_to": "",
+                      "message_id": ""
+                    },
+                    "simplified_html": "",
+                    "bot_id": "",
+                    "initial_comment": {
+                      "id": "",
+                      "created": 123,
+                      "timestamp": 123,
+                      "user": "",
+                      "comment": "",
+                      "channel": "",
+                      "is_intro": false
+                    },
+                    "num_stars": 123,
+                    "is_starred": false,
+                    "pinned_to": [
+                      ""
+                    ],
+                    "reactions": [
+                      {
+                        "name": "",
+                        "count": 123,
+                        "users": [
+                          ""
+                        ],
+                        "url": ""
+                      }
+                    ],
+                    "comments_count": 123,
+                    "id": "",
+                    "created": 123,
+                    "subject": "",
+                    "mimetype": "",
+                    "filetype": "",
+                    "pretty_type": "",
+                    "user": "",
+                    "user_team": "",
+                    "mode": "",
+                    "editable": false,
+                    "non_owner_editable": false,
+                    "editor": "",
+                    "last_editor": "",
+                    "updated": 123,
+                    "file_access": "",
+                    "subtype": "",
+                    "transcription": {
+                      "status": "",
+                      "locale": ""
+                    },
+                    "mp4": "",
+                    "vtt": "",
+                    "hls": "",
+                    "hls_embed": "",
+                    "duration_ms": 123,
+                    "thumb_video_w": 123,
+                    "thumb_video_h": 123,
+                    "original_attachment_count": 123,
+                    "is_external": false,
+                    "external_type": "",
+                    "external_id": "",
+                    "external_url": "",
+                    "username": "",
+                    "size": 123,
+                    "url_private": "",
+                    "url_private_download": "",
+                    "app_id": "",
+                    "app_name": "",
+                    "thumb_64": "",
+                    "thumb_64_gif": "",
+                    "thumb_64_w": "",
+                    "thumb_64_h": "",
+                    "thumb_80": "",
+                    "thumb_80_gif": "",
+                    "thumb_80_w": "",
+                    "thumb_80_h": "",
+                    "thumb_160": "",
+                    "thumb_160_gif": "",
+                    "thumb_160_w": "",
+                    "thumb_160_h": "",
+                    "thumb_360": "",
+                    "thumb_360_gif": "",
+                    "thumb_360_w": "",
+                    "thumb_360_h": "",
+                    "thumb_480": "",
+                    "thumb_480_gif": "",
+                    "thumb_480_w": "",
+                    "thumb_480_h": "",
+                    "thumb_720": "",
+                    "thumb_720_gif": "",
+                    "thumb_720_w": "",
+                    "thumb_720_h": "",
+                    "thumb_800": "",
+                    "thumb_800_gif": "",
+                    "thumb_800_w": "",
+                    "thumb_800_h": "",
+                    "thumb_960": "",
+                    "thumb_960_gif": "",
+                    "thumb_960_w": "",
+                    "thumb_960_h": "",
+                    "thumb_1024": "",
+                    "thumb_1024_gif": "",
+                    "thumb_1024_w": "",
+                    "thumb_1024_h": "",
+                    "thumb_video": "",
+                    "thumb_gif": "",
+                    "thumb_pdf": "",
+                    "thumb_pdf_w": "",
+                    "thumb_pdf_h": "",
+                    "thumb_tiny": "",
+                    "converted_pdf": "",
+                    "image_exif_rotation": 123,
+                    "original_w": "",
+                    "original_h": "",
+                    "deanimate": "",
+                    "deanimate_gif": "",
+                    "pjpeg": "",
+                    "permalink": "",
+                    "permalink_public": "",
+                    "edit_link": "",
+                    "has_rich_preview": false,
+                    "media_display_type": "",
+                    "preview_is_truncated": false,
+                    "preview": "",
+                    "preview_highlight": "",
+                    "plain_text": "",
+                    "preview_plain_text": "",
+                    "has_more": false,
+                    "sent_to_self": false,
+                    "lines": 123,
+                    "lines_more": 123,
+                    "is_public": false,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "channels": [
+                      ""
+                    ],
+                    "groups": [
+                      ""
+                    ],
+                    "ims": [
+                      ""
+                    ],
+                    "shares": {
+                      "public": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      },
+                      "private": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      }
+                    },
+                    "to": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "from": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "cc": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "channel_actions_ts": "",
+                    "channel_actions_count": 123,
+                    "headers": {
+                      "date": "",
+                      "in_reply_to": "",
+                      "reply_to": "",
+                      "message_id": ""
+                    },
+                    "simplified_html": "",
+                    "bot_id": "",
+                    "initial_comment": {
+                      "id": "",
+                      "created": 123,
+                      "timestamp": 123,
+                      "user": "",
+                      "comment": "",
+                      "channel": "",
+                      "is_intro": false
+                    },
+                    "num_stars": 123,
+                    "is_starred": false,
+                    "pinned_to": [
+                      ""
+                    ],
+                    "reactions": [
+                      {
+                        "name": "",
+                        "count": 123,
+                        "users": [
+                          ""
+                        ],
+                        "url": ""
+                      }
+                    ],
+                    "comments_count": 123,
                     "id": "",
                     "created": 123,
                     "timestamp": 123,
@@ -2829,6 +4260,15 @@
                   "author_name": "",
                   "provider_name": "",
                   "provider_icon_url": "",
+                  "function_trigger_id": "",
+                  "app_id": "",
+                  "is_workflow_app": false,
+                  "app_collaborators": [
+                    ""
+                  ],
+                  "button_label": "",
+                  "bot_user_id": "",
+                  "url": "",
                   "fields": [
                     {
                       "type": "",
@@ -3708,6 +5148,477 @@
               "source": "",
               "file_id": "",
               "file": {
+                "timestamp": 123,
+                "name": "",
+                "title": "",
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
+                "id": "",
+                "created": 123,
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
                 "id": "",
                 "created": 123,
                 "timestamp": 123,
@@ -3974,6 +5885,15 @@
               "author_name": "",
               "provider_name": "",
               "provider_icon_url": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "bot_user_id": "",
+              "url": "",
               "fields": [
                 {
                   "type": "",
@@ -4578,6 +6498,477 @@
             "source": "",
             "file_id": "",
             "file": {
+              "timestamp": 123,
+              "name": "",
+              "title": "",
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
+              "id": "",
+              "created": 123,
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
               "id": "",
               "created": 123,
               "timestamp": 123,
@@ -4844,6 +7235,15 @@
             "author_name": "",
             "provider_name": "",
             "provider_icon_url": "",
+            "function_trigger_id": "",
+            "app_id": "",
+            "is_workflow_app": false,
+            "app_collaborators": [
+              ""
+            ],
+            "button_label": "",
+            "bot_user_id": "",
+            "url": "",
             "fields": [
               {
                 "type": "",
@@ -5544,6 +7944,477 @@
                 "source": "",
                 "file_id": "",
                 "file": {
+                  "timestamp": 123,
+                  "name": "",
+                  "title": "",
+                  "subject": "",
+                  "mimetype": "",
+                  "filetype": "",
+                  "pretty_type": "",
+                  "user": "",
+                  "user_team": "",
+                  "mode": "",
+                  "editable": false,
+                  "non_owner_editable": false,
+                  "editor": "",
+                  "last_editor": "",
+                  "updated": 123,
+                  "file_access": "",
+                  "subtype": "",
+                  "transcription": {
+                    "status": "",
+                    "locale": ""
+                  },
+                  "mp4": "",
+                  "vtt": "",
+                  "hls": "",
+                  "hls_embed": "",
+                  "duration_ms": 123,
+                  "thumb_video_w": 123,
+                  "thumb_video_h": 123,
+                  "original_attachment_count": 123,
+                  "is_external": false,
+                  "external_type": "",
+                  "external_id": "",
+                  "external_url": "",
+                  "username": "",
+                  "size": 123,
+                  "url_private": "",
+                  "url_private_download": "",
+                  "app_id": "",
+                  "app_name": "",
+                  "thumb_64": "",
+                  "thumb_64_gif": "",
+                  "thumb_64_w": "",
+                  "thumb_64_h": "",
+                  "thumb_80": "",
+                  "thumb_80_gif": "",
+                  "thumb_80_w": "",
+                  "thumb_80_h": "",
+                  "thumb_160": "",
+                  "thumb_160_gif": "",
+                  "thumb_160_w": "",
+                  "thumb_160_h": "",
+                  "thumb_360": "",
+                  "thumb_360_gif": "",
+                  "thumb_360_w": "",
+                  "thumb_360_h": "",
+                  "thumb_480": "",
+                  "thumb_480_gif": "",
+                  "thumb_480_w": "",
+                  "thumb_480_h": "",
+                  "thumb_720": "",
+                  "thumb_720_gif": "",
+                  "thumb_720_w": "",
+                  "thumb_720_h": "",
+                  "thumb_800": "",
+                  "thumb_800_gif": "",
+                  "thumb_800_w": "",
+                  "thumb_800_h": "",
+                  "thumb_960": "",
+                  "thumb_960_gif": "",
+                  "thumb_960_w": "",
+                  "thumb_960_h": "",
+                  "thumb_1024": "",
+                  "thumb_1024_gif": "",
+                  "thumb_1024_w": "",
+                  "thumb_1024_h": "",
+                  "thumb_video": "",
+                  "thumb_gif": "",
+                  "thumb_pdf": "",
+                  "thumb_pdf_w": "",
+                  "thumb_pdf_h": "",
+                  "thumb_tiny": "",
+                  "converted_pdf": "",
+                  "image_exif_rotation": 123,
+                  "original_w": "",
+                  "original_h": "",
+                  "deanimate": "",
+                  "deanimate_gif": "",
+                  "pjpeg": "",
+                  "permalink": "",
+                  "permalink_public": "",
+                  "edit_link": "",
+                  "has_rich_preview": false,
+                  "media_display_type": "",
+                  "preview_is_truncated": false,
+                  "preview": "",
+                  "preview_highlight": "",
+                  "plain_text": "",
+                  "preview_plain_text": "",
+                  "has_more": false,
+                  "sent_to_self": false,
+                  "lines": 123,
+                  "lines_more": 123,
+                  "is_public": false,
+                  "public_url_shared": false,
+                  "display_as_bot": false,
+                  "channels": [
+                    ""
+                  ],
+                  "groups": [
+                    ""
+                  ],
+                  "ims": [
+                    ""
+                  ],
+                  "shares": {
+                    "public": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    },
+                    "private": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    }
+                  },
+                  "to": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "from": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "cc": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "channel_actions_ts": "",
+                  "channel_actions_count": 123,
+                  "headers": {
+                    "date": "",
+                    "in_reply_to": "",
+                    "reply_to": "",
+                    "message_id": ""
+                  },
+                  "simplified_html": "",
+                  "bot_id": "",
+                  "initial_comment": {
+                    "id": "",
+                    "created": 123,
+                    "timestamp": 123,
+                    "user": "",
+                    "comment": "",
+                    "channel": "",
+                    "is_intro": false
+                  },
+                  "num_stars": 123,
+                  "is_starred": false,
+                  "pinned_to": [
+                    ""
+                  ],
+                  "reactions": [
+                    {
+                      "name": "",
+                      "count": 123,
+                      "users": [
+                        ""
+                      ],
+                      "url": ""
+                    }
+                  ],
+                  "comments_count": 123,
+                  "id": "",
+                  "created": 123,
+                  "subject": "",
+                  "mimetype": "",
+                  "filetype": "",
+                  "pretty_type": "",
+                  "user": "",
+                  "user_team": "",
+                  "mode": "",
+                  "editable": false,
+                  "non_owner_editable": false,
+                  "editor": "",
+                  "last_editor": "",
+                  "updated": 123,
+                  "file_access": "",
+                  "subtype": "",
+                  "transcription": {
+                    "status": "",
+                    "locale": ""
+                  },
+                  "mp4": "",
+                  "vtt": "",
+                  "hls": "",
+                  "hls_embed": "",
+                  "duration_ms": 123,
+                  "thumb_video_w": 123,
+                  "thumb_video_h": 123,
+                  "original_attachment_count": 123,
+                  "is_external": false,
+                  "external_type": "",
+                  "external_id": "",
+                  "external_url": "",
+                  "username": "",
+                  "size": 123,
+                  "url_private": "",
+                  "url_private_download": "",
+                  "app_id": "",
+                  "app_name": "",
+                  "thumb_64": "",
+                  "thumb_64_gif": "",
+                  "thumb_64_w": "",
+                  "thumb_64_h": "",
+                  "thumb_80": "",
+                  "thumb_80_gif": "",
+                  "thumb_80_w": "",
+                  "thumb_80_h": "",
+                  "thumb_160": "",
+                  "thumb_160_gif": "",
+                  "thumb_160_w": "",
+                  "thumb_160_h": "",
+                  "thumb_360": "",
+                  "thumb_360_gif": "",
+                  "thumb_360_w": "",
+                  "thumb_360_h": "",
+                  "thumb_480": "",
+                  "thumb_480_gif": "",
+                  "thumb_480_w": "",
+                  "thumb_480_h": "",
+                  "thumb_720": "",
+                  "thumb_720_gif": "",
+                  "thumb_720_w": "",
+                  "thumb_720_h": "",
+                  "thumb_800": "",
+                  "thumb_800_gif": "",
+                  "thumb_800_w": "",
+                  "thumb_800_h": "",
+                  "thumb_960": "",
+                  "thumb_960_gif": "",
+                  "thumb_960_w": "",
+                  "thumb_960_h": "",
+                  "thumb_1024": "",
+                  "thumb_1024_gif": "",
+                  "thumb_1024_w": "",
+                  "thumb_1024_h": "",
+                  "thumb_video": "",
+                  "thumb_gif": "",
+                  "thumb_pdf": "",
+                  "thumb_pdf_w": "",
+                  "thumb_pdf_h": "",
+                  "thumb_tiny": "",
+                  "converted_pdf": "",
+                  "image_exif_rotation": 123,
+                  "original_w": "",
+                  "original_h": "",
+                  "deanimate": "",
+                  "deanimate_gif": "",
+                  "pjpeg": "",
+                  "permalink": "",
+                  "permalink_public": "",
+                  "edit_link": "",
+                  "has_rich_preview": false,
+                  "media_display_type": "",
+                  "preview_is_truncated": false,
+                  "preview": "",
+                  "preview_highlight": "",
+                  "plain_text": "",
+                  "preview_plain_text": "",
+                  "has_more": false,
+                  "sent_to_self": false,
+                  "lines": 123,
+                  "lines_more": 123,
+                  "is_public": false,
+                  "public_url_shared": false,
+                  "display_as_bot": false,
+                  "channels": [
+                    ""
+                  ],
+                  "groups": [
+                    ""
+                  ],
+                  "ims": [
+                    ""
+                  ],
+                  "shares": {
+                    "public": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    },
+                    "private": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    }
+                  },
+                  "to": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "from": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "cc": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "channel_actions_ts": "",
+                  "channel_actions_count": 123,
+                  "headers": {
+                    "date": "",
+                    "in_reply_to": "",
+                    "reply_to": "",
+                    "message_id": ""
+                  },
+                  "simplified_html": "",
+                  "bot_id": "",
+                  "initial_comment": {
+                    "id": "",
+                    "created": 123,
+                    "timestamp": 123,
+                    "user": "",
+                    "comment": "",
+                    "channel": "",
+                    "is_intro": false
+                  },
+                  "num_stars": 123,
+                  "is_starred": false,
+                  "pinned_to": [
+                    ""
+                  ],
+                  "reactions": [
+                    {
+                      "name": "",
+                      "count": 123,
+                      "users": [
+                        ""
+                      ],
+                      "url": ""
+                    }
+                  ],
+                  "comments_count": 123,
                   "id": "",
                   "created": 123,
                   "timestamp": 123,
@@ -5810,6 +8681,15 @@
                 "author_name": "",
                 "provider_name": "",
                 "provider_icon_url": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "bot_user_id": "",
+                "url": "",
                 "fields": [
                   {
                     "type": "",

--- a/json-logs/samples/api/search.messages.json
+++ b/json-logs/samples/api/search.messages.json
@@ -442,6 +442,477 @@
                   "source": "",
                   "file_id": "",
                   "file": {
+                    "timestamp": 123,
+                    "name": "",
+                    "title": "",
+                    "subject": "",
+                    "mimetype": "",
+                    "filetype": "",
+                    "pretty_type": "",
+                    "user": "",
+                    "user_team": "",
+                    "mode": "",
+                    "editable": false,
+                    "non_owner_editable": false,
+                    "editor": "",
+                    "last_editor": "",
+                    "updated": 123,
+                    "file_access": "",
+                    "subtype": "",
+                    "transcription": {
+                      "status": "",
+                      "locale": ""
+                    },
+                    "mp4": "",
+                    "vtt": "",
+                    "hls": "",
+                    "hls_embed": "",
+                    "duration_ms": 123,
+                    "thumb_video_w": 123,
+                    "thumb_video_h": 123,
+                    "original_attachment_count": 123,
+                    "is_external": false,
+                    "external_type": "",
+                    "external_id": "",
+                    "external_url": "",
+                    "username": "",
+                    "size": 123,
+                    "url_private": "",
+                    "url_private_download": "",
+                    "app_id": "",
+                    "app_name": "",
+                    "thumb_64": "",
+                    "thumb_64_gif": "",
+                    "thumb_64_w": "",
+                    "thumb_64_h": "",
+                    "thumb_80": "",
+                    "thumb_80_gif": "",
+                    "thumb_80_w": "",
+                    "thumb_80_h": "",
+                    "thumb_160": "",
+                    "thumb_160_gif": "",
+                    "thumb_160_w": "",
+                    "thumb_160_h": "",
+                    "thumb_360": "",
+                    "thumb_360_gif": "",
+                    "thumb_360_w": "",
+                    "thumb_360_h": "",
+                    "thumb_480": "",
+                    "thumb_480_gif": "",
+                    "thumb_480_w": "",
+                    "thumb_480_h": "",
+                    "thumb_720": "",
+                    "thumb_720_gif": "",
+                    "thumb_720_w": "",
+                    "thumb_720_h": "",
+                    "thumb_800": "",
+                    "thumb_800_gif": "",
+                    "thumb_800_w": "",
+                    "thumb_800_h": "",
+                    "thumb_960": "",
+                    "thumb_960_gif": "",
+                    "thumb_960_w": "",
+                    "thumb_960_h": "",
+                    "thumb_1024": "",
+                    "thumb_1024_gif": "",
+                    "thumb_1024_w": "",
+                    "thumb_1024_h": "",
+                    "thumb_video": "",
+                    "thumb_gif": "",
+                    "thumb_pdf": "",
+                    "thumb_pdf_w": "",
+                    "thumb_pdf_h": "",
+                    "thumb_tiny": "",
+                    "converted_pdf": "",
+                    "image_exif_rotation": 123,
+                    "original_w": "",
+                    "original_h": "",
+                    "deanimate": "",
+                    "deanimate_gif": "",
+                    "pjpeg": "",
+                    "permalink": "",
+                    "permalink_public": "",
+                    "edit_link": "",
+                    "has_rich_preview": false,
+                    "media_display_type": "",
+                    "preview_is_truncated": false,
+                    "preview": "",
+                    "preview_highlight": "",
+                    "plain_text": "",
+                    "preview_plain_text": "",
+                    "has_more": false,
+                    "sent_to_self": false,
+                    "lines": 123,
+                    "lines_more": 123,
+                    "is_public": false,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "channels": [
+                      ""
+                    ],
+                    "groups": [
+                      ""
+                    ],
+                    "ims": [
+                      ""
+                    ],
+                    "shares": {
+                      "public": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      },
+                      "private": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      }
+                    },
+                    "to": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "from": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "cc": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "channel_actions_ts": "",
+                    "channel_actions_count": 123,
+                    "headers": {
+                      "date": "",
+                      "in_reply_to": "",
+                      "reply_to": "",
+                      "message_id": ""
+                    },
+                    "simplified_html": "",
+                    "bot_id": "",
+                    "initial_comment": {
+                      "id": "",
+                      "created": 123,
+                      "timestamp": 123,
+                      "user": "",
+                      "comment": "",
+                      "channel": "",
+                      "is_intro": false
+                    },
+                    "num_stars": 123,
+                    "is_starred": false,
+                    "pinned_to": [
+                      ""
+                    ],
+                    "reactions": [
+                      {
+                        "name": "",
+                        "count": 123,
+                        "users": [
+                          ""
+                        ],
+                        "url": ""
+                      }
+                    ],
+                    "comments_count": 123,
+                    "id": "",
+                    "created": 123,
+                    "subject": "",
+                    "mimetype": "",
+                    "filetype": "",
+                    "pretty_type": "",
+                    "user": "",
+                    "user_team": "",
+                    "mode": "",
+                    "editable": false,
+                    "non_owner_editable": false,
+                    "editor": "",
+                    "last_editor": "",
+                    "updated": 123,
+                    "file_access": "",
+                    "subtype": "",
+                    "transcription": {
+                      "status": "",
+                      "locale": ""
+                    },
+                    "mp4": "",
+                    "vtt": "",
+                    "hls": "",
+                    "hls_embed": "",
+                    "duration_ms": 123,
+                    "thumb_video_w": 123,
+                    "thumb_video_h": 123,
+                    "original_attachment_count": 123,
+                    "is_external": false,
+                    "external_type": "",
+                    "external_id": "",
+                    "external_url": "",
+                    "username": "",
+                    "size": 123,
+                    "url_private": "",
+                    "url_private_download": "",
+                    "app_id": "",
+                    "app_name": "",
+                    "thumb_64": "",
+                    "thumb_64_gif": "",
+                    "thumb_64_w": "",
+                    "thumb_64_h": "",
+                    "thumb_80": "",
+                    "thumb_80_gif": "",
+                    "thumb_80_w": "",
+                    "thumb_80_h": "",
+                    "thumb_160": "",
+                    "thumb_160_gif": "",
+                    "thumb_160_w": "",
+                    "thumb_160_h": "",
+                    "thumb_360": "",
+                    "thumb_360_gif": "",
+                    "thumb_360_w": "",
+                    "thumb_360_h": "",
+                    "thumb_480": "",
+                    "thumb_480_gif": "",
+                    "thumb_480_w": "",
+                    "thumb_480_h": "",
+                    "thumb_720": "",
+                    "thumb_720_gif": "",
+                    "thumb_720_w": "",
+                    "thumb_720_h": "",
+                    "thumb_800": "",
+                    "thumb_800_gif": "",
+                    "thumb_800_w": "",
+                    "thumb_800_h": "",
+                    "thumb_960": "",
+                    "thumb_960_gif": "",
+                    "thumb_960_w": "",
+                    "thumb_960_h": "",
+                    "thumb_1024": "",
+                    "thumb_1024_gif": "",
+                    "thumb_1024_w": "",
+                    "thumb_1024_h": "",
+                    "thumb_video": "",
+                    "thumb_gif": "",
+                    "thumb_pdf": "",
+                    "thumb_pdf_w": "",
+                    "thumb_pdf_h": "",
+                    "thumb_tiny": "",
+                    "converted_pdf": "",
+                    "image_exif_rotation": 123,
+                    "original_w": "",
+                    "original_h": "",
+                    "deanimate": "",
+                    "deanimate_gif": "",
+                    "pjpeg": "",
+                    "permalink": "",
+                    "permalink_public": "",
+                    "edit_link": "",
+                    "has_rich_preview": false,
+                    "media_display_type": "",
+                    "preview_is_truncated": false,
+                    "preview": "",
+                    "preview_highlight": "",
+                    "plain_text": "",
+                    "preview_plain_text": "",
+                    "has_more": false,
+                    "sent_to_self": false,
+                    "lines": 123,
+                    "lines_more": 123,
+                    "is_public": false,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "channels": [
+                      ""
+                    ],
+                    "groups": [
+                      ""
+                    ],
+                    "ims": [
+                      ""
+                    ],
+                    "shares": {
+                      "public": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      },
+                      "private": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      }
+                    },
+                    "to": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "from": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "cc": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "channel_actions_ts": "",
+                    "channel_actions_count": 123,
+                    "headers": {
+                      "date": "",
+                      "in_reply_to": "",
+                      "reply_to": "",
+                      "message_id": ""
+                    },
+                    "simplified_html": "",
+                    "bot_id": "",
+                    "initial_comment": {
+                      "id": "",
+                      "created": 123,
+                      "timestamp": 123,
+                      "user": "",
+                      "comment": "",
+                      "channel": "",
+                      "is_intro": false
+                    },
+                    "num_stars": 123,
+                    "is_starred": false,
+                    "pinned_to": [
+                      ""
+                    ],
+                    "reactions": [
+                      {
+                        "name": "",
+                        "count": 123,
+                        "users": [
+                          ""
+                        ],
+                        "url": ""
+                      }
+                    ],
+                    "comments_count": 123,
                     "id": "",
                     "created": 123,
                     "timestamp": 123,
@@ -708,6 +1179,15 @@
                   "author_name": "",
                   "provider_name": "",
                   "provider_icon_url": "",
+                  "function_trigger_id": "",
+                  "app_id": "",
+                  "is_workflow_app": false,
+                  "app_collaborators": [
+                    ""
+                  ],
+                  "button_label": "",
+                  "bot_user_id": "",
+                  "url": "",
                   "fields": [
                     {
                       "type": "",
@@ -1587,6 +2067,477 @@
               "source": "",
               "file_id": "",
               "file": {
+                "timestamp": 123,
+                "name": "",
+                "title": "",
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
+                "id": "",
+                "created": 123,
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
                 "id": "",
                 "created": 123,
                 "timestamp": 123,
@@ -1853,6 +2804,15 @@
               "author_name": "",
               "provider_name": "",
               "provider_icon_url": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "bot_user_id": "",
+              "url": "",
               "fields": [
                 {
                   "type": "",
@@ -2562,6 +3522,477 @@
                   "source": "",
                   "file_id": "",
                   "file": {
+                    "timestamp": 123,
+                    "name": "",
+                    "title": "",
+                    "subject": "",
+                    "mimetype": "",
+                    "filetype": "",
+                    "pretty_type": "",
+                    "user": "",
+                    "user_team": "",
+                    "mode": "",
+                    "editable": false,
+                    "non_owner_editable": false,
+                    "editor": "",
+                    "last_editor": "",
+                    "updated": 123,
+                    "file_access": "",
+                    "subtype": "",
+                    "transcription": {
+                      "status": "",
+                      "locale": ""
+                    },
+                    "mp4": "",
+                    "vtt": "",
+                    "hls": "",
+                    "hls_embed": "",
+                    "duration_ms": 123,
+                    "thumb_video_w": 123,
+                    "thumb_video_h": 123,
+                    "original_attachment_count": 123,
+                    "is_external": false,
+                    "external_type": "",
+                    "external_id": "",
+                    "external_url": "",
+                    "username": "",
+                    "size": 123,
+                    "url_private": "",
+                    "url_private_download": "",
+                    "app_id": "",
+                    "app_name": "",
+                    "thumb_64": "",
+                    "thumb_64_gif": "",
+                    "thumb_64_w": "",
+                    "thumb_64_h": "",
+                    "thumb_80": "",
+                    "thumb_80_gif": "",
+                    "thumb_80_w": "",
+                    "thumb_80_h": "",
+                    "thumb_160": "",
+                    "thumb_160_gif": "",
+                    "thumb_160_w": "",
+                    "thumb_160_h": "",
+                    "thumb_360": "",
+                    "thumb_360_gif": "",
+                    "thumb_360_w": "",
+                    "thumb_360_h": "",
+                    "thumb_480": "",
+                    "thumb_480_gif": "",
+                    "thumb_480_w": "",
+                    "thumb_480_h": "",
+                    "thumb_720": "",
+                    "thumb_720_gif": "",
+                    "thumb_720_w": "",
+                    "thumb_720_h": "",
+                    "thumb_800": "",
+                    "thumb_800_gif": "",
+                    "thumb_800_w": "",
+                    "thumb_800_h": "",
+                    "thumb_960": "",
+                    "thumb_960_gif": "",
+                    "thumb_960_w": "",
+                    "thumb_960_h": "",
+                    "thumb_1024": "",
+                    "thumb_1024_gif": "",
+                    "thumb_1024_w": "",
+                    "thumb_1024_h": "",
+                    "thumb_video": "",
+                    "thumb_gif": "",
+                    "thumb_pdf": "",
+                    "thumb_pdf_w": "",
+                    "thumb_pdf_h": "",
+                    "thumb_tiny": "",
+                    "converted_pdf": "",
+                    "image_exif_rotation": 123,
+                    "original_w": "",
+                    "original_h": "",
+                    "deanimate": "",
+                    "deanimate_gif": "",
+                    "pjpeg": "",
+                    "permalink": "",
+                    "permalink_public": "",
+                    "edit_link": "",
+                    "has_rich_preview": false,
+                    "media_display_type": "",
+                    "preview_is_truncated": false,
+                    "preview": "",
+                    "preview_highlight": "",
+                    "plain_text": "",
+                    "preview_plain_text": "",
+                    "has_more": false,
+                    "sent_to_self": false,
+                    "lines": 123,
+                    "lines_more": 123,
+                    "is_public": false,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "channels": [
+                      ""
+                    ],
+                    "groups": [
+                      ""
+                    ],
+                    "ims": [
+                      ""
+                    ],
+                    "shares": {
+                      "public": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      },
+                      "private": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      }
+                    },
+                    "to": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "from": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "cc": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "channel_actions_ts": "",
+                    "channel_actions_count": 123,
+                    "headers": {
+                      "date": "",
+                      "in_reply_to": "",
+                      "reply_to": "",
+                      "message_id": ""
+                    },
+                    "simplified_html": "",
+                    "bot_id": "",
+                    "initial_comment": {
+                      "id": "",
+                      "created": 123,
+                      "timestamp": 123,
+                      "user": "",
+                      "comment": "",
+                      "channel": "",
+                      "is_intro": false
+                    },
+                    "num_stars": 123,
+                    "is_starred": false,
+                    "pinned_to": [
+                      ""
+                    ],
+                    "reactions": [
+                      {
+                        "name": "",
+                        "count": 123,
+                        "users": [
+                          ""
+                        ],
+                        "url": ""
+                      }
+                    ],
+                    "comments_count": 123,
+                    "id": "",
+                    "created": 123,
+                    "subject": "",
+                    "mimetype": "",
+                    "filetype": "",
+                    "pretty_type": "",
+                    "user": "",
+                    "user_team": "",
+                    "mode": "",
+                    "editable": false,
+                    "non_owner_editable": false,
+                    "editor": "",
+                    "last_editor": "",
+                    "updated": 123,
+                    "file_access": "",
+                    "subtype": "",
+                    "transcription": {
+                      "status": "",
+                      "locale": ""
+                    },
+                    "mp4": "",
+                    "vtt": "",
+                    "hls": "",
+                    "hls_embed": "",
+                    "duration_ms": 123,
+                    "thumb_video_w": 123,
+                    "thumb_video_h": 123,
+                    "original_attachment_count": 123,
+                    "is_external": false,
+                    "external_type": "",
+                    "external_id": "",
+                    "external_url": "",
+                    "username": "",
+                    "size": 123,
+                    "url_private": "",
+                    "url_private_download": "",
+                    "app_id": "",
+                    "app_name": "",
+                    "thumb_64": "",
+                    "thumb_64_gif": "",
+                    "thumb_64_w": "",
+                    "thumb_64_h": "",
+                    "thumb_80": "",
+                    "thumb_80_gif": "",
+                    "thumb_80_w": "",
+                    "thumb_80_h": "",
+                    "thumb_160": "",
+                    "thumb_160_gif": "",
+                    "thumb_160_w": "",
+                    "thumb_160_h": "",
+                    "thumb_360": "",
+                    "thumb_360_gif": "",
+                    "thumb_360_w": "",
+                    "thumb_360_h": "",
+                    "thumb_480": "",
+                    "thumb_480_gif": "",
+                    "thumb_480_w": "",
+                    "thumb_480_h": "",
+                    "thumb_720": "",
+                    "thumb_720_gif": "",
+                    "thumb_720_w": "",
+                    "thumb_720_h": "",
+                    "thumb_800": "",
+                    "thumb_800_gif": "",
+                    "thumb_800_w": "",
+                    "thumb_800_h": "",
+                    "thumb_960": "",
+                    "thumb_960_gif": "",
+                    "thumb_960_w": "",
+                    "thumb_960_h": "",
+                    "thumb_1024": "",
+                    "thumb_1024_gif": "",
+                    "thumb_1024_w": "",
+                    "thumb_1024_h": "",
+                    "thumb_video": "",
+                    "thumb_gif": "",
+                    "thumb_pdf": "",
+                    "thumb_pdf_w": "",
+                    "thumb_pdf_h": "",
+                    "thumb_tiny": "",
+                    "converted_pdf": "",
+                    "image_exif_rotation": 123,
+                    "original_w": "",
+                    "original_h": "",
+                    "deanimate": "",
+                    "deanimate_gif": "",
+                    "pjpeg": "",
+                    "permalink": "",
+                    "permalink_public": "",
+                    "edit_link": "",
+                    "has_rich_preview": false,
+                    "media_display_type": "",
+                    "preview_is_truncated": false,
+                    "preview": "",
+                    "preview_highlight": "",
+                    "plain_text": "",
+                    "preview_plain_text": "",
+                    "has_more": false,
+                    "sent_to_self": false,
+                    "lines": 123,
+                    "lines_more": 123,
+                    "is_public": false,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "channels": [
+                      ""
+                    ],
+                    "groups": [
+                      ""
+                    ],
+                    "ims": [
+                      ""
+                    ],
+                    "shares": {
+                      "public": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      },
+                      "private": {
+                        "C03E94MKU": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ],
+                        "C03E94MKU_": [
+                          {
+                            "share_user_id": "",
+                            "reply_users": [
+                              ""
+                            ],
+                            "reply_users_count": 123,
+                            "reply_count": 123,
+                            "ts": "",
+                            "thread_ts": "",
+                            "latest_reply": "",
+                            "channel_name": "",
+                            "team_id": ""
+                          }
+                        ]
+                      }
+                    },
+                    "to": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "from": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "cc": [
+                      {
+                        "address": "",
+                        "name": "",
+                        "original": ""
+                      }
+                    ],
+                    "channel_actions_ts": "",
+                    "channel_actions_count": 123,
+                    "headers": {
+                      "date": "",
+                      "in_reply_to": "",
+                      "reply_to": "",
+                      "message_id": ""
+                    },
+                    "simplified_html": "",
+                    "bot_id": "",
+                    "initial_comment": {
+                      "id": "",
+                      "created": 123,
+                      "timestamp": 123,
+                      "user": "",
+                      "comment": "",
+                      "channel": "",
+                      "is_intro": false
+                    },
+                    "num_stars": 123,
+                    "is_starred": false,
+                    "pinned_to": [
+                      ""
+                    ],
+                    "reactions": [
+                      {
+                        "name": "",
+                        "count": 123,
+                        "users": [
+                          ""
+                        ],
+                        "url": ""
+                      }
+                    ],
+                    "comments_count": 123,
                     "id": "",
                     "created": 123,
                     "timestamp": 123,
@@ -2828,6 +4259,15 @@
                   "author_name": "",
                   "provider_name": "",
                   "provider_icon_url": "",
+                  "function_trigger_id": "",
+                  "app_id": "",
+                  "is_workflow_app": false,
+                  "app_collaborators": [
+                    ""
+                  ],
+                  "button_label": "",
+                  "bot_user_id": "",
+                  "url": "",
                   "fields": [
                     {
                       "type": "",
@@ -3707,6 +5147,477 @@
               "source": "",
               "file_id": "",
               "file": {
+                "timestamp": 123,
+                "name": "",
+                "title": "",
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
+                "id": "",
+                "created": 123,
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": ""
+                      }
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
                 "id": "",
                 "created": 123,
                 "timestamp": 123,
@@ -3973,6 +5884,15 @@
               "author_name": "",
               "provider_name": "",
               "provider_icon_url": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "bot_user_id": "",
+              "url": "",
               "fields": [
                 {
                   "type": "",
@@ -4577,6 +6497,477 @@
             "source": "",
             "file_id": "",
             "file": {
+              "timestamp": 123,
+              "name": "",
+              "title": "",
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
+              "id": "",
+              "created": 123,
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
               "id": "",
               "created": 123,
               "timestamp": 123,
@@ -4843,6 +7234,15 @@
             "author_name": "",
             "provider_name": "",
             "provider_icon_url": "",
+            "function_trigger_id": "",
+            "app_id": "",
+            "is_workflow_app": false,
+            "app_collaborators": [
+              ""
+            ],
+            "button_label": "",
+            "bot_user_id": "",
+            "url": "",
             "fields": [
               {
                 "type": "",
@@ -5543,6 +7943,477 @@
                 "source": "",
                 "file_id": "",
                 "file": {
+                  "timestamp": 123,
+                  "name": "",
+                  "title": "",
+                  "subject": "",
+                  "mimetype": "",
+                  "filetype": "",
+                  "pretty_type": "",
+                  "user": "",
+                  "user_team": "",
+                  "mode": "",
+                  "editable": false,
+                  "non_owner_editable": false,
+                  "editor": "",
+                  "last_editor": "",
+                  "updated": 123,
+                  "file_access": "",
+                  "subtype": "",
+                  "transcription": {
+                    "status": "",
+                    "locale": ""
+                  },
+                  "mp4": "",
+                  "vtt": "",
+                  "hls": "",
+                  "hls_embed": "",
+                  "duration_ms": 123,
+                  "thumb_video_w": 123,
+                  "thumb_video_h": 123,
+                  "original_attachment_count": 123,
+                  "is_external": false,
+                  "external_type": "",
+                  "external_id": "",
+                  "external_url": "",
+                  "username": "",
+                  "size": 123,
+                  "url_private": "",
+                  "url_private_download": "",
+                  "app_id": "",
+                  "app_name": "",
+                  "thumb_64": "",
+                  "thumb_64_gif": "",
+                  "thumb_64_w": "",
+                  "thumb_64_h": "",
+                  "thumb_80": "",
+                  "thumb_80_gif": "",
+                  "thumb_80_w": "",
+                  "thumb_80_h": "",
+                  "thumb_160": "",
+                  "thumb_160_gif": "",
+                  "thumb_160_w": "",
+                  "thumb_160_h": "",
+                  "thumb_360": "",
+                  "thumb_360_gif": "",
+                  "thumb_360_w": "",
+                  "thumb_360_h": "",
+                  "thumb_480": "",
+                  "thumb_480_gif": "",
+                  "thumb_480_w": "",
+                  "thumb_480_h": "",
+                  "thumb_720": "",
+                  "thumb_720_gif": "",
+                  "thumb_720_w": "",
+                  "thumb_720_h": "",
+                  "thumb_800": "",
+                  "thumb_800_gif": "",
+                  "thumb_800_w": "",
+                  "thumb_800_h": "",
+                  "thumb_960": "",
+                  "thumb_960_gif": "",
+                  "thumb_960_w": "",
+                  "thumb_960_h": "",
+                  "thumb_1024": "",
+                  "thumb_1024_gif": "",
+                  "thumb_1024_w": "",
+                  "thumb_1024_h": "",
+                  "thumb_video": "",
+                  "thumb_gif": "",
+                  "thumb_pdf": "",
+                  "thumb_pdf_w": "",
+                  "thumb_pdf_h": "",
+                  "thumb_tiny": "",
+                  "converted_pdf": "",
+                  "image_exif_rotation": 123,
+                  "original_w": "",
+                  "original_h": "",
+                  "deanimate": "",
+                  "deanimate_gif": "",
+                  "pjpeg": "",
+                  "permalink": "",
+                  "permalink_public": "",
+                  "edit_link": "",
+                  "has_rich_preview": false,
+                  "media_display_type": "",
+                  "preview_is_truncated": false,
+                  "preview": "",
+                  "preview_highlight": "",
+                  "plain_text": "",
+                  "preview_plain_text": "",
+                  "has_more": false,
+                  "sent_to_self": false,
+                  "lines": 123,
+                  "lines_more": 123,
+                  "is_public": false,
+                  "public_url_shared": false,
+                  "display_as_bot": false,
+                  "channels": [
+                    ""
+                  ],
+                  "groups": [
+                    ""
+                  ],
+                  "ims": [
+                    ""
+                  ],
+                  "shares": {
+                    "public": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    },
+                    "private": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    }
+                  },
+                  "to": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "from": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "cc": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "channel_actions_ts": "",
+                  "channel_actions_count": 123,
+                  "headers": {
+                    "date": "",
+                    "in_reply_to": "",
+                    "reply_to": "",
+                    "message_id": ""
+                  },
+                  "simplified_html": "",
+                  "bot_id": "",
+                  "initial_comment": {
+                    "id": "",
+                    "created": 123,
+                    "timestamp": 123,
+                    "user": "",
+                    "comment": "",
+                    "channel": "",
+                    "is_intro": false
+                  },
+                  "num_stars": 123,
+                  "is_starred": false,
+                  "pinned_to": [
+                    ""
+                  ],
+                  "reactions": [
+                    {
+                      "name": "",
+                      "count": 123,
+                      "users": [
+                        ""
+                      ],
+                      "url": ""
+                    }
+                  ],
+                  "comments_count": 123,
+                  "id": "",
+                  "created": 123,
+                  "subject": "",
+                  "mimetype": "",
+                  "filetype": "",
+                  "pretty_type": "",
+                  "user": "",
+                  "user_team": "",
+                  "mode": "",
+                  "editable": false,
+                  "non_owner_editable": false,
+                  "editor": "",
+                  "last_editor": "",
+                  "updated": 123,
+                  "file_access": "",
+                  "subtype": "",
+                  "transcription": {
+                    "status": "",
+                    "locale": ""
+                  },
+                  "mp4": "",
+                  "vtt": "",
+                  "hls": "",
+                  "hls_embed": "",
+                  "duration_ms": 123,
+                  "thumb_video_w": 123,
+                  "thumb_video_h": 123,
+                  "original_attachment_count": 123,
+                  "is_external": false,
+                  "external_type": "",
+                  "external_id": "",
+                  "external_url": "",
+                  "username": "",
+                  "size": 123,
+                  "url_private": "",
+                  "url_private_download": "",
+                  "app_id": "",
+                  "app_name": "",
+                  "thumb_64": "",
+                  "thumb_64_gif": "",
+                  "thumb_64_w": "",
+                  "thumb_64_h": "",
+                  "thumb_80": "",
+                  "thumb_80_gif": "",
+                  "thumb_80_w": "",
+                  "thumb_80_h": "",
+                  "thumb_160": "",
+                  "thumb_160_gif": "",
+                  "thumb_160_w": "",
+                  "thumb_160_h": "",
+                  "thumb_360": "",
+                  "thumb_360_gif": "",
+                  "thumb_360_w": "",
+                  "thumb_360_h": "",
+                  "thumb_480": "",
+                  "thumb_480_gif": "",
+                  "thumb_480_w": "",
+                  "thumb_480_h": "",
+                  "thumb_720": "",
+                  "thumb_720_gif": "",
+                  "thumb_720_w": "",
+                  "thumb_720_h": "",
+                  "thumb_800": "",
+                  "thumb_800_gif": "",
+                  "thumb_800_w": "",
+                  "thumb_800_h": "",
+                  "thumb_960": "",
+                  "thumb_960_gif": "",
+                  "thumb_960_w": "",
+                  "thumb_960_h": "",
+                  "thumb_1024": "",
+                  "thumb_1024_gif": "",
+                  "thumb_1024_w": "",
+                  "thumb_1024_h": "",
+                  "thumb_video": "",
+                  "thumb_gif": "",
+                  "thumb_pdf": "",
+                  "thumb_pdf_w": "",
+                  "thumb_pdf_h": "",
+                  "thumb_tiny": "",
+                  "converted_pdf": "",
+                  "image_exif_rotation": 123,
+                  "original_w": "",
+                  "original_h": "",
+                  "deanimate": "",
+                  "deanimate_gif": "",
+                  "pjpeg": "",
+                  "permalink": "",
+                  "permalink_public": "",
+                  "edit_link": "",
+                  "has_rich_preview": false,
+                  "media_display_type": "",
+                  "preview_is_truncated": false,
+                  "preview": "",
+                  "preview_highlight": "",
+                  "plain_text": "",
+                  "preview_plain_text": "",
+                  "has_more": false,
+                  "sent_to_self": false,
+                  "lines": 123,
+                  "lines_more": 123,
+                  "is_public": false,
+                  "public_url_shared": false,
+                  "display_as_bot": false,
+                  "channels": [
+                    ""
+                  ],
+                  "groups": [
+                    ""
+                  ],
+                  "ims": [
+                    ""
+                  ],
+                  "shares": {
+                    "public": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    },
+                    "private": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    }
+                  },
+                  "to": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "from": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "cc": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "channel_actions_ts": "",
+                  "channel_actions_count": 123,
+                  "headers": {
+                    "date": "",
+                    "in_reply_to": "",
+                    "reply_to": "",
+                    "message_id": ""
+                  },
+                  "simplified_html": "",
+                  "bot_id": "",
+                  "initial_comment": {
+                    "id": "",
+                    "created": 123,
+                    "timestamp": 123,
+                    "user": "",
+                    "comment": "",
+                    "channel": "",
+                    "is_intro": false
+                  },
+                  "num_stars": 123,
+                  "is_starred": false,
+                  "pinned_to": [
+                    ""
+                  ],
+                  "reactions": [
+                    {
+                      "name": "",
+                      "count": 123,
+                      "users": [
+                        ""
+                      ],
+                      "url": ""
+                    }
+                  ],
+                  "comments_count": 123,
                   "id": "",
                   "created": 123,
                   "timestamp": 123,
@@ -5809,6 +8680,15 @@
                 "author_name": "",
                 "provider_name": "",
                 "provider_icon_url": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "bot_user_id": "",
+                "url": "",
                 "fields": [
                   {
                     "type": "",

--- a/json-logs/samples/api/stars.list.json
+++ b/json-logs/samples/api/stars.list.json
@@ -400,6 +400,477 @@
                 "source": "",
                 "file_id": "",
                 "file": {
+                  "timestamp": 123,
+                  "name": "",
+                  "title": "",
+                  "subject": "",
+                  "mimetype": "",
+                  "filetype": "",
+                  "pretty_type": "",
+                  "user": "",
+                  "user_team": "",
+                  "mode": "",
+                  "editable": false,
+                  "non_owner_editable": false,
+                  "editor": "",
+                  "last_editor": "",
+                  "updated": 123,
+                  "file_access": "",
+                  "subtype": "",
+                  "transcription": {
+                    "status": "",
+                    "locale": ""
+                  },
+                  "mp4": "",
+                  "vtt": "",
+                  "hls": "",
+                  "hls_embed": "",
+                  "duration_ms": 123,
+                  "thumb_video_w": 123,
+                  "thumb_video_h": 123,
+                  "original_attachment_count": 123,
+                  "is_external": false,
+                  "external_type": "",
+                  "external_id": "",
+                  "external_url": "",
+                  "username": "",
+                  "size": 123,
+                  "url_private": "",
+                  "url_private_download": "",
+                  "app_id": "",
+                  "app_name": "",
+                  "thumb_64": "",
+                  "thumb_64_gif": "",
+                  "thumb_64_w": "",
+                  "thumb_64_h": "",
+                  "thumb_80": "",
+                  "thumb_80_gif": "",
+                  "thumb_80_w": "",
+                  "thumb_80_h": "",
+                  "thumb_160": "",
+                  "thumb_160_gif": "",
+                  "thumb_160_w": "",
+                  "thumb_160_h": "",
+                  "thumb_360": "",
+                  "thumb_360_gif": "",
+                  "thumb_360_w": "",
+                  "thumb_360_h": "",
+                  "thumb_480": "",
+                  "thumb_480_gif": "",
+                  "thumb_480_w": "",
+                  "thumb_480_h": "",
+                  "thumb_720": "",
+                  "thumb_720_gif": "",
+                  "thumb_720_w": "",
+                  "thumb_720_h": "",
+                  "thumb_800": "",
+                  "thumb_800_gif": "",
+                  "thumb_800_w": "",
+                  "thumb_800_h": "",
+                  "thumb_960": "",
+                  "thumb_960_gif": "",
+                  "thumb_960_w": "",
+                  "thumb_960_h": "",
+                  "thumb_1024": "",
+                  "thumb_1024_gif": "",
+                  "thumb_1024_w": "",
+                  "thumb_1024_h": "",
+                  "thumb_video": "",
+                  "thumb_gif": "",
+                  "thumb_pdf": "",
+                  "thumb_pdf_w": "",
+                  "thumb_pdf_h": "",
+                  "thumb_tiny": "",
+                  "converted_pdf": "",
+                  "image_exif_rotation": 123,
+                  "original_w": "",
+                  "original_h": "",
+                  "deanimate": "",
+                  "deanimate_gif": "",
+                  "pjpeg": "",
+                  "permalink": "",
+                  "permalink_public": "",
+                  "edit_link": "",
+                  "has_rich_preview": false,
+                  "media_display_type": "",
+                  "preview_is_truncated": false,
+                  "preview": "",
+                  "preview_highlight": "",
+                  "plain_text": "",
+                  "preview_plain_text": "",
+                  "has_more": false,
+                  "sent_to_self": false,
+                  "lines": 123,
+                  "lines_more": 123,
+                  "is_public": false,
+                  "public_url_shared": false,
+                  "display_as_bot": false,
+                  "channels": [
+                    ""
+                  ],
+                  "groups": [
+                    ""
+                  ],
+                  "ims": [
+                    ""
+                  ],
+                  "shares": {
+                    "public": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    },
+                    "private": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    }
+                  },
+                  "to": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "from": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "cc": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "channel_actions_ts": "",
+                  "channel_actions_count": 123,
+                  "headers": {
+                    "date": "",
+                    "in_reply_to": "",
+                    "reply_to": "",
+                    "message_id": ""
+                  },
+                  "simplified_html": "",
+                  "bot_id": "",
+                  "initial_comment": {
+                    "id": "",
+                    "created": 123,
+                    "timestamp": 123,
+                    "user": "",
+                    "comment": "",
+                    "channel": "",
+                    "is_intro": false
+                  },
+                  "num_stars": 123,
+                  "is_starred": false,
+                  "pinned_to": [
+                    ""
+                  ],
+                  "reactions": [
+                    {
+                      "name": "",
+                      "count": 123,
+                      "users": [
+                        ""
+                      ],
+                      "url": ""
+                    }
+                  ],
+                  "comments_count": 123,
+                  "id": "",
+                  "created": 123,
+                  "subject": "",
+                  "mimetype": "",
+                  "filetype": "",
+                  "pretty_type": "",
+                  "user": "",
+                  "user_team": "",
+                  "mode": "",
+                  "editable": false,
+                  "non_owner_editable": false,
+                  "editor": "",
+                  "last_editor": "",
+                  "updated": 123,
+                  "file_access": "",
+                  "subtype": "",
+                  "transcription": {
+                    "status": "",
+                    "locale": ""
+                  },
+                  "mp4": "",
+                  "vtt": "",
+                  "hls": "",
+                  "hls_embed": "",
+                  "duration_ms": 123,
+                  "thumb_video_w": 123,
+                  "thumb_video_h": 123,
+                  "original_attachment_count": 123,
+                  "is_external": false,
+                  "external_type": "",
+                  "external_id": "",
+                  "external_url": "",
+                  "username": "",
+                  "size": 123,
+                  "url_private": "",
+                  "url_private_download": "",
+                  "app_id": "",
+                  "app_name": "",
+                  "thumb_64": "",
+                  "thumb_64_gif": "",
+                  "thumb_64_w": "",
+                  "thumb_64_h": "",
+                  "thumb_80": "",
+                  "thumb_80_gif": "",
+                  "thumb_80_w": "",
+                  "thumb_80_h": "",
+                  "thumb_160": "",
+                  "thumb_160_gif": "",
+                  "thumb_160_w": "",
+                  "thumb_160_h": "",
+                  "thumb_360": "",
+                  "thumb_360_gif": "",
+                  "thumb_360_w": "",
+                  "thumb_360_h": "",
+                  "thumb_480": "",
+                  "thumb_480_gif": "",
+                  "thumb_480_w": "",
+                  "thumb_480_h": "",
+                  "thumb_720": "",
+                  "thumb_720_gif": "",
+                  "thumb_720_w": "",
+                  "thumb_720_h": "",
+                  "thumb_800": "",
+                  "thumb_800_gif": "",
+                  "thumb_800_w": "",
+                  "thumb_800_h": "",
+                  "thumb_960": "",
+                  "thumb_960_gif": "",
+                  "thumb_960_w": "",
+                  "thumb_960_h": "",
+                  "thumb_1024": "",
+                  "thumb_1024_gif": "",
+                  "thumb_1024_w": "",
+                  "thumb_1024_h": "",
+                  "thumb_video": "",
+                  "thumb_gif": "",
+                  "thumb_pdf": "",
+                  "thumb_pdf_w": "",
+                  "thumb_pdf_h": "",
+                  "thumb_tiny": "",
+                  "converted_pdf": "",
+                  "image_exif_rotation": 123,
+                  "original_w": "",
+                  "original_h": "",
+                  "deanimate": "",
+                  "deanimate_gif": "",
+                  "pjpeg": "",
+                  "permalink": "",
+                  "permalink_public": "",
+                  "edit_link": "",
+                  "has_rich_preview": false,
+                  "media_display_type": "",
+                  "preview_is_truncated": false,
+                  "preview": "",
+                  "preview_highlight": "",
+                  "plain_text": "",
+                  "preview_plain_text": "",
+                  "has_more": false,
+                  "sent_to_self": false,
+                  "lines": 123,
+                  "lines_more": 123,
+                  "is_public": false,
+                  "public_url_shared": false,
+                  "display_as_bot": false,
+                  "channels": [
+                    ""
+                  ],
+                  "groups": [
+                    ""
+                  ],
+                  "ims": [
+                    ""
+                  ],
+                  "shares": {
+                    "public": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    },
+                    "private": {
+                      "C03E94MKU": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ],
+                      "C03E94MKU_": [
+                        {
+                          "share_user_id": "",
+                          "reply_users": [
+                            ""
+                          ],
+                          "reply_users_count": 123,
+                          "reply_count": 123,
+                          "ts": "",
+                          "thread_ts": "",
+                          "latest_reply": "",
+                          "channel_name": "",
+                          "team_id": ""
+                        }
+                      ]
+                    }
+                  },
+                  "to": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "from": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "cc": [
+                    {
+                      "address": "",
+                      "name": "",
+                      "original": ""
+                    }
+                  ],
+                  "channel_actions_ts": "",
+                  "channel_actions_count": 123,
+                  "headers": {
+                    "date": "",
+                    "in_reply_to": "",
+                    "reply_to": "",
+                    "message_id": ""
+                  },
+                  "simplified_html": "",
+                  "bot_id": "",
+                  "initial_comment": {
+                    "id": "",
+                    "created": 123,
+                    "timestamp": 123,
+                    "user": "",
+                    "comment": "",
+                    "channel": "",
+                    "is_intro": false
+                  },
+                  "num_stars": 123,
+                  "is_starred": false,
+                  "pinned_to": [
+                    ""
+                  ],
+                  "reactions": [
+                    {
+                      "name": "",
+                      "count": 123,
+                      "users": [
+                        ""
+                      ],
+                      "url": ""
+                    }
+                  ],
+                  "comments_count": 123,
                   "id": "",
                   "created": 123,
                   "timestamp": 123,
@@ -666,6 +1137,15 @@
                 "author_name": "",
                 "provider_name": "",
                 "provider_icon_url": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "bot_user_id": "",
+                "url": "",
                 "fields": [
                   {
                     "type": "",
@@ -1549,6 +2029,477 @@
             "source": "",
             "file_id": "",
             "file": {
+              "timestamp": 123,
+              "name": "",
+              "title": "",
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
+              "id": "",
+              "created": 123,
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": ""
+                    }
+                  ]
+                }
+              },
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
               "id": "",
               "created": 123,
               "timestamp": 123,
@@ -1815,6 +2766,15 @@
             "author_name": "",
             "provider_name": "",
             "provider_icon_url": "",
+            "function_trigger_id": "",
+            "app_id": "",
+            "is_workflow_app": false,
+            "app_collaborators": [
+              ""
+            ],
+            "button_label": "",
+            "bot_user_id": "",
+            "url": "",
             "fields": [
               {
                 "type": "",

--- a/json-logs/samples/rtm/MessageEvent.json
+++ b/json-logs/samples/rtm/MessageEvent.json
@@ -2282,6 +2282,21 @@
       "block_id": ""
     },
     {
+      "type": "share_shortcut",
+      "block_id": "",
+      "function_trigger_id": "",
+      "app_id": "",
+      "is_workflow_app": false,
+      "app_collaborators": [
+        ""
+      ],
+      "button_label": "",
+      "title": "",
+      "description": "",
+      "bot_user_id": "",
+      "url": ""
+    },
+    {
       "type": "section",
       "text": {
         "type": "plain_text",
@@ -5777,6 +5792,21 @@
             }
           ],
           "block_id": ""
+        },
+        {
+          "type": "share_shortcut",
+          "block_id": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "title": "",
+          "description": "",
+          "bot_user_id": "",
+          "url": ""
         },
         {
           "type": "section",

--- a/json-logs/samples/rtm/PinAddedEvent.json
+++ b/json-logs/samples/rtm/PinAddedEvent.json
@@ -2291,6 +2291,21 @@
           "block_id": ""
         },
         {
+          "type": "share_shortcut",
+          "block_id": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "title": "",
+          "description": "",
+          "bot_user_id": "",
+          "url": ""
+        },
+        {
           "type": "section",
           "text": {
             "type": "plain_text",
@@ -5786,6 +5801,21 @@
                 }
               ],
               "block_id": ""
+            },
+            {
+              "type": "share_shortcut",
+              "block_id": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "title": "",
+              "description": "",
+              "bot_user_id": "",
+              "url": ""
             },
             {
               "type": "section",

--- a/json-logs/samples/rtm/PinRemovedEvent.json
+++ b/json-logs/samples/rtm/PinRemovedEvent.json
@@ -2291,6 +2291,21 @@
           "block_id": ""
         },
         {
+          "type": "share_shortcut",
+          "block_id": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "title": "",
+          "description": "",
+          "bot_user_id": "",
+          "url": ""
+        },
+        {
           "type": "section",
           "text": {
             "type": "plain_text",
@@ -5786,6 +5801,21 @@
                 }
               ],
               "block_id": ""
+            },
+            {
+              "type": "share_shortcut",
+              "block_id": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "title": "",
+              "description": "",
+              "bot_user_id": "",
+              "url": ""
             },
             {
               "type": "section",

--- a/json-logs/samples/rtm/StarAddedEvent.json
+++ b/json-logs/samples/rtm/StarAddedEvent.json
@@ -2291,6 +2291,21 @@
           "block_id": ""
         },
         {
+          "type": "share_shortcut",
+          "block_id": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "title": "",
+          "description": "",
+          "bot_user_id": "",
+          "url": ""
+        },
+        {
           "type": "section",
           "text": {
             "type": "plain_text",
@@ -5786,6 +5801,21 @@
                 }
               ],
               "block_id": ""
+            },
+            {
+              "type": "share_shortcut",
+              "block_id": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "title": "",
+              "description": "",
+              "bot_user_id": "",
+              "url": ""
             },
             {
               "type": "section",

--- a/json-logs/samples/rtm/StarRemovedEvent.json
+++ b/json-logs/samples/rtm/StarRemovedEvent.json
@@ -2290,6 +2290,21 @@
           "block_id": ""
         },
         {
+          "type": "share_shortcut",
+          "block_id": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "title": "",
+          "description": "",
+          "bot_user_id": "",
+          "url": ""
+        },
+        {
           "type": "section",
           "text": {
             "type": "plain_text",
@@ -5785,6 +5800,21 @@
                 }
               ],
               "block_id": ""
+            },
+            {
+              "type": "share_shortcut",
+              "block_id": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "title": "",
+              "description": "",
+              "bot_user_id": "",
+              "url": ""
             },
             {
               "type": "section",

--- a/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
@@ -96,7 +96,8 @@ public class SampleObjects {
                             gson.toJsonTree(headerBlock),
                             gson.toJsonTree(imageBlock),
                             gson.toJsonTree(initProperties(video(v -> v.description(TextObject).title(TextObject)))),
-                            gson.toJsonTree(RichTextBlock)
+                            gson.toJsonTree(RichTextBlock),
+                            gson.toJsonTree(initProperties(ShareShortcutBlock.builder().appCollaborators(Arrays.asList("")).build()))
                     )
             );
 
@@ -204,7 +205,8 @@ public class SampleObjects {
                         .text(TextObject)
                         .fields(SectionBlockFieldElements))),
                 initProperties(video(v -> v.description(TextObject).title(TextObject))),
-                RichTextBlock
+                RichTextBlock,
+                initProperties(ShareShortcutBlock.builder().appCollaborators(Arrays.asList("")).build())
         ));
         Blocks.addAll(SectionBlocksWithAccessory);
     }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
@@ -108,4 +108,9 @@ public class Blocks {
         return configurator.configure(VideoBlock.builder()).build();
     }
 
+    // ShareShortcutBlock
+    public static ShareShortcutBlock shareShortcut() {
+        return ShareShortcutBlock.builder().build();
+    }
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/ShareShortcutBlock.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/ShareShortcutBlock.java
@@ -1,0 +1,30 @@
+package com.slack.api.model.block;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/future
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShareShortcutBlock implements LayoutBlock {
+    public static final String TYPE = "share_shortcut";
+    private final String type = TYPE;
+    private String blockId;
+    private String functionTriggerId;
+    private String appId;
+    private Boolean isWorkflowApp;
+    private List<String> appCollaborators;
+    private String buttonLabel;
+    private String title;
+    private String description;
+    private String botUserId;
+    private String url;
+}

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
@@ -55,6 +55,8 @@ public class GsonLayoutBlockFactory implements JsonDeserializer<LayoutBlock>, Js
                 return VideoBlock.class;
             case RichTextBlock.TYPE:
                 return RichTextBlock.class;
+            case ShareShortcutBlock.TYPE:
+                return ShareShortcutBlock.class;
             default:
                 if (failOnUnknownProperties) {
                     throw new JsonParseException("Unsupported layout block type: " + typeName);

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -1608,4 +1608,63 @@ public class BlockKitTest {
         assertEquals("bid", block.getBlockId());
         assertEquals("https://www.youtube.com/embed/RRxQQxiM7AA?feature=oembed&autoplay=1", block.getVideoUrl());
     }
+
+    @Test
+    public void parseLinkTriggerMessages() {
+        // https://api.slack.com/future
+        String json = "{\n" +
+                "  \"client_msg_id\": \"xxx\",\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"text\": \"https://slack.com/shortcuts/Ft111/xxx\",\n" +
+                "  \"user\": \"U111\",\n" +
+                "  \"ts\": \"1663233138.852489\",\n" +
+                "  \"team\": \"T111\",\n" +
+                "  \"attachments\": [\n" +
+                "    {\n" +
+                "      \"fallback\": \"Workflow\",\n" +
+                "      \"from_url\": \"https://slack.com/shortcuts/Ft111/xxx\",\n" +
+                "      \"blocks\": [\n" +
+                "        {\n" +
+                "          \"block_id\": \"shortcut-block\",\n" +
+                "          \"type\": \"share_shortcut\",\n" +
+                "          \"function_trigger_id\": \"Ft111\",\n" +
+                "          \"app_id\": \"A111\",\n" +
+                "          \"is_workflow_app\": false,\n" +
+                "          \"app_collaborators\": [\n" +
+                "            \"U111\"\n" +
+                "          ],\n" +
+                "          \"button_label\": \"\",\n" +
+                "          \"title\": \"Sample trigger\",\n" +
+                "          \"description\": \"A sample trigger\",\n" +
+                "          \"bot_user_id\": \"U111\",\n" +
+                "          \"url\": \"https://slack.com/shortcuts/Ft111/xxx\"\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"id\": 1,\n" +
+                "      \"original_url\": \"https://slack.com/shortcuts/Ft111/xxx\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"blocks\": [\n" +
+                "    {\n" +
+                "      \"type\": \"rich_text\",\n" +
+                "      \"block_id\": \"JZy\",\n" +
+                "      \"elements\": [\n" +
+                "        {\n" +
+                "          \"type\": \"rich_text_section\",\n" +
+                "          \"elements\": [\n" +
+                "            {\n" +
+                "              \"type\": \"link\",\n" +
+                "              \"url\": \"https://slack.com/shortcuts/Ft111/xxx\"\n" +
+                "            }\n" +
+                "          ]\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+        Message view = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+        assertNotNull(view);
+        assertEquals(1, view.getAttachments().get(0).getBlocks().size());
+        assertEquals(1, view.getBlocks().size());
+    }
 }


### PR DESCRIPTION
This pull request adds a new block that can be posted by the next-generation platform's link triggers. Although the next-gen features are still in beta, developers may need to parse those blocks in conversations.history/Discovery API response data and so on if they exist.

<img width="600" src="https://user-images.githubusercontent.com/19658/190373957-5b72f42a-2558-41dd-a8dd-e3263ad0f859.png">

We need to add the same in other SDKs.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
