### PR TITLE
Fix #1088 Update MethodsClient to be consistent on the text field warnings with Node / Python SDKs

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -2533,6 +2533,7 @@ public class RequestFormBuilder {
             }
         }
         if (fallbackMissing) {
+            log.warn(TEXT_WARN_MESSAGE_TEMPLATE, endpointName);
             log.warn(FALLBACK_WARN_MESSAGE_TEMPLATE, endpointName);
         }
     }
@@ -2543,19 +2544,19 @@ public class RequestFormBuilder {
             List<Attachment> attachments,
             String attachmentsAsString) {
 
-        if (text == null || text.trim().isEmpty()) {
-            // should always be providing a text argument
-            log.warn(TEXT_WARN_MESSAGE_TEMPLATE, endpointName);
-            // furthermore, if attachments are present without a fallback argument, then warn even more
-            if (attachments != null && attachments.size() > 0) {
-                // attachments
-                warnIfAttachmentWithoutFallbackDetected(endpointName, attachments);
-            } else if (attachmentsAsString != null && attachmentsAsString.trim().length() > 0) {
-                // attachments
-                warnIfAttachmentWithoutFallbackDetected(
-                        endpointName,
-                        Arrays.asList(GSON.fromJson(attachmentsAsString, Attachment[].class))
-                );
+        if (attachments != null && attachments.size() > 0) {
+            // when attachments exist, the top-level text is not always required
+            warnIfAttachmentWithoutFallbackDetected(endpointName, attachments);
+        } else if (attachmentsAsString != null && attachmentsAsString.trim().length() > 0) {
+            // when attachments exist, the top-level text is not always required
+            warnIfAttachmentWithoutFallbackDetected(
+                    endpointName,
+                    Arrays.asList(GSON.fromJson(attachmentsAsString, Attachment[].class))
+            );
+        } else {
+            // when attachments do not exist, the top-level text is always required
+            if (text == null || text.trim().isEmpty()) {
+                log.warn(TEXT_WARN_MESSAGE_TEMPLATE, endpointName);
             }
         }
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -1499,7 +1499,7 @@ public class MethodsClientImpl implements MethodsClient {
 
     @Override
     public ChatPostMessageResponse chatPostMessage(ChatPostMessageRequest req) throws IOException, SlackApiException {
-        return postFormWithTokenAndParseResponse(toForm(req), Methods.CHAT_POST_MESSAGE, getToken(req), ChatPostMessageResponse.class);
+    return postFormWithTokenAndParseResponse(toForm(req), Methods.CHAT_POST_MESSAGE, getToken(req), ChatPostMessageResponse.class);
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -1499,7 +1499,7 @@ public class MethodsClientImpl implements MethodsClient {
 
     @Override
     public ChatPostMessageResponse chatPostMessage(ChatPostMessageRequest req) throws IOException, SlackApiException {
-    return postFormWithTokenAndParseResponse(toForm(req), Methods.CHAT_POST_MESSAGE, getToken(req), ChatPostMessageResponse.class);
+        return postFormWithTokenAndParseResponse(toForm(req), Methods.CHAT_POST_MESSAGE, getToken(req), ChatPostMessageResponse.class);
     }
 
     @Override


### PR DESCRIPTION
This pull request resolves #1088 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
