### PR TITLE
Fix #821 emoji.list missing include_categories option

### DIFF
--- a/json-logs/samples/api/emoji.list.json
+++ b/json-logs/samples/api/emoji.list.json
@@ -7,5 +7,14 @@
   "cache_ts": "0000000000.000000",
   "error": "",
   "needed": "",
-  "provided": ""
+  "provided": "",
+  "categories_version": "12345",
+  "categories": [
+    {
+      "name": "",
+      "emoji_names": [
+        ""
+      ]
+    }
+  ]
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -1586,6 +1586,7 @@ public class RequestFormBuilder {
 
     public static FormBody.Builder toForm(EmojiListRequest req) {
         FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("include_categories", req.getIncludeCategories(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/emoji/EmojiListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/emoji/EmojiListRequest.java
@@ -16,4 +16,9 @@ public class EmojiListRequest implements SlackApiRequest {
      */
     private String token;
 
+    /**
+     * Include a list of categories for Unicode emoji and the emoji in each category
+     */
+    private Boolean includeCategories;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/emoji/EmojiListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/emoji/EmojiListResponse.java
@@ -18,4 +18,12 @@ public class EmojiListResponse implements SlackApiTextResponse {
 
     private Map<String, String> emoji;
     private String cacheTs;
+    private String categoriesVersion;
+    private List<Category> categories;
+
+    @Data
+    public static class Category {
+        private String name;
+        private List<String> emojiNames;
+    }
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/emoji_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/emoji_Test.java
@@ -40,6 +40,12 @@ public class emoji_Test {
             assertThat(response.isOk(), is(true));
             assertThat(response.getEmoji(), is(notNullValue()));
         }
+        {
+            EmojiListResponse response = slack.methods().emojiList(r -> r.token(botToken).includeCategories(true));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+            assertThat(response.getEmoji(), is(notNullValue()));
+        }
     }
 
     @Test
@@ -47,6 +53,12 @@ public class emoji_Test {
         String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
         {
             EmojiListResponse response = slack.methods().emojiList(r -> r.token(userToken));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+            assertThat(response.getEmoji(), is(notNullValue()));
+        }
+        {
+            EmojiListResponse response = slack.methods().emojiList(r -> r.token(userToken).includeCategories(true));
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
             assertThat(response.getEmoji(), is(notNullValue()));


### PR DESCRIPTION
This pull request resolves #821 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
