### PR TITLE
Upgrade GSON and other optional dependencies

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.33.1.0</http4k.version>
+        <http4k.version>4.33.3.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.32.2.0</http4k.version>
+        <http4k.version>4.33.1.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-kotlin-examples/pom.xml
+++ b/bolt-kotlin-examples/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${logback-slf4j-v2.version}</version>
         </dependency>
     </dependencies>
 

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>2.1.2</ktor.version>
+        <ktor.version>2.1.3</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,8 +10,8 @@
     </parent>
 
     <properties>
-        <micronaut.version>3.7.1</micronaut.version>
-        <micronaut-test-junit5.version>3.5.0</micronaut-test-junit5.version>
+        <micronaut.version>3.7.2</micronaut.version>
+        <micronaut-test-junit5.version>3.7.0</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>2.3.0</micronaut-rxjava3.version>
         <junit5-jupiter.version>5.9.1</junit5-jupiter.version>
         <!-- Note that upgrading this library breaks other dependency resolution -->

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.version>3.7.2</micronaut.version>
+        <micronaut.version>3.7.3</micronaut.version>
         <micronaut-test-junit5.version>3.7.0</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>2.3.0</micronaut-rxjava3.version>
         <junit5-jupiter.version>5.9.1</junit5-jupiter.version>

--- a/bolt-quarkus-examples/pom.xml
+++ b/bolt-quarkus-examples/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.12.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.13.3.Final</quarkus.platform.version>
         <mutiny.version>1.6.0</mutiny.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
     </properties>
@@ -73,6 +73,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow</artifactId>
             <version>${quarkus.platform.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback-slf4j-v2.version}</version>
         </dependency>
     </dependencies>
 

--- a/bolt-spring-boot-examples/pom.xml
+++ b/bolt-spring-boot-examples/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <spring-boot.version>2.7.4</spring-boot.version>
+        <spring-boot.version>2.7.5</spring-boot.version>
     </properties>
 
     <artifactId>bolt-spring-boot-examples</artifactId>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${logback-slf4j-v2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,7 +10,7 @@ sdkLatestVersion: 1.26.1
 okhttpVersion: 4.10.0
 slf4jApiVersion: 1.7.36
 kotlinVersion: 1.7.20
-springBootVersion: 2.7.4
+springBootVersion: 2.7.5
 compatibleMicronautVersion: 3.x
 quarkusVersion: 2.12.0.Final
 helidonVersion: 2.5.0

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <!-- We don't change the versions of servlet API interface to keep the backward compatibility with older versions of them -->
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <okhttp.version>4.10.0</okhttp.version>
-        <gson.version>2.9.1</gson.version>
+        <gson.version>2.10</gson.version>
         <kotlin.version>1.7.20</kotlin.version>
         <!-- Note that we should not upgrade sfl4j-api to v2 to avoid confusions on the users side.
             see also: https://github.com/slackapi/java-slack-sdk/issues/1034
@@ -68,6 +68,7 @@
         <aws.s3.version>[1.12.62,1.13.0)</aws.s3.version>
         <junit.version>4.13.2</junit.version>
         <logback.version>1.2.11</logback.version>
+        <logback-slf4j-v2.version>1.4.4</logback-slf4j-v2.version>
         <hamcrest.version>[1.3,2.0)</hamcrest.version>
         <mockito-core.version>[4.1.0,5.0.0)</mockito-core.version>
         <jetty-for-tests.version>9.2.27.v20190403</jetty-for-tests.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -20,7 +20,7 @@
          -->
         <tyrus-standalone-client.version>1.19</tyrus-standalone-client.version>
         <java-websocket.version>1.5.3</java-websocket.version>
-        <jedis.version>4.2.3</jedis.version>
+        <jedis.version>4.3.1</jedis.version>
         <jedis-mock.version>1.0.4</jedis-mock.version>
     </properties>
 

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/files_remote_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/files_remote_Test.java
@@ -232,7 +232,7 @@ public class files_remote_Test {
         boolean found = false;
         String query = externalId + ": Seamlessly start a voice call";
         long millis = 0;
-        while (!found && millis < 30 * 1000) {
+        while (!found && millis < 60 * 1000) {
             Thread.sleep(500);
             millis += 500;
             SearchFilesResponse searchResults = slack.methods(userToken).searchFiles(r -> r.query(query));


### PR DESCRIPTION
This pull request upgrades dependencies before the upcoming minor version release. The only critical one is GSON's minor upgrade but I believe that it's safe enough.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
