### PR TITLE
Fix #1212 Fails to parse channel_email_addresses in admin.conversations.search API response

### DIFF
--- a/json-logs/samples/api/admin.conversations.search.json
+++ b/json-logs/samples/api/admin.conversations.search.json
@@ -25,11 +25,24 @@
       ],
       "is_pending_ext_shared": false,
       "connected_team_ids": [
-        ""
+        "",
+        "T00000000"
       ],
       "conversation_host_id": "E00000000",
       "channel_email_addresses": [
-        ""
+        {
+          "team_id": "T00000000",
+          "user_id": "W00000000",
+          "conversation_id": "C00000000",
+          "date_created": 12345,
+          "address": "",
+          "name": "",
+          "icons": {
+            "image_36": "https://www.example.com/",
+            "image_48": "https://www.example.com/",
+            "image_72": "https://www.example.com/"
+          }
+        }
       ],
       "connected_limited_team_ids": [
         ""
@@ -56,5 +69,10 @@
   "error": "",
   "needed": "",
   "provided": "",
-  "total_count": 12345
+  "total_count": 12345,
+  "response_metadata": {
+    "messages": [
+      ""
+    ]
+  }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsSearchResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/conversations/AdminConversationsSearchResponse.java
@@ -1,6 +1,7 @@
 package com.slack.api.methods.response.admin.conversations;
 
 import com.slack.api.methods.SlackApiTextResponse;
+import com.slack.api.model.ChannelEmailAddress;
 import com.slack.api.model.ErrorResponseMetadata;
 import lombok.Data;
 
@@ -48,7 +49,7 @@ public class AdminConversationsSearchResponse implements SlackApiTextResponse {
         private List<String> pendingConnectedTeamIds;
         private List<String> connectedTeamIds;
         private List<String> connectedLimitedTeamIds;
-        private List<String> channelEmailAddresses;
+        private List<ChannelEmailAddress> channelEmailAddresses;
         private String contextTeamId;
         private Boolean isPendingExtShared;
         private Boolean isDisconnectInProgress;

--- a/slack-api-client/src/test/java/test_locally/api/methods/FieldValidation_a_to_c_Test.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/FieldValidation_a_to_c_Test.java
@@ -415,7 +415,8 @@ public class FieldValidation_a_to_c_Test {
                 "getPendingConnectedTeamIds",
                 "getConnectedLimitedTeamIds",
                 "getIsUserDeleted",
-                "getProperties"
+                "getProperties",
+                "getChannelEmailAddresses"
         );
     }
 
@@ -528,7 +529,8 @@ public class FieldValidation_a_to_c_Test {
                     "getParentUserId",
                     "getBotProfile",
                     "getIsUserDeleted",
-                    "getProperties"
+                    "getProperties",
+                    "getChannelEmailAddresses"
             );
         }
         {

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApi_conversations_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApi_conversations_Test.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 
 @Slf4j
 public class AdminApi_conversations_Test {
@@ -56,25 +57,23 @@ public class AdminApi_conversations_Test {
     public void search() throws Exception {
         if (orgAdminUserToken != null) {
             AdminConversationsSearchResponse search = methodsAsync.adminConversationsSearch(r -> r
-                    .limit(1)
+                    .limit(20)
                     .sort("member_count")
                     .sortDir("desc")
                     .searchChannelTypes(Arrays.asList("exclude_archived", "private_exclude"))
             ).get();
             assertThat(search.getError(), is(nullValue()));
-            // TODO: 2023-09-26: unexpectedly zero result
-            assertThat(search.getConversations().size(), is(1));
+            assertThat(search.getConversations().size(), is(greaterThan(0)));
 
             AdminConversationsSearchResponse search2 = methodsAsync.adminConversationsSearch(r -> r
-                    .limit(1)
+                    .limit(20)
                     .sort("member_count")
                     .sortDir("desc")
                     .searchChannelTypes(Arrays.asList("exclude_archived", "private_exclude"))
                     .cursor(search.getNextCursor())
             ).get();
             assertThat(search2.getError(), is(nullValue()));
-            // TODO: 2023-09-26: unexpectedly zero result
-            assertThat(search2.getConversations().size(), is(1));
+            assertThat(search2.getConversations().size(), is(greaterThan(1)));
         }
     }
 

--- a/slack-api-model/src/main/java/com/slack/api/model/ChannelEmailAddress.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/ChannelEmailAddress.java
@@ -1,0 +1,25 @@
+package com.slack.api.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class ChannelEmailAddress {
+    private String teamId;
+    private String userId;
+    private String conversationId;
+    private Integer dateCreated;
+    private String address;
+    private String name;
+    private Icons icons;
+
+    @Data
+    public static class Icons {
+        @SerializedName("image_36")
+        private String image36;
+        @SerializedName("image_48")
+        private String image48;
+        @SerializedName("image_72")
+        private String image72;
+    }
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/Conversation.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/Conversation.java
@@ -62,6 +62,7 @@ public class Conversation {
     private List<String> internalTeamIds;
     private List<String> connectedTeamIds;
     private List<String> connectedLimitedTeamIds;
+    private List<ChannelEmailAddress> channelEmailAddresses;
 
     private String contextTeamId;
 


### PR DESCRIPTION
This pull request resolves #1212 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
