### PR TITLE
Upgrade dependency patch/minor versions (kotlin, http4k, micronaut)

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.41.1.1</http4k.version>
+        <http4k.version>4.41.3.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.version>3.8.7</micronaut.version>
+        <micronaut.version>3.8.8</micronaut.version>
         <micronaut-test-junit5.version>3.9.2</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>2.4.1</micronaut-rxjava3.version>
         <junit5-jupiter.version>5.9.2</junit5-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <okhttp.version>4.10.0</okhttp.version>
         <gson.version>2.10.1</gson.version>
-        <kotlin.version>1.8.10</kotlin.version>
+        <kotlin.version>1.8.20</kotlin.version>
         <!-- Note that we should not upgrade sfl4j-api to v2 to avoid confusions on the users side.
             see also: https://github.com/slackapi/java-slack-sdk/issues/1034
         -->


### PR DESCRIPTION
This pull request upgrades a few dependencies.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
