### PR TITLE
OAuth Support for Micronaut

### DIFF
--- a/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppController.java
+++ b/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppController.java
@@ -35,8 +35,8 @@ public class SlackAppController {
     }
 
     @Get(uris = { "/slack/install", "/slack/oauth_redirect"})
-    public HttpResponse<String> oauth(HttpRequest<String> request, @Body String body) throws Exception {
-        Request<?> slackRequest = adapter.toSlackRequest(request, body);
+    public HttpResponse<String> oauth(HttpRequest<String> request) throws Exception {
+        Request<?> slackRequest = adapter.toSlackRequest(request, null);
         return adapter.toMicronautResponse(slackApp.run(slackRequest));
     }
 

--- a/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppController.java
+++ b/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppController.java
@@ -7,6 +7,7 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
 
 /**
@@ -28,7 +29,13 @@ public class SlackAppController {
     }
 
     @Post(value = "/events", consumes = {MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_JSON})
-    public HttpResponse<String> dispatch(HttpRequest<String> request, @Body String body) throws Exception {
+    public HttpResponse<String> events(HttpRequest<String> request, @Body String body) throws Exception {
+        Request<?> slackRequest = adapter.toSlackRequest(request, body);
+        return adapter.toMicronautResponse(slackApp.run(slackRequest));
+    }
+
+    @Get(uris = { "/slack/install", "/slack/oauth_redirect"})
+    public HttpResponse<String> oauth(HttpRequest<String> request, @Body String body) throws Exception {
         Request<?> slackRequest = adapter.toSlackRequest(request, body);
         return adapter.toMicronautResponse(slackApp.run(slackRequest));
     }

--- a/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppController.java
+++ b/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppController.java
@@ -30,13 +30,27 @@ public class SlackAppController {
 
     @Post(value = "/events", consumes = {MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_JSON})
     public HttpResponse<String> events(HttpRequest<String> request, @Body String body) throws Exception {
-        Request<?> slackRequest = adapter.toSlackRequest(request, body);
-        return adapter.toMicronautResponse(slackApp.run(slackRequest));
+        return adapt(request, body);
     }
 
-    @Get(uris = { "/slack/install", "/slack/oauth_redirect"})
-    public HttpResponse<String> oauth(HttpRequest<String> request) throws Exception {
-        Request<?> slackRequest = adapter.toSlackRequest(request, null);
+    @Get("/install")
+    public HttpResponse<String> install(HttpRequest<String> request) throws Exception {
+        if (!slackApp.config().isOAuthInstallPathEnabled()) {
+            return HttpResponse.notFound();
+        }
+        return adapt(request, null);
+    }
+
+    @Get("/oauth_redirect")
+    public HttpResponse<String> oauthRedirect(HttpRequest<String> request) throws Exception {
+        if (!slackApp.config().isOAuthRedirectUriPathEnabled()) {
+            return HttpResponse.notFound();
+        }
+        return adapt(request, null);
+    }
+
+    private HttpResponse<String> adapt(HttpRequest<String> request, String body) throws Exception {
+        Request<?> slackRequest = adapter.toSlackRequest(request, body);
         return adapter.toMicronautResponse(slackApp.run(slackRequest));
     }
 

--- a/bolt-micronaut/src/test/java/test_locally/ControllerTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/ControllerTest.java
@@ -9,47 +9,145 @@ import com.slack.api.bolt.micronaut.SlackAppMicronautAdapter;
 import io.micronaut.core.convert.DefaultConversionService;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpParameters;
+import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.simple.SimpleHttpHeaders;
 import io.micronaut.http.simple.SimpleHttpParameters;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import util.AuthTestMockServer;
 
 import java.util.HashMap;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ControllerTest {
 
-    @Test
-    public void test() throws Exception {
-        AuthTestMockServer slackApiServer = new AuthTestMockServer();
+    private AuthTestMockServer slackApiServer;
+
+    @Before
+    public void setupServer() throws Exception {
+        slackApiServer = new AuthTestMockServer();
         slackApiServer.start();
-        try {
-            SlackConfig slackConfig = new SlackConfig();
-            slackConfig.setMethodsEndpointUrlPrefix(slackApiServer.getMethodsEndpointPrefix());
-            Slack slack = Slack.getInstance(slackConfig);
-            AppConfig config = AppConfig.builder().slack(slack)
-                    .singleTeamBotToken(AuthTestMockServer.ValidToken)
-                    .signingSecret("secret")
-                    .build();
-            SlackAppController controller = new SlackAppController(new App(config), new SlackAppMicronautAdapter(config));
-            assertNotNull(controller);
+    }
 
-            HttpRequest<String> req = mock(HttpRequest.class);
-            SimpleHttpHeaders headers = new SimpleHttpHeaders(new HashMap<>(), new DefaultConversionService());
-            when(req.getHeaders()).thenReturn(headers);
-            SimpleHttpParameters parameters = new SimpleHttpParameters(new HashMap<>(), new DefaultConversionService());
-            when(req.getParameters()).thenReturn(parameters);
-
-            HttpResponse<String> response = controller.events(req, "token=random&ssl_check=1");
-            assertEquals(200, response.getStatus().getCode());
-
-        } finally {
+    @After
+    public void stopServer() throws Exception {
+        if (slackApiServer != null) {
             slackApiServer.stop();
         }
+    }
+
+    @Test
+    public void test() throws Exception {
+        SlackConfig slackConfig = new SlackConfig();
+        slackConfig.setMethodsEndpointUrlPrefix(slackApiServer.getMethodsEndpointPrefix());
+        Slack slack = Slack.getInstance(slackConfig);
+        AppConfig config = AppConfig.builder().slack(slack)
+                .singleTeamBotToken(AuthTestMockServer.ValidToken)
+                .signingSecret("secret")
+                .build();
+
+        App app = new App(config);
+        SlackAppController controller = new SlackAppController(app, new SlackAppMicronautAdapter(config));
+
+        assertNotNull(controller);
+
+        HttpRequest<String> req = mock(HttpRequest.class);
+        SimpleHttpHeaders headers = new SimpleHttpHeaders(new HashMap<>(), new DefaultConversionService());
+        when(req.getHeaders()).thenReturn(headers);
+        SimpleHttpParameters parameters = new SimpleHttpParameters(new HashMap<>(), new DefaultConversionService());
+        when(req.getParameters()).thenReturn(parameters);
+
+        HttpResponse<String> response = controller.events(req, "token=random&ssl_check=1");
+        assertEquals(200, response.getStatus().getCode());
+    }
+
+    @Test
+    public void oauthNotAvailableForStandardApp() throws Exception {
+        SlackConfig slackConfig = new SlackConfig();
+        slackConfig.setMethodsEndpointUrlPrefix(slackApiServer.getMethodsEndpointPrefix());
+        Slack slack = Slack.getInstance(slackConfig);
+        AppConfig config = AppConfig.builder().slack(slack)
+                .singleTeamBotToken(AuthTestMockServer.ValidToken)
+                .signingSecret("secret")
+                .build();
+
+        App app = new App(config);
+        SlackAppController controller = new SlackAppController(app, new SlackAppMicronautAdapter(config));
+
+        assertNotNull(controller);
+
+        HttpRequest<String> req = HttpRequest.GET("/slack/install");
+
+        HttpResponse<String> notFound = controller.oauth(req);
+        assertThat(notFound.getStatus().getCode(), equalTo(404));
+    }
+
+    @Test
+    public void oauth() throws Exception {
+        SlackConfig slackConfig = new SlackConfig();
+        slackConfig.setMethodsEndpointUrlPrefix(slackApiServer.getMethodsEndpointPrefix());
+        Slack slack = Slack.getInstance(slackConfig);
+
+        AppConfig config = AppConfig.builder()
+                .slack(slack)
+                .signingSecret("secret")
+                .clientId("111.222")
+                .clientSecret("cs")
+                .scope("commands,chat:write")
+                .oauthInstallPath("/slack/install")
+                .oauthRedirectUriPath("/slack/oauth_redirect")
+                .oauthCompletionUrl("https://www.example.com/success")
+                .oauthCancellationUrl("https://www.example.com/failure")
+                .oAuthInstallPageRenderingEnabled(false)
+                .build();
+
+        App oauthSlackApp = new App(config).asOAuthApp(true);
+        SlackAppController controller = new SlackAppController(oauthSlackApp, new SlackAppMicronautAdapter(config));
+
+        assertNotNull(controller);
+
+        HttpRequest<String> req = HttpRequest.GET("/slack/install");
+
+        HttpResponse<String> installResponse = controller.oauth(req);
+
+        assertThat(installResponse.getStatus().getCode(), equalTo(302));
+
+        String location = installResponse.header("Location");
+        assertNotNull(location);
+        assertTrue(location.startsWith(
+                "https://slack.com/oauth/v2/authorize?client_id=111.222&scope=commands%2Cchat%3Awrite&user_scope=&state="));
+
+        assertThat(installResponse.getStatus().getCode(), equalTo(302));
+
+        String state = extractStateValue(location);
+
+        MutableHttpRequest<String> redirectRequest = HttpRequest.GET("/slack/oauth_redirect");
+        MutableHttpParameters parameters = redirectRequest.getParameters();
+        parameters
+                .add("code", "111.111.111")
+                .add("state", state)
+                .add("Cookie", "slack-app-oauth-state=" + state);
+
+        HttpResponse<String> redirectResponse = controller.oauth(redirectRequest);
+        assertThat(redirectResponse.header("Location"), equalTo("https://www.example.com/success"));
+    }
+
+    private static String extractStateValue(String location) {
+        for (String element : location.split("&")) {
+            if (element.trim().startsWith("state=")) {
+                return element.trim().replaceFirst("state=", "");
+            }
+        }
+        return null;
     }
 
 }

--- a/bolt-micronaut/src/test/java/test_locally/ControllerTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/ControllerTest.java
@@ -44,7 +44,7 @@ public class ControllerTest {
             SimpleHttpParameters parameters = new SimpleHttpParameters(new HashMap<>(), new DefaultConversionService());
             when(req.getParameters()).thenReturn(parameters);
 
-            HttpResponse<String> response = controller.dispatch(req, "token=random&ssl_check=1");
+            HttpResponse<String> response = controller.events(req, "token=random&ssl_check=1");
             assertEquals(200, response.getStatus().getCode());
 
         } finally {

--- a/bolt-micronaut/src/test/java/test_locally/ControllerTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/ControllerTest.java
@@ -11,6 +11,7 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpParameters;
 import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.simple.SimpleHttpHeaders;
 import io.micronaut.http.simple.SimpleHttpParameters;
 import org.junit.After;
@@ -87,7 +88,7 @@ public class ControllerTest {
 
         HttpRequest<String> req = HttpRequest.GET("/slack/install");
 
-        HttpResponse<String> notFound = controller.oauth(req);
+        HttpResponse<String> notFound = controller.install(req);
         assertThat(notFound.getStatus().getCode(), equalTo(404));
     }
 
@@ -117,7 +118,7 @@ public class ControllerTest {
 
         HttpRequest<String> req = HttpRequest.GET("/slack/install");
 
-        HttpResponse<String> installResponse = controller.oauth(req);
+        HttpResponse<String> installResponse = controller.install(req);
 
         assertThat(installResponse.getStatus().getCode(), equalTo(302));
 
@@ -134,10 +135,10 @@ public class ControllerTest {
         MutableHttpParameters parameters = redirectRequest.getParameters();
         parameters
                 .add("code", "111.111.111")
-                .add("state", state)
-                .add("Cookie", "slack-app-oauth-state=" + state);
+                .add("state", state);
+        redirectRequest.cookie(Cookie.of("slack-app-oauth-state", state));
 
-        HttpResponse<String> redirectResponse = controller.oauth(redirectRequest);
+        HttpResponse<String> redirectResponse = controller.oauthRedirect(redirectRequest);
         assertThat(redirectResponse.header("Location"), equalTo("https://www.example.com/success"));
     }
 

--- a/bolt-micronaut/src/test/java/util/AuthTestMockServer.java
+++ b/bolt-micronaut/src/test/java/util/AuthTestMockServer.java
@@ -29,6 +29,29 @@ public class AuthTestMockServer {
             "  \"error\": \"invalid\"\n" +
             "}";
 
+    static String oauthV2Access = "{\n" +
+            "    \"ok\": true,\n" +
+            "    \"access_token\": \"" + ValidToken + "\",\n" +
+            "    \"token_type\": \"bot\",\n" +
+            "    \"scope\": \"commands,incoming-webhook\",\n" +
+            "    \"bot_user_id\": \"U0KRQLJ9H\",\n" +
+            "    \"app_id\": \"A0KRD7HC3\",\n" +
+            "    \"team\": {\n" +
+            "        \"name\": \"Slack Softball Team\",\n" +
+            "        \"id\": \"T9TK3CUKW\"\n" +
+            "    },\n" +
+            "    \"enterprise\": {\n" +
+            "        \"name\": \"slack-sports\",\n" +
+            "        \"id\": \"E12345678\"\n" +
+            "    },\n" +
+            "    \"authed_user\": {\n" +
+            "        \"id\": \"U1234\",\n" +
+            "        \"scope\": \"chat:write\",\n" +
+            "        \"access_token\": \"xoxp-1234\",\n" +
+            "        \"token_type\": \"user\"\n" +
+            "    }\n" +
+            "}";
+
     @WebServlet
     public static class AuthTestMockEndpoint extends HttpServlet {
 
@@ -36,6 +59,10 @@ public class AuthTestMockServer {
         protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
             resp.setStatus(200);
             resp.setContentType("application/json");
+            if (req.getRequestURI().equals("/api/oauth.v2.access")) {
+                resp.getWriter().write(oauthV2Access);
+                return;
+            }
             if (req.getHeader("Authorization") == null || !req.getHeader("Authorization").equals("Bearer " + ValidToken)) {
                 resp.getWriter().write(ng);
             } else {


### PR DESCRIPTION
Added a default OAuth controller. Fixes #1048.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
