### PR TITLE
Fix #1237 TeamBillableInfoRequest missing 2 optional arguments

### DIFF
--- a/json-logs/samples/api/team.billableInfo.json
+++ b/json-logs/samples/api/team.billableInfo.json
@@ -10,5 +10,8 @@
   },
   "error": "",
   "needed": "",
-  "provided": ""
+  "provided": "",
+  "response_metadata": {
+    "next_cursor": ""
+  }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -2469,6 +2469,8 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("user", req.getUser(), form);
         setIfNotNull("team_id", req.getTeamId(), form);
+        setIfNotNull("cursor", req.getCursor(), form);
+        setIfNotNull("limit", req.getLimit(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamBillableInfoRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/team/TeamBillableInfoRequest.java
@@ -26,4 +26,15 @@ public class TeamBillableInfoRequest implements SlackApiRequest {
      */
     private String teamId;
 
+    /**
+     * Set cursor to next_cursor returned by previous call,
+     * to indicate from where you want to list next page of users list.
+     * Default value fetches the first page.
+     */
+    private String cursor;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamBillableInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/team/TeamBillableInfoResponse.java
@@ -2,6 +2,7 @@ package com.slack.api.methods.response.team;
 
 import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.BillableInfo;
+import com.slack.api.model.ResponseMetadata;
 import lombok.Data;
 
 import java.util.List;
@@ -18,4 +19,5 @@ public class TeamBillableInfoResponse implements SlackApiTextResponse {
     private transient Map<String, List<String>> httpResponseHeaders;
 
     private Map<String, BillableInfo> billableInfo;
+    private ResponseMetadata responseMetadata;
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/team_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/team_Test.java
@@ -110,6 +110,23 @@ public class team_Test {
     }
 
     @Test
+    public void teamBillableInfo_pagination() throws Exception {
+        TeamBillableInfoResponse response = slack.methods().teamBillableInfo(r -> r
+                .token(userToken).limit(1));
+        int count = 0;
+        String nextCursor = response.getResponseMetadata().getNextCursor();
+        while (count < 5 && !nextCursor.equals("")) {
+            final String _nextCursor = nextCursor;
+            response = slack.methods().teamBillableInfo(r -> r
+                    .token(userToken).cursor(_nextCursor).limit(1));
+            assertThat(response.getError(), is(nullValue()));
+            assertThat(response.isOk(), is(true));
+            nextCursor = response.getResponseMetadata().getNextCursor();
+            count += 1;
+        }
+    }
+
+    @Test
     public void teamBillableInfo_async() throws Exception {
         // Using async client to avoid an exception due to rate limited errors
         List<User> users = slack.methodsAsync().usersList(r -> r.token(userToken)).get().getMembers();


### PR DESCRIPTION
This pull request resolves #1237 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
