### PR TITLE
Fix #1145 SCIM version 2.0 support

### DIFF
--- a/json-logs/samples/scim/v2/Groups.json
+++ b/json-logs/samples/scim/v2/Groups.json
@@ -1,0 +1,31 @@
+{
+  "schemas": [
+    ""
+  ],
+  "Resources": [
+    {
+      "schemas": [
+        ""
+      ],
+      "id": "S00000000",
+      "meta": {
+        "created": "",
+        "location": "https://www.example.com/"
+      },
+      "displayName": "",
+      "members": [
+        {
+          "value": "",
+          "display": ""
+        }
+      ]
+    }
+  ],
+  "totalResults": 12345,
+  "itemsPerPage": 12345,
+  "startIndex": 12345,
+  "Errors": {
+    "description": "",
+    "code": 12345
+  }
+}

--- a/json-logs/samples/scim/v2/Groups/00000000000.json
+++ b/json-logs/samples/scim/v2/Groups/00000000000.json
@@ -1,0 +1,17 @@
+{
+  "schemas": [
+    ""
+  ],
+  "id": "S00000000",
+  "meta": {
+    "created": "",
+    "location": "https://www.example.com/"
+  },
+  "displayName": "",
+  "members": [
+    {
+      "value": "",
+      "display": ""
+    }
+  ]
+}

--- a/json-logs/samples/scim/v2/ResourceTypes.json
+++ b/json-logs/samples/scim/v2/ResourceTypes.json
@@ -1,0 +1,27 @@
+{
+  "schemas": [
+    ""
+  ],
+  "Resources": [
+    {
+      "schemas": [
+        ""
+      ],
+      "id": "",
+      "name": "",
+      "endpoint": "",
+      "description": "",
+      "schema": "",
+      "meta": {
+        "location": "https://www.example.com/",
+        "resourceType": ""
+      },
+      "schemaExtensions": [
+        {
+          "schema": "",
+          "required": false
+        }
+      ]
+    }
+  ]
+}

--- a/json-logs/samples/scim/v2/ServiceProviderConfigs.json
+++ b/json-logs/samples/scim/v2/ServiceProviderConfigs.json
@@ -1,0 +1,35 @@
+{
+  "authenticationSchemes": [
+    {
+      "type": "",
+      "name": "",
+      "description": "",
+      "specUrl": "https://www.example.com/",
+      "primary": false
+    }
+  ],
+  "patch": {
+    "supported": false
+  },
+  "bulk": {
+    "supported": false,
+    "maxOperations": 12345,
+    "maxPayloadSize": 12345
+  },
+  "filter": {
+    "supported": false,
+    "maxResults": 12345
+  },
+  "changePassword": {
+    "supported": false
+  },
+  "sort": {
+    "supported": false
+  },
+  "etag": {
+    "supported": false
+  },
+  "xmlDataFormat": {
+    "supported": false
+  }
+}

--- a/json-logs/samples/scim/v2/Users.json
+++ b/json-logs/samples/scim/v2/Users.json
@@ -1,0 +1,98 @@
+{
+  "schemas": [
+    ""
+  ],
+  "Resources": [
+    {
+      "schemas": [
+        ""
+      ],
+      "id": "W00000000",
+      "externalId": "",
+      "meta": {
+        "created": "",
+        "location": "https://www.example.com/"
+      },
+      "userName": "",
+      "nickName": "",
+      "name": {
+        "givenName": "",
+        "familyName": ""
+      },
+      "displayName": "",
+      "profileUrl": "https://www.example.com/",
+      "title": "",
+      "timezone": "",
+      "active": false,
+      "emails": [
+        {
+          "value": "",
+          "primary": false
+        },
+        {
+          "value": "",
+          "type": "",
+          "primary": false
+        }
+      ],
+      "photos": [
+        {
+          "value": "",
+          "type": ""
+        }
+      ],
+      "addresses": [
+        {},
+        {
+          "streetAddress": "",
+          "locality": "",
+          "region": "",
+          "postalCode": "",
+          "country": "",
+          "primary": false
+        }
+      ],
+      "phoneNumbers": [
+        {
+          "type": "",
+          "primary": false
+        },
+        {
+          "value": "",
+          "type": "",
+          "primary": false
+        }
+      ],
+      "roles": [
+        {
+          "primary": false
+        },
+        {
+          "value": "",
+          "type": "",
+          "primary": false
+        }
+      ],
+      "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+        "manager": {}
+      },
+      "groups": [
+        {
+          "value": "",
+          "display": ""
+        }
+      ],
+      "urn:ietf:params:scim:schemas:extension:slack:guest:2.0:User": {
+        "type": "",
+        "expiration": ""
+      }
+    }
+  ],
+  "totalResults": 12345,
+  "itemsPerPage": 12345,
+  "startIndex": 12345,
+  "Errors": {
+    "description": "",
+    "code": 12345
+  }
+}

--- a/json-logs/samples/scim/v2/Users/00000000000.json
+++ b/json-logs/samples/scim/v2/Users/00000000000.json
@@ -1,0 +1,76 @@
+{
+  "Errors": {
+    "description": "",
+    "code": 12345
+  },
+  "schemas": [
+    ""
+  ],
+  "id": "W00000000",
+  "externalId": "",
+  "meta": {
+    "created": "",
+    "location": "https://www.example.com/"
+  },
+  "userName": "",
+  "nickName": "",
+  "name": {
+    "givenName": "",
+    "familyName": ""
+  },
+  "displayName": "",
+  "profileUrl": "https://www.example.com/",
+  "title": "",
+  "timezone": "",
+  "active": false,
+  "emails": [
+    {
+      "value": "",
+      "type": "",
+      "primary": false
+    }
+  ],
+  "photos": [
+    {
+      "value": "",
+      "type": ""
+    }
+  ],
+  "addresses": [
+    {
+      "streetAddress": "",
+      "locality": "",
+      "region": "",
+      "postalCode": "",
+      "country": "",
+      "primary": false
+    }
+  ],
+  "phoneNumbers": [
+    {
+      "value": "",
+      "type": "",
+      "primary": false
+    }
+  ],
+  "roles": [
+    {
+      "value": "",
+      "type": "",
+      "primary": false
+    }
+  ],
+  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+    "manager": {}
+  },
+  "groups": [
+    {
+      "value": "",
+      "display": ""
+    }
+  ],
+  "urn:ietf:params:scim:schemas:extension:slack:guest:2.0:User": {
+    "type": "",
+    "expiration": ""
+  }
+}

--- a/slack-api-client/src/main/java/com/slack/api/Slack.java
+++ b/slack-api-client/src/main/java/com/slack/api/Slack.java
@@ -27,6 +27,11 @@ import com.slack.api.scim.SCIMClient;
 import com.slack.api.scim.SCIMConfig;
 import com.slack.api.scim.impl.AsyncSCIMClientImpl;
 import com.slack.api.scim.impl.SCIMClientImpl;
+import com.slack.api.scim2.AsyncSCIM2Client;
+import com.slack.api.scim2.SCIM2Client;
+import com.slack.api.scim2.SCIM2Config;
+import com.slack.api.scim2.impl.AsyncSCIM2ClientImpl;
+import com.slack.api.scim2.impl.SCIM2ClientImpl;
 import com.slack.api.socket_mode.SocketModeClient;
 import com.slack.api.socket_mode.impl.SocketModeClientJavaWSImpl;
 import com.slack.api.socket_mode.impl.SocketModeClientTyrusImpl;
@@ -318,6 +323,42 @@ public class Slack implements AutoCloseable {
     /**
      * Creates a SCIM API client.
      */
+    public SCIM2Client scim2() {
+        return scim2(null);
+    }
+
+    public SCIM2Client scim2(String token) {
+        MethodsClientImpl methods = new MethodsClientImpl(httpClient, token);
+        methods.setEndpointUrlPrefix(config.getMethodsEndpointUrlPrefix());
+        SCIM2ClientImpl client = new SCIM2ClientImpl(
+                config,
+                httpClient,
+                new TeamIdCache(methods), // will create a cache with enterprise_id
+                token);
+        client.setEndpointUrlPrefix(config.getScim2EndpointUrlPrefix());
+        return client;
+    }
+
+    public AsyncSCIM2Client scim2Async(String token) {
+        MethodsClientImpl methods = new MethodsClientImpl(httpClient, token);
+        methods.setEndpointUrlPrefix(config.getMethodsEndpointUrlPrefix());
+        SCIM2ClientImpl client = new SCIM2ClientImpl(
+                config,
+                httpClient,
+                new TeamIdCache(methods), // will create a cache with enterprise_id
+                token);
+        client.setEndpointUrlPrefix(config.getScim2EndpointUrlPrefix());
+        return new AsyncSCIM2ClientImpl(token, client, methods, config);
+    }
+
+    public RequestStats scim2Stats(String enterpriseId) {
+        return scim2Stats(SCIM2Config.DEFAULT_SINGLETON_EXECUTOR_NAME, enterpriseId);
+    }
+
+    public RequestStats scim2Stats(String executorName, String enterpriseId) {
+        return config.getSCIM2Config().getMetricsDatastore().getStats(executorName, enterpriseId);
+    }
+
     public SCIMClient scim() {
         return scim(null);
     }

--- a/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
+++ b/slack-api-client/src/main/java/com/slack/api/SlackConfig.java
@@ -7,6 +7,8 @@ import com.slack.api.methods.MethodsConfig;
 import com.slack.api.rate_limits.RateLimiter;
 import com.slack.api.scim.SCIMClient;
 import com.slack.api.scim.SCIMConfig;
+import com.slack.api.scim2.SCIM2Client;
+import com.slack.api.scim2.SCIM2Config;
 import com.slack.api.status.v1.LegacyStatusClient;
 import com.slack.api.status.v2.StatusClient;
 import com.slack.api.util.http.listener.DetailedLoggingListener;
@@ -257,6 +259,8 @@ public class SlackConfig implements AutoCloseable {
 
     private String scimEndpointUrlPrefix = SCIMClient.ENDPOINT_URL_PREFIX;
 
+    private String scim2EndpointUrlPrefix = SCIM2Client.ENDPOINT_URL_PREFIX;
+
     private String statusEndpointUrlPrefix = StatusClient.ENDPOINT_URL_PREFIX;
 
     private String legacyStatusEndpointUrlPrefix = LegacyStatusClient.ENDPOINT_URL_PREFIX;
@@ -292,6 +296,8 @@ public class SlackConfig implements AutoCloseable {
     private AuditConfig auditConfig = new AuditConfig();
 
     private SCIMConfig sCIMConfig = new SCIMConfig();
+
+    private SCIM2Config sCIM2Config = new SCIM2Config();
 
     public void synchronizeMetricsDatabases() {
         this.synchronizeExecutorServiceProviders();
@@ -329,6 +335,17 @@ public class SlackConfig implements AutoCloseable {
                 sCIMConfig.getMetricsDatastore().setStatsEnabled(false);
             }
         }
+        if (!sCIM2Config.equals(sCIM2Config.DEFAULT_SINGLETON)) {
+            if (sCIM2Config.isStatsEnabled()) {
+                if (sCIM2Config.getMetricsDatastore().getRateLimiterBackgroundJobIntervalMillis()
+                        != this.getRateLimiterBackgroundJobIntervalMillis()) {
+                    sCIM2Config.getMetricsDatastore().setRateLimiterBackgroundJobIntervalMillis(
+                            this.getRateLimiterBackgroundJobIntervalMillis());
+                }
+            } else {
+                sCIM2Config.getMetricsDatastore().setStatsEnabled(false);
+            }
+        }
     }
 
     public void synchronizeExecutorServiceProviders() {
@@ -349,6 +366,12 @@ public class SlackConfig implements AutoCloseable {
                 && !sCIMConfig.getExecutorServiceProvider().equals(executorServiceProvider)) {
             sCIMConfig.setExecutorServiceProvider(executorServiceProvider);
             sCIMConfig.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
+        }
+        if (!sCIM2Config.equals(SCIM2Config.DEFAULT_SINGLETON)
+                && sCIM2Config.isStatsEnabled()
+                && !sCIM2Config.getExecutorServiceProvider().equals(executorServiceProvider)) {
+            sCIM2Config.setExecutorServiceProvider(executorServiceProvider);
+            sCIM2Config.getMetricsDatastore().setExecutorServiceProvider(executorServiceProvider);
         }
         this.synchronizeLibraryMaintainerMode();
     }

--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncRateLimitExecutor.java
@@ -40,15 +40,15 @@ public class AsyncRateLimitExecutor {
     }
 
     public static AsyncRateLimitExecutor getOrCreate(MethodsClientImpl methods, SlackConfig config) {
-        AsyncRateLimitExecutor executor = ALL_EXECUTORS.get(config.getMethodsConfig().getExecutorName());
-        if (executor != null && executor.metricsDatastore != config.getMethodsConfig().getMetricsDatastore()) {
+        AsyncRateLimitExecutor executor = ALL_EXECUTORS.get(config.getAuditConfig().getExecutorName());
+        if (executor != null && executor.metricsDatastore != config.getAuditConfig().getMetricsDatastore()) {
             // As the metrics datastore has been changed, we should replace the executor
             executor.config = config.getAuditConfig();
             executor.metricsDatastore = config.getAuditConfig().getMetricsDatastore();
         }
         if (executor == null) {
             executor = new AsyncRateLimitExecutor(methods, config);
-            ALL_EXECUTORS.putIfAbsent(config.getMethodsConfig().getExecutorName(), executor);
+            ALL_EXECUTORS.putIfAbsent(config.getAuditConfig().getExecutorName(), executor);
         }
         return executor;
     }

--- a/slack-api-client/src/main/java/com/slack/api/scim2/AsyncSCIM2Client.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/AsyncSCIM2Client.java
@@ -1,0 +1,121 @@
+package com.slack.api.scim2;
+
+import com.slack.api.RequestConfigurator;
+import com.slack.api.scim2.request.*;
+import com.slack.api.scim2.response.*;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Slack SCIM API client.
+ * <p>
+ * Provision and manage user accounts and groups with the Slack SCIM API.
+ * SCIM is used by Single Sign-On (SSO) services and identity providers to manage people
+ * across a variety of tools, including Slack.
+ * <p>
+ * It's also possible to write your own apps
+ * and scripts using the SCIM API to programmatically manage the members of your workspace.
+ *
+ * @see <a href="https://api.slack.com/admins/scim2">Slack SCIM 2.0 API</a>
+ */
+public interface AsyncSCIM2Client {
+
+    String ENDPOINT_URL_PREFIX = "https://api.slack.com/scim/v2/";
+
+    String getEndpointUrlPrefix();
+
+    void setEndpointUrlPrefix(String endpointUrlPrefix);
+
+    // --------------------
+    // ServiceProviderConfigs
+    // --------------------
+
+    CompletableFuture<ServiceProviderConfigsGetResponse> getServiceProviderConfigs(ServiceProviderConfigsGetRequest req);
+
+    CompletableFuture<ServiceProviderConfigsGetResponse> getServiceProviderConfigs(RequestConfigurator<ServiceProviderConfigsGetRequest.ServiceProviderConfigsGetRequestBuilder> req);
+
+    // --------------------
+    // ResourceTypes
+    // --------------------
+
+    CompletableFuture<ResourceTypesGetResponse> getResourceTypes(ResourceTypesGetRequest req);
+
+    CompletableFuture<ResourceTypesGetResponse> getResourceTypes(RequestConfigurator<ResourceTypesGetRequest.ResourceTypesGetRequestBuilder> req);
+
+    // --------------------
+    // Users
+    // --------------------
+
+    CompletableFuture<UsersSearchResponse> searchUsers(UsersSearchRequest req);
+
+    CompletableFuture<UsersSearchResponse> searchUsers(RequestConfigurator<UsersSearchRequest.UsersSearchRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<UsersReadResponse> readUser(UsersReadRequest req);
+
+    CompletableFuture<UsersReadResponse> readUser(RequestConfigurator<UsersReadRequest.UsersReadRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<UsersCreateResponse> createUser(UsersCreateRequest req);
+
+    CompletableFuture<UsersCreateResponse> createUser(RequestConfigurator<UsersCreateRequest.UsersCreateRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<UsersPatchResponse> patchUser(UsersPatchRequest req);
+
+    CompletableFuture<UsersPatchResponse> patchUser(RequestConfigurator<UsersPatchRequest.UsersPatchRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<UsersUpdateResponse> updateUser(UsersUpdateRequest req);
+
+    CompletableFuture<UsersUpdateResponse> updateUser(RequestConfigurator<UsersUpdateRequest.UsersUpdateRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<UsersDeleteResponse> deleteUser(UsersDeleteRequest req);
+
+    CompletableFuture<UsersDeleteResponse> deleteUser(RequestConfigurator<UsersDeleteRequest.UsersDeleteRequestBuilder> req);
+
+    // --------------------
+    // Groups
+    // --------------------
+
+    CompletableFuture<GroupsSearchResponse> searchGroups(GroupsSearchRequest req);
+
+    CompletableFuture<GroupsSearchResponse> searchGroups(RequestConfigurator<GroupsSearchRequest.GroupsSearchRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<GroupsReadResponse> readGroup(GroupsReadRequest req);
+
+    CompletableFuture<GroupsReadResponse> readGroup(RequestConfigurator<GroupsReadRequest.GroupsReadRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<GroupsCreateResponse> createGroup(GroupsCreateRequest req);
+
+    CompletableFuture<GroupsCreateResponse> createGroup(RequestConfigurator<GroupsCreateRequest.GroupsCreateRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<GroupsPatchResponse> patchGroup(GroupsPatchRequest req);
+
+    CompletableFuture<GroupsPatchResponse> patchGroup(RequestConfigurator<GroupsPatchRequest.GroupsPatchRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<GroupsUpdateResponse> updateGroup(GroupsUpdateRequest req);
+
+    CompletableFuture<GroupsUpdateResponse> updateGroup(RequestConfigurator<GroupsUpdateRequest.GroupsUpdateRequestBuilder> req);
+
+    // ---
+
+    CompletableFuture<GroupsDeleteResponse> deleteGroup(GroupsDeleteRequest req);
+
+    CompletableFuture<GroupsDeleteResponse> deleteGroup(RequestConfigurator<GroupsDeleteRequest.GroupsDeleteRequestBuilder> req);
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2ApiCompletionException.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2ApiCompletionException.java
@@ -1,0 +1,24 @@
+package com.slack.api.scim2;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Data
+@Slf4j
+@EqualsAndHashCode(callSuper = false)
+public class SCIM2ApiCompletionException extends RuntimeException {
+
+    private final IOException ioException;
+    private final SCIM2ApiException scimApiException;
+    private final Exception otherException;
+
+    public SCIM2ApiCompletionException(IOException ioException, SCIM2ApiException scimApiException, Exception otherException) {
+        this.ioException = ioException;
+        this.scimApiException = scimApiException;
+        this.otherException = otherException;
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2ApiErrorResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2ApiErrorResponse.java
@@ -1,0 +1,26 @@
+package com.slack.api.scim2;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class SCIM2ApiErrorResponse implements SCIM2ApiResponse {
+
+    private List<String> schemas;
+    private String detail;
+    private Integer status;
+
+    @SerializedName("Errors")
+    private Errors errors;
+
+    @Data
+    public static class Errors {
+        private String description;
+        private Integer code;
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2ApiException.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2ApiException.java
@@ -1,0 +1,58 @@
+package com.slack.api.scim2;
+
+import com.slack.api.SlackConfig;
+import com.slack.api.util.json.GsonFactory;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Response;
+
+@Data
+@Slf4j
+@EqualsAndHashCode(callSuper = false)
+public class SCIM2ApiException extends Exception {
+
+    private final Response response;
+    private final String responseBody;
+    private final SCIM2ApiErrorResponse error;
+
+    public SCIM2ApiException(Response response, String responseBody) {
+        this(SlackConfig.DEFAULT, response, responseBody);
+    }
+
+    public SCIM2ApiException(SlackConfig config, Response response, String responseBody) {
+        this(response, responseBody, parse(config, responseBody));
+    }
+
+    public SCIM2ApiException(Response response, String responseBody, SCIM2ApiErrorResponse error) {
+        super(buildErrorMessage(response, error));
+        this.response = response;
+        this.responseBody = responseBody;
+        this.error = error;
+    }
+
+    private static String buildErrorMessage(Response response, SCIM2ApiErrorResponse error) {
+        String message = "status: " + response.code();
+        if (error != null && error.getErrors() != null) {
+            return message + ", description: " + error.getErrors().getDescription();
+        } else if (error != null && error.getDetail() != null) {
+            return message + ", detail: " + error.getDetail();
+        } else {
+            return message + ", no response body";
+        }
+    }
+
+    private static SCIM2ApiErrorResponse parse(SlackConfig config, String responseBody) {
+        SCIM2ApiErrorResponse parsedErrorResponse = null;
+        try {
+            parsedErrorResponse = GsonFactory.createCamelCase(config).fromJson(responseBody, SCIM2ApiErrorResponse.class);
+        } catch (Exception e) {
+            if (log.isDebugEnabled()) {
+                String responseToPrint = responseBody.length() > 1000 ? responseBody.subSequence(0, 1000) + " ..." : responseBody;
+                log.debug("Failed to parse the error response body: {}", responseToPrint);
+            }
+        }
+        return parsedErrorResponse;
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2ApiRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2ApiRequest.java
@@ -1,0 +1,10 @@
+package com.slack.api.scim2;
+
+/**
+ * A marker interface for Slack API request objects.
+ */
+public interface SCIM2ApiRequest {
+
+    String getToken();
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2ApiResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2ApiResponse.java
@@ -1,0 +1,4 @@
+package com.slack.api.scim2;
+
+public interface SCIM2ApiResponse {
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2Client.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2Client.java
@@ -1,0 +1,121 @@
+package com.slack.api.scim2;
+
+import com.slack.api.RequestConfigurator;
+import com.slack.api.scim2.request.*;
+import com.slack.api.scim2.response.*;
+
+import java.io.IOException;
+
+/**
+ * Slack SCIM API client.
+ * <p>
+ * Provision and manage user accounts and groups with the Slack SCIM API.
+ * SCIM is used by Single Sign-On (SSO) services and identity providers to manage people
+ * across a variety of tools, including Slack.
+ * <p>
+ * It's also possible to write your own apps
+ * and scripts using the SCIM API to programmatically manage the members of your workspace.
+ *
+ * @see <a href="https://api.slack.com/admins/scim2">Slack SCIM 2.0 API</a>
+ */
+public interface SCIM2Client {
+
+    String ENDPOINT_URL_PREFIX = "https://api.slack.com/scim/v2/";
+
+    String getEndpointUrlPrefix();
+
+    void setEndpointUrlPrefix(String endpointUrlPrefix);
+
+    // --------------------
+    // ServiceProviderConfigs
+    // --------------------
+
+    ServiceProviderConfigsGetResponse getServiceProviderConfigs(ServiceProviderConfigsGetRequest req) throws IOException, SCIM2ApiException;
+
+    ServiceProviderConfigsGetResponse getServiceProviderConfigs(RequestConfigurator<ServiceProviderConfigsGetRequest.ServiceProviderConfigsGetRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // --------------------
+    // ResourceTypes
+    // --------------------
+
+    ResourceTypesGetResponse getResourceTypes(ResourceTypesGetRequest req) throws IOException, SCIM2ApiException;
+
+    ResourceTypesGetResponse getResourceTypes(RequestConfigurator<ResourceTypesGetRequest.ResourceTypesGetRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // --------------------
+    // Users
+    // --------------------
+
+    UsersSearchResponse searchUsers(UsersSearchRequest req) throws IOException, SCIM2ApiException;
+
+    UsersSearchResponse searchUsers(RequestConfigurator<UsersSearchRequest.UsersSearchRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // ---
+
+    UsersReadResponse readUser(UsersReadRequest req) throws IOException, SCIM2ApiException;
+
+    UsersReadResponse readUser(RequestConfigurator<UsersReadRequest.UsersReadRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // ---
+
+    UsersCreateResponse createUser(UsersCreateRequest req) throws IOException, SCIM2ApiException;
+
+    UsersCreateResponse createUser(RequestConfigurator<UsersCreateRequest.UsersCreateRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // ---
+
+    UsersPatchResponse patchUser(UsersPatchRequest req) throws IOException, SCIM2ApiException;
+
+    UsersPatchResponse patchUser(RequestConfigurator<UsersPatchRequest.UsersPatchRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // ---
+
+    UsersUpdateResponse updateUser(UsersUpdateRequest req) throws IOException, SCIM2ApiException;
+
+    UsersUpdateResponse updateUser(RequestConfigurator<UsersUpdateRequest.UsersUpdateRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // ---
+
+    UsersDeleteResponse deleteUser(UsersDeleteRequest req) throws IOException, SCIM2ApiException;
+
+    UsersDeleteResponse deleteUser(RequestConfigurator<UsersDeleteRequest.UsersDeleteRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // --------------------
+    // Groups
+    // --------------------
+
+    GroupsSearchResponse searchGroups(GroupsSearchRequest req) throws IOException, SCIM2ApiException;
+
+    GroupsSearchResponse searchGroups(RequestConfigurator<GroupsSearchRequest.GroupsSearchRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // ---
+
+    GroupsReadResponse readGroup(GroupsReadRequest req) throws IOException, SCIM2ApiException;
+
+    GroupsReadResponse readGroup(RequestConfigurator<GroupsReadRequest.GroupsReadRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // ---
+
+    GroupsCreateResponse createGroup(GroupsCreateRequest req) throws IOException, SCIM2ApiException;
+
+    GroupsCreateResponse createGroup(RequestConfigurator<GroupsCreateRequest.GroupsCreateRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // ---
+
+    GroupsPatchResponse patchGroup(GroupsPatchRequest req) throws IOException, SCIM2ApiException;
+
+    GroupsPatchResponse patchGroup(RequestConfigurator<GroupsPatchRequest.GroupsPatchRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // ---
+
+    GroupsUpdateResponse updateGroup(GroupsUpdateRequest req) throws IOException, SCIM2ApiException;
+
+    GroupsUpdateResponse updateGroup(RequestConfigurator<GroupsUpdateRequest.GroupsUpdateRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+    // ---
+
+    GroupsDeleteResponse deleteGroup(GroupsDeleteRequest req) throws IOException, SCIM2ApiException;
+
+    GroupsDeleteResponse deleteGroup(RequestConfigurator<GroupsDeleteRequest.GroupsDeleteRequestBuilder> req) throws IOException, SCIM2ApiException;
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2Config.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2Config.java
@@ -1,0 +1,111 @@
+package com.slack.api.scim2;
+
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.scim2.metrics.MemoryMetricsDatastore;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration for {@link SCIM2Client}.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SCIM2Config {
+
+    /**
+     * If you don't have a special reason, we recommend going with the singleton executor to track all the traffic
+     * your app generated towards the Slack Platform in one place (= in one metrics datastore).
+     */
+    public static final String DEFAULT_SINGLETON_EXECUTOR_NAME = MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME;
+
+    /**
+     * The default configuration. It's not allowed to modify this runtime for any reasons.
+     */
+    public static final SCIM2Config DEFAULT_SINGLETON = new SCIM2Config() {
+
+        void throwException() {
+            throw new UnsupportedOperationException("This config is immutable");
+        }
+
+        @Override
+        public void setStatsEnabled(boolean statsEnabled) {
+            throwException();
+        }
+
+        @Override
+        public void setExecutorName(String executorName) {
+            throwException();
+        }
+
+        @Override
+        public void setMaxIdleMills(int maxIdleMills) {
+            throwException();
+        }
+
+        @Override
+        public void setDefaultThreadPoolSize(int defaultThreadPoolSize) {
+            throwException();
+        }
+
+        @Override
+        public void setMetricsDatastore(MetricsDatastore metricsDatastore) {
+            throwException();
+        }
+
+        @Override
+        public void setCustomThreadPoolSizes(Map<String, Integer> customThreadPoolSizes) {
+            throwException();
+        }
+
+        @Override
+        public void setExecutorServiceProvider(ExecutorServiceProvider executorServiceProvider) {
+            throwException();
+        }
+    };
+
+    @Builder.Default
+    private boolean statsEnabled = true;
+
+    /**
+     * If you need to have multiple executors in the same Slack app, name this accordingly.
+     */
+    @Builder.Default
+    private String executorName = DEFAULT_SINGLETON_EXECUTOR_NAME;
+
+    /**
+     * The max period to keep asynchronous API method calls idle.
+     */
+    @Builder.Default
+    private int maxIdleMills = 60 * 60 * 1000;
+
+    /**
+     * The default thread pool size used for asynchronous API method calls.
+     */
+    @Builder.Default
+    private int defaultThreadPoolSize = 5;
+
+    @Builder.Default
+    private ExecutorServiceProvider executorServiceProvider = DaemonThreadExecutorServiceProvider.getInstance();
+
+    /**
+     * Enterprise ID -> thread pool size
+     */
+    @Builder.Default
+    private Map<String, Integer> customThreadPoolSizes = new HashMap<>();
+
+    /**
+     * The metrics datastore to track the traffic associated to this executor name.
+     */
+    @Builder.Default
+    private MetricsDatastore metricsDatastore = new MemoryMetricsDatastore(1);
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2EndpointName.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/SCIM2EndpointName.java
@@ -1,0 +1,18 @@
+package com.slack.api.scim2;
+
+public enum SCIM2EndpointName {
+    getServiceProviderConfigs,
+    getResourceTypes,
+    searchUsers,
+    readUser,
+    createUser,
+    patchUser,
+    updateUser,
+    deleteUser,
+    searchGroups,
+    readGroup,
+    createGroup,
+    patchGroup,
+    updateGroup,
+    deleteGroup,
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/impl/AsyncExecutionSupplier.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/impl/AsyncExecutionSupplier.java
@@ -1,0 +1,16 @@
+package com.slack.api.scim2.impl;
+
+import com.slack.api.scim2.SCIM2ApiException;
+import com.slack.api.scim2.SCIM2ApiResponse;
+
+import java.io.IOException;
+
+/**
+ * A Supplier that holds an API Method execution.
+ */
+@FunctionalInterface
+public interface AsyncExecutionSupplier<T extends SCIM2ApiResponse> {
+
+    T execute() throws IOException, SCIM2ApiException;
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/impl/AsyncRateLimitQueue.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/impl/AsyncRateLimitQueue.java
@@ -1,0 +1,93 @@
+package com.slack.api.scim2.impl;
+
+import com.slack.api.rate_limits.WaitTime;
+import com.slack.api.rate_limits.queue.QueueMessage;
+import com.slack.api.rate_limits.queue.RateLimitQueue;
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.SCIM2Config;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
+@Slf4j
+public class AsyncRateLimitQueue extends RateLimitQueue<
+        AsyncExecutionSupplier<? extends SCIM2ApiResponse>,
+        AsyncRateLimitQueue.SCIMMessage> {
+
+    @Data
+    @AllArgsConstructor
+    public static class SCIMMessage extends QueueMessage<AsyncExecutionSupplier> {
+        private String id;
+        private long millisToRun;
+        private WaitTime waitTime;
+        private AsyncExecutionSupplier<?> supplier;
+    }
+
+    // Executor name -> Team ID -> Queue
+    private static final ConcurrentMap<String, ConcurrentMap<String, AsyncRateLimitQueue>> ALL_QUEUES = new ConcurrentHashMap<>();
+
+    private static ConcurrentMap<String, AsyncRateLimitQueue> getInstance(String executorName) {
+        ConcurrentMap<String, AsyncRateLimitQueue> teamIdToQueue = ALL_QUEUES.get(executorName);
+        if (teamIdToQueue == null) {
+            teamIdToQueue = new ConcurrentHashMap<>();
+            ALL_QUEUES.put(executorName, teamIdToQueue);
+        }
+        return teamIdToQueue;
+    }
+
+    private AsyncSCIM2RateLimiter rateLimiter; // intentionally mutable
+
+    public AsyncSCIM2RateLimiter getRateLimiter() {
+        return rateLimiter;
+    }
+
+    public void setRateLimiter(AsyncSCIM2RateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    private final ConcurrentMap<String, LinkedBlockingQueue<SCIMMessage>> methodNameToActiveQueue = new ConcurrentHashMap<>();
+
+    private AsyncRateLimitQueue(SCIM2Config config) {
+        this.rateLimiter = new AsyncSCIM2RateLimiter(config);
+    }
+
+    public static AsyncRateLimitQueue get(String executorName, String teamId) {
+        if (executorName == null || teamId == null) {
+            throw new IllegalArgumentException("`executorName` and `teamId` are required");
+        }
+        ConcurrentMap<String, AsyncRateLimitQueue> teamIdToQueue = getInstance(executorName);
+        return teamIdToQueue.get(teamId);
+    }
+
+    public static AsyncRateLimitQueue getOrCreate(SCIM2Config config, String teamId) {
+        if (teamId == null) {
+            throw new IllegalArgumentException("`teamId` is required");
+        }
+        ConcurrentMap<String, AsyncRateLimitQueue> teamIdToQueue = getInstance(config.getExecutorName());
+        AsyncRateLimitQueue queue = teamIdToQueue.get(teamId);
+        if (queue != null && queue.getRateLimiter().getMetricsDatastore() != config.getMetricsDatastore()) {
+            // As the metrics datastore has been changed, we should replace the executor
+            queue.setRateLimiter(new AsyncSCIM2RateLimiter(config));
+        }
+        if (queue == null) {
+            queue = new AsyncRateLimitQueue(config);
+            teamIdToQueue.put(teamId, queue);
+        }
+        return queue;
+    }
+
+    @Override
+    protected SCIMMessage buildNewMessage(
+            String messageId,
+            long epochMillisToRun,
+            WaitTime waitTime,
+            AsyncExecutionSupplier<? extends SCIM2ApiResponse> methodsSupplier
+    ) {
+        return new SCIMMessage(messageId, epochMillisToRun, waitTime, methodsSupplier);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/impl/AsyncSCIM2ClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/impl/AsyncSCIM2ClientImpl.java
@@ -1,0 +1,260 @@
+package com.slack.api.scim2.impl;
+
+import com.slack.api.RequestConfigurator;
+import com.slack.api.SlackConfig;
+import com.slack.api.methods.impl.MethodsClientImpl;
+import com.slack.api.scim2.AsyncSCIM2Client;
+import com.slack.api.scim2.SCIM2ApiRequest;
+import com.slack.api.scim2.request.*;
+import com.slack.api.scim2.response.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static com.slack.api.scim2.SCIM2EndpointName.*;
+
+@Slf4j
+public class AsyncSCIM2ClientImpl implements AsyncSCIM2Client {
+
+    private final String token;
+    private final SCIM2ClientImpl underlying;
+    private final AsyncRateLimitExecutor executor;
+
+    public AsyncSCIM2ClientImpl(
+            String token,
+            SCIM2ClientImpl scim,
+            MethodsClientImpl methods,
+            SlackConfig config
+    ) {
+        this.token = token;
+        this.underlying = scim;
+        this.executor = AsyncRateLimitExecutor.getOrCreate(methods, config);
+    }
+
+    private String token(SCIM2ApiRequest req) {
+        if (req.getToken() != null) {
+            return req.getToken();
+        } else {
+            return this.token;
+        }
+    }
+
+    private Map<String, String> toMap(SCIM2ApiRequest req) {
+        Map<String, String> params = new HashMap<>();
+        params.put("token", token(req));
+        return params;
+    }
+
+    // ----------------------------------------------------------------------------------
+    // public methods
+    // ----------------------------------------------------------------------------------
+
+    @Override
+    public String getEndpointUrlPrefix() {
+        return this.underlying.getEndpointUrlPrefix();
+    }
+
+    @Override
+    public void setEndpointUrlPrefix(String endpointUrlPrefix) {
+        this.underlying.setEndpointUrlPrefix(endpointUrlPrefix);
+    }
+
+    @Override
+    public CompletableFuture<ServiceProviderConfigsGetResponse> getServiceProviderConfigs(ServiceProviderConfigsGetRequest req) {
+        return executor.execute(
+                getServiceProviderConfigs,
+                toMap(req),
+                () -> this.underlying.getServiceProviderConfigs(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<ServiceProviderConfigsGetResponse> getServiceProviderConfigs(RequestConfigurator<ServiceProviderConfigsGetRequest.ServiceProviderConfigsGetRequestBuilder> req) {
+        return getServiceProviderConfigs(req.configure(ServiceProviderConfigsGetRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<ResourceTypesGetResponse> getResourceTypes(ResourceTypesGetRequest req) {
+        return executor.execute(
+                getResourceTypes,
+                toMap(req),
+                () -> this.underlying.getResourceTypes(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<ResourceTypesGetResponse> getResourceTypes(RequestConfigurator<ResourceTypesGetRequest.ResourceTypesGetRequestBuilder> req) {
+        return getResourceTypes(req.configure(ResourceTypesGetRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersSearchResponse> searchUsers(UsersSearchRequest req) {
+        return executor.execute(
+                searchUsers,
+                toMap(req),
+                () -> this.underlying.searchUsers(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersSearchResponse> searchUsers(RequestConfigurator<UsersSearchRequest.UsersSearchRequestBuilder> req) {
+        return searchUsers(req.configure(UsersSearchRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersReadResponse> readUser(UsersReadRequest req) {
+        return executor.execute(
+                readUser,
+                toMap(req),
+                () -> this.underlying.readUser(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersReadResponse> readUser(RequestConfigurator<UsersReadRequest.UsersReadRequestBuilder> req) {
+        return readUser(req.configure(UsersReadRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersCreateResponse> createUser(UsersCreateRequest req) {
+        return executor.execute(
+                createUser,
+                toMap(req),
+                () -> this.underlying.createUser(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersCreateResponse> createUser(RequestConfigurator<UsersCreateRequest.UsersCreateRequestBuilder> req) {
+        return createUser(req.configure(UsersCreateRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersPatchResponse> patchUser(UsersPatchRequest req) {
+        return executor.execute(
+                patchUser,
+                toMap(req),
+                () -> this.underlying.patchUser(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersPatchResponse> patchUser(RequestConfigurator<UsersPatchRequest.UsersPatchRequestBuilder> req) {
+        return patchUser(req.configure(UsersPatchRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersUpdateResponse> updateUser(UsersUpdateRequest req) {
+        return executor.execute(
+                updateUser,
+                toMap(req),
+                () -> this.underlying.updateUser(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersUpdateResponse> updateUser(RequestConfigurator<UsersUpdateRequest.UsersUpdateRequestBuilder> req) {
+        return updateUser(req.configure(UsersUpdateRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<UsersDeleteResponse> deleteUser(UsersDeleteRequest req) {
+        return executor.execute(
+                deleteUser,
+                toMap(req),
+                () -> this.underlying.deleteUser(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<UsersDeleteResponse> deleteUser(RequestConfigurator<UsersDeleteRequest.UsersDeleteRequestBuilder> req) {
+        return deleteUser(req.configure(UsersDeleteRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsSearchResponse> searchGroups(GroupsSearchRequest req) {
+        return executor.execute(
+                searchGroups,
+                toMap(req),
+                () -> this.underlying.searchGroups(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsSearchResponse> searchGroups(RequestConfigurator<GroupsSearchRequest.GroupsSearchRequestBuilder> req) {
+        return searchGroups(req.configure(GroupsSearchRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsReadResponse> readGroup(GroupsReadRequest req) {
+        return executor.execute(
+                readGroup,
+                toMap(req),
+                () -> this.underlying.readGroup(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsReadResponse> readGroup(RequestConfigurator<GroupsReadRequest.GroupsReadRequestBuilder> req) {
+        return readGroup(req.configure(GroupsReadRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsCreateResponse> createGroup(GroupsCreateRequest req) {
+        return executor.execute(
+                createGroup,
+                toMap(req),
+                () -> this.underlying.createGroup(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsCreateResponse> createGroup(RequestConfigurator<GroupsCreateRequest.GroupsCreateRequestBuilder> req) {
+        return createGroup(req.configure(GroupsCreateRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsPatchResponse> patchGroup(GroupsPatchRequest req) {
+        return executor.execute(
+                patchGroup,
+                toMap(req),
+                () -> this.underlying.patchGroup(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsPatchResponse> patchGroup(RequestConfigurator<GroupsPatchRequest.GroupsPatchRequestBuilder> req) {
+        return patchGroup(req.configure(GroupsPatchRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsUpdateResponse> updateGroup(GroupsUpdateRequest req) {
+        return executor.execute(
+                updateGroup,
+                toMap(req),
+                () -> this.underlying.updateGroup(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsUpdateResponse> updateGroup(RequestConfigurator<GroupsUpdateRequest.GroupsUpdateRequestBuilder> req) {
+        return updateGroup(req.configure(GroupsUpdateRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<GroupsDeleteResponse> deleteGroup(GroupsDeleteRequest req) {
+        return executor.execute(
+                deleteGroup,
+                toMap(req),
+                () -> this.underlying.deleteGroup(req)
+        );
+    }
+
+    @Override
+    public CompletableFuture<GroupsDeleteResponse> deleteGroup(RequestConfigurator<GroupsDeleteRequest.GroupsDeleteRequestBuilder> req) {
+        return deleteGroup(req.configure(GroupsDeleteRequest.builder()).build());
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/impl/AsyncSCIM2RateLimiter.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/impl/AsyncSCIM2RateLimiter.java
@@ -1,0 +1,149 @@
+package com.slack.api.scim2.impl;
+
+import com.slack.api.rate_limits.RateLimiter;
+import com.slack.api.rate_limits.WaitTime;
+import com.slack.api.rate_limits.WaitTimeCalculator;
+import com.slack.api.rate_limits.metrics.LastMinuteRequests;
+import com.slack.api.rate_limits.metrics.MetricsDatastore;
+import com.slack.api.rate_limits.metrics.RequestPace;
+import com.slack.api.rate_limits.metrics.RequestStats;
+import com.slack.api.scim2.SCIM2Config;
+import com.slack.api.scim2.SCIM2EndpointName;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.slack.api.scim2.SCIM2EndpointName.*;
+
+@Slf4j
+public class AsyncSCIM2RateLimiter implements RateLimiter {
+
+    private final MetricsDatastore metricsDatastore;
+    private final String executorName;
+    private final SCIMWaitTimeCalculator waitTimeCalculator;
+
+    public MetricsDatastore getMetricsDatastore() {
+        return metricsDatastore;
+    }
+
+    public AsyncSCIM2RateLimiter(SCIM2Config config) {
+        this.metricsDatastore = config.getMetricsDatastore();
+        this.executorName = config.getExecutorName();
+        this.waitTimeCalculator = new SCIMWaitTimeCalculator(config);
+    }
+
+    public static class SCIMWaitTimeCalculator extends WaitTimeCalculator {
+        private final SCIM2Config config;
+
+        public SCIMWaitTimeCalculator(SCIM2Config config) {
+            this.config = config;
+        }
+
+        @Override
+        public Integer getNumberOfNodes() {
+            return config.getMetricsDatastore().getNumberOfNodes();
+        }
+
+        @Override
+        public String getExecutorName() {
+            return config.getExecutorName();
+        }
+
+        @Override
+        public Optional<Long> getRateLimitedMethodRetryEpochMillis(
+                String executorName, String teamId, String key) {
+            return Optional.ofNullable(config.getMetricsDatastore().getRateLimitedMethodRetryEpochMillis(
+                    executorName, teamId, key
+            ));
+        }
+
+        @Override
+        public LastMinuteRequests getLastMinuteRequests(
+                String executorName, String teamId, String key) {
+            return config.getMetricsDatastore().getLastMinuteRequests(executorName, teamId, key);
+        }
+    }
+
+    public int getAllowedRequestsPerMinutes(SCIM2EndpointName endpoint) {
+        switch (endpoint) {
+            case getServiceProviderConfigs:
+            case searchUsers:
+            case searchGroups:
+                return 1000; // the maximum (the org-wide limits will be applied later)
+            case readUser:
+            case readGroup:
+                return 300;
+            case createUser:
+            case patchUser:
+            case updateUser:
+            case deleteUser:
+            case createGroup:
+            case patchGroup:
+            case updateGroup:
+            case deleteGroup:
+                return 180;
+            default:
+                break;
+        }
+        return 180; // the most conservative value
+    }
+
+    public int getRemainingAllowedRequestsPerMinutesForOrg(SCIM2EndpointName endpoint, RequestStats stats) {
+        Map<String, Integer> r = stats.getLastMinuteRequests();
+        switch (endpoint) {
+            case getServiceProviderConfigs:
+            case searchUsers:
+            case searchGroups:
+            case readUser:
+            case readGroup:
+                return 1000 - (Optional.ofNullable(r.get(getServiceProviderConfigs.name())).orElse(0)
+                        + Optional.ofNullable(r.get(searchUsers.name())).orElse(0)
+                        + Optional.ofNullable(r.get(searchGroups.name())).orElse(0)
+                        + Optional.ofNullable(r.get(readUser.name())).orElse(0)
+                        + Optional.ofNullable(r.get(readGroup.name())).orElse(0)
+                );
+            case createUser:
+            case patchUser:
+            case updateUser:
+            case deleteUser:
+            case createGroup:
+            case patchGroup:
+            case updateGroup:
+            case deleteGroup:
+            default:
+                return 600 - (Optional.ofNullable(r.get(createUser.name())).orElse(0)
+                        + Optional.ofNullable(r.get(patchUser.name())).orElse(0)
+                        + Optional.ofNullable(r.get(updateUser.name())).orElse(0)
+                        + Optional.ofNullable(r.get(deleteUser.name())).orElse(0)
+                        + Optional.ofNullable(r.get(createGroup.name())).orElse(0)
+                        + Optional.ofNullable(r.get(patchGroup.name())).orElse(0)
+                        + Optional.ofNullable(r.get(updateGroup.name())).orElse(0)
+                        + Optional.ofNullable(r.get(deleteGroup.name())).orElse(0)
+                );
+        }
+    }
+
+    @Override
+    public WaitTime acquireWaitTime(String teamId, String methodName) {
+        Optional<Long> rateLimitedEpochMillis = waitTimeCalculator
+                .getRateLimitedMethodRetryEpochMillis(executorName, teamId, methodName);
+        if (rateLimitedEpochMillis.isPresent()) {
+            long millisToWait = rateLimitedEpochMillis.get() - System.currentTimeMillis();
+            return new WaitTime(millisToWait, RequestPace.RateLimited);
+        }
+        SCIM2EndpointName endpoint = SCIM2EndpointName.valueOf(methodName);
+        int orgRemainingRequests = getRemainingAllowedRequestsPerMinutesForOrg(
+                endpoint, metricsDatastore.getStats(this.executorName, teamId));
+        int endpointAllowedRequests = getAllowedRequestsPerMinutes(endpoint);
+        int allowedRequests = endpointAllowedRequests > orgRemainingRequests
+                ? endpointAllowedRequests : orgRemainingRequests;
+        return waitTimeCalculator.calculateWaitTime(teamId, methodName, allowedRequests);
+    }
+
+    @Override
+    public WaitTime acquireWaitTimeForChatPostMessage(String teamId, String channel) {
+        return waitTimeCalculator.calculateWaitTimeForChatPostMessage(teamId, channel);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/impl/ThreadPools.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/impl/ThreadPools.java
@@ -1,0 +1,70 @@
+package com.slack.api.scim2.impl;
+
+import com.slack.api.scim2.SCIM2Config;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+
+public class ThreadPools {
+
+    // ExecutorServiceProvider ID -> Executor Name -> Executor
+    private static final ConcurrentMap<String, ConcurrentMap<String, ExecutorService>> ALL_DEFAULT = new ConcurrentHashMap<>();
+    // ExecutorServiceProvider ID -> Executor Name -> Enterprise ID -> Executor
+    private static final ConcurrentMap<String, ConcurrentMap<String, ConcurrentMap<String, ExecutorService>>> ENTERPRISE_CUSTOM =
+            new ConcurrentHashMap<>();
+
+    private ThreadPools() {
+    }
+
+    public static ExecutorService getDefault(SCIM2Config config) {
+        return getOrCreate(config, null);
+    }
+
+    public static ExecutorService getOrCreate(SCIM2Config config, String enterpriseId) {
+        String providerInstanceId = config.getExecutorServiceProvider().getInstanceId();
+        Integer orgCustomPoolSize = enterpriseId != null ? config.getCustomThreadPoolSizes().get(enterpriseId) : null;
+        if (orgCustomPoolSize != null) {
+            return ENTERPRISE_CUSTOM
+                    .computeIfAbsent(providerInstanceId, _id -> new ConcurrentHashMap<>())
+                    .computeIfAbsent(config.getExecutorName(), _name -> new ConcurrentHashMap<>())
+                    .computeIfAbsent(enterpriseId, _id -> buildNewExecutorService(config, enterpriseId, orgCustomPoolSize));
+        } else {
+            return ALL_DEFAULT
+                    .computeIfAbsent(providerInstanceId, _id -> new ConcurrentHashMap<>())
+                    .computeIfAbsent(config.getExecutorName(), _name -> buildNewExecutorService(config));
+        }
+    }
+
+    public static void shutdownAll(SCIM2Config config) {
+        String providerInstanceId = config.getExecutorServiceProvider().getInstanceId();
+        if (ENTERPRISE_CUSTOM.get(providerInstanceId) != null) {
+            for (ConcurrentMap<String, ExecutorService> each : ENTERPRISE_CUSTOM.get(providerInstanceId).values()) {
+                for (ExecutorService es : each.values()) {
+                    es.shutdownNow();
+                }
+                each.clear();
+            }
+            ENTERPRISE_CUSTOM.remove(providerInstanceId);
+        }
+        if (ALL_DEFAULT.get(providerInstanceId) != null) {
+            for (ExecutorService es : ALL_DEFAULT.get(providerInstanceId).values()) {
+                es.shutdownNow();
+            }
+            ALL_DEFAULT.remove(providerInstanceId);
+        }
+    }
+
+    private static ExecutorService buildNewExecutorService(SCIM2Config config) {
+        String threadGroupName = "slack-scim2-" + config.getExecutorName();
+        int poolSize = config.getDefaultThreadPoolSize();
+        return config.getExecutorServiceProvider().createThreadPoolExecutor(threadGroupName, poolSize);
+    }
+
+    private static ExecutorService buildNewExecutorService(
+            SCIM2Config config, String enterpriseId, Integer customPoolSize) {
+        String threadGroupName = "slack-scim2-" + config.getExecutorName() + "-" + enterpriseId;
+        return config.getExecutorServiceProvider().createThreadPoolExecutor(threadGroupName, customPoolSize);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/metrics/MemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/metrics/MemoryMetricsDatastore.java
@@ -1,0 +1,52 @@
+package com.slack.api.scim2.metrics;
+
+import com.slack.api.rate_limits.RateLimiter;
+import com.slack.api.rate_limits.metrics.impl.BaseMemoryMetricsDatastore;
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.impl.AsyncExecutionSupplier;
+import com.slack.api.scim2.impl.AsyncRateLimitQueue;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
+
+public class MemoryMetricsDatastore extends BaseMemoryMetricsDatastore<
+        AsyncExecutionSupplier<? extends SCIM2ApiResponse>, AsyncRateLimitQueue.SCIMMessage> {
+
+    public MemoryMetricsDatastore(int numberOfNodes) {
+        super(numberOfNodes);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            boolean statsEnabled
+    ) {
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), statsEnabled, RateLimiter.DEFAULT_BACKGROUND_JOB_INTERVAL_MILLIS);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            boolean statsEnabled,
+            long backgroundJobIntervalMilliseconds
+    ) {
+        super(numberOfNodes, DaemonThreadExecutorServiceProvider.getInstance(), statsEnabled, backgroundJobIntervalMilliseconds);
+    }
+
+    public MemoryMetricsDatastore(
+            int numberOfNodes,
+            ExecutorServiceProvider executorServiceProvider,
+            boolean statsEnabled,
+            long backgroundJobIntervalMilliseconds
+    ) {
+        super(numberOfNodes, executorServiceProvider, statsEnabled, backgroundJobIntervalMilliseconds);
+    }
+
+    @Override
+    protected String getMetricsType() {
+        return "SCIM";
+    }
+
+    @Override
+    public AsyncRateLimitQueue getRateLimitQueue(String executorName, String teamId) {
+        return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/metrics/RedisMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/metrics/RedisMetricsDatastore.java
@@ -1,0 +1,46 @@
+package com.slack.api.scim2.metrics;
+
+import com.slack.api.rate_limits.metrics.impl.BaseRedisMetricsDatastore;
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.impl.AsyncExecutionSupplier;
+import com.slack.api.scim2.impl.AsyncRateLimitQueue;
+import com.slack.api.util.thread.ExecutorServiceProvider;
+import redis.clients.jedis.JedisPool;
+
+public class RedisMetricsDatastore extends BaseRedisMetricsDatastore<
+        AsyncExecutionSupplier<? extends SCIM2ApiResponse>, AsyncRateLimitQueue.SCIMMessage> {
+
+    public RedisMetricsDatastore(String appName, JedisPool jedisPool) {
+        super(appName, jedisPool);
+    }
+
+    public RedisMetricsDatastore(
+            String appName,
+            JedisPool jedisPool,
+            boolean statsEnabled,
+            long backgroundJobIntervalMilliseconds
+    ) {
+        super(appName, jedisPool, statsEnabled, backgroundJobIntervalMilliseconds);
+    }
+
+    public RedisMetricsDatastore(
+            String appName,
+            JedisPool jedisPool,
+            ExecutorServiceProvider executorServiceProvider,
+            boolean statsEnabled,
+            long backgroundJobIntervalMilliseconds
+    ) {
+        super(appName, jedisPool, executorServiceProvider, statsEnabled, backgroundJobIntervalMilliseconds);
+    }
+
+    @Override
+    public AsyncRateLimitQueue getRateLimitQueue(String executorName, String teamId) {
+        return AsyncRateLimitQueue.get(executorName, teamId);
+    }
+
+    @Override
+    protected String getMetricsType() {
+        return "SCIM";
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/model/Group.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/model/Group.java
@@ -1,0 +1,29 @@
+package com.slack.api.scim2.model;
+
+import lombok.Data;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Data
+public class Group {
+
+    private List<String> schemas = Arrays.asList(Schemas.SCHEMA_CORE_GROUP);
+
+    private String id;
+    private String displayName;
+    private Meta meta;
+    private List<Member> members;
+
+    @Data
+    public static class Meta {
+        private String created;
+        private String location;
+    }
+
+    @Data
+    public static class Member {
+        private String value;
+        private String display;
+    }
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/model/PatchOperation.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/model/PatchOperation.java
@@ -1,0 +1,12 @@
+package com.slack.api.scim2.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum PatchOperation {
+    @SerializedName("add")
+    Add,
+    @SerializedName("replace")
+    Replace,
+    @SerializedName("remove")
+    Remove,
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/model/Schemas.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/model/Schemas.java
@@ -1,0 +1,16 @@
+package com.slack.api.scim2.model;
+
+public class Schemas {
+
+    private Schemas() {
+    }
+
+    public static final String SCHEMA_CORE_USER = "urn:ietf:params:scim:schemas:core:2.0:User";
+    public static final String SCHEMA_EXTENSION_ENTERPRISE_USER = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+    public static final String SCHEMA_EXTENSION_SLACK_GUEST_USER = "urn:ietf:params:scim:schemas:extension:slack:guest:2.0:User";
+
+    public static final String SCHEMA_CORE_GROUP = "urn:ietf:params:scim:schemas:core:2.0:Group";
+
+    public static final String SCHEMA_API_MESSAGES_ERROR = "urn:ietf:params:scim:api:messages:2.0:Error";
+    public static final String SCHEMA_API_MESSAGES_PATCH_OP = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/model/User.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/model/User.java
@@ -1,0 +1,174 @@
+package com.slack.api.scim2.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Data
+public class User {
+
+    private List<String> schemas = Arrays.asList(
+            Schemas.SCHEMA_CORE_USER,
+            Schemas.SCHEMA_EXTENSION_ENTERPRISE_USER,
+            Schemas.SCHEMA_EXTENSION_SLACK_GUEST_USER
+    );
+
+    private String id;
+    private String externalId;
+    private Meta meta;
+    private String userName;
+    private String nickName;
+    private Name name;
+    private String displayName;
+    private String profileUrl;
+    private List<Email> emails;
+    private List<Address> addresses;
+    private List<PhoneNumber> phoneNumbers;
+    private List<Photo> photos;
+    private List<Role> roles;
+    private String userType;
+    private String title;
+    private String preferredLanguage;
+    private String locale;
+    private String timezone;
+    private Boolean active;
+    // The password attribute is never returned
+    // but can be used to set the initial password for a user
+    // if the team is not using an identity manager.
+    private String password;
+
+    @SerializedName(Schemas.SCHEMA_EXTENSION_ENTERPRISE_USER)
+    private Extension extension;
+    @SerializedName(Schemas.SCHEMA_EXTENSION_SLACK_GUEST_USER)
+    private SlackGuest slackGuest;
+
+    private List<Group> groups;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Meta {
+        private String created;
+        private String location;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Name {
+        private String givenName;
+        private String familyName;
+        private String honorificPrefix;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Email {
+        private String value;
+        private String type;
+        private Boolean primary;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Address {
+        private String streetAddress;
+        private String locality;
+        private String region;
+        private String postalCode;
+        private String country;
+        private Boolean primary;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PhoneNumber {
+        private String value;
+        private String type;
+        private Boolean primary;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Photo {
+        private String value;
+        private String type;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Role {
+        private String value;
+        private String type;
+        private Boolean primary;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Extension {
+        private String employeeNumber;
+        private String costCenter;
+        private String organization;
+        private String division;
+        private String department;
+        private Manager manager;
+
+        @Data
+        public static class Manager {
+            private String managerId;
+        }
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Group {
+        private String value;
+        private String display;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SlackGuest {
+        public static class Types {
+            private Types() {
+            }
+
+            public static final String MULTI = "multi";
+        }
+
+        /**
+         * This value is mandatory.
+         * possible values: "multi"
+         */
+        private String type;
+        /**
+         * This value is optional.
+         * possible values: ISO 8601 date time string (e.g., "2020-11-30T23:59:59Z")
+         */
+        private String expiration;
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/package-info.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * SCIM API client.
+ */
+package com.slack.api.scim2;

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsCreateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsCreateRequest.java
@@ -1,0 +1,13 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import com.slack.api.scim2.model.Group;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GroupsCreateRequest implements SCIM2ApiRequest {
+    private String token;
+    private Group group;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsDeleteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsDeleteRequest.java
@@ -1,0 +1,12 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GroupsDeleteRequest implements SCIM2ApiRequest {
+    private String token;
+    private String id;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsPatchOperation.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsPatchOperation.java
@@ -1,0 +1,51 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.model.PatchOperation;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GroupsPatchOperation {
+    private PatchOperation op;
+    private String path;
+
+    private List<Member> memberValues;
+
+    @Data
+    @Builder
+    public static class Member {
+        private String value;
+    }
+
+    @Data
+    @Builder
+    public static class Serializable {
+        private PatchOperation op;
+        private String path;
+        private Object value;
+    }
+
+    public Serializable toSerializable() {
+        return Serializable.builder()
+                .op(this.getOp())
+                .path(this.getPath())
+                .value(this.extractValue())
+                .build();
+    }
+
+    private Object extractValue() {
+        if (this.getMemberValues() != null) {
+            return this.getMemberValues();
+        } else {
+            // "remove" operation does not require any value
+            return null;
+        }
+    }
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsPatchRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsPatchRequest.java
@@ -1,0 +1,22 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import com.slack.api.scim2.model.Schemas;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Data
+@Builder
+public class GroupsPatchRequest implements SCIM2ApiRequest {
+    private String token;
+    private String id;
+    @Builder.Default
+    private List<String> schemas = Arrays.asList(Schemas.SCHEMA_API_MESSAGES_PATCH_OP);
+    @Builder.Default
+    private List<GroupsPatchOperation> operations = new ArrayList<>();
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsReadRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsReadRequest.java
@@ -1,0 +1,12 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GroupsReadRequest implements SCIM2ApiRequest {
+    private String token;
+    private String id;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsSearchRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsSearchRequest.java
@@ -1,0 +1,16 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GroupsSearchRequest implements SCIM2ApiRequest {
+    private String token;
+    // https://api.slack.com/scim#filter
+    private String filter;
+    // https://api.slack.com/changelog/2019-06-have-scim-will-paginate
+    private Integer count;
+    private Integer startIndex;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/GroupsUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import com.slack.api.scim2.model.Group;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GroupsUpdateRequest implements SCIM2ApiRequest {
+    private String token;
+    private String id;
+    private Group group;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/ResourceTypesGetRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/ResourceTypesGetRequest.java
@@ -1,0 +1,11 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ResourceTypesGetRequest implements SCIM2ApiRequest {
+    private String token;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/ServiceProviderConfigsGetRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/ServiceProviderConfigsGetRequest.java
@@ -1,0 +1,11 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ServiceProviderConfigsGetRequest implements SCIM2ApiRequest {
+    private String token;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersCreateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersCreateRequest.java
@@ -1,0 +1,13 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import com.slack.api.scim2.model.User;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UsersCreateRequest implements SCIM2ApiRequest {
+    private String token;
+    private User user;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersDeleteRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersDeleteRequest.java
@@ -1,0 +1,12 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UsersDeleteRequest implements SCIM2ApiRequest {
+    private String token;
+    private String id;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersPatchOperation.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersPatchOperation.java
@@ -1,0 +1,93 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.model.PatchOperation;
+import com.slack.api.scim2.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UsersPatchOperation {
+    private PatchOperation op;
+    private String path;
+
+    private String stringValue;
+    // only when the "path" is about "emails"
+    private User.Email emailValue;
+    private List<User.Email> emailValues;
+    // only when the "path" is about "phoneNumbers"
+    private User.PhoneNumber phoneNumberValue;
+    private List<User.PhoneNumber> phoneNumberValues;
+    // only when the "path" is about "photos"
+    private User.Photo photoValue;
+    private List<User.Photo> photoValues;
+    // only when the "path" is about "addresses"
+    private User.Address addressValue;
+    private List<User.Address> addressValues;
+    // only when the "path" is about "roles"
+    private User.Role roleValue;
+    private List<User.Role> roleValues;
+    // only when the "path" is about "name"
+    private User.Name nameValue;
+    // only when the "path" is about "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+    private User.Extension extensionValue;
+    // only when the "path" is about "urn:ietf:params:scim:schemas:extension:slack:guest:2.0:User"
+    private User.SlackGuest slackGuestValue;
+
+    @Data
+    @Builder
+    public static class Serializable {
+        private PatchOperation op;
+        private String path;
+        private Object value;
+    }
+
+    public Serializable toSerializable() {
+        return Serializable.builder()
+                .op(this.getOp())
+                .path(this.getPath())
+                .value(this.extractValue())
+                .build();
+    }
+
+    private Object extractValue() {
+        if (this.getStringValue() != null) {
+            return this.getStringValue();
+        } else if (this.getEmailValue() != null) {
+            return this.getEmailValue();
+        } else if (this.getEmailValues() != null) {
+            return this.getEmailValues();
+        } else if (this.getPhoneNumberValue() != null) {
+            return this.getPhoneNumberValue();
+        } else if (this.getPhoneNumberValues() != null) {
+            return this.getPhoneNumberValues();
+        } else if (this.getPhotoValue() != null) {
+            return this.getPhotoValue();
+        } else if (this.getPhotoValues() != null) {
+            return this.getPhotoValues();
+        } else if (this.getAddressValue() != null) {
+            return this.getAddressValue();
+        } else if (this.getAddressValues() != null) {
+            return this.getAddressValues();
+        } else if (this.getRoleValue() != null) {
+            return this.getRoleValue();
+        } else if (this.getRoleValues() != null) {
+            return this.getRoleValues();
+        } else if (this.getNameValue() != null) {
+            return this.getNameValue();
+        } else if (this.getExtensionValue() != null) {
+            return this.getExtensionValue();
+        } else if (this.getSlackGuestValue() != null) {
+            return this.getSlackGuestValue();
+        } else {
+            // "remove" operation does not require any value
+            return null;
+        }
+    }
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersPatchRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersPatchRequest.java
@@ -1,0 +1,21 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import com.slack.api.scim2.model.Schemas;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Data
+@Builder
+public class UsersPatchRequest implements SCIM2ApiRequest {
+    private String token;
+    private String id;
+    @Builder.Default
+    private List<String> schemas = Arrays.asList(Schemas.SCHEMA_API_MESSAGES_PATCH_OP);
+    @Builder.Default
+    private List<UsersPatchOperation> operations = new ArrayList<>();
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersReadRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersReadRequest.java
@@ -1,0 +1,12 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UsersReadRequest implements SCIM2ApiRequest {
+    private String token;
+    private String id;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersSearchRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersSearchRequest.java
@@ -1,0 +1,16 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UsersSearchRequest implements SCIM2ApiRequest {
+    private String token;
+    // https://api.slack.com/scim#filter
+    private String filter;
+    // https://api.slack.com/changelog/2019-06-have-scim-will-paginate
+    private Integer count;
+    private Integer startIndex;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/request/UsersUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.slack.api.scim2.request;
+
+import com.slack.api.scim2.SCIM2ApiRequest;
+import com.slack.api.scim2.model.User;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UsersUpdateRequest implements SCIM2ApiRequest {
+    private String token;
+    private String id;
+    private User user;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsCreateResponse.java
@@ -1,0 +1,11 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.model.Group;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GroupsCreateResponse extends Group implements SCIM2ApiResponse {
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsDeleteResponse.java
@@ -1,0 +1,10 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GroupsDeleteResponse implements SCIM2ApiResponse {
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsPatchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsPatchResponse.java
@@ -1,0 +1,11 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.model.Group;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GroupsPatchResponse extends Group implements SCIM2ApiResponse {
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsReadResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsReadResponse.java
@@ -1,0 +1,11 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.model.Group;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GroupsReadResponse extends Group implements SCIM2ApiResponse {
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsSearchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsSearchResponse.java
@@ -1,0 +1,20 @@
+package com.slack.api.scim2.response;
+
+import com.google.gson.annotations.SerializedName;
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.model.Group;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GroupsSearchResponse implements SCIM2ApiResponse {
+    private Integer totalResults;
+    private Integer itemsPerPage;
+    private Integer startIndex;
+    private List<String> schemas;
+    @SerializedName("Resources")
+    private List<Group> resources;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/GroupsUpdateResponse.java
@@ -1,0 +1,11 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.model.Group;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GroupsUpdateResponse extends Group implements SCIM2ApiResponse {
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/ResourceTypesGetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/ResourceTypesGetResponse.java
@@ -1,0 +1,40 @@
+package com.slack.api.scim2.response;
+
+import com.google.gson.annotations.SerializedName;
+import com.slack.api.scim2.SCIM2ApiResponse;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class ResourceTypesGetResponse implements SCIM2ApiResponse {
+    private List<String> schemas;
+    @SerializedName("Resources")
+    private List<Resource> resources;
+
+    @Data
+    public static class Resource {
+        private List<String> schemas;
+        private String id;
+        private String name;
+        private String endpoint;
+        private String description;
+        private String schema;
+        private Meta meta;
+        private List<SchemaExtension> schemaExtensions;
+    }
+
+    @Data
+    public static class Meta {
+        private String location;
+        private String resourceType;
+    }
+
+    @Data
+    public static class SchemaExtension {
+        private String schema;
+        private boolean required;
+    }
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/ServiceProviderConfigsGetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/ServiceProviderConfigsGetResponse.java
@@ -1,0 +1,69 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class ServiceProviderConfigsGetResponse implements SCIM2ApiResponse {
+
+    private List<AuthenticationScheme> authenticationSchemes;
+    private Patch patch;
+    private Bulk bulk;
+    private Filter filter;
+    private ChangePassword changePassword;
+    private Sort sort;
+    private Etag etag;
+    private XmlDataFormat xmlDataFormat;
+
+    @Data
+    public static class AuthenticationScheme {
+        private String type;
+        private String name;
+        private String description;
+        private String specUrl;
+        private Boolean primary;
+    }
+
+    @Data
+    public static class Patch {
+        private Boolean supported;
+    }
+
+    @Data
+    public static class Bulk {
+        private Boolean supported;
+        private Integer maxOperations;
+        private Integer maxPayloadSize;
+    }
+
+    @Data
+    public static class Filter {
+        private Boolean supported;
+        private Integer maxResults;
+    }
+
+    @Data
+    public static class ChangePassword {
+        private Boolean supported;
+    }
+
+    @Data
+    public static class Sort {
+        private Boolean supported;
+    }
+
+    @Data
+    public static class Etag {
+        private Boolean supported;
+    }
+
+    @Data
+    public static class XmlDataFormat {
+        private Boolean supported;
+    }
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersCreateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersCreateResponse.java
@@ -1,0 +1,11 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.model.User;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class UsersCreateResponse extends User implements SCIM2ApiResponse {
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersDeleteResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersDeleteResponse.java
@@ -1,0 +1,10 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class UsersDeleteResponse implements SCIM2ApiResponse {
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersPatchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersPatchResponse.java
@@ -1,0 +1,11 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.model.User;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class UsersPatchResponse extends User implements SCIM2ApiResponse {
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersReadResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersReadResponse.java
@@ -1,0 +1,11 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.model.User;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class UsersReadResponse extends User implements SCIM2ApiResponse {
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersSearchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersSearchResponse.java
@@ -1,0 +1,20 @@
+package com.slack.api.scim2.response;
+
+import com.google.gson.annotations.SerializedName;
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.model.User;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class UsersSearchResponse implements SCIM2ApiResponse {
+    private Integer totalResults;
+    private Integer itemsPerPage;
+    private Integer startIndex;
+    private List<String> schemas;
+    @SerializedName("Resources")
+    private List<User> resources;
+}

--- a/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersUpdateResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/response/UsersUpdateResponse.java
@@ -1,0 +1,11 @@
+package com.slack.api.scim2.response;
+
+import com.slack.api.scim2.SCIM2ApiResponse;
+import com.slack.api.scim2.model.User;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class UsersUpdateResponse extends User implements SCIM2ApiResponse {
+}

--- a/slack-api-client/src/test/java/test_locally/api/scim2/ApiTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim2/ApiTest.java
@@ -1,0 +1,272 @@
+package test_locally.api.scim2;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.scim2.SCIM2Client;
+import com.slack.api.scim2.model.Group;
+import com.slack.api.scim2.model.PatchOperation;
+import com.slack.api.scim2.model.User;
+import com.slack.api.scim2.request.GroupsPatchOperation;
+import com.slack.api.scim2.request.UsersPatchOperation;
+import com.slack.api.scim2.response.*;
+import com.slack.api.util.http.listener.HttpResponseListener;
+import com.slack.api.util.json.GsonFactory;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import com.slack.api.util.thread.ExecutorServiceProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import util.FileReader;
+import util.PortProvider;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ApiTest {
+
+    public static final String ValidToken = "xoxb-this-is-valid-scim";
+
+    private static final FileReader reader = new FileReader("../json-logs/samples/scim/v2/");
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiTest.class);
+
+    @Slf4j
+    @WebServlet
+    public static class SCIMMockApi extends HttpServlet {
+        @Override
+        protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            handle(req, resp);
+        }
+
+        private void handle(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            try (InputStream is = req.getInputStream();
+                 InputStreamReader isr = new InputStreamReader(is);
+                 BufferedReader br = new BufferedReader(isr)) {
+                String requestBody = br.lines().collect(Collectors.joining());
+                log.info("request body: {}", requestBody);
+            }
+            String endpoint = req.getRequestURI().replaceFirst("^/api/", "");
+            if (endpoint.equals("auth.test")) {
+                String body = "{\n" +
+                        "  \"ok\": true,\n" +
+                        "  \"url\": \"https://java-slack-sdk-test.slack.com/\",\n" +
+                        "  \"team\": \"java-slack-sdk-test\",\n" +
+                        "  \"user\": \"test_user\",\n" +
+                        "  \"team_id\": \"E12345678\",\n" +
+                        "  \"enterprise_id\": \"E12345678\",\n" +
+                        "  \"is_enterprise_install\": true,\n" +
+                        "  \"user_id\": \"U1234567\"\n" +
+                        "}";
+                resp.setStatus(200);
+                resp.getWriter().write(body);
+                resp.setContentType("application/json");
+                return;
+            }
+
+            if (!req.getMethod().equals("GET") && !endpoint.endsWith("/00000000000")) {
+                endpoint += "/00000000000";
+            }
+            String body = reader.readWholeAsString(endpoint + ".json");
+            body = body.replaceFirst("\"ok\": false,", "\"ok\": true,");
+            if (body == null || body.trim().isEmpty()) {
+                resp.setStatus(400);
+                return;
+            }
+            resp.setStatus(200);
+            resp.getWriter().write(body);
+            resp.setContentType("application/json");
+        }
+    }
+
+    int port = PortProvider.getPort(ApiTest.class.getName());
+    Server server = new Server(port);
+
+    {
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(SCIMMockApi.class, "/*");
+    }
+
+    SlackConfig config = new SlackConfig();
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+        config = new SlackConfig();
+        config.setPrettyResponseLoggingEnabled(true);
+        config.setMethodsEndpointUrlPrefix("http://127.0.0.1:" + port + "/api/");
+        config.setScim2EndpointUrlPrefix("http://127.0.0.1:" + port + "/api/");
+        config.getHttpClientResponseHandlers().add(new HttpResponseListener() {
+            @Override
+            public void accept(State state) {
+                logger.debug("--- (SCIM Stats) ---\n" + GsonFactory.createSnakeCase(config).toJson(
+                        config.getSCIM2Config().getMetricsDatastore().getAllStats()));
+            }
+        });
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void searchUsers() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        UsersSearchResponse response = scim.searchUsers(r -> r.filter("some filter").count(123).startIndex(1));
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void searchGroups() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        GroupsSearchResponse response = scim.searchGroups(r -> r.filter("some filter").count(123).startIndex(1));
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void getServiceProviderConfigs() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        ServiceProviderConfigsGetResponse response = scim.getServiceProviderConfigs(r -> r);
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void readUser() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        UsersReadResponse response = scim.readUser(r -> r.id("00000000000"));
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("W00000000"));
+    }
+
+    @Test
+    public void createUser() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        User user = new User();
+        user.setUserName("Kazuhiro Sera");
+        UsersCreateResponse response = scim.createUser(r -> r.user(user));
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("W00000000"));
+    }
+
+    @Test
+    public void patchUser() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        UsersPatchResponse response = scim.patchUser(r -> r.id("00000000000").operations(Arrays.asList(
+                UsersPatchOperation.builder().op(PatchOperation.Add).path("userName").stringValue("foo").build()
+        )));
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void updateUser() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        User user = new User();
+        user.setUserName("Kazuhiro Sera");
+        UsersUpdateResponse response = scim.updateUser(r -> r.id("00000000000").user(user));
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void deleteUser() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        UsersDeleteResponse response = scim.deleteUser(r -> r.id("00000000000"));
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void readGroup() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        GroupsReadResponse response = scim.readGroup(r -> r.id("00000000000"));
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("S00000000"));
+    }
+
+    @Test
+    public void createGroup() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        Group group = new Group();
+        group.setDisplayName("Kazuhiro Sera");
+        GroupsCreateResponse response = scim.createGroup(r -> r.group(group));
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("S00000000"));
+    }
+
+    @Test
+    public void patchGroup() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        GroupsPatchResponse response = scim.patchGroup(r -> r.id("00000000000").operations(Arrays.asList(
+                GroupsPatchOperation.builder().op(PatchOperation.Remove).path("members").build()
+        )));
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void updateGroup() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        Group group = new Group();
+        group.setDisplayName("Kazuhiro Sera");
+        GroupsUpdateResponse response = scim.updateGroup(r -> r.id("00000000000").group(group));
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void deleteGroup() throws Exception {
+        SCIM2Client scim = Slack.getInstance(config).scim2(ValidToken);
+        GroupsDeleteResponse response = scim.deleteGroup(r -> r.id("00000000000"));
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void customizeExecutorService() throws Exception {
+        final AtomicBoolean executorCreationCalled = new AtomicBoolean(false);
+        final AtomicBoolean schedulerCreationCalled = new AtomicBoolean(false);
+        config.setExecutorServiceProvider(new ExecutorServiceProvider() {
+            @Override
+            public ExecutorService createThreadPoolExecutor(String threadGroupName, int poolSize) {
+                executorCreationCalled.set(true);
+                return DaemonThreadExecutorServiceProvider.getInstance()
+                        .createThreadPoolExecutor(threadGroupName, poolSize);
+            }
+
+            @Override
+            public ScheduledExecutorService createThreadScheduledExecutor(String threadGroupName) {
+                schedulerCreationCalled.set(true);
+                return DaemonThreadExecutorServiceProvider.getInstance()
+                        .createThreadScheduledExecutor(threadGroupName);
+            }
+        });
+        {
+            Slack.getInstance(config).scim2(ValidToken).searchUsers(r -> r.count(1));
+            // the sync client does not use ExecutorService under the hood
+            assertThat(executorCreationCalled.get(), is(false));
+            assertThat(schedulerCreationCalled.get(), is(true));
+        }
+        {
+            Slack.getInstance(config).scim2Async(ValidToken).searchUsers(r -> r.count(1)).get();
+            assertThat(executorCreationCalled.get(), is(true));
+        }
+
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/scim2/AsyncApiTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim2/AsyncApiTest.java
@@ -1,0 +1,236 @@
+package test_locally.api.scim2;
+
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.scim2.AsyncSCIM2Client;
+import com.slack.api.scim2.model.Group;
+import com.slack.api.scim2.model.PatchOperation;
+import com.slack.api.scim2.model.User;
+import com.slack.api.scim2.request.GroupsPatchOperation;
+import com.slack.api.scim2.request.UsersPatchOperation;
+import com.slack.api.scim2.response.*;
+import com.slack.api.util.http.listener.HttpResponseListener;
+import com.slack.api.util.json.GsonFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import util.FileReader;
+import util.PortProvider;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AsyncApiTest {
+
+    public static final String ValidToken = "xoxb-this-is-valid-scim";
+
+    private static final FileReader reader = new FileReader("../json-logs/samples/scim/v2/");
+
+    private static final Logger logger = LoggerFactory.getLogger(AsyncApiTest.class);
+
+    @Slf4j
+    @WebServlet
+    public static class SCIMMockApi extends HttpServlet {
+        @Override
+        protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            handle(req, resp);
+        }
+
+        private void handle(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+            try (InputStream is = req.getInputStream();
+                 InputStreamReader isr = new InputStreamReader(is);
+                 BufferedReader br = new BufferedReader(isr)) {
+                String requestBody = br.lines().collect(Collectors.joining());
+                log.info("request body: {}", requestBody);
+            }
+            String endpoint = req.getRequestURI().replaceFirst("^/api/", "");
+            if (endpoint.equals("auth.test")) {
+                String body = "{\n" +
+                        "  \"ok\": true,\n" +
+                        "  \"url\": \"https://java-slack-sdk-test.slack.com/\",\n" +
+                        "  \"team\": \"java-slack-sdk-test\",\n" +
+                        "  \"user\": \"test_user\",\n" +
+                        "  \"team_id\": \"E12345678\",\n" +
+                        "  \"enterprise_id\": \"E12345678\",\n" +
+                        "  \"is_enterprise_install\": true,\n" +
+                        "  \"user_id\": \"U1234567\"\n" +
+                        "}";
+                resp.setStatus(200);
+                resp.getWriter().write(body);
+                resp.setContentType("application/json");
+                return;
+            }
+
+            if (!req.getMethod().equals("GET") && !endpoint.endsWith("/00000000000")) {
+                endpoint += "/00000000000";
+            }
+            String body = reader.readWholeAsString(endpoint + ".json");
+            body = body.replaceFirst("\"ok\": false,", "\"ok\": true,");
+            if (body == null || body.trim().isEmpty()) {
+                resp.setStatus(400);
+                return;
+            }
+            resp.setStatus(200);
+            resp.getWriter().write(body);
+            resp.setContentType("application/json");
+        }
+    }
+
+    int port = PortProvider.getPort(AsyncApiTest.class.getName());
+    Server server = new Server(port);
+
+    {
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(SCIMMockApi.class, "/*");
+    }
+
+    SlackConfig config = new SlackConfig();
+
+    @Before
+    public void setup() throws Exception {
+        server.start();
+        config = new SlackConfig();
+        config.setMethodsEndpointUrlPrefix("http://127.0.0.1:" + port + "/api/");
+        config.setScim2EndpointUrlPrefix("http://127.0.0.1:" + port + "/api/");
+        config.getHttpClientResponseHandlers().add(new HttpResponseListener() {
+            @Override
+            public void accept(State state) {
+                logger.debug("--- (SCIM Stats) ---\n" + GsonFactory.createSnakeCase(config).toJson(
+                        config.getSCIM2Config().getMetricsDatastore().getAllStats()));
+            }
+        });
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void searchUsers() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        UsersSearchResponse response = scim.searchUsers(r -> r
+                .filter("some filter").count(123).startIndex(1)).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void searchGroups() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        GroupsSearchResponse response = scim.searchGroups(r -> r
+                .filter("some filter").count(123).startIndex(1)).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void getServiceProviderConfigs() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        ServiceProviderConfigsGetResponse response = scim.getServiceProviderConfigs(r -> r).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void readUser() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        UsersReadResponse response = scim.readUser(r -> r.id("00000000000")).get();
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("W00000000"));
+    }
+
+    @Test
+    public void createUser() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        User user = new User();
+        user.setUserName("Kazuhiro Sera");
+        UsersCreateResponse response = scim.createUser(r -> r.user(user)).get();
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("W00000000"));
+    }
+
+    @Test
+    public void patchUser() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        UsersPatchResponse response = scim.patchUser(r -> r.id("00000000000").operations(Arrays.asList(
+                UsersPatchOperation.builder().op(PatchOperation.Add).path("userName").stringValue("foo").build()
+        ))).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void updateUser() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        User user = new User();
+        user.setUserName("Kazuhiro Sera");
+        UsersUpdateResponse response = scim.updateUser(r -> r.id("00000000000").user(user)).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void deleteUser() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        UsersDeleteResponse response = scim.deleteUser(r -> r.id("00000000000")).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void readGroup() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        GroupsReadResponse response = scim.readGroup(r -> r.id("00000000000")).get();
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("S00000000"));
+    }
+
+    @Test
+    public void createGroup() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        Group group = new Group();
+        group.setDisplayName("Kazuhiro Sera");
+        GroupsCreateResponse response = scim.createGroup(r -> r.group(group)).get();
+        assertThat(response, is(notNullValue()));
+        assertThat(response.getId(), is("S00000000"));
+    }
+
+    @Test
+    public void patchGroup() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        GroupsPatchResponse response = scim.patchGroup(r -> r.id("00000000000").operations(Arrays.asList(
+                GroupsPatchOperation.builder().op(PatchOperation.Remove).path("members").build()
+        ))).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void updateGroup() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        Group group = new Group();
+        group.setDisplayName("Kazuhiro Sera");
+        GroupsUpdateResponse response = scim.updateGroup(r -> r.id("00000000000").group(group)).get();
+        assertThat(response, is(notNullValue()));
+    }
+
+    @Test
+    public void deleteGroup() throws Exception {
+        AsyncSCIM2Client scim = Slack.getInstance(config).scim2Async(ValidToken);
+        GroupsDeleteResponse response = scim.deleteGroup(r -> r.id("00000000000")).get();
+        assertThat(response, is(notNullValue()));
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/scim2/AsyncRateLimitExecutorTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim2/AsyncRateLimitExecutorTest.java
@@ -1,0 +1,67 @@
+package test_locally.api.scim2;
+
+import com.slack.api.SlackConfig;
+import com.slack.api.methods.impl.MethodsClientImpl;
+import com.slack.api.scim2.*;
+import com.slack.api.scim2.impl.AsyncRateLimitExecutor;
+import com.slack.api.scim2.response.UsersReadResponse;
+import com.slack.api.util.http.SlackHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AsyncRateLimitExecutorTest {
+
+    private AsyncRateLimitExecutor executor;
+
+    @Before
+    public void setup() {
+        SlackConfig config = new SlackConfig();
+        SlackHttpClient httpClient = new SlackHttpClient();
+        MethodsClientImpl clientForTeamIdCache = new MethodsClientImpl(httpClient);
+        this.executor = AsyncRateLimitExecutor.getOrCreate(clientForTeamIdCache, config);
+    }
+
+    @Test
+    public void get_with_invalid_key() {
+        String executorName = "invalid-" + System.currentTimeMillis();
+        AsyncRateLimitExecutor executor = AsyncRateLimitExecutor.get(executorName);
+        assertThat(executor, is(nullValue()));
+    }
+
+    @Test
+    public void getOrCreate() {
+        assertThat(executor, is(notNullValue()));
+    }
+
+    @Test
+    public void runWithoutQueue() {
+        executor.runWithoutQueue("T111", SCIM2EndpointName.readUser, () -> new UsersReadResponse());
+    }
+
+    @Test(expected = SCIM2ApiCompletionException.class)
+    public void runWithoutQueue_RuntimeException() {
+        executor.runWithoutQueue("T111", SCIM2EndpointName.readUser, () -> {
+            throw new RuntimeException("foo");
+        });
+    }
+
+    @Test(expected = SCIM2ApiCompletionException.class)
+    public void runWithoutQueue_IOException() {
+        executor.runWithoutQueue("T111", SCIM2EndpointName.readUser, () -> {
+            throw new IOException("foo");
+        });
+    }
+
+    @Test(expected = SCIM2ApiCompletionException.class)
+    public void runWithoutQueue_AuditApiException() {
+        executor.runWithoutQueue("T111", SCIM2EndpointName.readUser, () -> {
+            throw new SCIM2ApiException(null, "foo");
+        });
+    }
+
+}

--- a/slack-api-client/src/test/java/test_locally/api/scim2/AsyncThreadPoolsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim2/AsyncThreadPoolsTest.java
@@ -1,0 +1,34 @@
+package test_locally.api.scim2;
+
+import com.slack.api.scim2.SCIM2Config;
+import com.slack.api.scim2.impl.ThreadPools;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class AsyncThreadPoolsTest {
+
+    @Test
+    public void getDefault() {
+        ExecutorService service = ThreadPools.getDefault(SCIM2Config.DEFAULT_SINGLETON);
+        assertThat(service, is(notNullValue()));
+    }
+
+    @Test
+    public void getOrCreate() {
+        SCIM2Config config = new SCIM2Config();
+        config.setExecutorName("getOrCreate" + System.currentTimeMillis());
+        Map<String, Integer> poolSizes = new HashMap<>();
+        poolSizes.put("E111", 1);
+        config.setCustomThreadPoolSizes(poolSizes);
+        ExecutorService service = ThreadPools.getOrCreate(config, "E111");
+        assertThat(service, is(notNullValue()));
+    }
+
+}

--- a/slack-api-client/src/test/java/test_locally/api/scim2/EqualityTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim2/EqualityTest.java
@@ -1,0 +1,46 @@
+package test_locally.api.scim2;
+
+import com.slack.api.scim2.SCIM2ApiErrorResponse;
+import com.slack.api.scim2.SCIM2ApiException;
+import com.slack.api.scim2.response.*;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EqualityTest {
+
+    @Test
+    public void test() {
+        Request request = new Request.Builder()
+                .url("https://www.example.com/")
+                .build();
+        Response response = new Response.Builder()
+                .request(request)
+                .code(200)
+                .protocol(Protocol.HTTP_1_1)
+                .message("")
+                .build();
+
+        assertEquals(new SCIM2ApiErrorResponse(), new SCIM2ApiErrorResponse());
+        assertEquals(new SCIM2ApiException(response, ""), new SCIM2ApiException(response, ""));
+
+        assertEquals(new GroupsCreateResponse(), new GroupsCreateResponse());
+        assertEquals(new GroupsDeleteResponse(), new GroupsDeleteResponse());
+        assertEquals(new GroupsPatchResponse(), new GroupsPatchResponse());
+        assertEquals(new GroupsReadResponse(), new GroupsReadResponse());
+        assertEquals(new GroupsSearchResponse(), new GroupsSearchResponse());
+        assertEquals(new GroupsUpdateResponse(), new GroupsUpdateResponse());
+
+        assertEquals(new ServiceProviderConfigsGetResponse(), new ServiceProviderConfigsGetResponse());
+
+        assertEquals(new UsersCreateResponse(), new UsersCreateResponse());
+        assertEquals(new UsersDeleteResponse(), new UsersDeleteResponse());
+        assertEquals(new UsersPatchResponse(), new UsersPatchResponse());
+        assertEquals(new UsersReadResponse(), new UsersReadResponse());
+        assertEquals(new UsersSearchResponse(), new UsersSearchResponse());
+        assertEquals(new UsersUpdateResponse(), new UsersUpdateResponse());
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/scim2/ExceptionsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim2/ExceptionsTest.java
@@ -1,0 +1,18 @@
+package test_locally.api.scim2;
+
+import com.slack.api.scim2.SCIM2ApiException;
+import okhttp3.Response;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertNotNull;
+
+public class ExceptionsTest {
+
+    @Test
+    public void test() {
+        Response response = Mockito.mock(Response.class);
+        SCIM2ApiException exception = new SCIM2ApiException(response, "");
+        assertNotNull(exception);
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/scim2/ModelsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/scim2/ModelsTest.java
@@ -1,0 +1,40 @@
+package test_locally.api.scim2;
+
+import com.slack.api.SlackConfig;
+import com.slack.api.scim2.model.User;
+import com.slack.api.util.json.GsonFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ModelsTest {
+
+    @Test
+    public void extensions() {
+        assertEquals(User.SlackGuest.Types.MULTI, "multi");
+
+        User user = new User();
+        user.setId("W1234567890");
+        User.Extension enterprise = new User.Extension();
+        enterprise.setDivision("Engineering");
+        user.setExtension(User.Extension.builder()
+                .employeeNumber("123-456")
+                .organization("PDE")
+                .division("Product")
+                .department("Product")
+                .build());
+        user.setSlackGuest(User.SlackGuest.builder()
+                .type("multi")
+                .expiration("2020-11-30T23:59:59Z")
+                .build());
+
+        assertNotNull(user);
+        assertNotNull(user.getExtension().getDivision());
+        assertNotNull(user.getSlackGuest().getType());
+
+        String json = GsonFactory.createCamelCase(SlackConfig.DEFAULT).toJson(user);
+        String expectedJson = "{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:User\",\"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\",\"urn:ietf:params:scim:schemas:extension:slack:guest:2.0:User\"],\"id\":\"W1234567890\",\"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User\":{\"employeeNumber\":\"123-456\",\"organization\":\"PDE\",\"division\":\"Product\",\"department\":\"Product\"},\"urn:ietf:params:scim:schemas:extension:slack:guest:2.0:User\":{\"type\":\"multi\",\"expiration\":\"2020-11-30T23:59:59Z\"}}";
+        assertEquals(expectedJson, json);
+    }
+}

--- a/slack-api-client/src/test/java/test_with_remote_apis/scim2/ApiTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/scim2/ApiTest.java
@@ -1,0 +1,358 @@
+package test_with_remote_apis.scim2;
+
+import com.slack.api.Slack;
+import com.slack.api.scim2.SCIM2ApiException;
+import com.slack.api.scim2.model.Group;
+import com.slack.api.scim2.model.PatchOperation;
+import com.slack.api.scim2.model.User;
+import com.slack.api.scim2.request.GroupsPatchOperation;
+import com.slack.api.scim2.request.UsersPatchOperation;
+import com.slack.api.scim2.response.*;
+import config.Constants;
+import config.SlackTestConfig;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+// required scope - admin
+public class ApiTest {
+
+    static SlackTestConfig testConfig = SlackTestConfig.getInstance();
+    static Slack slack = Slack.getInstance(testConfig.getConfig());
+
+    @AfterClass
+    public static void tearDown() throws InterruptedException {
+        SlackTestConfig.awaitCompletion(testConfig);
+    }
+
+    String orgAdminToken = System.getenv(Constants.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN);
+
+    private UsersCreateResponse createNewFullUser() throws IOException, SCIM2ApiException {
+        return createNewUser(true);
+    }
+
+    private UsersCreateResponse createNewGuestUser() throws IOException, SCIM2ApiException {
+        return createNewUser(false);
+    }
+
+    private UsersCreateResponse createNewUser(boolean isFullMember) throws IOException, SCIM2ApiException {
+        String userName = "user" + System.currentTimeMillis();
+        User newUser = new User();
+        newUser.setName(new User.Name());
+        newUser.getName().setGivenName("Kazuhiro");
+        newUser.getName().setFamilyName("Sera");
+        newUser.setUserName(userName);
+        User.Email email = new User.Email();
+        email.setValue("seratch+" + System.currentTimeMillis() + "@gmail.com");
+        newUser.setEmails(Arrays.asList(email));
+        if (!isFullMember) {
+            // guest
+            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+            String expiration = df.format(Date.from(ZonedDateTime.now().plusDays(14).toInstant()));
+            newUser.setSlackGuest(User.SlackGuest.builder()
+                    .type(User.SlackGuest.Types.MULTI)
+                    .expiration(expiration)
+                    .build());
+        }
+        return slack.scim2(orgAdminToken).createUser(req -> req.user(newUser));
+    }
+
+    @Test
+    public void getServiceProviderConfigs() throws IOException, SCIM2ApiException {
+        if (orgAdminToken != null) {
+            ServiceProviderConfigsGetResponse response = slack.scim2(orgAdminToken).getServiceProviderConfigs(req -> req);
+            assertThat(response.getAuthenticationSchemes(), is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getServiceProviderConfigs_dummy() throws IOException, SCIM2ApiException {
+        ServiceProviderConfigsGetResponse response = slack.scim2("dummy").getServiceProviderConfigs(req -> req);
+        assertThat(response.getAuthenticationSchemes(), is(notNullValue()));
+    }
+
+    @Test
+    public void getResourceTypes() throws IOException, SCIM2ApiException {
+        if (orgAdminToken != null) {
+            ResourceTypesGetResponse response = slack.scim2(orgAdminToken).getResourceTypes(req -> req);
+        }
+    }
+
+    @Test
+    public void searchAndReadUser() throws IOException, SCIM2ApiException {
+        if (orgAdminToken != null) {
+            {
+                UsersSearchResponse users = slack.scim2(orgAdminToken).searchUsers(req -> req.count(1000));
+                final String userId = users.getResources().get(0).getId();
+                UsersReadResponse read = slack.scim2(orgAdminToken).readUser(req -> req.id(userId));
+                assertThat(read.getId(), is(userId));
+            }
+            {
+                // pagination
+                UsersSearchResponse users = slack.scim2(orgAdminToken).searchUsers(req -> req.count(1).startIndex(2));
+                assertThat(users.getItemsPerPage(), is(1));
+                assertThat(users.getResources().size(), is(1));
+                assertThat(users.getStartIndex(), is(2));
+            }
+        }
+    }
+
+    @Test
+    public void searchUser_dummy() throws IOException {
+        try {
+            slack.scim2("dummy").searchUsers(req -> req.count(1000));
+        } catch (SCIM2ApiException e) {
+            assertThat(e.getMessage(), is("status: 400, description: unsupported_version"));
+            assertThat(e.getError(), is(notNullValue()));
+            assertThat(e.getError().getErrors().getCode(), is(400));
+            assertThat(e.getError().getErrors().getDescription(), is("unsupported_version"));
+        }
+    }
+
+    @Test
+    public void readUser_dummy() throws IOException {
+        try {
+            slack.scim2("dummy").readUser(req -> req.id("U12345678"));
+        } catch (SCIM2ApiException e) {
+            assertThat(e.getMessage(), is("status: 400, description: unsupported_version"));
+            assertThat(e.getError(), is(notNullValue()));
+            assertThat(e.getError().getErrors().getCode(), is(400));
+            assertThat(e.getError().getErrors().getDescription(), is("unsupported_version"));
+        }
+    }
+
+    @Test
+    public void createAndDeleteFullUser() throws Exception {
+        if (orgAdminToken != null) {
+            UsersCreateResponse creation = createNewFullUser();
+            assertThat(creation.getId(), is(notNullValue()));
+
+            UsersReadResponse readResp = slack.scim2(orgAdminToken).readUser(req -> req.id(creation.getId()));
+            assertThat(readResp.getId(), is(creation.getId()));
+            assertThat(readResp.getUserName(), is(creation.getUserName()));
+
+            try {
+                // https://api.slack.com/scim#filter
+                // filter query matching the created data
+                String userName = creation.getUserName();
+                UsersSearchResponse searchResp = slack.scim2(orgAdminToken).searchUsers(req -> req.count(1).filter("userName eq \"" + userName + "\""));
+                assertThat(searchResp.getItemsPerPage(), is(1));
+                assertThat(searchResp.getResources().size(), is(1));
+                assertThat(searchResp.getResources().get(0).getId(), is(creation.getId()));
+                assertThat(searchResp.getResources().get(0).getUserName(), is(creation.getUserName()));
+
+                String originalUserName = creation.getUserName();
+
+                slack.scim2(orgAdminToken).patchUser(req -> req.id(creation.getId()).operations(Arrays.asList(
+                        UsersPatchOperation.builder()
+                                .op(PatchOperation.Replace)
+                                .path("userName")
+                                .stringValue(originalUserName + "_ed")
+                                .build()
+                )));
+
+                readResp = slack.scim2(orgAdminToken).readUser(req -> req.id(creation.getId()));
+                assertThat(readResp.getId(), is(creation.getId()));
+                assertThat(readResp.getUserName(), is(originalUserName + "_ed"));
+
+                User modifiedUser = readResp;
+                modifiedUser.setUserName(originalUserName + "_rv");
+                modifiedUser.setNickName(originalUserName + "_rv"); // required
+                slack.scim2(orgAdminToken).updateUser(req -> req.id(modifiedUser.getId()).user(modifiedUser));
+
+                readResp = slack.scim2(orgAdminToken).readUser(req -> req.id(modifiedUser.getId()));
+                assertThat(readResp.getId(), is(creation.getId()));
+                assertThat(readResp.getUserName(), is(originalUserName + "_rv"));
+
+            } finally {
+                UsersDeleteResponse deletion = slack.scim2(orgAdminToken).deleteUser(req -> req.id(creation.getId()));
+                assertThat(deletion, is(nullValue()));
+                // can call twice
+                UsersDeleteResponse deletion2 = slack.scim2(orgAdminToken).deleteUser(req -> req.id(creation.getId()));
+                assertThat(deletion2, is(nullValue()));
+
+                int counter = 0;
+                UsersReadResponse supposedToBeDeleted = null;
+                while (counter < 10) {
+                    Thread.sleep(1000);
+                    supposedToBeDeleted = slack.scim2(orgAdminToken).readUser(req -> req.id(creation.getId()));
+                    if (!supposedToBeDeleted.getActive()) {
+                        break;
+                    }
+                }
+                assertThat(supposedToBeDeleted, is(notNullValue()));
+                assertThat(supposedToBeDeleted.getActive(), is(false));
+
+                // can call again
+                UsersDeleteResponse deletion3 = slack.scim2(orgAdminToken).deleteUser(req -> req.id(creation.getId()));
+                assertThat(deletion3, is(nullValue()));
+            }
+        }
+    }
+
+    @Test
+    public void createAndDeleteGuestUser() throws Exception {
+        if (orgAdminToken != null) {
+            UsersCreateResponse creation = createNewGuestUser();
+            assertThat(creation.getId(), is(notNullValue()));
+
+            UsersReadResponse readResp = slack.scim2(orgAdminToken).readUser(req -> req.id(creation.getId()));
+            assertThat(readResp.getId(), is(creation.getId()));
+            assertThat(readResp.getUserName(), is(creation.getUserName()));
+            assertThat(readResp.getSlackGuest().getType(), is(User.SlackGuest.Types.MULTI));
+            assertThat(readResp.getSlackGuest().getExpiration(), is(notNullValue()));
+
+            try {
+                // https://api.slack.com/scim#filter
+                // filter query matching the created data
+                String userName = creation.getUserName();
+                UsersSearchResponse searchResp = slack.scim2(orgAdminToken).searchUsers(req -> req.count(1).filter("userName eq \"" + userName + "\""));
+                assertThat(searchResp.getItemsPerPage(), is(1));
+                assertThat(searchResp.getResources().size(), is(1));
+                assertThat(searchResp.getResources().get(0).getId(), is(creation.getId()));
+                assertThat(searchResp.getResources().get(0).getUserName(), is(creation.getUserName()));
+                assertThat(searchResp.getResources().get(0).getSlackGuest(), is(notNullValue()));
+
+                String originalUserName = creation.getUserName();
+                slack.scim2(orgAdminToken).patchUser(req -> req.id(creation.getId()).operations(Arrays.asList(
+                        UsersPatchOperation.builder()
+                                .op(PatchOperation.Replace)
+                                .path("userName")
+                                .stringValue(originalUserName + "_ed")
+                                .build()
+                )));
+
+                readResp = slack.scim2(orgAdminToken).readUser(req -> req.id(creation.getId()));
+                assertThat(readResp.getId(), is(creation.getId()));
+                assertThat(readResp.getUserName(), is(originalUserName + "_ed"));
+
+                User modifiedUser = readResp;
+                modifiedUser.setUserName(originalUserName + "_rv");
+                modifiedUser.setNickName(originalUserName + "_rv"); // required
+                slack.scim2(orgAdminToken).updateUser(req -> req.id(modifiedUser.getId()).user(modifiedUser));
+
+                readResp = slack.scim2(orgAdminToken).readUser(req -> req.id(modifiedUser.getId()));
+                assertThat(readResp.getId(), is(creation.getId()));
+                assertThat(readResp.getUserName(), is(originalUserName + "_rv"));
+                assertThat(readResp.getSlackGuest().getType(), is(User.SlackGuest.Types.MULTI));
+                assertThat(readResp.getSlackGuest().getExpiration(), is(notNullValue()));
+
+            } finally {
+                UsersDeleteResponse deletion = slack.scim2(orgAdminToken).deleteUser(req -> req.id(creation.getId()));
+                assertThat(deletion, is(nullValue()));
+
+                // can call twice
+                UsersDeleteResponse deletion2 = slack.scim2(orgAdminToken).deleteUser(req -> req.id(creation.getId()));
+                assertThat(deletion2, is(nullValue()));
+
+                // Verify if the deletion is completed (there is some delay)
+                int counter = 0;
+                UsersReadResponse supposedToBeDeleted = null;
+                while (counter < 10) {
+                    Thread.sleep(1000);
+                    supposedToBeDeleted = slack.scim2(orgAdminToken).readUser(req -> req.id(creation.getId()));
+                    if (!supposedToBeDeleted.getActive()) {
+                        break;
+                    }
+                }
+                assertThat(supposedToBeDeleted, is(notNullValue()));
+                assertThat(supposedToBeDeleted.getActive(), is(false));
+
+                // can call again
+                UsersDeleteResponse deletion3 = slack.scim2(orgAdminToken).deleteUser(req -> req.id(creation.getId()));
+                assertThat(deletion3, is(nullValue()));
+            }
+        }
+    }
+
+    @Test
+    public void groups() throws IOException, SCIM2ApiException {
+        if (orgAdminToken != null) {
+            GroupsSearchResponse groups = slack.scim2(orgAdminToken).searchGroups(req -> req.count(1000));
+            if (groups.getResources().size() == 0) {
+                Group newGroup = new Group();
+                newGroup.setDisplayName("Test Group" + System.currentTimeMillis());
+
+                Group.Member member = new Group.Member();
+                UsersCreateResponse newUser = createNewFullUser();
+                assertThat(newUser.getId(), is(notNullValue()));
+                member.setValue(newUser.getId());
+                newGroup.setMembers(Arrays.asList(member));
+
+                GroupsCreateResponse createdGroup = slack.scim2(orgAdminToken).createGroup(req -> req.group(newGroup));
+                assertThat(createdGroup.getMembers().size(), is(1));
+            }
+
+            // pagination
+            GroupsSearchResponse pagination = slack.scim2(orgAdminToken).searchGroups(req -> req.count(1));
+            assertThat(pagination.getResources().size(), is(1));
+
+            Group group = groups.getResources().get(0);
+
+            User user = slack.scim2(orgAdminToken).searchUsers(req -> req.count(1)).getResources().get(0);
+            slack.scim2(orgAdminToken).patchGroup(req -> req.id(group.getId()).operations(Arrays.asList(
+                    GroupsPatchOperation.builder()
+                            .path("members")
+                            .op(PatchOperation.Remove)
+                            .memberValues(Arrays.asList(GroupsPatchOperation.Member.builder().value(user.getId()).build()))
+                            .build()
+            )));
+
+            slack.scim2(orgAdminToken).updateGroup(req -> req.id(group.getId()).group(group));
+
+            GroupsReadResponse read = slack.scim2(orgAdminToken).readGroup(req -> req.id(group.getId()));
+            assertThat(read.getId(), is(group.getId()));
+        }
+    }
+
+    @Test
+    public void groupAndUsers() throws IOException, SCIM2ApiException {
+        if (orgAdminToken != null) {
+            Group newGroup = new Group();
+            newGroup.setDisplayName("Test Group" + System.currentTimeMillis());
+            UsersCreateResponse newUser = createNewFullUser();
+            assertThat(newUser.getId(), is(notNullValue()));
+            try {
+                Group.Member member = new Group.Member();
+                member.setValue(newUser.getId());
+                newGroup.setMembers(Arrays.asList(member));
+                GroupsCreateResponse createdGroup = slack.scim2(orgAdminToken).createGroup(req -> req.group(newGroup));
+                assertThat(createdGroup.getMembers().size(), is(1));
+                try {
+                    String userName = newUser.getUserName();
+                    UsersSearchResponse searchResp = slack.scim2(orgAdminToken).searchUsers(req -> req.count(1).filter("userName eq \"" + userName + "\""));
+                    assertThat(searchResp.getResources().size(), is(1));
+                    assertThat(searchResp.getResources().get(0).getGroups().size(), is(1));
+                } finally {
+                    GroupsDeleteResponse groupDeletion = slack.scim2(orgAdminToken).deleteGroup(req -> req.id(createdGroup.getId()));
+                    assertThat(groupDeletion, is(nullValue()));
+                }
+            } finally {
+                UsersDeleteResponse deletion = slack.scim2(orgAdminToken).deleteUser(req -> req.id(newUser.getId()));
+                assertThat(deletion, is(nullValue()));
+            }
+        }
+    }
+
+    @Test
+    public void groups_dummy() throws IOException {
+        try {
+            slack.scim2("dummy").searchGroups(req -> req.count(1000));
+        } catch (SCIM2ApiException e) {
+            assertThat(e.getMessage(), is("status: 400, description: unsupported_version"));
+            assertThat(e.getError(), is(notNullValue()));
+            assertThat(e.getError().getErrors().getCode(), is(400));
+            assertThat(e.getError().getErrors().getDescription(), is("unsupported_version"));
+        }
+    }
+
+}

--- a/slack-api-client/src/test/java/test_with_remote_apis/scim2/AsyncApiTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/scim2/AsyncApiTest.java
@@ -1,0 +1,408 @@
+package test_with_remote_apis.scim2;
+
+import com.slack.api.Slack;
+import com.slack.api.scim2.SCIM2ApiCompletionException;
+import com.slack.api.scim2.SCIM2ApiException;
+import com.slack.api.scim2.model.Group;
+import com.slack.api.scim2.model.PatchOperation;
+import com.slack.api.scim2.model.User;
+import com.slack.api.scim2.request.GroupsPatchOperation;
+import com.slack.api.scim2.request.UsersPatchOperation;
+import com.slack.api.scim2.response.*;
+import com.slack.api.util.thread.DaemonThreadExecutorServiceProvider;
+import config.Constants;
+import config.SlackTestConfig;
+import org.junit.AfterClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+// required scope - admin
+public class AsyncApiTest {
+
+    static SlackTestConfig testConfig = SlackTestConfig.getInstance();
+    static Slack slack = Slack.getInstance(testConfig.getConfig());
+
+    @AfterClass
+    public static void tearDown() throws InterruptedException {
+        SlackTestConfig.awaitCompletion(testConfig);
+    }
+
+    String orgAdminToken = System.getenv(Constants.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN);
+
+    private UsersCreateResponse createNewFullUser() throws Exception {
+        return createNewUser(true);
+    }
+
+    private UsersCreateResponse createNewGuestUser() throws Exception {
+        return createNewUser(false);
+    }
+
+    private UsersCreateResponse createNewUser(boolean isFullMember) throws Exception {
+        String userName = "user" + System.currentTimeMillis();
+        User newUser = new User();
+        newUser.setName(new User.Name());
+        newUser.getName().setGivenName("Kazuhiro");
+        newUser.getName().setFamilyName("Sera");
+        newUser.setUserName(userName);
+        User.Email email = new User.Email();
+        email.setValue("seratch+" + System.currentTimeMillis() + "@gmail.com");
+        newUser.setEmails(Arrays.asList(email));
+        if (!isFullMember) {
+            // guest
+            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+            String expiration = df.format(Date.from(ZonedDateTime.now().plusDays(14).toInstant()));
+            newUser.setSlackGuest(User.SlackGuest.builder()
+                    .type(User.SlackGuest.Types.MULTI)
+                    .expiration(expiration)
+                    .build());
+        }
+        return slack.scim2Async(orgAdminToken).createUser(req -> req.user(newUser)).get();
+    }
+
+    @Test
+    public void getServiceProviderConfigs() throws ExecutionException, InterruptedException {
+        if (orgAdminToken != null) {
+            ServiceProviderConfigsGetResponse response = slack.scim2Async(orgAdminToken)
+                    .getServiceProviderConfigs(req -> req).get();
+            assertThat(response.getAuthenticationSchemes(), is(notNullValue()));
+        }
+    }
+
+    @Test
+    public void getServiceProviderConfigs_dummy() throws ExecutionException, InterruptedException {
+        ServiceProviderConfigsGetResponse response = slack.scim2Async("dummy")
+                .getServiceProviderConfigs(req -> req).get();
+        assertThat(response.getAuthenticationSchemes(), is(notNullValue()));
+    }
+
+    @Test
+    public void searchAndReadUser() throws ExecutionException, InterruptedException {
+        if (orgAdminToken != null) {
+            {
+                UsersSearchResponse users = slack.scim2Async(orgAdminToken).searchUsers(req -> req.count(1000)).get();
+                final String userId = users.getResources().get(0).getId();
+                UsersReadResponse read = slack.scim2Async(orgAdminToken).readUser(req -> req.id(userId)).get();
+                assertThat(read.getId(), is(userId));
+            }
+            {
+                // pagination
+                UsersSearchResponse users = slack.scim2Async(orgAdminToken)
+                        .searchUsers(req -> req.count(1).startIndex(2)).get();
+                assertThat(users.getItemsPerPage(), is(1));
+                assertThat(users.getResources().size(), is(1));
+                assertThat(users.getStartIndex(), is(2));
+            }
+        }
+    }
+
+    @Test
+    public void searchUser_dummy() throws IOException, ExecutionException, InterruptedException {
+        try {
+            slack.scim2Async("dummy").searchUsers(req -> req.count(1000)).get();
+        } catch (Exception _e) {
+            SCIM2ApiException e = ((SCIM2ApiCompletionException) _e.getCause()).getScimApiException();
+            assertThat(e.getMessage(), is("status: 400, description: unsupported_version"));
+            assertThat(e.getError(), is(notNullValue()));
+            assertThat(e.getError().getErrors().getCode(), is(400));
+            assertThat(e.getError().getErrors().getDescription(), is("unsupported_version"));
+        }
+    }
+
+    @Test
+    public void readUser_dummy() {
+        try {
+            slack.scim2Async("dummy").readUser(req -> req.id("U12345678")).get();
+        } catch (Exception _e) {
+            SCIM2ApiException e = ((SCIM2ApiCompletionException) _e.getCause()).getScimApiException();
+            assertThat(e.getMessage(), is("status: 400, description: unsupported_version"));
+            assertThat(e.getError(), is(notNullValue()));
+            assertThat(e.getError().getErrors().getCode(), is(400));
+            assertThat(e.getError().getErrors().getDescription(), is("unsupported_version"));
+        }
+    }
+
+    @Test
+    public void createAndDeleteFullUser() throws Exception {
+        if (orgAdminToken != null) {
+            UsersCreateResponse creation = createNewFullUser();
+            assertThat(creation.getId(), is(notNullValue()));
+
+            UsersReadResponse readResp = slack.scim2Async(orgAdminToken)
+                    .readUser(req -> req.id(creation.getId())).get();
+            assertThat(readResp.getId(), is(creation.getId()));
+            assertThat(readResp.getUserName(), is(creation.getUserName()));
+
+            try {
+                // https://api.slack.com/scim#filter
+                // filter query matching the created data
+                String userName = creation.getUserName();
+                UsersSearchResponse searchResp = slack.scim2Async(orgAdminToken)
+                        .searchUsers(req -> req.count(1).filter("userName eq \"" + userName + "\"")).get();
+                assertThat(searchResp.getItemsPerPage(), is(1));
+                assertThat(searchResp.getResources().size(), is(1));
+                assertThat(searchResp.getResources().get(0).getId(), is(creation.getId()));
+                assertThat(searchResp.getResources().get(0).getUserName(), is(creation.getUserName()));
+
+                String originalUserName = creation.getUserName();
+
+                slack.scim2Async(orgAdminToken).patchUser(req -> req.id(creation.getId()).operations(Arrays.asList(
+                        UsersPatchOperation.builder()
+                                .op(PatchOperation.Replace)
+                                .path("userName")
+                                .stringValue(originalUserName + "_ed")
+                                .build()
+                )));
+
+                Thread.sleep(500L);
+                readResp = slack.scim2Async(orgAdminToken).readUser(req -> req.id(creation.getId())).get();
+                assertThat(readResp.getId(), is(creation.getId()));
+                assertThat(readResp.getUserName(), is(originalUserName + "_ed"));
+
+                User modifiedUser = readResp;
+                modifiedUser.setUserName(originalUserName + "_rv");
+                modifiedUser.setNickName(originalUserName + "_rv"); // required
+                slack.scim2Async(orgAdminToken).updateUser(req -> req.id(modifiedUser.getId()).user(modifiedUser));
+
+                Thread.sleep(500L);
+                readResp = slack.scim2Async(orgAdminToken).readUser(req -> req.id(modifiedUser.getId())).get();
+                assertThat(readResp.getId(), is(creation.getId()));
+                assertThat(readResp.getUserName(), is(originalUserName + "_rv"));
+
+            } finally {
+                UsersDeleteResponse deletion = slack.scim2Async(orgAdminToken)
+                        .deleteUser(req -> req.id(creation.getId())).get();
+                assertThat(deletion, is(nullValue()));
+
+                // can call twice
+                UsersDeleteResponse deletion2 = slack.scim2Async(orgAdminToken)
+                        .deleteUser(req -> req.id(creation.getId())).get();
+                assertThat(deletion2, is(nullValue()));
+
+                // Verify if the deletion is completed (there is some delay)
+                int counter = 0;
+                UsersReadResponse supposedToBeDeleted = null;
+                while (counter < 10) {
+                    Thread.sleep(1000);
+                    supposedToBeDeleted = slack.scim2Async(orgAdminToken)
+                            .readUser(req -> req.id(creation.getId())).get();
+                    if (!supposedToBeDeleted.getActive()) {
+                        break;
+                    }
+                }
+                assertThat(supposedToBeDeleted, is(notNullValue()));
+                assertThat(supposedToBeDeleted.getActive(), is(false));
+
+                // can call again
+                UsersDeleteResponse deletion3 = slack.scim2Async(orgAdminToken)
+                        .deleteUser(req -> req.id(creation.getId())).get();
+                assertThat(deletion3, is(nullValue()));
+            }
+        }
+    }
+
+    @Test
+    public void createAndDeleteGuestUser() throws Exception {
+        if (orgAdminToken != null) {
+            UsersCreateResponse creation = createNewGuestUser();
+            assertThat(creation.getId(), is(notNullValue()));
+
+            UsersReadResponse readResp = slack.scim2Async(orgAdminToken)
+                    .readUser(req -> req.id(creation.getId())).get();
+            assertThat(readResp.getId(), is(creation.getId()));
+            assertThat(readResp.getUserName(), is(creation.getUserName()));
+            assertThat(readResp.getSlackGuest().getType(), is(User.SlackGuest.Types.MULTI));
+            assertThat(readResp.getSlackGuest().getExpiration(), is(notNullValue()));
+
+            try {
+                // https://api.slack.com/scim#filter
+                // filter query matching the created data
+                String userName = creation.getUserName();
+                UsersSearchResponse searchResp = slack.scim2Async(orgAdminToken)
+                        .searchUsers(req -> req.count(1).filter("userName eq \"" + userName + "\"")).get();
+                assertThat(searchResp.getItemsPerPage(), is(1));
+                assertThat(searchResp.getResources().size(), is(1));
+                assertThat(searchResp.getResources().get(0).getId(), is(creation.getId()));
+                assertThat(searchResp.getResources().get(0).getUserName(), is(creation.getUserName()));
+                assertThat(searchResp.getResources().get(0).getUserName(), is(creation.getUserName()));
+                assertThat(searchResp.getResources().get(0).getSlackGuest(), is(notNullValue()));
+
+                String originalUserName = creation.getUserName();
+
+                slack.scim2Async(orgAdminToken).patchUser(req -> req.id(creation.getId()).operations(Arrays.asList(
+                        UsersPatchOperation.builder()
+                                .op(PatchOperation.Replace)
+                                .path("userName")
+                                .stringValue(originalUserName + "_ed")
+                                .build()
+                )));
+
+                Thread.sleep(500L);
+                readResp = slack.scim2Async(orgAdminToken).readUser(req -> req.id(creation.getId())).get();
+                assertThat(readResp.getId(), is(creation.getId()));
+                assertThat(readResp.getUserName(), is(originalUserName + "_ed"));
+
+                User modifiedUser = readResp;
+                modifiedUser.setUserName(originalUserName + "_rv");
+                modifiedUser.setNickName(originalUserName + "_rv"); // required
+                slack.scim2Async(orgAdminToken).updateUser(req -> req.id(modifiedUser.getId()).user(modifiedUser));
+
+                Thread.sleep(500L);
+                readResp = slack.scim2Async(orgAdminToken).readUser(req -> req.id(modifiedUser.getId())).get();
+                assertThat(readResp.getId(), is(creation.getId()));
+                assertThat(readResp.getUserName(), is(originalUserName + "_rv"));
+                assertThat(readResp.getSlackGuest().getType(), is(User.SlackGuest.Types.MULTI));
+                assertThat(readResp.getSlackGuest().getExpiration(), is(notNullValue()));
+
+            } finally {
+                UsersDeleteResponse deletion = slack.scim2Async(orgAdminToken)
+                        .deleteUser(req -> req.id(creation.getId())).get();
+                assertThat(deletion, is(nullValue()));
+                // can call twice
+                UsersDeleteResponse deletion2 = slack.scim2Async(orgAdminToken)
+                        .deleteUser(req -> req.id(creation.getId())).get();
+                assertThat(deletion2, is(nullValue()));
+
+                int counter = 0;
+                UsersReadResponse supposedToBeDeleted = null;
+                while (counter < 10) {
+                    Thread.sleep(1000);
+                    supposedToBeDeleted = slack.scim2Async(orgAdminToken)
+                            .readUser(req -> req.id(creation.getId())).get();
+                    if (!supposedToBeDeleted.getActive()) {
+                        break;
+                    }
+                }
+                assertThat(supposedToBeDeleted, is(notNullValue()));
+                assertThat(supposedToBeDeleted.getActive(), is(false));
+
+                // can call again
+                UsersDeleteResponse deletion3 = slack.scim2Async(orgAdminToken)
+                        .deleteUser(req -> req.id(creation.getId())).get();
+                assertThat(deletion3, is(nullValue()));
+            }
+        }
+    }
+
+    @Test
+    public void groups() throws Exception {
+        if (orgAdminToken != null) {
+            GroupsSearchResponse groups = slack.scim2Async(orgAdminToken)
+                    .searchGroups(req -> req.count(1000)).get();
+            if (groups.getResources().size() == 0) {
+                Group newGroup = new Group();
+                newGroup.setDisplayName("Test Group" + System.currentTimeMillis());
+
+                Group.Member member = new Group.Member();
+                UsersCreateResponse newUser = createNewFullUser();
+                assertThat(newUser.getId(), is(notNullValue()));
+                member.setValue(newUser.getId());
+                newGroup.setMembers(Arrays.asList(member));
+
+                GroupsCreateResponse createdGroup = slack.scim2Async(orgAdminToken)
+                        .createGroup(req -> req.group(newGroup)).get();
+                assertThat(createdGroup.getMembers().size(), is(1));
+            }
+
+            // pagination
+            GroupsSearchResponse pagination = slack.scim2Async(orgAdminToken)
+                    .searchGroups(req -> req.count(1)).get();
+            assertThat(pagination.getResources().size(), is(1));
+
+            Group group = groups.getResources().get(0);
+            User user = slack.scim2Async(orgAdminToken).searchUsers(req -> req.count(1)).get().getResources().get(0);
+            slack.scim2Async(orgAdminToken).patchGroup(req -> req.id(group.getId()).operations(Arrays.asList(
+                    GroupsPatchOperation.builder()
+                            .path("members")
+                            .op(PatchOperation.Remove)
+                            .memberValues(Arrays.asList(GroupsPatchOperation.Member.builder().value(user.getId()).build()))
+                            .build()
+            ))).get();
+
+            slack.scim2Async(orgAdminToken).updateGroup(req -> req.id(group.getId()).group(group)).get();
+
+            GroupsReadResponse read = slack.scim2Async(orgAdminToken).readGroup(req -> req.id(group.getId())).get();
+            assertThat(read.getId(), is(group.getId()));
+        }
+    }
+
+    @Test
+    public void groupAndUsers() throws Exception {
+        if (orgAdminToken != null) {
+            Group newGroup = new Group();
+            newGroup.setDisplayName("Test Group" + System.currentTimeMillis());
+            UsersCreateResponse newUser = createNewFullUser();
+            assertThat(newUser.getId(), is(notNullValue()));
+            try {
+                Group.Member member = new Group.Member();
+                member.setValue(newUser.getId());
+                newGroup.setMembers(Arrays.asList(member));
+                GroupsCreateResponse createdGroup = slack.scim2Async(orgAdminToken)
+                        .createGroup(req -> req.group(newGroup)).get();
+                assertThat(createdGroup.getMembers().size(), is(1));
+                try {
+                    String userName = newUser.getUserName();
+                    UsersSearchResponse searchResp = slack.scim2Async(orgAdminToken)
+                            .searchUsers(req -> req.count(1).filter("userName eq \"" + userName + "\"")).get();
+                    assertThat(searchResp.getResources().size(), is(1));
+                    assertThat(searchResp.getResources().get(0).getGroups().size(), is(1));
+                } finally {
+                    GroupsDeleteResponse groupDeletion = slack.scim2Async(orgAdminToken)
+                            .deleteGroup(req -> req.id(createdGroup.getId())).get();
+                    assertThat(groupDeletion, is(nullValue()));
+                }
+            } finally {
+                UsersDeleteResponse deletion = slack.scim2Async(orgAdminToken)
+                        .deleteUser(req -> req.id(newUser.getId())).get();
+                assertThat(deletion, is(nullValue()));
+            }
+        }
+    }
+
+    @Test
+    public void groups_dummy() throws IOException, ExecutionException, InterruptedException {
+        try {
+            slack.scim2Async("dummy").searchGroups(req -> req.count(1000)).get();
+        } catch (Exception _e) {
+            SCIM2ApiException e = ((SCIM2ApiCompletionException) _e.getCause()).getScimApiException();
+            assertThat(e.getMessage(), is("status: 400, description: unsupported_version"));
+            assertThat(e.getError(), is(notNullValue()));
+            assertThat(e.getError().getErrors().getCode(), is(400));
+            assertThat(e.getError().getErrors().getDescription(), is("unsupported_version"));
+        }
+    }
+
+    @Ignore
+    @Test
+    public void demonstrateRateLimitedErrors() throws Exception {
+        Logger logger = LoggerFactory.getLogger(AsyncApiTest.class);
+        int concurrency = 10;
+        ExecutorService executorService = DaemonThreadExecutorServiceProvider.getInstance().createThreadPoolExecutor("test", concurrency);
+        for (int i = 0; i < concurrency; i++) {
+            executorService.execute(() -> {
+                while (true) {
+                    try {
+                        slack.scim2Async(orgAdminToken).searchUsers(r -> r.count(1)).get();
+                    } catch (Exception e) {
+                        logger.info(e.getMessage(), e);
+                    }
+                }
+            });
+        }
+        Thread.sleep(300_000L);
+    }
+
+}


### PR DESCRIPTION
This pull request resolves #1145 -- implementing https://api.slack.com/admins/scim2

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
