### PR TITLE
Fix #1256 Socket Mode connection error issue

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/socket_mode/impl/SocketModeClientJavaWSImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/socket_mode/impl/SocketModeClientJavaWSImpl.java
@@ -41,6 +41,7 @@ public class SocketModeClientJavaWSImpl implements SocketModeClient {
     private final Gson gson;
     private URI wssUri;
     private boolean autoReconnectEnabled;
+    private boolean autoReconnectOnCloseEnabled;
     private SocketModeMessageQueue messageQueue;
     private ScheduledExecutorService messageProcessorExecutor;
     private boolean sessionMonitorEnabled;
@@ -110,6 +111,8 @@ public class SocketModeClientJavaWSImpl implements SocketModeClient {
 
         setMessageQueue(messageQueue);
         setAutoReconnectEnabled(autoReconnectEnabled);
+        // You can use the setter method if you set the value to true
+        setAutoReconnectOnCloseEnabled(false);
         setSessionMonitorEnabled(sessionMonitorEnabled);
         initializeSessionMonitorExecutor(sessionMonitorIntervalMillis);
         initializeMessageProcessorExecutor(concurrency);
@@ -154,6 +157,16 @@ public class SocketModeClientJavaWSImpl implements SocketModeClient {
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean isAutoReconnectOnCloseEnabled() {
+        return this.autoReconnectOnCloseEnabled;
+    }
+
+    @Override
+    public void setAutoReconnectOnCloseEnabled(boolean autoReconnectOnCloseEnabled) {
+        this.autoReconnectOnCloseEnabled = autoReconnectOnCloseEnabled;
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/socket_mode/impl/SocketModeClientTyrusImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/socket_mode/impl/SocketModeClientTyrusImpl.java
@@ -43,6 +43,7 @@ public class SocketModeClientTyrusImpl implements SocketModeClient {
     private final Gson gson;
     private URI wssUri;
     private boolean autoReconnectEnabled;
+    private boolean autoReconnectOnCloseEnabled;
     private SocketModeMessageQueue messageQueue;
     private ScheduledExecutorService messageProcessorExecutor;
     private boolean sessionMonitorEnabled;
@@ -121,6 +122,8 @@ public class SocketModeClientTyrusImpl implements SocketModeClient {
 
         setMessageQueue(messageQueue);
         setAutoReconnectEnabled(autoReconnectEnabled);
+        // You can use the setter method if you set the value to true
+        setAutoReconnectOnCloseEnabled(false);
         setSessionMonitorEnabled(sessionMonitorEnabled);
         initializeSessionMonitorExecutor(sessionMonitorIntervalMillis);
         initializeMessageProcessorExecutor(concurrency);
@@ -215,6 +218,16 @@ public class SocketModeClientTyrusImpl implements SocketModeClient {
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean isAutoReconnectOnCloseEnabled() {
+        return this.autoReconnectOnCloseEnabled;
+    }
+
+    @Override
+    public void setAutoReconnectOnCloseEnabled(boolean autoReconnectOnCloseEnabled) {
+        this.autoReconnectOnCloseEnabled = autoReconnectOnCloseEnabled;
     }
 
     @Override


### PR DESCRIPTION
This pull request resolves #1256 (and probably #1223 too) by improving the internals of the Socket Mode client code, thanks to @oppokui. This pull request changes the default behavior of the onClose listener not to try to reconnect. Originally, the logic was introduced to let the client get back to online much faster, and it has been working well as long as the server side behaves as the code expects. However, it seems that the server now works differently for some reason. Thus, revisiting the logic should be reasonable. Also, the change should be safe enough for the reasons mentioned in the code comment.

If some users would like to switch back to the previous logic for a certain logic, calling `SocketModeClient#setAutoReconnectOnCloseEnabled(true)` enables them to do so.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
