### PR TITLE
Fix #1092 by reducing info level logging in AmazonS3InstallationService/AmazonS3OAuthStateService

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
@@ -233,9 +233,7 @@ public class AmazonS3InstallationService implements InstallationService {
             return s3.getObjectMetadata(bucketName, fullKey);
         } catch (AmazonS3Exception e) {
             if (log.isDebugEnabled()) {
-                log.debug("Amazon S3 object metadata not found (key: {}, AmazonS3Exception: {})", fullKey, e.toString(), e);
-            } else {
-                log.info("Amazon S3 object metadata not found (key: {}, AmazonS3Exception: {})", fullKey, e.toString());
+                log.debug("Amazon S3 object metadata not found (key: {}, AmazonS3Exception: {})", fullKey, e.toString());
             }
             return null;
         }
@@ -246,9 +244,7 @@ public class AmazonS3InstallationService implements InstallationService {
             return s3.getObject(bucketName, fullKey);
         } catch (AmazonS3Exception e) {
             if (log.isDebugEnabled()) {
-                log.debug("Amazon S3 object metadata not found (key: {}, AmazonS3Exception: {})", fullKey, e.toString(), e);
-            } else {
-                log.info("Amazon S3 object metadata not found (key: {}, AmazonS3Exception: {})", fullKey, e.toString());
+                log.debug("Amazon S3 object metadata not found (key: {}, AmazonS3Exception: {})", fullKey, e.toString());
             }
             return null;
         }

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3OAuthStateService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3OAuthStateService.java
@@ -100,9 +100,7 @@ public class AmazonS3OAuthStateService implements OAuthStateService {
             return s3.getObject(bucketName, fullKey);
         } catch (AmazonS3Exception e) {
             if (log.isDebugEnabled()) {
-                log.debug("Amazon S3 object metadata not found (key: {}, AmazonS3Exception: {})", fullKey, e.toString(), e);
-            } else {
-                log.info("Amazon S3 object metadata not found (key: {}, AmazonS3Exception: {})", fullKey, e.toString());
+                log.debug("Amazon S3 object metadata not found (key: {}, AmazonS3Exception: {})", fullKey, e.toString());
             }
             return null;
         }


### PR DESCRIPTION
This pull request resolves #1092 

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)