### PR TITLE
Mark stars.* API methods as deprecated

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
@@ -1156,16 +1156,22 @@ public interface AsyncMethodsClient {
     // stars
     // ------------------------------
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     CompletableFuture<StarsAddResponse> starsAdd(StarsAddRequest req);
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     CompletableFuture<StarsAddResponse> starsAdd(RequestConfigurator<StarsAddRequest.StarsAddRequestBuilder> req);
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     CompletableFuture<StarsListResponse> starsList(StarsListRequest req);
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     CompletableFuture<StarsListResponse> starsList(RequestConfigurator<StarsListRequest.StarsListRequestBuilder> req);
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     CompletableFuture<StarsRemoveResponse> starsRemove(StarsRemoveRequest req);
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     CompletableFuture<StarsRemoveResponse> starsRemove(RequestConfigurator<StarsRemoveRequest.StarsRemoveRequestBuilder> req);
 
     // ------------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
@@ -1697,16 +1697,22 @@ public interface MethodsClient {
     // stars
     // ------------------------------
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     StarsAddResponse starsAdd(StarsAddRequest req) throws IOException, SlackApiException;
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     StarsAddResponse starsAdd(RequestConfigurator<StarsAddRequest.StarsAddRequestBuilder> req) throws IOException, SlackApiException;
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     StarsListResponse starsList(StarsListRequest req) throws IOException, SlackApiException;
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     StarsListResponse starsList(RequestConfigurator<StarsListRequest.StarsListRequestBuilder> req) throws IOException, SlackApiException;
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     StarsRemoveResponse starsRemove(StarsRemoveRequest req) throws IOException, SlackApiException;
 
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     StarsRemoveResponse starsRemove(RequestConfigurator<StarsRemoveRequest.StarsRemoveRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
@@ -2093,31 +2093,37 @@ public class AsyncMethodsClientImpl implements AsyncMethodsClient {
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public CompletableFuture<StarsAddResponse> starsAdd(StarsAddRequest req) {
         return executor.execute(STARS_ADD, toMap(req), () -> methods.starsAdd(req));
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public CompletableFuture<StarsAddResponse> starsAdd(RequestConfigurator<StarsAddRequest.StarsAddRequestBuilder> req) {
         return starsAdd(req.configure(StarsAddRequest.builder()).build());
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public CompletableFuture<StarsListResponse> starsList(StarsListRequest req) {
         return executor.execute(STARS_LIST, toMap(req), () -> methods.starsList(req));
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public CompletableFuture<StarsListResponse> starsList(RequestConfigurator<StarsListRequest.StarsListRequestBuilder> req) {
         return starsList(req.configure(StarsListRequest.builder()).build());
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public CompletableFuture<StarsRemoveResponse> starsRemove(StarsRemoveRequest req) {
         return executor.execute(STARS_REMOVE, toMap(req), () -> methods.starsRemove(req));
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public CompletableFuture<StarsRemoveResponse> starsRemove(RequestConfigurator<StarsRemoveRequest.StarsRemoveRequestBuilder> req) {
         return starsRemove(req.configure(StarsRemoveRequest.builder()).build());
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -2771,31 +2771,37 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public StarsAddResponse starsAdd(StarsAddRequest req) throws IOException, SlackApiException {
         return postFormWithTokenAndParseResponse(toForm(req), Methods.STARS_ADD, getToken(req), StarsAddResponse.class);
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public StarsAddResponse starsAdd(RequestConfigurator<StarsAddRequest.StarsAddRequestBuilder> req) throws IOException, SlackApiException {
         return starsAdd(req.configure(StarsAddRequest.builder()).build());
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public StarsListResponse starsList(StarsListRequest req) throws IOException, SlackApiException {
         return postFormWithTokenAndParseResponse(toForm(req), Methods.STARS_LIST, getToken(req), StarsListResponse.class);
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public StarsListResponse starsList(RequestConfigurator<StarsListRequest.StarsListRequestBuilder> req) throws IOException, SlackApiException {
         return starsList(req.configure(StarsListRequest.builder()).build());
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public StarsRemoveResponse starsRemove(StarsRemoveRequest req) throws IOException, SlackApiException {
         return postFormWithTokenAndParseResponse(toForm(req), Methods.STARS_REMOVE, getToken(req), StarsRemoveResponse.class);
     }
 
     @Override
+    @Deprecated // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public StarsRemoveResponse starsRemove(RequestConfigurator<StarsRemoveRequest.StarsRemoveRequestBuilder> req) throws IOException, SlackApiException {
         return starsRemove(req.configure(StarsRemoveRequest.builder()).build());
     }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/stars_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/stars_Test.java
@@ -12,6 +12,7 @@ import config.SlackTestConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -28,19 +29,20 @@ public class stars_Test {
     static SlackTestConfig testConfig = SlackTestConfig.getInstance();
     static Slack slack = Slack.getInstance(testConfig.getConfig());
 
-    @BeforeClass
-    public static void setUp() throws Exception {
-        SlackTestConfig.initializeRawJSONDataFiles("stars.*");
-    }
-
-    @AfterClass
-    public static void tearDown() throws InterruptedException {
-        SlackTestConfig.awaitCompletion(testConfig);
-    }
+//    @BeforeClass
+//    public static void setUp() throws Exception {
+//        SlackTestConfig.initializeRawJSONDataFiles("stars.*");
+//    }
+//
+//    @AfterClass
+//    public static void tearDown() throws InterruptedException {
+//        SlackTestConfig.awaitCompletion(testConfig);
+//    }
 
     String userToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
 
     @Test
+    @Ignore // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public void list() throws IOException, SlackApiException {
         StarsListResponse response = slack.methods().starsList(r -> r.token(userToken));
         assertThat(response.getError(), is(nullValue()));
@@ -49,6 +51,7 @@ public class stars_Test {
     }
 
     @Test
+    @Ignore // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public void list_async() throws Exception {
         StarsListResponse response = slack.methodsAsync().starsList(r -> r.token(userToken)).get();
         assertThat(response.getError(), is(nullValue()));
@@ -57,6 +60,7 @@ public class stars_Test {
     }
 
     @Test
+    @Ignore // https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders
     public void add() throws IOException, SlackApiException {
         List<Conversation> channels = slack.methods().conversationsList(r -> r.token(userToken)).getChannels();
         List<String> channelIds = new ArrayList<>();


### PR DESCRIPTION
see also: https://api.slack.com/changelog/2023-07-its-later-already-for-stars-and-reminders

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
