### PR TITLE
Fix context.teamId for view interactions in a Slack Connect channel

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewClosedRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewClosedRequest.java
@@ -28,7 +28,13 @@ public class ViewClosedRequest extends Request<DefaultContext> {
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
+        if (payload.getView() != null && payload.getView().getAppInstalledTeamId() != null) {
+            // view_submission payloads can have `view.app_installed_team_id` when a modal view that was opened
+            // in a different workspace via some operations inside a Slack Connect channel.
+            // Note that the same for enterprise_id does not exist. When you need to know the enterprise_id as well,
+            // you have to run some query toward your InstallationStore to know the org where the team_id belongs to.
+            getContext().setTeamId(payload.getView().getAppInstalledTeamId());
+        } else if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
         } else if (payload.getView() != null && payload.getView().getTeamId() != null) {
             getContext().setTeamId(payload.getView().getTeamId());

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewSubmissionRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/ViewSubmissionRequest.java
@@ -28,7 +28,13 @@ public class ViewSubmissionRequest extends Request<ViewSubmissionContext> {
         } else if (payload.getTeam() != null) {
             getContext().setEnterpriseId(payload.getTeam().getEnterpriseId());
         }
-        if (payload.getTeam() != null && payload.getTeam().getId() != null) {
+        if (payload.getView() != null && payload.getView().getAppInstalledTeamId() != null) {
+            // view_submission payloads can have `view.app_installed_team_id` when a modal view that was opened
+            // in a different workspace via some operations inside a Slack Connect channel.
+            // Note that the same for enterprise_id does not exist. When you need to know the enterprise_id as well,
+            // you have to run some query toward your InstallationStore to know the org where the team_id belongs to.
+            getContext().setTeamId(payload.getView().getAppInstalledTeamId());
+        } else if (payload.getTeam() != null && payload.getTeam().getId() != null) {
             getContext().setTeamId(payload.getTeam().getId());
         } else if (payload.getView() != null && payload.getView().getTeamId() != null) {
             getContext().setTeamId(payload.getView().getTeamId());

--- a/bolt/src/test/java/test_locally/request/ViewClosedRequestTest.java
+++ b/bolt/src/test/java/test_locally/request/ViewClosedRequestTest.java
@@ -89,4 +89,88 @@ public class ViewClosedRequestTest {
         ViewClosedRequest req = new ViewClosedRequest("payload=" + URLEncoder.encode(orgWideInstallationPayload, "UTF-8"), orgWideInstallationPayload, headers);
         assertEquals("T_expected", req.getContext().getTeamId());
     }
+
+    String sharedChannelPayload = "{\n" +
+            "  \"type\": \"view_closed\",\n" +
+            "  \"team\": {\n" +
+            "    \"id\": \"T-other-side\",\n" +
+            "    \"domain\": \"other-side\",\n" +
+            "    \"enterprise_id\": \"E-other-side\",\n" +
+            "    \"enterprise_name\": \"Kaz Sandbox Org\"\n" +
+            "  },\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"W111\",\n" +
+            "    \"username\": \"kaz\",\n" +
+            "    \"name\": \"kaz\",\n" +
+            "    \"team_id\": \"T-other-side\"\n" +
+            "  },\n" +
+            "  \"api_app_id\": \"A1111\",\n" +
+            "  \"token\": \"legacy-fixed-token\",\n" +
+            "  \"trigger_id\": \"111.222.xxx\",\n" +
+            "  \"view\": {\n" +
+            "    \"id\": \"V11111\",\n" +
+            "    \"team_id\": \"T-other-side\",\n" +
+            "    \"type\": \"modal\",\n" +
+            "    \"blocks\": [\n" +
+            "      {\n" +
+            "        \"type\": \"input\",\n" +
+            "        \"block_id\": \"zniAM\",\n" +
+            "        \"label\": {\n" +
+            "          \"type\": \"plain_text\",\n" +
+            "          \"text\": \"Label\"\n" +
+            "        },\n" +
+            "        \"element\": {\n" +
+            "          \"type\": \"plain_text_input\",\n" +
+            "          \"dispatch_action_config\": {\n" +
+            "            \"trigger_actions_on\": [\n" +
+            "              \"on_enter_pressed\"\n" +
+            "            ]\n" +
+            "          },\n" +
+            "          \"action_id\": \"qEJr\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"private_metadata\": \"\",\n" +
+            "    \"callback_id\": \"view-id\",\n" +
+            "    \"state\": {\n" +
+            "      \"values\": {\n" +
+            "        \"zniAM\": {\n" +
+            "          \"qEJr\": {\n" +
+            "            \"type\": \"plain_text_input\",\n" +
+            "            \"value\": \"Hi there!\"\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"hash\": \"1664950703.CmTS8F7U\",\n" +
+            "    \"title\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"My App\"\n" +
+            "    },\n" +
+            "    \"close\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"Cancel\"\n" +
+            "    },\n" +
+            "    \"submit\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"Submit\"\n" +
+            "    },\n" +
+            "    \"root_view_id\": \"V00000\",\n" +
+            "    \"app_id\": \"A1111\",\n" +
+            "    \"external_id\": \"\",\n" +
+            "    \"app_installed_team_id\": \"T-installed-workspace\",\n" +
+            "    \"bot_id\": \"B1111\"\n" +
+            "  },\n" +
+            "  \"enterprise\": {\n" +
+            "    \"id\": \"E-other-side\",\n" +
+            "    \"name\": \"Kaz Sandbox Org\"\n" +
+            "  }\n" +
+            "}\n";
+
+    @Test
+    public void sharedChannels() throws UnsupportedEncodingException {
+        RequestHeaders headers = new RequestHeaders(Collections.emptyMap());
+        ViewClosedRequest req = new ViewClosedRequest("payload=" + URLEncoder.encode(sharedChannelPayload, "UTF-8"), sharedChannelPayload, headers);
+        assertEquals("T-installed-workspace", req.getContext().getTeamId());
+    }
 }

--- a/bolt/src/test/java/test_locally/request/ViewClosedRequestTest.java
+++ b/bolt/src/test/java/test_locally/request/ViewClosedRequestTest.java
@@ -19,13 +19,13 @@ public class ViewClosedRequestTest {
             "    \"id\": \"W111\",\n" +
             "    \"username\": \"primary-owner\",\n" +
             "    \"name\": \"primary-owner\",\n" +
-            "    \"team_id\": \"T_expected\"\n" +
+            "    \"team_id\": \"T_unexpected\"\n" +
             "  },\n" +
             "  \"api_app_id\": \"A111\",\n" +
             "  \"token\": \"fixed-value\",\n" +
             "  \"view\": {\n" +
             "    \"id\": \"V111\",\n" +
-            "    \"team_id\": \"T_expected\",\n" +
+            "    \"team_id\": \"T_unexpected\",\n" +
             "    \"type\": \"modal\",\n" +
             "    \"blocks\": [\n" +
             "      {\n" +
@@ -72,7 +72,7 @@ public class ViewClosedRequestTest {
             "    \"root_view_id\": \"V111\",\n" +
             "    \"app_id\": \"A111\",\n" +
             "    \"external_id\": \"\",\n" +
-            "    \"app_installed_team_id\": \"E111\",\n" +
+            "    \"app_installed_team_id\": \"T_expected\",\n" +
             "    \"bot_id\": \"B0302M47727\"\n" +
             "  },\n" +
             "  \"is_cleared\": false,\n" +

--- a/bolt/src/test/java/test_locally/request/ViewSubmissionRequestTest.java
+++ b/bolt/src/test/java/test_locally/request/ViewSubmissionRequestTest.java
@@ -175,14 +175,14 @@ public class ViewSubmissionRequestTest {
             "    \"id\": \"W111\",\n" +
             "    \"username\": \"primary-owner\",\n" +
             "    \"name\": \"primary-owner\",\n" +
-            "    \"team_id\": \"T_expected\"\n" +
+            "    \"team_id\": \"T_unexpected\"\n" +
             "  },\n" +
             "  \"api_app_id\": \"A111\",\n" +
             "  \"token\": \"fixed-value\",\n" +
             "  \"trigger_id\": \"1111.222.xxx\",\n" +
             "  \"view\": {\n" +
             "    \"id\": \"V111\",\n" +
-            "    \"team_id\": \"T_expected\",\n" +
+            "    \"team_id\": \"T_unexpected\",\n" +
             "    \"type\": \"modal\",\n" +
             "    \"blocks\": [\n" +
             "      {\n" +
@@ -238,7 +238,7 @@ public class ViewSubmissionRequestTest {
             "    \"root_view_id\": \"V111\",\n" +
             "    \"app_id\": \"A111\",\n" +
             "    \"external_id\": \"\",\n" +
-            "    \"app_installed_team_id\": \"E111\",\n" +
+            "    \"app_installed_team_id\": \"T_expected\",\n" +
             "    \"bot_id\": \"B111\"\n" +
             "  },\n" +
             "  \"response_urls\": [],\n" +

--- a/bolt/src/test/java/test_locally/request/ViewSubmissionRequestTest.java
+++ b/bolt/src/test/java/test_locally/request/ViewSubmissionRequestTest.java
@@ -255,4 +255,88 @@ public class ViewSubmissionRequestTest {
         ViewSubmissionRequest req = new ViewSubmissionRequest("payload=" + URLEncoder.encode(orgWideInstallationPayload, "UTF-8"), orgWideInstallationPayload, headers);
         assertEquals("T_expected", req.getContext().getTeamId());
     }
+
+    String sharedChannelPayload = "{\n" +
+            "  \"type\": \"view_submission\",\n" +
+            "  \"team\": {\n" +
+            "    \"id\": \"T-other-side\",\n" +
+            "    \"domain\": \"other-side\",\n" +
+            "    \"enterprise_id\": \"E-other-side\",\n" +
+            "    \"enterprise_name\": \"Kaz Sandbox Org\"\n" +
+            "  },\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"W111\",\n" +
+            "    \"username\": \"kaz\",\n" +
+            "    \"name\": \"kaz\",\n" +
+            "    \"team_id\": \"T-other-side\"\n" +
+            "  },\n" +
+            "  \"api_app_id\": \"A1111\",\n" +
+            "  \"token\": \"legacy-fixed-token\",\n" +
+            "  \"trigger_id\": \"111.222.xxx\",\n" +
+            "  \"view\": {\n" +
+            "    \"id\": \"V11111\",\n" +
+            "    \"team_id\": \"T-other-side\",\n" +
+            "    \"type\": \"modal\",\n" +
+            "    \"blocks\": [\n" +
+            "      {\n" +
+            "        \"type\": \"input\",\n" +
+            "        \"block_id\": \"zniAM\",\n" +
+            "        \"label\": {\n" +
+            "          \"type\": \"plain_text\",\n" +
+            "          \"text\": \"Label\"\n" +
+            "        },\n" +
+            "        \"element\": {\n" +
+            "          \"type\": \"plain_text_input\",\n" +
+            "          \"dispatch_action_config\": {\n" +
+            "            \"trigger_actions_on\": [\n" +
+            "              \"on_enter_pressed\"\n" +
+            "            ]\n" +
+            "          },\n" +
+            "          \"action_id\": \"qEJr\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"private_metadata\": \"\",\n" +
+            "    \"callback_id\": \"view-id\",\n" +
+            "    \"state\": {\n" +
+            "      \"values\": {\n" +
+            "        \"zniAM\": {\n" +
+            "          \"qEJr\": {\n" +
+            "            \"type\": \"plain_text_input\",\n" +
+            "            \"value\": \"Hi there!\"\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"hash\": \"1664950703.CmTS8F7U\",\n" +
+            "    \"title\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"My App\"\n" +
+            "    },\n" +
+            "    \"close\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"Cancel\"\n" +
+            "    },\n" +
+            "    \"submit\": {\n" +
+            "      \"type\": \"plain_text\",\n" +
+            "      \"text\": \"Submit\"\n" +
+            "    },\n" +
+            "    \"root_view_id\": \"V00000\",\n" +
+            "    \"app_id\": \"A1111\",\n" +
+            "    \"external_id\": \"\",\n" +
+            "    \"app_installed_team_id\": \"T-installed-workspace\",\n" +
+            "    \"bot_id\": \"B1111\"\n" +
+            "  },\n" +
+            "  \"enterprise\": {\n" +
+            "    \"id\": \"E-other-side\",\n" +
+            "    \"name\": \"Kaz Sandbox Org\"\n" +
+            "  }\n" +
+            "}\n";
+
+    @Test
+    public void sharedChannels() throws UnsupportedEncodingException {
+        RequestHeaders headers = new RequestHeaders(Collections.emptyMap());
+        ViewSubmissionRequest req = new ViewSubmissionRequest("payload=" + URLEncoder.encode(sharedChannelPayload, "UTF-8"), sharedChannelPayload, headers);
+        assertEquals("T-installed-workspace", req.getContext().getTeamId());
+    }
 }


### PR DESCRIPTION
This pull request resolves a bug where context.team_id can be invalid for view interactions (view_submission / view_closed) in a Slack Connect channel, which was reported at https://github.com/slackapi/bolt-js/issues/1614

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
