### PR TITLE
Fix #1060 Enable Slack#close() method to shutdown thread pools behind its SlackConfig

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/Slack.java
+++ b/slack-api-client/src/main/java/com/slack/api/Slack.java
@@ -113,7 +113,12 @@ public class Slack implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        getHttpClient().close();
+        if (getHttpClient() != null) {
+            getHttpClient().close();
+        }
+        if (getConfig() != null) {
+            getConfig().close();
+        }
     }
 
     /**

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/ThreadPools.java
@@ -36,6 +36,25 @@ public class ThreadPools {
         }
     }
 
+    public static void shutdownAll(AuditConfig config) {
+        String providerInstanceId = config.getExecutorServiceProvider().getInstanceId();
+        if (ENTERPRISE_CUSTOM.get(providerInstanceId) != null) {
+            for (ConcurrentMap<String, ExecutorService> each : ENTERPRISE_CUSTOM.get(providerInstanceId).values()) {
+                for (ExecutorService es : each.values()) {
+                    es.shutdownNow();
+                }
+                each.clear();
+            }
+            ENTERPRISE_CUSTOM.remove(providerInstanceId);
+        }
+        if (ALL_DEFAULT.get(providerInstanceId) != null) {
+            for (ExecutorService es : ALL_DEFAULT.get(providerInstanceId).values()) {
+                es.shutdownNow();
+            }
+            ALL_DEFAULT.remove(providerInstanceId);
+        }
+    }
+
     private static ExecutorService buildNewExecutorService(AuditConfig config) {
         String threadGroupName = "slack-audit-logs-" + config.getExecutorName();
         int poolSize = config.getDefaultThreadPoolSize();

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/ThreadPools.java
@@ -36,6 +36,25 @@ public class ThreadPools {
         }
     }
 
+    public static void shutdownAll(MethodsConfig config) {
+        String providerInstanceId = config.getExecutorServiceProvider().getInstanceId();
+        if (TEAM_CUSTOM.get(providerInstanceId) != null) {
+            for (ConcurrentMap<String, ExecutorService> each : TEAM_CUSTOM.get(providerInstanceId).values()) {
+                for (ExecutorService es : each.values()) {
+                    es.shutdownNow();
+                }
+                each.clear();
+            }
+            TEAM_CUSTOM.remove(providerInstanceId);
+        }
+        if (ALL_DEFAULT.get(providerInstanceId) != null) {
+            for (ExecutorService es : ALL_DEFAULT.get(providerInstanceId).values()) {
+                es.shutdownNow();
+            }
+            ALL_DEFAULT.remove(providerInstanceId);
+        }
+    }
+
     private static ExecutorService buildNewExecutorService(MethodsConfig config) {
         String threadGroupName = "slack-methods-" + config.getExecutorName();
         int poolSize = config.getDefaultThreadPoolSize();

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/ThreadPools.java
@@ -36,6 +36,25 @@ public class ThreadPools {
         }
     }
 
+    public static void shutdownAll(SCIMConfig config) {
+        String providerInstanceId = config.getExecutorServiceProvider().getInstanceId();
+        if (ENTERPRISE_CUSTOM.get(providerInstanceId) != null) {
+            for (ConcurrentMap<String, ExecutorService> each : ENTERPRISE_CUSTOM.get(providerInstanceId).values()) {
+                for (ExecutorService es : each.values()) {
+                    es.shutdownNow();
+                }
+                each.clear();
+            }
+            ENTERPRISE_CUSTOM.remove(providerInstanceId);
+        }
+        if (ALL_DEFAULT.get(providerInstanceId) != null) {
+            for (ExecutorService es : ALL_DEFAULT.get(providerInstanceId).values()) {
+                es.shutdownNow();
+            }
+            ALL_DEFAULT.remove(providerInstanceId);
+        }
+    }
+
     private static ExecutorService buildNewExecutorService(SCIMConfig config) {
         String threadGroupName = "slack-scim-" + config.getExecutorName();
         int poolSize = config.getDefaultThreadPoolSize();

--- a/slack-api-client/src/test/java/test_locally/SlackConfigTest.java
+++ b/slack-api-client/src/test/java/test_locally/SlackConfigTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -158,11 +159,23 @@ public class SlackConfigTest {
         ExecutorService methods = ThreadPools.getDefault(config.getMethodsConfig());
         ExecutorService scim = com.slack.api.scim.impl.ThreadPools.getDefault(config.getSCIMConfig());
         ExecutorService audit = com.slack.api.audit.impl.ThreadPools.getDefault(config.getAuditConfig());
+        assertThat(methods.isShutdown(), is(false));
+        assertThat(scim.isShutdown(), is(false));
+        assertThat(audit.isShutdown(), is(false));
         assertThat(methods.isTerminated(), is(false));
         assertThat(scim.isTerminated(), is(false));
         assertThat(audit.isTerminated(), is(false));
 
         config.close();
+
+        assertThat(methods.isShutdown(), is(true));
+        assertThat(scim.isShutdown(), is(true));
+        assertThat(audit.isShutdown(), is(true));
+
+        // await for the termination for test stability
+        methods.awaitTermination(1, TimeUnit.MINUTES);
+        scim.awaitTermination(1, TimeUnit.MINUTES);
+        audit.awaitTermination(1, TimeUnit.MINUTES);
 
         assertThat(methods.isTerminated(), is(true));
         assertThat(scim.isTerminated(), is(true));

--- a/slack-api-client/src/test/java/test_locally/SlackTest.java
+++ b/slack-api-client/src/test/java/test_locally/SlackTest.java
@@ -18,6 +18,7 @@ import util.MockWebhookServer;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static com.slack.api.webhook.WebhookPayloads.payload;
 import static org.hamcrest.CoreMatchers.is;
@@ -171,11 +172,23 @@ public class SlackTest {
         ExecutorService methods = ThreadPools.getDefault(config.getMethodsConfig());
         ExecutorService scim = com.slack.api.scim.impl.ThreadPools.getDefault(config.getSCIMConfig());
         ExecutorService audit = com.slack.api.audit.impl.ThreadPools.getDefault(config.getAuditConfig());
+        assertThat(methods.isShutdown(), is(false));
+        assertThat(scim.isShutdown(), is(false));
+        assertThat(audit.isShutdown(), is(false));
         assertThat(methods.isTerminated(), is(false));
         assertThat(scim.isTerminated(), is(false));
         assertThat(audit.isTerminated(), is(false));
 
         slack.close();
+
+        assertThat(methods.isShutdown(), is(true));
+        assertThat(scim.isShutdown(), is(true));
+        assertThat(audit.isShutdown(), is(true));
+
+        // await for the termination for test stability
+        methods.awaitTermination(1, TimeUnit.MINUTES);
+        scim.awaitTermination(1, TimeUnit.MINUTES);
+        audit.awaitTermination(1, TimeUnit.MINUTES);
 
         assertThat(methods.isTerminated(), is(true));
         assertThat(scim.isTerminated(), is(true));


### PR DESCRIPTION
This pull request resolves #1060 by enhancing Slack and SlackConfig classes to shutdown thread pools once close() method is called. Also, I've updated the javadoc of the SlackConfig class to clearly mention that reusing the instance is recommended.

To reviewers:

Please don't feel pressured even if you are not familiar with the internals of this SDK. To learn how SlackConfig and its sub config classes are connected to the ThreadPools classes, you can check how `ThreadPools.getOrCreate()` method works.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
