### PR TITLE
Make the same change to chat.postMessage with #1274

### DIFF
--- a/slack-api-client/src/test/java/test_locally/api/methods/RateLimitedTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/RateLimitedTest.java
@@ -2,6 +2,7 @@ package test_locally.api.methods;
 
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
+import com.slack.api.methods.Methods;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.rate_limits.metrics.MetricsDatastore;
@@ -22,17 +23,20 @@ import static util.MockSlackApi.RateLimitedToken;
 public class RateLimitedTest {
 
     MockSlackApiServer server = new MockSlackApiServer();
-    SlackConfig config = new SlackConfig();
-    Slack slack = Slack.getInstance(config);
-
-    String executorName = RateLimitedTest.class.getCanonicalName();
+    String executorName;
+    SlackConfig config;
+    Slack slack;
 
     @Before
     public void setup() throws Exception {
         server.start();
+        executorName = RateLimitedTest.class.getCanonicalName() + "_" + System.currentTimeMillis();
+        config = new SlackConfig();
         config.getMethodsConfig().setExecutorName(executorName);
         config.synchronizeMetricsDatabases();
         config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+
+        slack = Slack.getInstance(config);
     }
 
     @After
@@ -54,13 +58,13 @@ public class RateLimitedTest {
             Integer numOfRequests = datastore.getNumberOfLastMinuteRequests(
                     executorName,
                     "T1234567",
-                    "users.list");
+                    Methods.USERS_LIST);
             assertThat(numOfRequests, is(1));
 
             Long millisToResume = datastore.getRateLimitedMethodRetryEpochMillis(
                     executorName,
                     "T1234567",
-                    "users.list");
+                    Methods.USERS_LIST);
             assertThat(millisToResume, is(greaterThan(0L)));
         }
     }
@@ -76,15 +80,63 @@ public class RateLimitedTest {
             Integer numOfRequests = datastore.getNumberOfLastMinuteRequests(
                     executorName,
                     "T1234567",
-                    "users.list");
+                    Methods.USERS_LIST);
             assertThat(numOfRequests, is(1));
 
             Long millisToResume = datastore.getRateLimitedMethodRetryEpochMillis(
                     executorName,
                     "T1234567",
-                    "users.list");
+                    Methods.USERS_LIST);
             assertThat(millisToResume, is(greaterThan(0L)));
         }
     }
 
+    @Test
+    public void chatPostMessageSync() throws Exception {
+        MethodsClient client = slack.methods(RateLimitedToken);
+        try {
+            client.chatPostMessage(r -> r.text("Hey!").channel("C12345"));
+        } catch (SlackApiException e) {
+            assertThat(e.getResponse().code(), is(429));
+            assertThat(e.getResponse().header("Retry-After"), is("3"));
+            MetricsDatastore datastore = config.getMethodsConfig().getMetricsDatastore();
+            log.debug("stats: {}", datastore.getAllStats());
+
+            Integer numOfRequests = datastore.getNumberOfLastMinuteRequests(
+                    executorName,
+                    "T1234567",
+                    Methods.CHAT_POST_MESSAGE + "_C12345");
+            assertThat(numOfRequests, is(1));
+
+            Long millisToResume = datastore.getRateLimitedMethodRetryEpochMillis(
+                    executorName,
+                    "T1234567",
+                    Methods.CHAT_POST_MESSAGE + "_C12345");
+            assertThat(millisToResume, is(greaterThan(0L)));
+        }
+    }
+
+    @Test
+    public void chatPostMessageAsync() throws Exception {
+        try {
+            slack.methodsAsync(RateLimitedToken)
+                    .chatPostMessage(r -> r.text("Hey!").channel("C12345"))
+                    .get(2, TimeUnit.SECONDS);
+        } catch (Exception ee) {
+            MetricsDatastore datastore = config.getMethodsConfig().getMetricsDatastore();
+            log.debug("stats: {}", datastore.getAllStats());
+
+            Integer numOfRequests = datastore.getNumberOfLastMinuteRequests(
+                    executorName,
+                    "T1234567",
+                    Methods.CHAT_POST_MESSAGE + "_C12345");
+            assertThat(numOfRequests, is(1));
+
+            Long millisToResume = datastore.getRateLimitedMethodRetryEpochMillis(
+                    executorName,
+                    "T1234567",
+                    Methods.CHAT_POST_MESSAGE + "_C12345");
+            assertThat(millisToResume, is(greaterThan(0L)));
+        }
+    }
 }


### PR DESCRIPTION
This pull request applies the same change with #1274 to chat.postMessage API patterns. Actually, this is not a major problem for chat.postMessage at all because the API's rate limit is pretty generous. With that being said, having this change to it as well should improve the consistency of the SDK behavior.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
