### PR TITLE
Add cursor-based pagination to team.accessLogs API calls

### DIFF
--- a/json-logs/samples/api/team.accessLogs.json
+++ b/json-logs/samples/api/team.accessLogs.json
@@ -22,5 +22,8 @@
   },
   "error": "",
   "needed": "",
-  "provided": ""
+  "provided": "",
+  "response_metadata": {
+    "next_cursor": ""
+  }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -2286,6 +2286,8 @@ public class RequestFormBuilder {
         setIfNotNull("count", req.getCount(), form);
         setIfNotNull("page", req.getPage(), form);
         setIfNotNull("team_id", req.getTeamId(), form);
+        setIfNotNull("limit", req.getLimit(), form);
+        setIfNotNull("cursor", req.getCursor(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamAccessLogsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamAccessLogsRequest.java
@@ -30,4 +30,18 @@ public class TeamAccessLogsRequest implements SlackApiRequest {
      */
     private String teamId;
 
+    /**
+     * The maximum number of items to return. Fewer than the requested number of items may be returned,
+     * even if the end of the list hasn't been reached.
+     * If specified, result is returned using a cursor-based approach instead of a classic one.
+     */
+    private Integer limit;
+
+    /**
+     * Parameter for pagination. Set cursor equal to the next_cursor attribute returned
+     * by the previous request's response_metadata. This parameter is optional,
+     * but pagination is mandatory: the default value simply fetches the first "page" of the collection.
+     */
+    private String cursor;
+
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamAccessLogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamAccessLogsResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.methods.response.team;
 import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Login;
 import com.slack.api.model.Paging;
+import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
@@ -20,4 +21,5 @@ public class TeamAccessLogsResponse implements SlackApiTextResponse {
 
     private List<Login> logins;
     private Paging paging;
+    private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/team_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/team_Test.java
@@ -14,8 +14,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @Slf4j
@@ -47,6 +46,29 @@ public class team_Test {
             // when you pay for this team
             assertThat(response.getError(), is(nullValue()));
             assertThat(response.isOk(), is(true));
+        } else {
+            // when you don't pay for this team
+            assertThat(response.isOk(), is(false));
+            assertThat(response.getError(), is("paid_only"));
+        }
+    }
+
+    @Test
+    public void teamAccessLogs_cursor() throws Exception {
+        TeamAccessLogsResponse error = slack.methods(userToken).teamAccessLogs(r -> r.cursor("xxxx"));
+        assertThat(error.getError(), is(notNullValue()));
+
+        TeamAccessLogsResponse response = slack.methods(userToken).teamAccessLogs(r -> r.limit(1));
+        if (response.isOk()) {
+            // when you pay for this team
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+
+            String nextCursor = response.getResponseMetadata().getNextCursor();
+            response = slack.methods(userToken).teamAccessLogs(r -> r.limit(1).cursor(nextCursor));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+            assertThat(response.getResponseMetadata().getNextCursor(), is(not(equals(nextCursor))));
         } else {
             // when you don't pay for this team
             assertThat(response.isOk(), is(false));


### PR DESCRIPTION
This pull request adds a new feature to team.accessLogs API method. See https://api.slack.com/changelog for details.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
