### PR TITLE
Upgrade gson, kotlin, and so on

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.34.2.0</http4k.version>
+        <http4k.version>4.35.4.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>2.1.3</ktor.version>
+        <ktor.version>2.2.2</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,10 +10,10 @@
     </parent>
 
     <properties>
-        <micronaut.version>3.7.4</micronaut.version>
+        <micronaut.version>3.8.0</micronaut.version>
         <micronaut-test-junit5.version>3.8.0</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>2.4.0</micronaut-rxjava3.version>
-        <junit5-jupiter.version>5.9.1</junit5-jupiter.version>
+        <junit5-jupiter.version>5.9.2</junit5-jupiter.version>
         <!-- Note that upgrading this library breaks other dependency resolution -->
         <mockito-all.version>1.10.19</mockito-all.version>
         <jakarta.inject.version>2.0.1.MR</jakarta.inject.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
         <!-- We don't change the versions of servlet API interface to keep the backward compatibility with older versions of them -->
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <okhttp.version>4.10.0</okhttp.version>
-        <gson.version>2.10</gson.version>
-        <kotlin.version>1.7.22</kotlin.version>
+        <gson.version>2.10.1</gson.version>
+        <kotlin.version>1.8.0</kotlin.version>
         <!-- Note that we should not upgrade sfl4j-api to v2 to avoid confusions on the users side.
             see also: https://github.com/slackapi/java-slack-sdk/issues/1034
         -->


### PR DESCRIPTION
This pull request upgrades gson patch and kotlin minor versions (and other optional deps too). These should be safe enough to include in the next version.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
