### PR TITLE
Add threadTs to BlockActionPayload.Container

### DIFF
--- a/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
@@ -27,7 +27,8 @@
     "text": "",
     "is_ephemeral": false,
     "is_app_unfurl": false,
-    "app_unfurl_url": ""
+    "app_unfurl_url": "",
+    "thread_ts": ""
   },
   "trigger_id": "",
   "channel": {

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/payload/BlockActionPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/payload/BlockActionPayload.java
@@ -78,6 +78,7 @@ public class BlockActionPayload {
         @SerializedName("is_app_unfurl")
         private boolean appUnfurl;
         private String appUnfurlUrl;
+        private String threadTs;
     }
 
     @Data

--- a/slack-app-backend/src/test/java/test_locally/app_backend/interactive_components/payload/BlockActionPayloadTest.java
+++ b/slack-app-backend/src/test/java/test_locally/app_backend/interactive_components/payload/BlockActionPayloadTest.java
@@ -322,4 +322,79 @@ public class BlockActionPayloadTest {
     }
 
 
+
+    String jsonInThread = "{\n" +
+            "  \"type\": \"block_actions\",\n" +
+            "  \"user\": {\n" +
+            "    \"id\": \"U111\",\n" +
+            "    \"username\": \"seratch\",\n" +
+            "    \"name\": \"seratch\",\n" +
+            "    \"team_id\": \"T111\"\n" +
+            "  },\n" +
+            "  \"api_app_id\": \"A111\",\n" +
+            "  \"token\": \"xxx\",\n" +
+            "  \"container\": {\n" +
+            "    \"type\": \"message\",\n" +
+            "    \"message_ts\": \"1693635296.000500\",\n" +
+            "    \"thread_ts\": \"1693616242.466609\",\n" +
+            "    \"channel_id\": \"C111\",\n" +
+            "    \"is_ephemeral\": true\n" +
+            "  },\n" +
+            "  \"trigger_id\": \"111.222.xxx\",\n" +
+            "  \"team\": {\n" +
+            "    \"id\": \"T111\",\n" +
+            "    \"domain\": \"xxx\"\n" +
+            "  },\n" +
+            "  \"channel\": {\n" +
+            "    \"id\": \"C111\",\n" +
+            "    \"name\": \"random\"\n" +
+            "  },\n" +
+            "  \"state\": {\n" +
+            "    \"values\": {\n" +
+            "      \"block_1\": {\n" +
+            "        \"action_1\": {\n" +
+            "          \"type\": \"external_select\",\n" +
+            "          \"selected_option\": {\n" +
+            "            \"text\": {\n" +
+            "              \"type\": \"plain_text\",\n" +
+            "              \"text\": \"Schedule\",\n" +
+            "              \"emoji\": true\n" +
+            "            },\n" +
+            "            \"value\": \"schedule\"\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"response_url\": \"https://hooks.slack.com/actions/T111/111/xxx\",\n" +
+            "  \"actions\": [\n" +
+            "    {\n" +
+            "      \"action_id\": \"save\",\n" +
+            "      \"block_id\": \"block_1\",\n" +
+            "      \"text\": {\n" +
+            "        \"type\": \"plain_text\",\n" +
+            "        \"text\": \"Save\",\n" +
+            "        \"emoji\": true\n" +
+            "      },\n" +
+            "      \"value\": \"1\",\n" +
+            "      \"type\": \"button\",\n" +
+            "      \"action_ts\": \"1606455407.603639\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    @Test
+    public void threaded_message() {
+        BlockActionPayload payload = GSON.fromJson(jsonInThread, BlockActionPayload.class);
+        assertThat(payload.getType(), is("block_actions"));
+        assertThat(payload.getActions().size(), is(1));
+        assertThat(payload.getContainer().getMessageTs(), is("1693635296.000500"));
+        assertThat(payload.getContainer().getThreadTs(), is("1693616242.466609"));
+
+        assertThat(payload.getState().getValues()
+                        .get("block_1")
+                        .get("action_1")
+                        .getSelectedOption().getValue(),
+                is("schedule"));
+    }
 }


### PR DESCRIPTION
This PR adds `threadTs` to `BlockActionPayload.Container`, resolving #1200 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
