### PR TITLE
Fix #1224 Jetty 9.x security upgrades + http4k, ktor upgrades

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>5.8.2.0</http4k.version>
+        <http4k.version>5.9.0.0</http4k.version>
     </properties>
 
     <artifactId>bolt-http4k</artifactId>

--- a/bolt-jetty/pom.xml
+++ b/bolt-jetty/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <jetty.version>9.4.51.v20230217</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
     </properties>
 
     <artifactId>bolt-jetty</artifactId>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <ktor.version>2.3.4</ktor.version>
+        <ktor.version>2.3.5</ktor.version>
     </properties>
 
     <pluginRepositories>

--- a/bolt-servlet/pom.xml
+++ b/bolt-servlet/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <!-- TODO: Upgrade to 11.x in the next major version - v2 -->
-        <jetty.version>9.4.24.v20191120</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
     </properties>
 
     <artifactId>bolt-servlet</artifactId>


### PR DESCRIPTION
This pull request resolves #1224 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
