### PR TITLE
Fix #1264 bolt-http4k fails to parse a request with duplicated header lines

### DIFF
--- a/bolt-http4k/src/test/java/test_locally/Http4kSlackAppTest.java
+++ b/bolt-http4k/src/test/java/test_locally/Http4kSlackAppTest.java
@@ -85,6 +85,8 @@ public class Http4kSlackAppTest {
                 .header(X_SLACK_REQUEST_TIMESTAMP, timestamp)
                 .header(X_SLACK_SIGNATURE, signature)
                 .header("Content-Type", "application/json")
+                .header("X-Forwarded-Host", "proxy1.example.com")
+                .header("X-Forwarded-Host", "proxy2.example.com")
                 .query("query", "queryValue")
                 .body(requestBody);
     }
@@ -108,7 +110,7 @@ public class Http4kSlackAppTest {
                 .header("Content-Type", "application/json; charset=utf-8")
                 .body("{\"text\":\"" +
                         "query: query " +
-                        "headers: content-type,x-slack-request-timestamp,x-slack-signature " +
+                        "headers: x-forwarded-host,content-type,x-slack-request-timestamp,x-slack-signature " +
                         "body: command\\u003decho" +
                         "\"}");
 


### PR DESCRIPTION
This pull request resolves #1264 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
