### PR TITLE
Add custom error handler support to Socket Mode adapter

### DIFF
--- a/json-logs/samples/events/DndUpdatedPayload.json
+++ b/json-logs/samples/events/DndUpdatedPayload.json
@@ -12,7 +12,8 @@
       "next_dnd_end_ts": 12345,
       "snooze_enabled": false,
       "snooze_endtime": 12345,
-      "snooze_remaining": 12345
+      "snooze_remaining": 12345,
+      "snooze_is_indefinite": false
     },
     "event_ts": "0000000000.000000"
   },

--- a/json-logs/samples/events/FilePublicPayload.json
+++ b/json-logs/samples/events/FilePublicPayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "team_id": "",
   "enterprise_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "event": {
     "file_id": "",

--- a/json-logs/samples/events/FileSharedPayload.json
+++ b/json-logs/samples/events/FileSharedPayload.json
@@ -2,15 +2,17 @@
   "token": "",
   "team_id": "",
   "enterprise_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "event": {
+    "type": "file_shared",
     "file_id": "",
     "user_id": "",
     "file": {
       "id": ""
     },
     "channel_id": "",
-    "type": "file_shared",
     "event_ts": "0000000000.000000"
   },
   "type": "event_callback",

--- a/json-logs/samples/events/FileUnsharedPayload.json
+++ b/json-logs/samples/events/FileUnsharedPayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "team_id": "",
   "enterprise_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "event": {
     "file_id": "",

--- a/json-logs/samples/events/GroupArchivePayload.json
+++ b/json-logs/samples/events/GroupArchivePayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "team_id": "",
   "enterprise_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "event": {
     "type": "group_archive",

--- a/json-logs/samples/events/GroupRenamePayload.json
+++ b/json-logs/samples/events/GroupRenamePayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "team_id": "",
   "enterprise_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "event": {
     "type": "group_rename",

--- a/json-logs/samples/events/MemberJoinedChannelPayload.json
+++ b/json-logs/samples/events/MemberJoinedChannelPayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "team_id": "",
   "enterprise_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "event": {
     "type": "member_joined_channel",

--- a/json-logs/samples/events/MemberLeftChannelPayload.json
+++ b/json-logs/samples/events/MemberLeftChannelPayload.json
@@ -2,6 +2,8 @@
   "token": "",
   "team_id": "",
   "enterprise_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "event": {
     "type": "member_left_channel",

--- a/json-logs/samples/events/ReactionAddedPayload.json
+++ b/json-logs/samples/events/ReactionAddedPayload.json
@@ -2,16 +2,18 @@
   "token": "",
   "team_id": "",
   "enterprise_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "event": {
     "type": "reaction_added",
     "user": "",
+    "reaction": "",
     "item": {
       "type": "message",
       "channel": "",
       "ts": "0000000000.000000"
     },
-    "reaction": "",
     "item_user": "",
     "event_ts": "0000000000.000000"
   },

--- a/json-logs/samples/events/ReactionRemovedPayload.json
+++ b/json-logs/samples/events/ReactionRemovedPayload.json
@@ -2,16 +2,18 @@
   "token": "",
   "team_id": "",
   "enterprise_id": "",
+  "context_team_id": "",
+  "context_enterprise_id": "",
   "api_app_id": "",
   "event": {
     "type": "reaction_removed",
     "user": "",
+    "reaction": "",
     "item": {
       "type": "message",
       "channel": "",
       "ts": "0000000000.000000"
     },
-    "reaction": "",
     "item_user": "",
     "event_ts": "0000000000.000000"
   },

--- a/json-logs/samples/events/SubteamMembersChangedPayload.json
+++ b/json-logs/samples/events/SubteamMembersChangedPayload.json
@@ -6,7 +6,6 @@
   "event": {
     "type": "subteam_members_changed",
     "subteam_id": "",
-    "team_id": "",
     "date_previous_update": 12345,
     "date_update": 12345,
     "added_users": [
@@ -17,6 +16,7 @@
       ""
     ],
     "removed_users_count": 12345,
+    "team_id": "",
     "event_ts": "0000000000.000000"
   },
   "type": "event_callback",

--- a/json-logs/samples/events/SubteamUpdatedPayload.json
+++ b/json-logs/samples/events/SubteamUpdatedPayload.json
@@ -33,8 +33,7 @@
         ""
       ],
       "user_count": 12345,
-      "channel_count": 12345,
-      "deleted_by": ""
+      "channel_count": 12345
     },
     "event_ts": "0000000000.000000"
   },


### PR DESCRIPTION
ref: https://github.com/slack-samples/bolt-java-starter-template/issues/199

This pull request adds custom error handler support to SocketModeApp, which is a built-in Socket Mode adapter. I've checked other adapters too but I don't see the necessity to add similar to others so far.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
