### PR TITLE
Add botScopes and requestUserScopes to context object

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/context/Context.java
+++ b/bolt/src/main/java/com/slack/api/bolt/context/Context.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -53,6 +54,10 @@ public abstract class Context {
      */
     protected String botToken;
     /**
+     * The scopes associated to the botToken
+     */
+    protected List<String> botScopes;
+    /**
      * bot_id associated with this request.
      */
     protected String botId; // set by MultiTeamsAuthorization
@@ -69,6 +74,10 @@ public abstract class Context {
      * The user token that is associated with the request user ID.
      */
     protected String requestUserToken;
+    /**
+     * The scopes associated to the requestUserToken
+     */
+    protected List<String> requestUserScopes;
 
     protected final Map<String, String> additionalValues = new HashMap<>();
 

--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/SingleTeamAuthorization.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/SingleTeamAuthorization.java
@@ -14,6 +14,9 @@ import com.slack.api.methods.response.auth.AuthTestResponse;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -57,11 +60,13 @@ public class SingleTeamAuthorization implements Middleware {
         }
 
         Context context = req.getContext();
-        AuthTestResponse authResult = callAuthTest(appConfig, context.client());
+        String botToken = context.getBotToken() != null ? context.getBotToken() : appConfig.getSingleTeamBotToken();
+        AuthTestResponse authResult = callAuthTest(botToken, appConfig, context.client());
         if (authResult.isOk()) {
-            if (context.getBotToken() == null) {
-                context.setBotToken(appConfig.getSingleTeamBotToken());
-            }
+            context.setBotToken(botToken);
+            Map<String, List<String>> botHeaders = authResult.getHttpResponseHeaders();
+            List<String> botScopesHeader = botHeaders != null ? botHeaders.get("x-oauth-scopes") : null;
+            context.setBotScopes(botScopesHeader != null ? Arrays.asList(botScopesHeader.get(0).split(",")) : null);
             context.setBotUserId(authResult.getUserId());
             context.setTeamId(authResult.getTeamId());
             context.setEnterpriseId(authResult.getEnterpriseId());
@@ -79,7 +84,12 @@ public class SingleTeamAuthorization implements Middleware {
                             context.getRequestUserId()
                     );
                     if (installer != null) {
-                        context.setRequestUserToken(installer.getInstallerUserAccessToken());
+                        String userToken = installer.getInstallerUserAccessToken();
+                        context.setRequestUserToken(userToken);
+                        AuthTestResponse userAuthTestResponse = callAuthTest(userToken, appConfig, context.client());
+                        Map<String, List<String>> userHeaders = userAuthTestResponse.getHttpResponseHeaders();
+                        List<String> userScopesHeader = userHeaders != null ? userHeaders.get("x-oauth-scopes") : null;
+                        context.setRequestUserScopes(userScopesHeader != null ? Arrays.asList(userScopesHeader.get(0).split(",")) : null);
                     }
                 }
             }
@@ -96,7 +106,7 @@ public class SingleTeamAuthorization implements Middleware {
         }
     }
 
-    protected AuthTestResponse callAuthTest(AppConfig config, MethodsClient client) throws IOException, SlackApiException {
+    protected AuthTestResponse callAuthTest(String token, AppConfig config, MethodsClient client) throws IOException, SlackApiException {
         if (cachedAuthTestResponse.isPresent()) {
             boolean permanentCacheEnabled = config.getAuthTestCacheExpirationMillis() < 0;
             if (permanentCacheEnabled) {
@@ -108,7 +118,7 @@ public class SingleTeamAuthorization implements Middleware {
                 return cachedAuthTestResponse.get();
             }
         }
-        AuthTestResponse response = client.authTest(r -> r.token(config.getSingleTeamBotToken()));
+        AuthTestResponse response = client.authTest(r -> r.token(token));
         cachedAuthTestResponse = Optional.of(response); // response here is non-null for sure
         lastCachedMillis.set(System.currentTimeMillis());
         return response;


### PR DESCRIPTION
This pull request adds botScopes and requestUserScopes to context object in the same way with https://github.com/slackapi/bolt-python/pull/855

While testing this new feauture, I found that the logic to set context.requestUserId can be improved for Events API patterns. I will make changes for it in a different pull request.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
