### PR TITLE
Fix #1058 Add include_all_metadata to conversations.replies arguments

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -1446,6 +1446,7 @@ public class RequestFormBuilder {
         setIfNotNull("channel", req.getChannel(), form);
         setIfNotNull("oldest", req.getOldest(), form);
         setIfNotNull("latest", req.getLatest(), form);
+        setIfNotNull("include_all_metadata", req.isIncludeAllMetadata(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsRepliesRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/ConversationsRepliesRequest.java
@@ -54,4 +54,9 @@ public class ConversationsRepliesRequest implements SlackApiRequest {
      */
     private String latest;
 
+    /**
+     * Return all metadata associated with this message.
+     */
+    private boolean includeAllMetadata;
+
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/message_metadata_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/message_metadata_Test.java
@@ -3,12 +3,14 @@ package test_with_remote_apis.methods;
 import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.conversations.ConversationsRepliesRequest;
 import com.slack.api.methods.response.chat.ChatDeleteResponse;
 import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.methods.response.chat.ChatScheduleMessageResponse;
 import com.slack.api.methods.response.chat.ChatUpdateResponse;
 import com.slack.api.methods.response.conversations.ConversationsHistoryResponse;
 import com.slack.api.methods.response.conversations.ConversationsListResponse;
+import com.slack.api.methods.response.conversations.ConversationsRepliesResponse;
 import com.slack.api.model.Conversation;
 import com.slack.api.model.Message;
 import config.Constants;
@@ -136,6 +138,20 @@ public class message_metadata_Test {
         assertThat(history.getError(), is(nullValue()));
         {
             Map<String, Object> returnedPayload = history.getMessages().get(0).getMetadata().getEventPayload();
+            assertThat(returnedPayload.get("id"), is(messageEventPayload.get("id")));
+            assertThat(returnedPayload.get("tags"), is(messageEventPayload.get("tags")));
+            assertThat(returnedPayload.get("objects"), is(parsedObjects));
+        }
+
+        ConversationsRepliesResponse replies = client.conversationsReplies(req -> req
+                .channel(randomChannelId)
+                .ts(messageWithMetadata.getTs())
+                .limit(1)
+                .includeAllMetadata(true)
+        );
+        assertThat(replies.getError(), is(nullValue()));
+        {
+            Map<String, Object> returnedPayload = replies.getMessages().get(0).getMetadata().getEventPayload();
             assertThat(returnedPayload.get("id"), is(messageEventPayload.get("id")));
             assertThat(returnedPayload.get("tags"), is(messageEventPayload.get("tags")));
             assertThat(returnedPayload.get("objects"), is(parsedObjects));


### PR DESCRIPTION
This pull request resolves #1058

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)
