### PR TITLE
Fix #1273 AsyncMethodsRateLimiter does not handle ratelimitted errors properly

### DIFF
--- a/slack-api-client/src/test/java/test_locally/api/methods/RateLimitedTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/RateLimitedTest.java
@@ -11,18 +11,12 @@ import org.junit.Before;
 import org.junit.Test;
 import util.MockSlackApiServer;
 
-import java.sql.Time;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static util.MockSlackApi.RateLimitedToken;
-import static util.MockSlackApi.ValidToken;
 
 @Slf4j
 public class RateLimitedTest {
@@ -31,9 +25,13 @@ public class RateLimitedTest {
     SlackConfig config = new SlackConfig();
     Slack slack = Slack.getInstance(config);
 
+    String executorName = RateLimitedTest.class.getCanonicalName();
+
     @Before
     public void setup() throws Exception {
         server.start();
+        config.getMethodsConfig().setExecutorName(executorName);
+        config.synchronizeMetricsDatabases();
         config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
     }
 
@@ -54,13 +52,13 @@ public class RateLimitedTest {
             log.debug("stats: {}", datastore.getAllStats());
 
             Integer numOfRequests = datastore.getNumberOfLastMinuteRequests(
-                    MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME,
+                    executorName,
                     "T1234567",
                     "users.list");
             assertThat(numOfRequests, is(1));
 
             Long millisToResume = datastore.getRateLimitedMethodRetryEpochMillis(
-                    MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME,
+                    executorName,
                     "T1234567",
                     "users.list");
             assertThat(millisToResume, is(greaterThan(0L)));
@@ -76,13 +74,13 @@ public class RateLimitedTest {
             log.debug("stats: {}", datastore.getAllStats());
 
             Integer numOfRequests = datastore.getNumberOfLastMinuteRequests(
-                    MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME,
+                    executorName,
                     "T1234567",
                     "users.list");
             assertThat(numOfRequests, is(1));
 
             Long millisToResume = datastore.getRateLimitedMethodRetryEpochMillis(
-                    MetricsDatastore.DEFAULT_SINGLETON_EXECUTOR_NAME,
+                    executorName,
                     "T1234567",
                     "users.list");
             assertThat(millisToResume, is(greaterThan(0L)));


### PR DESCRIPTION
This pull request resolves #1273 ; Only the AsyncMethodsClient has been having this bug, so we don't need to make similar changes to SCIM/SCIMv2/Audit Logs API clients.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
