### PR TITLE
Add rich_text_input block element support

### DIFF
--- a/json-logs/samples/api/users.list.json
+++ b/json-logs/samples/api/users.list.json
@@ -75,8 +75,7 @@
         "is_admin": false,
         "is_owner": false,
         "teams": [
-          "",
-          "T00000000"
+          ""
         ],
         "is_primary_owner": false
       },

--- a/json-logs/samples/api/views.open.json
+++ b/json-logs/samples/api/views.open.json
@@ -33,6 +33,1432 @@
           "emoji": false
         },
         "element": {
+          "type": "rich_text_input",
+          "action_id": "",
+          "initial_value": {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_list",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "style": "",
+                "indent": 123,
+                "offset": 123,
+                "border": 123
+              },
+              {
+                "type": "rich_text_preformatted",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "border": 123
+              },
+              {
+                "type": "rich_text_quote",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "block_id": ""
+          },
+          "dispatch_action_config": {
+            "trigger_actions_on": [
+              ""
+            ]
+          },
+          "focus_on_load": false,
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
           "type": "plain_text_input",
           "action_id": "",
           "placeholder": {

--- a/json-logs/samples/api/views.publish.json
+++ b/json-logs/samples/api/views.publish.json
@@ -33,6 +33,1432 @@
           "emoji": false
         },
         "element": {
+          "type": "rich_text_input",
+          "action_id": "",
+          "initial_value": {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_list",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "style": "",
+                "indent": 123,
+                "offset": 123,
+                "border": 123
+              },
+              {
+                "type": "rich_text_preformatted",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "border": 123
+              },
+              {
+                "type": "rich_text_quote",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "block_id": ""
+          },
+          "dispatch_action_config": {
+            "trigger_actions_on": [
+              ""
+            ]
+          },
+          "focus_on_load": false,
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
           "type": "plain_text_input",
           "action_id": "",
           "placeholder": {

--- a/json-logs/samples/api/views.push.json
+++ b/json-logs/samples/api/views.push.json
@@ -33,6 +33,1432 @@
           "emoji": false
         },
         "element": {
+          "type": "rich_text_input",
+          "action_id": "",
+          "initial_value": {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_list",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "style": "",
+                "indent": 123,
+                "offset": 123,
+                "border": 123
+              },
+              {
+                "type": "rich_text_preformatted",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "border": 123
+              },
+              {
+                "type": "rich_text_quote",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "block_id": ""
+          },
+          "dispatch_action_config": {
+            "trigger_actions_on": [
+              ""
+            ]
+          },
+          "focus_on_load": false,
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
           "type": "plain_text_input",
           "action_id": "",
           "placeholder": {

--- a/json-logs/samples/api/views.update.json
+++ b/json-logs/samples/api/views.update.json
@@ -33,6 +33,1432 @@
           "emoji": false
         },
         "element": {
+          "type": "rich_text_input",
+          "action_id": "",
+          "initial_value": {
+            "type": "rich_text",
+            "elements": [
+              {
+                "type": "rich_text_list",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "style": "",
+                "indent": 123,
+                "offset": 123,
+                "border": 123
+              },
+              {
+                "type": "rich_text_preformatted",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "border": 123
+              },
+              {
+                "type": "rich_text_quote",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": ""
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": ""
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": ""
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "code": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "block_id": ""
+          },
+          "dispatch_action_config": {
+            "trigger_actions_on": [
+              ""
+            ]
+          },
+          "focus_on_load": false,
+          "placeholder": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          }
+        },
+        "dispatch_action": false,
+        "hint": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "optional": false
+      },
+      {
+        "type": "input",
+        "block_id": "",
+        "label": {
+          "type": "plain_text",
+          "text": "",
+          "emoji": false
+        },
+        "element": {
           "type": "plain_text_input",
           "action_id": "",
           "placeholder": {

--- a/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
@@ -1508,7 +1508,12 @@
       "selected_date": "",
       "initial_date": "",
       "selected_time": "",
-      "initial_time": ""
+      "initial_time": "",
+      "rich_text_value": {
+        "type": "rich_text",
+        "elements": [],
+        "block_id": ""
+      }
     }
   ],
   "is_enterprise_install": false

--- a/json-logs/samples/events/DndUpdatedPayload.json
+++ b/json-logs/samples/events/DndUpdatedPayload.json
@@ -12,7 +12,8 @@
       "next_dnd_end_ts": 12345,
       "snooze_enabled": false,
       "snooze_endtime": 12345,
-      "snooze_remaining": 12345
+      "snooze_remaining": 12345,
+      "snooze_is_indefinite": false
     },
     "event_ts": "0000000000.000000"
   },

--- a/json-logs/samples/events/FileChangePayload.json
+++ b/json-logs/samples/events/FileChangePayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "enterprise_id": "",
   "team_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "type": "",
   "authed_users": [

--- a/json-logs/samples/events/FilePublicPayload.json
+++ b/json-logs/samples/events/FilePublicPayload.json
@@ -25,5 +25,7 @@
     }
   ],
   "is_ext_shared_channel": false,
-  "event_context": ""
+  "event_context": "",
+  "context_team_id": "",
+  "context_enterprise_id": ""
 }

--- a/json-logs/samples/events/FileSharedPayload.json
+++ b/json-logs/samples/events/FileSharedPayload.json
@@ -26,5 +26,7 @@
     }
   ],
   "is_ext_shared_channel": false,
-  "event_context": ""
+  "event_context": "",
+  "context_team_id": "",
+  "context_enterprise_id": ""
 }

--- a/json-logs/samples/events/FileUnsharedPayload.json
+++ b/json-logs/samples/events/FileUnsharedPayload.json
@@ -26,5 +26,7 @@
     }
   ],
   "is_ext_shared_channel": false,
-  "event_context": ""
+  "event_context": "",
+  "context_team_id": "",
+  "context_enterprise_id": ""
 }

--- a/json-logs/samples/events/GroupArchivePayload.json
+++ b/json-logs/samples/events/GroupArchivePayload.json
@@ -23,5 +23,7 @@
     }
   ],
   "is_ext_shared_channel": false,
-  "event_context": ""
+  "event_context": "",
+  "context_team_id": "",
+  "context_enterprise_id": ""
 }

--- a/json-logs/samples/events/GroupClosePayload.json
+++ b/json-logs/samples/events/GroupClosePayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "enterprise_id": "",
   "team_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "type": "",
   "authed_users": [

--- a/json-logs/samples/events/GroupDeletedPayload.json
+++ b/json-logs/samples/events/GroupDeletedPayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "enterprise_id": "",
   "team_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "type": "",
   "authed_users": [

--- a/json-logs/samples/events/GroupHistoryChangedPayload.json
+++ b/json-logs/samples/events/GroupHistoryChangedPayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "enterprise_id": "",
   "team_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "type": "",
   "authed_users": [

--- a/json-logs/samples/events/GroupOpenPayload.json
+++ b/json-logs/samples/events/GroupOpenPayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "enterprise_id": "",
   "team_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "type": "",
   "authed_users": [

--- a/json-logs/samples/events/GroupRenamePayload.json
+++ b/json-logs/samples/events/GroupRenamePayload.json
@@ -28,5 +28,7 @@
     }
   ],
   "is_ext_shared_channel": false,
-  "event_context": ""
+  "event_context": "",
+  "context_team_id": "",
+  "context_enterprise_id": ""
 }

--- a/json-logs/samples/events/MemberJoinedChannelPayload.json
+++ b/json-logs/samples/events/MemberJoinedChannelPayload.json
@@ -25,5 +25,7 @@
     }
   ],
   "is_ext_shared_channel": false,
-  "event_context": ""
+  "event_context": "",
+  "context_team_id": "",
+  "context_enterprise_id": ""
 }

--- a/json-logs/samples/events/MemberLeftChannelPayload.json
+++ b/json-logs/samples/events/MemberLeftChannelPayload.json
@@ -24,5 +24,7 @@
     }
   ],
   "is_ext_shared_channel": false,
-  "event_context": ""
+  "event_context": "",
+  "context_team_id": "",
+  "context_enterprise_id": ""
 }

--- a/json-logs/samples/events/ReactionAddedPayload.json
+++ b/json-logs/samples/events/ReactionAddedPayload.json
@@ -28,5 +28,7 @@
     }
   ],
   "is_ext_shared_channel": false,
-  "event_context": ""
+  "event_context": "",
+  "context_team_id": "",
+  "context_enterprise_id": ""
 }

--- a/json-logs/samples/events/ReactionRemovedPayload.json
+++ b/json-logs/samples/events/ReactionRemovedPayload.json
@@ -28,5 +28,7 @@
     }
   ],
   "is_ext_shared_channel": false,
-  "event_context": ""
+  "event_context": "",
+  "context_team_id": "",
+  "context_enterprise_id": ""
 }

--- a/json-logs/samples/rtm/DndUpdatedEvent.json
+++ b/json-logs/samples/rtm/DndUpdatedEvent.json
@@ -7,6 +7,7 @@
     "next_dnd_start_ts": 123,
     "next_dnd_end_ts": 123,
     "snooze_enabled": false,
+    "snooze_is_indefinite": false,
     "snooze_endtime": 123
   },
   "event_ts": ""

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/BlockKit_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/BlockKit_Test.java
@@ -31,8 +31,7 @@ import java.util.List;
 import static com.slack.api.model.block.Blocks.*;
 import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
 import static com.slack.api.model.block.composition.BlockCompositions.plainText;
-import static com.slack.api.model.block.element.BlockElements.asElements;
-import static com.slack.api.model.block.element.BlockElements.button;
+import static com.slack.api.model.block.element.BlockElements.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -321,4 +320,21 @@ public class BlockKit_Test {
         assertThat(response.getError(), is(nullValue()));
     }
 
+    @Test
+    public void richTextInputTest() throws Exception {
+        loadRandomChannel();
+        ChatPostMessageResponse response = slack.methods(botToken).chatPostMessage(r -> r
+                .channel(randomChannelId)
+                .text("test")
+                .blocks(Arrays.asList(
+                        section(s ->s.text(plainText("rich text input test"))),
+                        input(i -> i
+                                .element(richTextInput(rti -> rti.actionId("action")))
+                                .label(plainText("rich input"))
+                        )
+                ))
+        );
+        // rich_text_input is not allowed in a channel message
+        assertThat(response.getError(), is("invalid_blocks"));
+    }
 }

--- a/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
@@ -227,6 +227,13 @@ public class SampleObjects {
             .placeholder(initProperties(PlainTextObject.builder().build()))
             .dispatchActionConfig(initProperties(DispatchActionConfig.builder().triggerActionsOn(Arrays.asList("")).build()))
             .build());
+
+    public static RichTextInputElement richTextInputElement = initProperties(RichTextInputElement.builder()
+            .placeholder(initProperties(PlainTextObject.builder().build()))
+            .initialValue(RichTextBlock)
+            .dispatchActionConfig(initProperties(DispatchActionConfig.builder().triggerActionsOn(Arrays.asList("")).build()))
+            .build());
+
     public static RadioButtonsElement radioButtonsElement = initProperties(RadioButtonsElement.builder()
             .confirm(initProperties(ConfirmationDialogObject.builder()
                     .text(initProperties(PlainTextObject.builder().build()))
@@ -239,6 +246,7 @@ public class SampleObjects {
             .build());
 
     public static List<LayoutBlock> ModalBlocks = asBlocks(
+            initProperties(input(i -> i.element(richTextInputElement))),
             initProperties(input(i -> i.element(plainTextInputElement))),
             initProperties(input(i -> i.element(radioButtonsElement))),
             initProperties(input(i -> i.element(initProperties(button(b -> b.confirm(Confirm)))))),

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/RichTextInputElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/RichTextInputElementBuilder.kt
@@ -1,0 +1,74 @@
+package com.slack.api.model.kotlin_extension.block.element
+
+import com.slack.api.model.block.RichTextBlock
+import com.slack.api.model.block.composition.DispatchActionConfig
+import com.slack.api.model.block.composition.PlainTextObject
+import com.slack.api.model.block.element.RichTextInputElement
+import com.slack.api.model.kotlin_extension.block.BlockLayoutBuilder
+import com.slack.api.model.kotlin_extension.block.Builder
+import com.slack.api.model.kotlin_extension.block.composition.DispatchActionConfigBuilder
+
+@BlockLayoutBuilder
+class RichTextInputElementBuilder : Builder<RichTextInputElement> {
+    private var actionId: String? = null
+    private var placeholder: PlainTextObject? = null
+    private var initialValue: RichTextBlock? = null
+    private var dispatchActionConfig: DispatchActionConfig? = null
+    private var _focusOnLoad: Boolean? = null
+
+    /**
+     * An identifier for the input value when the parent modal is submitted. You can use this when you receive a
+     * view_submission payload to identify the value of the input element. Should be unique among all other action_ids
+     * used elsewhere by your app. Maximum length for this field is 255 characters.*
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#input">Plain text input documentation</a>
+     */
+    fun actionId(id: String) {
+        actionId = id
+    }
+
+    /**
+     * Adds a plain text object to the placeholder field.
+     *
+     * The placeholder text shown in the plain-text input. Maximum length for the text in this field is 150 characters.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/block-elements#input">Plain text input documentation</a>
+     */
+    fun placeholder(text: String, emoji: Boolean? = null) {
+        placeholder = PlainTextObject(text, emoji)
+    }
+
+    fun initialValue(value: RichTextBlock) {
+        initialValue = value
+    }
+
+
+    /**
+     * Determines when a plain-text input element will return a block_actions interaction payload.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config">The document</a>
+     */
+    fun dispatchActionConfig(builder: DispatchActionConfigBuilder.() -> Unit) {
+        dispatchActionConfig = DispatchActionConfigBuilder().apply(builder).build()
+    }
+
+    /**
+     * Indicates whether the element will be set to autofocus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     *
+     * @see <a href="https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config">The document</a>
+     */
+    fun focusOnLoad(focusOnLoad: Boolean) {
+        _focusOnLoad = focusOnLoad
+    }
+
+    override fun build(): RichTextInputElement {
+        return RichTextInputElement.builder()
+            .actionId(actionId)
+            .placeholder(placeholder)
+            .initialValue(initialValue)
+            .dispatchActionConfig(dispatchActionConfig)
+            .focusOnLoad(_focusOnLoad)
+            .build()
+    }
+}

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/container/MultiBlockElementContainer.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/container/MultiBlockElementContainer.kt
@@ -85,6 +85,10 @@ class MultiBlockElementContainer : BlockElementDsl {
         underlying += MultiUsersSelectElementBuilder().apply(builder).build()
     }
 
+    override fun richTextInput(builder: RichTextInputElementBuilder.() -> Unit) {
+        underlying += RichTextInputElementBuilder().apply(builder).build()
+    }
+
     override fun overflowMenu(builder: OverflowMenuElementBuilder.() -> Unit) {
         underlying += OverflowMenuElementBuilder().apply(builder).build()
     }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/container/SingleBlockElementContainer.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/container/SingleBlockElementContainer.kt
@@ -85,6 +85,10 @@ class SingleBlockElementContainer() : BlockElementDsl {
         underlying = MultiUsersSelectElementBuilder().apply(builder).build()
     }
 
+    override fun richTextInput(builder: RichTextInputElementBuilder.() -> Unit) {
+        underlying = RichTextInputElementBuilder().apply(builder).build()
+    }
+
     override fun overflowMenu(builder: OverflowMenuElementBuilder.() -> Unit) {
         underlying = OverflowMenuElementBuilder().apply(builder).build()
     }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/dsl/BlockElementInputDsl.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/dsl/BlockElementInputDsl.kt
@@ -91,6 +91,8 @@ interface BlockElementInputDsl {
      */
     fun multiUsersSelect(builder: MultiUsersSelectElementBuilder.() -> Unit)
 
+    fun richTextInput(builder: RichTextInputElementBuilder.() -> Unit)
+
     /**
      * A plain-text input, similar to the HTML input tag, creates a field where a user can enter freeform data. It can
      * appear as a single-line field or a larger textarea using the multiline flag.

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/InputBlockTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/InputBlockTest.kt
@@ -38,9 +38,22 @@ class InputBlockTest {
                 }
                 label("Test")
             }
+            input {
+                blockId("b-3")
+                dispatchAction(true)
+                element {
+                    richTextInput {
+                        actionId("a-3")
+                        dispatchActionConfig {
+                            triggerActionsOn(TriggerActionOn.ON_ENTER_PRESSED, TriggerActionOn.ON_CHARACTER_ENTERED)
+                        }
+                    }
+                }
+                label("Test")
+            }
         }
         val result = gson.toJson(blocks)
-        val expected = """[{"type":"input","block_id":"b-1","label":{"type":"plain_text","text":"Test"},"element":{"type":"plain_text_input","action_id":"a-1","multiline":false,"dispatch_action_config":{"trigger_actions_on":["on_enter_pressed","on_character_entered"]}},"dispatch_action":true,"optional":false},{"type":"input","block_id":"b-2","label":{"type":"plain_text","text":"Test"},"element":{"type":"plain_text_input","action_id":"a-2","multiline":false,"dispatch_action_config":{"trigger_actions_on":["on_enter_pressed","on_character_entered"]}},"dispatch_action":true,"optional":false}]"""
+        val expected = """[{"type":"input","block_id":"b-1","label":{"type":"plain_text","text":"Test"},"element":{"type":"plain_text_input","action_id":"a-1","multiline":false,"dispatch_action_config":{"trigger_actions_on":["on_enter_pressed","on_character_entered"]}},"dispatch_action":true,"optional":false},{"type":"input","block_id":"b-2","label":{"type":"plain_text","text":"Test"},"element":{"type":"plain_text_input","action_id":"a-2","multiline":false,"dispatch_action_config":{"trigger_actions_on":["on_enter_pressed","on_character_entered"]}},"dispatch_action":true,"optional":false},{"type":"input","block_id":"b-3","label":{"type":"plain_text","text":"Test"},"element":{"type":"rich_text_input","action_id":"a-3","dispatch_action_config":{"trigger_actions_on":["on_enter_pressed","on_character_entered"]}},"dispatch_action":true,"optional":false}]"""
         assertEquals(expected, result)
     }
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
@@ -89,10 +89,6 @@ public class Blocks {
 
     // RichTextBlock
 
-    /**
-     * @deprecated The SDK cannot send rich text blocks. Use Markdown text instead.
-     */
-    @Deprecated
     public static RichTextBlock richText(ModelConfigurator<RichTextBlock.RichTextBlockBuilder> configurator) {
         return configurator.configure(RichTextBlock.builder()).build();
     }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/BlockElements.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/BlockElements.java
@@ -47,6 +47,12 @@ public class BlockElements {
         return configurator.configure(OverflowMenuElement.builder()).build();
     }
 
+    // RichTextInputElement
+
+    public static RichTextInputElement richTextInput(ModelConfigurator<RichTextInputElement.RichTextInputElementBuilder> configurator) {
+        return configurator.configure(RichTextInputElement.builder()).build();
+    }
+
     // PlainTextInputElement
 
     public static PlainTextInputElement plainTextInput(ModelConfigurator<PlainTextInputElement.PlainTextInputElementBuilder> configurator) {
@@ -174,40 +180,24 @@ public class BlockElements {
 
     // RichTextListElement
 
-    /**
-     * @deprecated The SDK cannot send rich text blocks. Use Markdown text instead.
-     */
-    @Deprecated
     public static RichTextListElement richTextList(ModelConfigurator<RichTextListElement.RichTextListElementBuilder> configurator) {
         return configurator.configure(RichTextListElement.builder()).build();
     }
 
     // RichTextPreformattedElement
 
-    /**
-     * @deprecated The SDK cannot send rich text blocks. Use Markdown text instead.
-     */
-    @Deprecated
     public static RichTextPreformattedElement richTextPreformatted(ModelConfigurator<RichTextPreformattedElement.RichTextPreformattedElementBuilder> configurator) {
         return configurator.configure(RichTextPreformattedElement.builder()).build();
     }
 
     // RichTextQuoteElement
 
-    /**
-     * @deprecated The SDK cannot send rich text blocks. Use Markdown text instead.
-     */
-    @Deprecated
     public static RichTextQuoteElement richTextQuote(ModelConfigurator<RichTextQuoteElement.RichTextQuoteElementBuilder> configurator) {
         return configurator.configure(RichTextQuoteElement.builder()).build();
     }
 
     // RichTextSectionElement
 
-    /**
-     * @deprecated The SDK cannot send rich text blocks. Use Markdown text instead.
-     */
-    @Deprecated
     public static RichTextSectionElement richTextSection(ModelConfigurator<RichTextSectionElement.RichTextSectionElementBuilder> configurator) {
         return configurator.configure(RichTextSectionElement.builder()).build();
     }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextInputElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextInputElement.java
@@ -1,0 +1,50 @@
+package com.slack.api.model.block.element;
+
+import com.slack.api.model.block.RichTextBlock;
+import com.slack.api.model.block.composition.DispatchActionConfig;
+import com.slack.api.model.block.composition.PlainTextObject;
+import lombok.*;
+
+/**
+ * https://api.slack.com/reference/block-kit/block-elements#rich_text_input
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class RichTextInputElement extends BlockElement {
+    public static final String TYPE = "rich_text_input";
+    private final String type = TYPE;
+
+    /**
+     * An identifier for the input value when the parent modal is submitted.
+     * You can use this when you receive a view_submission payload to identify the value of the input element.
+     * Should be unique among all other action_ids used elsewhere by your app.
+     * Maximum length for this field is 255 characters.
+     */
+    private String actionId;
+
+    /**
+     * The initial value in the rich text input when it is loaded.
+     */
+    private RichTextBlock initialValue;
+
+    /**
+     * A dispatch configuration object that determines
+     * when during text input the element returns a block_actions payload.
+     */
+    private DispatchActionConfig dispatchActionConfig;
+
+    /**
+     * Indicates whether the element will be set to autofocus within the view object.
+     * Only one element can be set to true. Defaults to false.
+     */
+    private Boolean focusOnLoad;
+
+    /**
+     * A plain_text only text object that defines the placeholder text shown in the plain-text input.
+     * Maximum length for the text in this field is 150 characters.
+     */
+    private PlainTextObject placeholder;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/DndUpdatedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/DndUpdatedEvent.java
@@ -26,6 +26,7 @@ public class DndUpdatedEvent implements Event {
         private Integer nextDndStartTs;
         private Integer nextDndEndTs;
         private boolean snoozeEnabled;
+        private boolean snoozeIsIndefinite;
         private Integer snoozeEndtime;
     }
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/view/ViewState.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/view/ViewState.java
@@ -1,5 +1,6 @@
 package com.slack.api.model.view;
 
+import com.slack.api.model.block.RichTextBlock;
 import com.slack.api.model.block.composition.PlainTextObject;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,6 +36,7 @@ public class ViewState {
         private List<String> selectedUsers;
         private List<SelectedOption> selectedOptions;
         private String timezone; // for timepicker
+        private RichTextBlock richTextValue; // "rich_text_input" type
     }
 
     @Data

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonBlockElementFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonBlockElementFactory.java
@@ -76,6 +76,8 @@ public class GsonBlockElementFactory implements JsonDeserializer<BlockElement>, 
                 return DatetimePickerElement.class;
             case PlainTextInputElement.TYPE:
                 return PlainTextInputElement.class;
+            case RichTextInputElement.TYPE:
+                return RichTextInputElement.class;
             case URLTextInputElement.TYPE:
                 return URLTextInputElement.class;
             case EmailTextInputElement.TYPE:

--- a/slack-api-model/src/test/java/test_locally/api/model/event/DndUpdatedEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/DndUpdatedEventTest.java
@@ -47,7 +47,7 @@ public class DndUpdatedEventTest {
         event.setUser("u");
         event.setDndStatus(new DndUpdatedEvent.DndStatus());
         String generatedJson = gson.toJson(event);
-        String expectedJson = "{\"type\":\"dnd_updated\",\"user\":\"u\",\"dnd_status\":{\"dnd_enabled\":false,\"snooze_enabled\":false}}";
+        String expectedJson = "{\"type\":\"dnd_updated\",\"user\":\"u\",\"dnd_status\":{\"dnd_enabled\":false,\"snooze_enabled\":false,\"snooze_is_indefinite\":false}}";
         assertThat(generatedJson, is(expectedJson));
     }
 

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileChangePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileChangePayload.java
@@ -11,6 +11,8 @@ public class FileChangePayload implements EventsApiPayload<FileChangeEvent> {
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileCreatedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileCreatedPayload.java
@@ -11,6 +11,8 @@ public class FileCreatedPayload implements EventsApiPayload<FileCreatedEvent> {
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileDeletedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileDeletedPayload.java
@@ -11,6 +11,8 @@ public class FileDeletedPayload implements EventsApiPayload<FileDeletedEvent> {
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FilePublicPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FilePublicPayload.java
@@ -11,6 +11,8 @@ public class FilePublicPayload implements EventsApiPayload<FilePublicEvent> {
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileSharedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileSharedPayload.java
@@ -11,6 +11,8 @@ public class FileSharedPayload implements EventsApiPayload<FileSharedEvent> {
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileUnsharedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/FileUnsharedPayload.java
@@ -11,6 +11,8 @@ public class FileUnsharedPayload implements EventsApiPayload<FileUnsharedEvent> 
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupArchivePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupArchivePayload.java
@@ -11,6 +11,8 @@ public class GroupArchivePayload implements EventsApiPayload<GroupArchiveEvent> 
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupClosePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupClosePayload.java
@@ -11,6 +11,8 @@ public class GroupClosePayload implements EventsApiPayload<GroupCloseEvent> {
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupDeletedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupDeletedPayload.java
@@ -11,6 +11,8 @@ public class GroupDeletedPayload implements EventsApiPayload<GroupDeletedEvent> 
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupHistoryChangedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupHistoryChangedPayload.java
@@ -11,6 +11,8 @@ public class GroupHistoryChangedPayload implements EventsApiPayload<GroupHistory
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupLeftPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupLeftPayload.java
@@ -11,6 +11,8 @@ public class GroupLeftPayload implements EventsApiPayload<GroupLeftEvent> {
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupOpenPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupOpenPayload.java
@@ -11,6 +11,8 @@ public class GroupOpenPayload implements EventsApiPayload<GroupOpenEvent> {
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupRenamePayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/GroupRenamePayload.java
@@ -11,6 +11,8 @@ public class GroupRenamePayload implements EventsApiPayload<GroupRenameEvent> {
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MemberJoinedChannelPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MemberJoinedChannelPayload.java
@@ -11,6 +11,8 @@ public class MemberJoinedChannelPayload implements EventsApiPayload<MemberJoined
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MemberLeftChannelPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MemberLeftChannelPayload.java
@@ -11,6 +11,8 @@ public class MemberLeftChannelPayload implements EventsApiPayload<MemberLeftChan
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ReactionAddedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ReactionAddedPayload.java
@@ -11,6 +11,8 @@ public class ReactionAddedPayload implements EventsApiPayload<ReactionAddedEvent
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ReactionRemovedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/ReactionRemovedPayload.java
@@ -11,6 +11,8 @@ public class ReactionRemovedPayload implements EventsApiPayload<ReactionRemovedE
     private String token;
     private String enterpriseId;
     private String teamId;
+    private String contextTeamId;
+    private String contextEnterpriseId;
     private String apiAppId;
     private String type;
     private List<String> authedUsers;

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/payload/BlockActionPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/payload/BlockActionPayload.java
@@ -3,6 +3,7 @@ package com.slack.api.app_backend.interactive_components.payload;
 import com.google.gson.annotations.SerializedName;
 import com.slack.api.model.Message;
 import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.RichTextBlock;
 import com.slack.api.model.block.composition.ConfirmationDialogObject;
 import com.slack.api.model.block.composition.OptionObject;
 import com.slack.api.model.block.composition.PlainTextObject;
@@ -172,6 +173,8 @@ public class BlockActionPayload {
             private PlainTextObject text;
             private String value;
         }
+
+        private RichTextBlock richTextValue;
     }
 
 }


### PR DESCRIPTION
This pull request adds a few changes for supporting rich_text_input block element on modals and Home tabs:
* Add rich_text_input block element to slack-api-model and slack-api-model-kotlin-extension
* Add rich_text_value patterns (view_submission and block_actions) to slack-app-backend library

references:
* https://api.slack.com/reference/block-kit/block-elements#rich_text_input

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
