### PR TITLE
Upgrade okhttp to 4.12.0 for security fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <!-- We don't change the versions of servlet API interface to keep the backward compatibility with older versions of them -->
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
-        <okhttp.version>4.11.0</okhttp.version>
+        <okhttp.version>4.12.0</okhttp.version>
         <gson.version>2.10.1</gson.version>
         <kotlin.version>1.9.10</kotlin.version>
         <!-- Note that we should not upgrade sfl4j-api to v2 to avoid confusions on the users side.


### PR DESCRIPTION
Upgrading okhttp to the latest version is required for publishing a new version.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
