### PR TITLE
Add thread_ts parameter to response_url sender inputs

### DIFF
--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/response/ActionResponse.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/response/ActionResponse.java
@@ -22,4 +22,5 @@ public class ActionResponse {
     private List<Attachment> attachments;
     private List<LayoutBlock> blocks;
     private Message.Metadata metadata;
+    private String threadTs;
 }

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/slash_commands/response/SlashCommandResponse.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/slash_commands/response/SlashCommandResponse.java
@@ -23,4 +23,5 @@ public class SlashCommandResponse {
     private List<Attachment> attachments;
     private List<LayoutBlock> blocks;
     private Message.Metadata metadata;
+    private String threadTs;
 }

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/views/response/InputBlockResponse.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/views/response/InputBlockResponse.java
@@ -20,4 +20,5 @@ public class InputBlockResponse {
     private List<Attachment> attachments;
     private List<LayoutBlock> blocks;
     private Message.Metadata metadata;
+    private String threadTs;
 }

--- a/slack-app-backend/src/test/java/test_locally/app_backend/interactive_components/response/ActionResponseTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/interactive_components/response/ActionResponseTest.java
@@ -19,6 +19,7 @@ public class ActionResponseTest {
         response.setBlocks(Collections.emptyList());
         response.setDeleteOriginal(false);
         response.setReplaceOriginal(true);
+        response.setThreadTs("111.222");
 
         assertThat(response.getText(), is("something to say"));
 
@@ -28,7 +29,8 @@ public class ActionResponseTest {
                 "\"replace_original\":true," +
                 "\"delete_original\":false," +
                 "\"attachments\":[]," +
-                "\"blocks\":[]" +
+                "\"blocks\":[]," +
+                "\"thread_ts\":\"111.222\"" +
                 "}"));
     }
 

--- a/slack-app-backend/src/test/java/test_locally/app_backend/slash_commands/SlashCommandResponseSenderTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/slash_commands/SlashCommandResponseSenderTest.java
@@ -23,6 +23,8 @@ public class SlashCommandResponseSenderTest {
             SlashCommandResponseSender sender = new SlashCommandResponseSender(slack);
             SlashCommandResponse data = SlashCommandResponse.builder()
                     .text("Hi there!")
+                    .responseType("in_channel")
+                    .threadTs("111.222")
                     .build();
             WebhookResponse response = sender.send(slackApiServer.getWebhookUrl(), data);
             assertNotNull(response);

--- a/slack-app-backend/src/test/java/test_locally/app_backend/views/InputBlockResponseSenderTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/views/InputBlockResponseSenderTest.java
@@ -26,6 +26,8 @@ public class InputBlockResponseSenderTest {
 
             InputBlockResponse data = InputBlockResponse.builder()
                     .text("Hi there!")
+                    .responseType("in_channel")
+                    .threadTs("111.222")
                     .build();
             WebhookResponse response = sender.send(slackApiServer.getWebhookUrl(), data);
             assertNotNull(response);


### PR DESCRIPTION
This pull request fixes the issue originally reported for bolt-python. Refer to https://github.com/slackapi/bolt-python/pull/844 for the equivalent changes in Python.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
