### PR TITLE
Fix #1128 MessageMeEvent does not have user property

### DIFF
--- a/json-logs/samples/events/MessageMePayload.json
+++ b/json-logs/samples/events/MessageMePayload.json
@@ -28,6 +28,7 @@
     "subtype": "me_message",
     "channel": "",
     "username": "",
+    "user": "",
     "bot_id": "",
     "text": "",
     "event_ts": "",

--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageMeEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageMeEvent.java
@@ -1,6 +1,9 @@
 package com.slack.api.model.event;
 
+import com.slack.api.model.block.LayoutBlock;
 import lombok.Data;
+
+import java.util.List;
 
 /**
  * https://api.slack.com/events/message/me_message
@@ -16,9 +19,11 @@ public class MessageMeEvent implements Event {
     private String channel;
 
     private String username;
+    private String user;
     private String botId;
 
     private String text;
+    private List<LayoutBlock> blocks; // rich_text blocks
 
     private String eventTs;
     private String ts;

--- a/slack-api-model/src/test/java/test_locally/api/model/event/MessageMeEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/MessageMeEventTest.java
@@ -1,0 +1,54 @@
+package test_locally.api.model.event;
+
+import com.slack.api.model.event.MessageMeEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MessageMeEventTest {
+
+    @Test
+    public void typeName() {
+        assertThat(MessageMeEvent.TYPE_NAME, is("message"));
+        assertThat(MessageMeEvent.SUBTYPE_NAME, is("me_message"));
+    }
+
+    @Test
+    public void test() {
+        String json = "{\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"subtype\": \"me_message\",\n" +
+                "  \"text\": \"hey\",\n" +
+                "  \"user\": \"U03E94MK0\",\n" +
+                "  \"ts\": \"1679895454.657169\",\n" +
+                "  \"blocks\": [\n" +
+                "    {\n" +
+                "      \"type\": \"rich_text\",\n" +
+                "      \"block_id\": \"YUITq\",\n" +
+                "      \"elements\": [\n" +
+                "        {\n" +
+                "          \"type\": \"rich_text_section\",\n" +
+                "          \"elements\": [\n" +
+                "            {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"text\": \"hey\"\n" +
+                "            }\n" +
+                "          ]\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"channel\": \"C03E94MKS\",\n" +
+                "  \"event_ts\": \"1679895454.657169\",\n" +
+                "  \"channel_type\": \"channel\"\n" +
+                "}";
+        MessageMeEvent event = GsonFactory.createSnakeCase().fromJson(json, MessageMeEvent.class);
+        assertThat(event.getType(), is("message"));
+        assertThat(event.getSubtype(), is("me_message"));
+        assertThat(event.getUser(), is("U03E94MK0"));
+        assertThat(event.getText(), is("hey"));
+        assertThat(event.getBlocks().size(), is(1));
+    }
+}


### PR DESCRIPTION
This pull request resolves #1128 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
