### PR TITLE
Add requestFileInfo param to MethodsClient#filesUploadV2 method

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadV2Request.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadV2Request.java
@@ -71,6 +71,12 @@ public class FilesUploadV2Request implements SlackApiRequest {
      */
     private String snippetType;
 
+    /**
+     * Fetches all the file metadata for better v1 compatibility when this property is true.
+     */
+    @Builder.Default
+    private boolean requestFileInfo = true;
+
     @Data
     @Builder
     @NoArgsConstructor

--- a/slack-api-client/src/test/java/test_locally/api/methods/FilesTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/FilesTest.java
@@ -133,8 +133,16 @@ public class FilesTest {
                 r.file(file).filename("sample.txt").title("sample.txt"));
         assertThat(response.isOk(), is(true));
 
+        response = slack.methods(ValidToken).filesUploadV2(r ->
+                r.file(file).filename("sample.txt").title("sample.txt").requestFileInfo(false));
+        assertThat(response.isOk(), is(true));
+
         response = slack.methodsAsync(ValidToken).filesUploadV2(r ->
                 r.file(file).filename("sample.txt").title("sample.txt")).get();
+        assertThat(response.isOk(), is(true));
+
+        response = slack.methodsAsync(ValidToken).filesUploadV2(r ->
+                r.file(file).filename("sample.txt").title("sample.txt").requestFileInfo(false)).get();
         assertThat(response.isOk(), is(true));
     }
 

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
@@ -391,6 +391,45 @@ public class files_Test {
             );
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
+            assertThat(response.getFile().getTitle(), is("file title"));
+            assertThat(response.getFile().getName(), is("sample.txt"));
+
+            // I know this is a bit long but this can be necessary for test stability
+            Thread.sleep(10000L);
+            fileObj = slack.methods(botToken).filesInfo(r -> r.file(response.getFile().getId())).getFile();
+
+            assertThat(fileObj.getTitle(), is("file title"));
+            assertThat(fileObj.getName(), is("sample.txt"));
+        }
+        {
+            ChatDeleteResponse response = slack.methods(botToken).chatDelete(r -> r
+                    .channel(channelId)
+                    .ts(fileObj
+                            .getShares()
+                            .getPublicChannels().get(channelId).get(0)
+                            .getTs())
+            );
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+        }
+    }
+
+    @Test
+    public void createLongTextFile_v2_no_file_info() throws Exception {
+        com.slack.api.model.File fileObj;
+        {
+            FilesUploadV2Response response = slack.methods(botToken).filesUploadV2(r -> r
+                    .content("test")
+                    .channel(channelId)
+                    .initialComment("initial comment")
+                    .filename("sample.txt")
+                    .title("file title")
+                    .requestFileInfo(false) // Added
+            );
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+            assertThat(response.getFile().getTitle(), is("file title"));
+            assertThat(response.getFile().getName(), is(nullValue())); // this must be absent
 
             // I know this is a bit long but this can be necessary for test stability
             Thread.sleep(10000L);


### PR DESCRIPTION
This pull request adds requestFileInfo option to MethodsClient#filesUploadV2 method for feature parity with Node and Python SDKs. See the following PRs for its context:
* https://github.com/slackapi/python-slack-sdk/pull/1282
* https://github.com/slackapi/node-slack-sdk/pull/1544

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
