### PR TITLE
Fix #1061 Add message metadata support for response_url / Incoming Webhooks calls

### DIFF
--- a/bolt-socket-mode/src/test/java/samples/SimpleApp.java
+++ b/bolt-socket-mode/src/test/java/samples/SimpleApp.java
@@ -3,12 +3,16 @@ package samples;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.socket_mode.SocketModeApp;
+import com.slack.api.model.Message;
 import com.slack.api.model.event.AppMentionEvent;
 import com.slack.api.model.event.MessageChangedEvent;
 import com.slack.api.model.event.MessageDeletedEvent;
 import com.slack.api.model.event.MessageEvent;
 import com.slack.api.model.view.ViewState;
 import config.Constants;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.slack.api.model.block.Blocks.asBlocks;
 import static com.slack.api.model.block.Blocks.input;
@@ -45,6 +49,13 @@ public class SimpleApp {
         app.event(MessageDeletedEvent.class, (req, ctx) -> ctx.ack());
 
         app.command("/hello-socket-mode", (req, ctx) -> {
+            Map<String, Object> eventPayload = new HashMap<>();
+            eventPayload.put("something", "great");
+            Message.Metadata metadata = Message.Metadata.builder()
+                    .eventType("foo")
+                    .eventPayload(eventPayload)
+                    .build();
+            ctx.respond(r -> r.responseType("in_channel").text("hi!").metadata(metadata));
             ctx.asyncClient().viewsOpen(r -> r
                     .triggerId(req.getContext().getTriggerId())
                     .view(view(v -> v

--- a/slack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
@@ -4,6 +4,7 @@ import com.slack.api.Slack;
 import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.model.Attachment;
 import com.slack.api.model.Field;
+import com.slack.api.model.Message;
 import com.slack.api.model.block.ActionsBlock;
 import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.model.block.SectionBlock;
@@ -19,9 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -101,6 +100,22 @@ public class IncomingWebhooksTest {
         assertThat(response.getCode(), is(200));
         // The behavior has been change (Jun 2019)
         // assertThat(response.getMessage(), is("OK"));
+    }
+
+    @Test
+    public void testWithMessageMetadata() throws IOException {
+        Map<String, Object> eventPayload = new HashMap<>();
+        eventPayload.put("something", "great");
+        Message.Metadata metadata = Message.Metadata.builder().eventType("foo").eventPayload(eventPayload).build();
+        Payload payload = Payload.builder()
+                .text("Hello World!")
+                .metadata(metadata)
+                .build();
+        WebhookResponse response = slack.send(url, payload);
+        log.info(response.toString());
+
+        assertThat(response.getBody(), is("ok"));
+        assertThat(response.getCode(), is(200));
     }
 
     @Test

--- a/slack-api-model/src/main/java/com/slack/api/webhook/Payload.java
+++ b/slack-api-model/src/main/java/com/slack/api/webhook/Payload.java
@@ -1,6 +1,7 @@
 package com.slack.api.webhook;
 
 import com.slack.api.model.Attachment;
+import com.slack.api.model.Message;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.Builder;
 import lombok.Data;
@@ -87,4 +88,9 @@ public class Payload {
      * Pass false to disable unfurling of media content.
      */
     private Boolean unfurlMedia;
+
+    /**
+     * https://api.slack.com/metadata
+     */
+    private Message.Metadata metadata;
 }

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/response/ActionResponse.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/response/ActionResponse.java
@@ -1,6 +1,7 @@
 package com.slack.api.app_backend.interactive_components.response;
 
 import com.slack.api.model.Attachment;
+import com.slack.api.model.Message;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,4 +21,5 @@ public class ActionResponse {
     private boolean deleteOriginal;
     private List<Attachment> attachments;
     private List<LayoutBlock> blocks;
+    private Message.Metadata metadata;
 }

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/slash_commands/response/SlashCommandResponse.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/slash_commands/response/SlashCommandResponse.java
@@ -1,6 +1,7 @@
 package com.slack.api.app_backend.slash_commands.response;
 
 import com.slack.api.model.Attachment;
+import com.slack.api.model.Message;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,4 +22,5 @@ public class SlashCommandResponse {
     private String text;
     private List<Attachment> attachments;
     private List<LayoutBlock> blocks;
+    private Message.Metadata metadata;
 }

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/views/response/InputBlockResponse.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/views/response/InputBlockResponse.java
@@ -1,6 +1,7 @@
 package com.slack.api.app_backend.views.response;
 
 import com.slack.api.model.Attachment;
+import com.slack.api.model.Message;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,4 +19,5 @@ public class InputBlockResponse {
     private String text;
     private List<Attachment> attachments;
     private List<LayoutBlock> blocks;
+    private Message.Metadata metadata;
 }


### PR DESCRIPTION
This pull request resolves #1061 by adding message metada support for:
* Various response_url (a.k.a. context.respond() method in bolt) calls
* Incoming Webhooks

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
