### PR TITLE
docs(typo): replace `blow` with `below`

### DIFF
--- a/docs/guides/interactive-components.md
+++ b/docs/guides/interactive-components.md
@@ -70,7 +70,7 @@ app.blockAction("button-action", (req, ctx) -> {
 });
 ```
 
-The sample code in Kotlin looks like as blow.
+The sample code in Kotlin looks like as below.
 
 ```kotlin
 app.blockAction("button-action") { req, ctx ->


### PR DESCRIPTION
This fixes a simple docs typo.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
