### PR TITLE
Fix #1129 Setting schema-less URL for proxy URLs results in NullPointerException

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/util/http/ProxyUrlUtil.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/ProxyUrlUtil.java
@@ -34,8 +34,9 @@ public class ProxyUrlUtil {
             return null;
         }
         String[] proxyUrlElements = proxyUrl.split("://");
-        String schema = proxyUrlElements[0] + "://";
-        String urlWithoutSchema = proxyUrlElements[1];
+        boolean withSchema = proxyUrlElements.length == 2;
+        String schema = withSchema ? proxyUrlElements[0] + "://" : "http://";
+        String urlWithoutSchema = withSchema ? proxyUrlElements[1] : proxyUrlElements[0];
         String[] urlWithUserAndPasswordIfTwoElements = urlWithoutSchema.split("@");
         if (urlWithUserAndPasswordIfTwoElements.length == 2) {
             String[] userAndPassword = urlWithUserAndPasswordIfTwoElements[0].split(":");
@@ -51,7 +52,7 @@ public class ProxyUrlUtil {
                     .port(hostAndPort.length == 2 ? Integer.parseInt(hostAndPort[1].replace("/", "")) : 80)
                     .build();
         } else {
-            String[] hostAndPort = proxyUrl.split("://")[1].split(":");
+            String[] hostAndPort = (withSchema ? proxyUrlElements[1] : proxyUrlElements[0]).split(":");
             return ProxyUrl.builder()
                     .schema(schema)
                     .host(hostAndPort[0])

--- a/slack-api-client/src/test/java/test_locally/api/util/http/ProxyUrlUtilTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/util/http/ProxyUrlUtilTest.java
@@ -51,4 +51,26 @@ public class ProxyUrlUtilTest {
     public void parse_invalid_format() {
         ProxyUrlUtil.parse("http://foo:bar:baz@localhost:9000");
     }
+
+    @Test
+    public void parse_no_schema() {
+        ProxyUrlUtil.ProxyUrl expected = ProxyUrlUtil.ProxyUrl.builder()
+                .schema("http://")
+                .host("localhost")
+                .port(9000)
+                .build();
+        assertThat(ProxyUrlUtil.parse("localhost:9000"), is(expected));
+    }
+
+    @Test
+    public void parse_username_password_no_schema() {
+        ProxyUrlUtil.ProxyUrl expected = ProxyUrlUtil.ProxyUrl.builder()
+                .schema("http://")
+                .host("localhost")
+                .username("user")
+                .password("password")
+                .port(9000)
+                .build();
+        assertThat(ProxyUrlUtil.parse("user:password@localhost:9000"), is(expected));
+    }
 }


### PR DESCRIPTION
This pull request resolves #1129 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
