### PR TITLE
initialize status in 3-args constructor

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/App.java
+++ b/bolt/src/main/java/com/slack/api/bolt/App.java
@@ -490,6 +490,7 @@ public class App {
         this.oAuthExceptionHandler = new OAuthDefaultExceptionHandler(config());
 
         this.oAuthCallbackService = null; // will be initialized by initOAuthServicesIfNecessary()
+        this.status = Status.Stopped;
     }
 
     // --------------------------------------


### PR DESCRIPTION
The 3-args constructor does not initialize the `status` field which leads to NPE when calling `synchronized(status)` blocks

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
