### PR TITLE
Migrate from status.slack.com to slack-status.com

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/status/v1/LegacyStatusClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/status/v1/LegacyStatusClient.java
@@ -13,7 +13,7 @@ import java.util.List;
  */
 public interface LegacyStatusClient {
 
-    String ENDPOINT_URL_PREFIX = "https://status.slack.com/api/v1.0.0/";
+    String ENDPOINT_URL_PREFIX = "https://slack-status.com/api/v1.0.0/";
 
     String getEndpointUrlPrefix();
 

--- a/slack-api-client/src/main/java/com/slack/api/status/v2/StatusClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/status/v2/StatusClient.java
@@ -13,7 +13,7 @@ import java.util.List;
  */
 public interface StatusClient {
 
-    String ENDPOINT_URL_PREFIX = "https://status.slack.com/api/v2.0.0/";
+    String ENDPOINT_URL_PREFIX = "https://slack-status.com/api/v2.0.0/";
 
     String getEndpointUrlPrefix();
 


### PR DESCRIPTION
The status API endpoints are now on a new domain.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
