### PR TITLE
Fix #1161 Internal thread resources are not shut down when calling SlackConfig#close()

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/MetricsDatastore.java
@@ -4,7 +4,7 @@ import com.slack.api.util.thread.ExecutorServiceProvider;
 
 import java.util.Map;
 
-public interface MetricsDatastore {
+public interface MetricsDatastore extends AutoCloseable {
 
     String DEFAULT_SINGLETON_EXECUTOR_NAME = "DEFAULT_SINGLETON_EXECUTOR";
 
@@ -66,4 +66,5 @@ public interface MetricsDatastore {
 
     void setRateLimiterBackgroundJobIntervalMillis(long rateLimiterBackgroundJobIntervalMillis);
 
+    boolean isClosed();
 }

--- a/slack-api-client/src/test/java/test_locally/SlackConfigTest.java
+++ b/slack-api-client/src/test/java/test_locally/SlackConfigTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -158,6 +157,7 @@ public class SlackConfigTest {
         SlackConfig config = new SlackConfig();
         ExecutorService methods = ThreadPools.getDefault(config.getMethodsConfig());
         ExecutorService scim = com.slack.api.scim.impl.ThreadPools.getDefault(config.getSCIMConfig());
+        ExecutorService scim2 = com.slack.api.scim2.impl.ThreadPools.getDefault(config.getSCIM2Config());
         ExecutorService audit = com.slack.api.audit.impl.ThreadPools.getDefault(config.getAuditConfig());
         assertThat(methods.isShutdown(), is(false));
         assertThat(scim.isShutdown(), is(false));
@@ -170,16 +170,17 @@ public class SlackConfigTest {
 
         assertThat(methods.isShutdown(), is(true));
         assertThat(scim.isShutdown(), is(true));
+        assertThat(scim2.isShutdown(), is(true));
         assertThat(audit.isShutdown(), is(true));
-
-        // await for the termination for test stability
-        methods.awaitTermination(1, TimeUnit.MINUTES);
-        scim.awaitTermination(1, TimeUnit.MINUTES);
-        audit.awaitTermination(1, TimeUnit.MINUTES);
-
         assertThat(methods.isTerminated(), is(true));
         assertThat(scim.isTerminated(), is(true));
+        assertThat(scim2.isTerminated(), is(true));
         assertThat(audit.isTerminated(), is(true));
+
+        assertThat(config.getMethodsConfig().getMetricsDatastore().isClosed(), is(true));
+        assertThat(config.getAuditConfig().getMetricsDatastore().isClosed(), is(true));
+        assertThat(config.getSCIMConfig().getMetricsDatastore().isClosed(), is(true));
+        assertThat(config.getSCIM2Config().getMetricsDatastore().isClosed(), is(true));
     }
 
 }


### PR DESCRIPTION
This pull request resolves #1161 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
