### PR TITLE
Fix #1127 AuthTeamsListResponse.Team doesn't provide icon when include_icon: true is passed

### DIFF
--- a/json-logs/samples/api/auth.teams.list.json
+++ b/json-logs/samples/api/auth.teams.list.json
@@ -3,7 +3,17 @@
   "teams": [
     {
       "id": "T00000000",
-      "name": ""
+      "name": "",
+      "icon": {
+        "image_default": false,
+        "image_34": "https://www.example.com/",
+        "image_44": "https://www.example.com/",
+        "image_68": "https://www.example.com/",
+        "image_88": "https://www.example.com/",
+        "image_102": "https://www.example.com/",
+        "image_230": "https://www.example.com/",
+        "image_132": "https://www.example.com/"
+      }
     }
   ],
   "error": "",

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/auth/teams/AuthTeamsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/auth/teams/AuthTeamsListResponse.java
@@ -2,6 +2,7 @@ package com.slack.api.methods.response.auth.teams;
 
 import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.ResponseMetadata;
+import com.slack.api.model.TeamIcon;
 import lombok.Data;
 
 import java.util.List;
@@ -24,5 +25,6 @@ public class AuthTeamsListResponse implements SlackApiTextResponse {
     public static class Team {
         private String id;
         private String name;
+        private TeamIcon icon;
     }
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/auth_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/auth_Test.java
@@ -223,6 +223,21 @@ public class auth_Test {
     }
 
     @Test
+    public void authTeamsList_include_icon() throws Exception {
+        String token = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+        {
+            AuthTeamsListResponse response = slack.methods(token).authTeamsList(req -> req.limit(1).includeIcon(true));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+        }
+        {
+            AuthTeamsListResponse response = slack.methodsAsync(token).authTeamsList(req -> req.limit(1).includeIcon(true)).get();
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+        }
+    }
+
+    @Test
     public void authTest_x_oauth_scopes() throws IOException, SlackApiException {
         AuthTestResponse response = slack.methods().authTest(req -> req.token(botToken));
         assertThat(response.getError(), is(nullValue()));


### PR DESCRIPTION
This pull request resolves #1127 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
