### PR TITLE
Fix #1269 A bug on the metric calculation inside async API clients

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/impl/AsyncRateLimitExecutor.java
@@ -65,7 +65,7 @@ public class AsyncRateLimitExecutor {
         return CompletableFuture.supplyAsync(() -> {
             String messageId = messageIdGenerator.generate();
             addMessageId(teamId, methodName, messageId);
-            initCurrentQueueSizeStatsIfAbsent(teamId, methodName);
+            syncCurrentQueueSizeStats(teamId, methodName);
             if (NO_TOKEN_METHOD_NAMES.contains(methodName) || teamId == null) {
                 return runWithoutQueue(teamId, methodName, methodsSupplier);
             } else {
@@ -80,9 +80,9 @@ public class AsyncRateLimitExecutor {
         }, executorService);
     }
 
-    private void initCurrentQueueSizeStatsIfAbsent(String teamId, String methodNameWithSuffix) {
+    private void syncCurrentQueueSizeStats(String teamId, String methodNameWithSuffix) {
         if (teamId != null) {
-            metricsDatastore.setCurrentQueueSize(config.getExecutorName(), teamId, methodNameWithSuffix, 0);
+            metricsDatastore.updateCurrentQueueSize(config.getExecutorName(), teamId, methodNameWithSuffix);
         }
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
@@ -73,7 +73,7 @@ public class AsyncRateLimitExecutor {
                 String messageId = messageIdGenerator.generate();
                 String methodNameWithSuffix = toMethodNameWithSuffix(methodName, params);
                 addMessageId(teamId, methodNameWithSuffix, messageId);
-                initCurrentQueueSizeStatsIfAbsent(teamId, methodNameWithSuffix);
+                syncCurrentQueueSizeStats(teamId, methodNameWithSuffix);
                 return enqueueThenRun(
                         messageId,
                         teamId,
@@ -85,9 +85,9 @@ public class AsyncRateLimitExecutor {
         }, executorService);
     }
 
-    private void initCurrentQueueSizeStatsIfAbsent(String teamId, String methodNameWithSuffix) {
+    private void syncCurrentQueueSizeStats(String teamId, String methodNameWithSuffix) {
         if (teamId != null) {
-            metricsDatastore.setCurrentQueueSize(config.getExecutorName(), teamId, methodNameWithSuffix, 0);
+            metricsDatastore.updateCurrentQueueSize(config.getExecutorName(), teamId, methodNameWithSuffix);
         }
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseMemoryMetricsDatastore.java
+++ b/slack-api-client/src/main/java/com/slack/api/rate_limits/metrics/impl/BaseMemoryMetricsDatastore.java
@@ -264,13 +264,6 @@ public abstract class BaseMemoryMetricsDatastore<SUPPLIER, MSG extends QueueMess
     @Override
     public void setCurrentQueueSize(String executorName, String teamId, String methodName, Integer size) {
         if (this.isStatsEnabled()) {
-            CopyOnWriteArrayList<String> messageIds = getOrCreateMessageIds(executorName, teamId, methodName);
-            Integer totalSize = messageIds.size();
-            RateLimitQueue<SUPPLIER, MSG> queue = getRateLimitQueue(executorName, teamId);
-            if (queue != null) {
-                totalSize += queue.getCurrentActiveQueueSize(methodName);
-            }
-            getOrCreateTeamLiveStats(executorName, teamId).getCurrentQueueSize().put(methodName, totalSize);
             getOrCreateTeamLiveStats(executorName, teamId).getCurrentQueueSize().put(methodName, size);
         }
     }

--- a/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim/impl/AsyncRateLimitExecutor.java
@@ -62,7 +62,7 @@ public class AsyncRateLimitExecutor {
         return CompletableFuture.supplyAsync(() -> {
             String messageId = messageIdGenerator.generate();
             addMessageId(teamId, endpointName, messageId);
-            initCurrentQueueSizeStatsIfAbsent(teamId, endpointName);
+            syncCurrentQueueSizeStats(teamId, endpointName);
             if (NO_TOKEN_METHOD_NAMES.contains(endpointName) || teamId == null) {
                 return runWithoutQueue(teamId, endpointName, methodsSupplier);
             } else {
@@ -77,14 +77,9 @@ public class AsyncRateLimitExecutor {
         }, executorService);
     }
 
-    private void initCurrentQueueSizeStatsIfAbsent(String teamId, SCIMEndpointName endpointName) {
+    private void syncCurrentQueueSizeStats(String teamId, SCIMEndpointName endpointName) {
         if (teamId != null) {
-            metricsDatastore.setCurrentQueueSize(
-                    config.getExecutorName(),
-                    teamId,
-                    endpointName.name(),
-                    0
-            );
+            metricsDatastore.updateCurrentQueueSize(config.getExecutorName(), teamId, endpointName.name());
         }
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/scim2/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/scim2/impl/AsyncRateLimitExecutor.java
@@ -62,7 +62,7 @@ public class AsyncRateLimitExecutor {
         return CompletableFuture.supplyAsync(() -> {
             String messageId = messageIdGenerator.generate();
             addMessageId(teamId, endpointName, messageId);
-            initCurrentQueueSizeStatsIfAbsent(teamId, endpointName);
+            syncCurrentQueueSizeStats(teamId, endpointName);
             if (NO_TOKEN_METHOD_NAMES.contains(endpointName) || teamId == null) {
                 return runWithoutQueue(teamId, endpointName, methodsSupplier);
             } else {
@@ -77,14 +77,9 @@ public class AsyncRateLimitExecutor {
         }, executorService);
     }
 
-    private void initCurrentQueueSizeStatsIfAbsent(String teamId, SCIM2EndpointName endpointName) {
+    private void syncCurrentQueueSizeStats(String teamId, SCIM2EndpointName endpointName) {
         if (teamId != null) {
-            metricsDatastore.setCurrentQueueSize(
-                    config.getExecutorName(),
-                    teamId,
-                    endpointName.name(),
-                    0
-            );
+            metricsDatastore.updateCurrentQueueSize(config.getExecutorName(), teamId, endpointName.name());
         }
     }
 


### PR DESCRIPTION
This pull request resolves #1269, thank you so much @gunrein !

The bug had been affecting only the output of the visible metrics data for developers. The internal smart rate limiter mechanism does not use the data at all, so the impact of the misbehavior should be relatively small.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
