### PR TITLE
Fix #1174 admin.inviteRequests.* API response data classes

### DIFF
--- a/json-logs/samples/api/admin.inviteRequests.approved.list.json
+++ b/json-logs/samples/api/admin.inviteRequests.approved.list.json
@@ -1,7 +1,39 @@
 {
   "ok": false,
   "approved_requests": [
-    ""
+    {
+      "invite_request": {
+        "id": "",
+        "email": "",
+        "date_created": 12345,
+        "requester_ids": [
+          "W00000000"
+        ],
+        "channel_ids": [
+          ""
+        ],
+        "invite_type": ""
+      },
+      "approved_by": {
+        "actor_type": "",
+        "actor_id": "W00000000"
+      },
+      "invite": {
+        "id": "I00000000",
+        "email": "",
+        "inviter_id": "W00000000",
+        "date_created": 12345,
+        "is_bouncing": false,
+        "invite_preferences": {
+          "is_restricted": false,
+          "is_ultra_restricted": false,
+          "channel_ids": [
+            ""
+          ],
+          "is_domain_matched": false
+        }
+      }
+    }
   ],
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/admin.inviteRequests.denied.list.json
+++ b/json-logs/samples/api/admin.inviteRequests.denied.list.json
@@ -1,7 +1,25 @@
 {
   "ok": false,
   "denied_requests": [
-    ""
+    {
+      "invite_request": {
+        "id": "",
+        "email": "",
+        "date_created": 12345,
+        "requester_ids": [
+          "W00000000"
+        ],
+        "channel_ids": [
+          ""
+        ],
+        "invite_type": "",
+        "request_reason": ""
+      },
+      "denied_by": {
+        "actor_type": "",
+        "actor_id": "W00000000"
+      }
+    }
   ],
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/admin.inviteRequests.list.json
+++ b/json-logs/samples/api/admin.inviteRequests.list.json
@@ -1,7 +1,20 @@
 {
   "ok": false,
   "invite_requests": [
-    ""
+    {
+      "id": "",
+      "email": "",
+      "date_created": 12345,
+      "requester_ids": [
+        "W00000000"
+      ],
+      "channel_ids": [
+        ""
+      ],
+      "invite_type": "",
+      "request_reason": "",
+      "date_expire": 12345
+    }
   ],
   "error": "",
   "needed": "",

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsApprovedListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsApprovedListResponse.java
@@ -1,6 +1,8 @@
 package com.slack.api.methods.response.admin.invite_requests;
 
 import com.slack.api.methods.SlackApiTextResponse;
+import com.slack.api.model.admin.Invite;
+import com.slack.api.model.admin.InviteRequest;
 import lombok.Data;
 
 import java.util.List;
@@ -16,6 +18,18 @@ public class AdminInviteRequestsApprovedListResponse implements SlackApiTextResp
     private String provided;
     private transient Map<String, List<String>> httpResponseHeaders;
 
-    private List<String> approvedRequests;
+    private List<ApprovedInviteRequest> approvedRequests;
 
+    @Data
+    public static class ApprovedInviteRequest {
+        private InviteRequest inviteRequest;
+        private ApprovedBy approvedBy;
+        private Invite invite;
+    }
+
+    @Data
+    public static class ApprovedBy {
+        private String actorType;
+        private String actorId;
+    }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsDeniedListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsDeniedListResponse.java
@@ -1,6 +1,7 @@
 package com.slack.api.methods.response.admin.invite_requests;
 
 import com.slack.api.methods.SlackApiTextResponse;
+import com.slack.api.model.admin.InviteRequest;
 import lombok.Data;
 
 import java.util.List;
@@ -16,6 +17,17 @@ public class AdminInviteRequestsDeniedListResponse implements SlackApiTextRespon
     private String provided;
     private transient Map<String, List<String>> httpResponseHeaders;
 
-    private List<String> deniedRequests;
+    private List<DeniedInviteRequest> deniedRequests;
 
+    @Data
+    public static class DeniedInviteRequest {
+        private InviteRequest inviteRequest;
+        private DeniedBy deniedBy;
+    }
+
+    @Data
+    public static class DeniedBy {
+        private String actorType;
+        private String actorId;
+    }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/invite_requests/AdminInviteRequestsListResponse.java
@@ -1,6 +1,7 @@
 package com.slack.api.methods.response.admin.invite_requests;
 
 import com.slack.api.methods.SlackApiTextResponse;
+import com.slack.api.model.admin.InviteRequest;
 import lombok.Data;
 
 import java.util.List;
@@ -16,6 +17,5 @@ public class AdminInviteRequestsListResponse implements SlackApiTextResponse {
     private String provided;
     private transient Map<String, List<String>> httpResponseHeaders;
 
-    private List<String> inviteRequests;
-
+    private List<InviteRequest> inviteRequests;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/admin/Invite.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/admin/Invite.java
@@ -1,0 +1,26 @@
+package com.slack.api.model.admin;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class Invite {
+    private String id;
+    private String email;
+    private String inviterId;
+    private Integer dateCreated;
+    private Integer dateResent;
+    private Boolean isBouncing;
+    private InvitePreferences invitePreferences;
+
+    @Data
+    public static class InvitePreferences {
+        private Boolean isRestricted;
+        private Boolean isUltraRestricted;
+        private List<String> channelIds;
+        private Boolean isDomainMatched;
+        private Integer dateExpire;
+        private String realName;
+    }
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/admin/InviteRequest.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/admin/InviteRequest.java
@@ -1,0 +1,18 @@
+package com.slack.api.model.admin;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class InviteRequest {
+    private String id;
+    private String email;
+    private Integer dateCreated;
+    private List<String> requesterIds;
+    private List<String> channelIds;
+    private String inviteType;
+    private String realName;
+    private Integer dateExpire;
+    private String requestReason;
+}


### PR DESCRIPTION
This pull request resolves #1174 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
