### PR TITLE
Fix #1122 A request toward an invalid webhook URL get 200 OK response (expected: 302 redirection)

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
@@ -43,6 +43,14 @@ public class SlackHttpClient implements AutoCloseable {
 
     public static OkHttpClient buildOkHttpClient(SlackConfig config, Map<String, String> userAgentCustomInfo) {
         final OkHttpClient.Builder okHttpClient = new OkHttpClient.Builder();
+
+        // For context, this change was applied to resolves https://github.com/slackapi/java-slack-sdk/issues/1122
+        // There is no use case to follow redirects as of Feb 2023.
+        // If this SDK needs to enable developers to customize these options,
+        // we may want to add overloaded buildOkHttpClient() method or add such an option to the SlackConfig object.
+        okHttpClient.followRedirects(false);
+        okHttpClient.followSslRedirects(false);
+
         okHttpClient.addInterceptor(new UserAgentInterceptor(userAgentCustomInfo));
         if (config.getHttpClientReadTimeoutMillis() != null) {
             okHttpClient.readTimeout(config.getHttpClientReadTimeoutMillis(), TimeUnit.MILLISECONDS);

--- a/slack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/IncomingWebhooksTest.java
@@ -315,4 +315,11 @@ public class IncomingWebhooksTest {
         assertThat(response.getCode(), is(200));
         assertThat(response.getHeaders().size(),is(greaterThan(0)));
     }
+
+    @Test
+    public void issue_1122_invalid_url() throws Exception {
+        String invalidUrl = "https://hooks.slack.com/services/invalid-url";
+        WebhookResponse response = slack.send(invalidUrl, Payload.builder().text("Hello world!").build());
+        assertThat(response.getCode(), is(302));
+    }
 }


### PR DESCRIPTION
This pull request resolves #1122 

As mentioned in the code comments, changing the default HTTP client behavior does not affect any API client features as of today. It's safe to change for sure, but we will release the change in the next minor version release, not a patch one.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
