### PR TITLE
Add new arguments to admin.users.list API method

### DIFF
--- a/json-logs/samples/api/admin.users.list.json
+++ b/json-logs/samples/api/admin.users.list.json
@@ -17,7 +17,12 @@
       "date_created": 12345,
       "roles": [
         ""
-      ]
+      ],
+      "workspaces": [
+        "T00000000"
+      ],
+      "has_2fa": false,
+      "has_sso": false
     }
   ],
   "response_metadata": {

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -883,6 +883,8 @@ public class RequestFormBuilder {
     public static FormBody.Builder toForm(AdminUsersListRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("team_id", req.getTeamId(), form);
+        setIfNotNull("include_deactivated_user_workspaces", req.getIncludeDeactivatedUserWorkspaces(), form);
+        setIfNotNull("is_active", req.getIsActive(), form);
         setIfNotNull("cursor", req.getCursor(), form);
         setIfNotNull("limit", req.getLimit(), form);
         return form;

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/admin/users/AdminUsersListRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/admin/users/AdminUsersListRequest.java
@@ -22,6 +22,20 @@ public class AdminUsersListRequest implements SlackApiRequest {
     private String teamId;
 
     /**
+     * Only applies with org token and no team_id. If true,
+     * return workspaces for a user even if they may be deactivated on them.
+     * If false, return workspaces for a user only when user is active on them.
+     * Default is false.
+     */
+    private Boolean includeDeactivatedUserWorkspaces;
+
+    /**
+     * If true, only active users will be returned.
+     * If false, only deactivated users will be returned. Default is true.
+     */
+    private Boolean isActive;
+
+    /**
      * Set cursor to next_cursor returned by the previous call to list items in the next page.
      */
     private String cursor;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/admin/users/AdminUsersListResponse.java
@@ -41,8 +41,13 @@ public class AdminUsersListResponse implements SlackApiTextResponse {
         private boolean bot;
         @SerializedName("is_active")
         private boolean active;
+        @SerializedName("has_2fa")
+        private Boolean has2fa;
+        @SerializedName("has_sso")
+        private Boolean hasSso;
         private Long expirationTs;
         private Integer dateCreated;
         private List<String> roles;
+        private List<String> workspaces;
     }
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApi_users_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods_admin_api/AdminApi_users_Test.java
@@ -164,6 +164,27 @@ public class AdminApi_users_Test {
     }
 
     @Test
+    public void users_with_options() throws Exception {
+        if (teamAdminUserToken != null && orgAdminUserToken != null) {
+            AsyncMethodsClient methodsAsync = slack.methodsAsync(orgAdminUserToken);
+
+            AdminUsersListResponse.User user = null;
+            String nextCursor = "dummy";
+            while (!nextCursor.equals("")) {
+                final String cursor = nextCursor.equals("dummy") ? null : nextCursor;
+                AdminUsersListResponse users = methodsAsync.adminUsersList(r -> r
+                        .limit(100)
+                        .includeDeactivatedUserWorkspaces(true)
+                        .isActive(true)
+                        .cursor(cursor)
+                ).get();
+                assertThat(users.getError(), is(nullValue()));
+                nextCursor = users.getResponseMetadata().getNextCursor();
+            }
+        }
+    }
+
+    @Test
     public void usersUnsupportedVersions() throws Exception {
         if (teamAdminUserToken != null && orgAdminUserToken != null) {
             int nextMonth = (int) ZonedDateTime.now().plusMonths(1).toInstant().toEpochMilli() / 1000;


### PR DESCRIPTION
This pull request adds two newly added options to https://api.slack.com/methods/admin.users.list

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
