### PR TITLE
docs(contrib): use default branch of `main`

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -52,7 +52,7 @@ If the contribution doesn't meet the above criteria, you may fail our automated 
 3.  :herb: Create a new branch and check it out.
 4.  :crystal_ball: Make your changes and commit them locally. Magic happens here!
 5.  :arrow_heading_up: Push your new branch to your fork. (e.g. `git push username fix-issue-16`).
-6.  :inbox_tray: Open a Pull Request on github.com from your new branch on your fork to `master` in this
+6.  :inbox_tray: Open a Pull Request on github.com from your new branch on your fork to `main` in this
     repository.
 
 ## Maintainers


### PR DESCRIPTION
It looks like the default branch has been changed from master to main. This PR references that in the contributing docs.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
