### PR TITLE
Upgrade http4k to v5, patch upgrades for others

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>4.47.2.0</http4k.version>
+        <http4k.version>5.2.1.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>2.3.1</ktor.version>
+        <ktor.version>2.3.2</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <micronaut.version>3.9.3</micronaut.version>
+        <micronaut.version>3.9.4</micronaut.version>
         <micronaut-test-junit5.version>3.9.2</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>2.4.1</micronaut-rxjava3.version>
         <junit5-jupiter.version>5.9.3</junit5-jupiter.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -20,7 +20,7 @@
          -->
         <tyrus-standalone-client.version>1.20</tyrus-standalone-client.version>
         <java-websocket.version>1.5.3</java-websocket.version>
-        <jedis.version>4.4.2</jedis.version>
+        <jedis.version>4.4.3</jedis.version>
         <jedis-mock.version>1.0.9</jedis-mock.version>
     </properties>
 


### PR DESCRIPTION
This pull request upgrades http4k version to the latset (including the major upgrade from v4 to v5) along with patch upgrades for other dependencies.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
