### PR TITLE
minor typo fix for `ExecutorService`

### DIFF
--- a/docs/guides/bolt-basics.md
+++ b/docs/guides/bolt-basics.md
@@ -128,7 +128,7 @@ app.globalShortcut("callback-id", (req, ctx) -> {
 });
 ```
 
-If you want to take full control of the `ExecutorSerivce` to use, you don't need to use `app.executorService()`. You can go with the preferable way to manage asynchronous code execution for your app.
+If you want to take full control of the `ExecutorService` to use, you don't need to use `app.executorService()`. You can go with the preferable way to manage asynchronous code execution for your app.
 
 ---
 ## Respond to User Actions


### PR DESCRIPTION
This is a single, minor spelling fix. No code changes.

### Category (place an `x` in each of the `[ ]`)

* [x ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
