### PR TITLE
Bolt micronaut/micronaut 4 upgrade

### DIFF
--- a/.github/workflows/unit-tests-jdk-17.yml
+++ b/.github/workflows/unit-tests-jdk-17.yml
@@ -1,0 +1,31 @@
+name: JDK 17 Build & Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    strategy:
+      matrix:
+        java-version: ['17']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java-version }}
+        distribution: 'adopt'
+    - name: Run all tests
+      run: |
+        ./scripts/run_no_prep_tests.sh -ci
+      env:
+        SKIP_UNSTABLE_TESTS: 1
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: true

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -171,14 +171,6 @@
                         </execution>
                     </executions>
                 </plugin>
-                <!-- mockito + java 9+ fix, open modules in java.lang -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-                    </configuration>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,14 +10,21 @@
     </parent>
 
     <properties>
-        <!-- TODO: upgrading to v4 -->
-        <micronaut.version>3.9.4</micronaut.version>
-        <micronaut-test-junit5.version>3.9.2</micronaut-test-junit5.version>
-        <micronaut-rxjava3.version>2.4.1</micronaut-rxjava3.version>
+        <micronaut.version>4.3.12</micronaut.version>
+        <micronaut-test-junit5.version>4.2.1</micronaut-test-junit5.version>
+        <micronaut-rxjava3.version>3.2.1</micronaut-rxjava3.version>
         <junit5-jupiter.version>5.10.2</junit5-jupiter.version>
+
         <!-- Note that upgrading this library breaks other dependency resolution -->
         <mockito-all.version>1.10.19</mockito-all.version>
+
         <jakarta.inject.version>2.0.1.MR</jakarta.inject.version>
+
+        <!-- Micronaut 4 requires jdk 17 -->
+        <jdk.version>17</jdk.version>
+        <release.version>17</release.version>
+        <maven.compiler.source>1.17</maven.compiler.source>
+        <maven.compiler.target>1.17</maven.compiler.target>
     </properties>
 
     <artifactId>bolt-micronaut</artifactId>
@@ -55,6 +62,11 @@
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-http-server-netty</artifactId>
+            <version>${micronaut.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut</groupId>
+            <artifactId>micronaut-jackson-databind</artifactId>
             <version>${micronaut.version}</version>
         </dependency>
 
@@ -148,6 +160,7 @@
                                 <goal>testCompile</goal>
                             </goals>
                             <configuration>
+                                <!-- mockito + java 9+ -->
                                 <compilerArgs>
                                     <arg>-parameters</arg>
                                 </compilerArgs>
@@ -161,6 +174,14 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                <!-- mockito + java 9+ fix, open modules in java.lang -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -14,12 +14,9 @@
         <micronaut-test-junit5.version>4.2.1</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>3.2.1</micronaut-rxjava3.version>
         <junit5-jupiter.version>5.10.2</junit5-jupiter.version>
-
         <!-- Note that upgrading this library breaks other dependency resolution -->
         <mockito-all.version>1.10.19</mockito-all.version>
-
         <jakarta.inject.version>2.0.1.MR</jakarta.inject.version>
-
         <!-- Micronaut 4 requires jdk 17 -->
         <jdk.version>17</jdk.version>
         <release.version>17</release.version>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -160,7 +160,6 @@
                                 <goal>testCompile</goal>
                             </goals>
                             <configuration>
-                                <!-- mockito + java 9+ -->
                                 <compilerArgs>
                                     <arg>-parameters</arg>
                                 </compilerArgs>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -23,8 +23,8 @@
         <!-- Micronaut 4 requires jdk 17 -->
         <jdk.version>17</jdk.version>
         <release.version>17</release.version>
-        <maven.compiler.source>1.17</maven.compiler.source>
-        <maven.compiler.target>1.17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <artifactId>bolt-micronaut</artifactId>

--- a/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppController.java
+++ b/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppController.java
@@ -2,11 +2,9 @@ package com.slack.api.bolt.micronaut;
 
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.request.Request;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
-import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;

--- a/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppController.java
+++ b/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppController.java
@@ -2,6 +2,7 @@ package com.slack.api.bolt.micronaut;
 
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.request.Request;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
@@ -29,7 +30,8 @@ public class SlackAppController {
     }
 
     @Post(value = "/events", consumes = {MediaType.APPLICATION_FORM_URLENCODED, MediaType.APPLICATION_JSON})
-    public HttpResponse<String> events(HttpRequest<String> request, @Body String body) throws Exception {
+    public HttpResponse<String> events(HttpRequest<String> request) throws Exception {
+        String body = request.getBody().orElse(null);
         return adapt(request, body);
     }
 

--- a/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppMicronautAdapter.java
+++ b/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppMicronautAdapter.java
@@ -5,7 +5,6 @@ import com.slack.api.bolt.request.Request;
 import com.slack.api.bolt.request.RequestHeaders;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.util.SlackRequestParser;
-import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -13,7 +12,6 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.server.netty.NettyHttpResponseFactory;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
-
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;

--- a/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppMicronautAdapter.java
+++ b/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppMicronautAdapter.java
@@ -5,6 +5,7 @@ import com.slack.api.bolt.request.Request;
 import com.slack.api.bolt.request.RequestHeaders;
 import com.slack.api.bolt.response.Response;
 import com.slack.api.bolt.util.SlackRequestParser;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;

--- a/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppMicronautAdapter.java
+++ b/bolt-micronaut/src/main/java/com/slack/api/bolt/micronaut/SlackAppMicronautAdapter.java
@@ -12,6 +12,7 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.server.netty.NettyHttpResponseFactory;
 import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
+
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;

--- a/bolt-micronaut/src/test/java/test_locally/AdapterTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/AdapterTest.java
@@ -52,7 +52,7 @@ public class AdapterTest {
         AppConfig config = AppConfig.builder().build();
         SlackAppMicronautAdapter adapter = new SlackAppMicronautAdapter(config);
 
-        HttpRequest<String> req = mock(HttpRequest.class) ;
+        HttpRequest<String> req = mock(HttpRequest.class);
 
         InetSocketAddress isa = new InetSocketAddress("127.0.0.1", 443);
         when(req.getRemoteAddress()).thenReturn(isa);

--- a/bolt-micronaut/src/test/java/test_locally/AdapterTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/AdapterTest.java
@@ -4,7 +4,7 @@ import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.micronaut.SlackAppMicronautAdapter;
 import com.slack.api.bolt.request.Request;
 import com.slack.api.bolt.response.Response;
-import io.micronaut.core.convert.DefaultConversionService;
+import io.micronaut.core.convert.DefaultMutableConversionService;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.simple.SimpleHttpHeaders;
@@ -32,11 +32,11 @@ public class AdapterTest {
         HttpRequest<String> req = mock(HttpRequest.class);
         Map<String, String> rawHeaders = new HashMap<>();
         rawHeaders.put("X-Slack-Signature", "xxxxxxx");
-        SimpleHttpHeaders headers = new SimpleHttpHeaders(rawHeaders, new DefaultConversionService());
+        SimpleHttpHeaders headers = new SimpleHttpHeaders(rawHeaders, new DefaultMutableConversionService());
         when(req.getHeaders()).thenReturn(headers);
         Map<CharSequence, List<String>> params = new HashMap<>();
         params.put("foo", Arrays.asList("bar", "baz"));
-        SimpleHttpParameters parameters = new SimpleHttpParameters(params, new DefaultConversionService());
+        SimpleHttpParameters parameters = new SimpleHttpParameters(params, new DefaultMutableConversionService());
         when(req.getParameters()).thenReturn(parameters);
 
         Request<?> slackRequest = adapter.toSlackRequest(req, "token=random&ssl_check=1");
@@ -52,7 +52,7 @@ public class AdapterTest {
         AppConfig config = AppConfig.builder().build();
         SlackAppMicronautAdapter adapter = new SlackAppMicronautAdapter(config);
 
-        HttpRequest<String> req = mock(HttpRequest.class);
+        HttpRequest<String> req = mock(HttpRequest.class) ;
 
         InetSocketAddress isa = new InetSocketAddress("127.0.0.1", 443);
         when(req.getRemoteAddress()).thenReturn(isa);

--- a/bolt-micronaut/src/test/java/test_locally/ControllerTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/ControllerTest.java
@@ -6,7 +6,7 @@ import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.micronaut.SlackAppController;
 import com.slack.api.bolt.micronaut.SlackAppMicronautAdapter;
-import io.micronaut.core.convert.DefaultConversionService;
+import io.micronaut.core.convert.DefaultMutableConversionService;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpParameters;
@@ -20,6 +20,7 @@ import org.junit.Test;
 import util.AuthTestMockServer;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -62,12 +63,13 @@ public class ControllerTest {
         assertNotNull(controller);
 
         HttpRequest<String> req = mock(HttpRequest.class);
-        SimpleHttpHeaders headers = new SimpleHttpHeaders(new HashMap<>(), new DefaultConversionService());
+        SimpleHttpHeaders headers = new SimpleHttpHeaders(new HashMap<>(), new DefaultMutableConversionService());
         when(req.getHeaders()).thenReturn(headers);
-        SimpleHttpParameters parameters = new SimpleHttpParameters(new HashMap<>(), new DefaultConversionService());
+        SimpleHttpParameters parameters = new SimpleHttpParameters(new HashMap<>(), new DefaultMutableConversionService());
         when(req.getParameters()).thenReturn(parameters);
+        when(req.getBody()).thenReturn(Optional.of("token=random&ssl_check=1"));
 
-        HttpResponse<String> response = controller.events(req, "token=random&ssl_check=1");
+        HttpResponse<String> response = controller.events(req);
         assertEquals(200, response.getStatus().getCode());
     }
 

--- a/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
@@ -71,7 +71,7 @@ public class CommandsTest {
         when(methods.authTest(any(RequestConfigurator.class))).thenReturn(authTestResponse);
         return slack;
     }
-    
+
     @Test
     public void command() {
         MutableHttpRequest<String> request = HttpRequest.POST("/slack/events", "");

--- a/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
@@ -72,11 +72,12 @@ public class CommandsTest {
         return slack;
     }
 
+
     @Test
     public void command() {
         MutableHttpRequest<String> request = HttpRequest.POST("/slack/events", "");
         request.header("Content-Type", "application/x-www-form-urlencoded");
-        String timestamp = "" + (System.currentTimeMillis() / 1000);
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
         request.header(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP, timestamp);
         String signature = signatureGenerator.generate(timestamp, helloBody);
         request.header(SlackSignature.HeaderNames.X_SLACK_SIGNATURE, signature);
@@ -90,7 +91,7 @@ public class CommandsTest {
     public void invalidSignature() {
         MutableHttpRequest<String> request = HttpRequest.POST("/slack/events", "");
         request.header("Content-Type", "application/x-www-form-urlencoded");
-        String timestamp = "" + (System.currentTimeMillis() / 1000 - 30 * 60);
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000 - 30 * 60);
         request.header(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP, timestamp);
         String signature = signatureGenerator.generate(timestamp, helloBody);
         request.header(SlackSignature.HeaderNames.X_SLACK_SIGNATURE, signature);
@@ -122,7 +123,7 @@ public class CommandsTest {
     public void regexp_matching() {
         MutableHttpRequest<String> request = HttpRequest.POST("/slack/events", "");
         request.header("Content-Type", "application/x-www-form-urlencoded");
-        String timestamp = "" + (System.currentTimeMillis() / 1000);
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
         request.header(SlackSignature.HeaderNames.X_SLACK_REQUEST_TIMESTAMP, timestamp);
         String signature = signatureGenerator.generate(timestamp, submissionBody);
         request.header(SlackSignature.HeaderNames.X_SLACK_SIGNATURE, signature);

--- a/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
@@ -18,6 +18,7 @@ import io.micronaut.rxjava3.http.client.Rx3HttpClient;
 import io.micronaut.test.annotation.MockBean;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +52,7 @@ public class CommandsTest {
     SlackSignature.Generator signatureGenerator = new SlackSignature.Generator(signingSecret);
 
     @Primary
-    @MockBean(AppConfig.class)
+    @Singleton
     AppConfig mockSlackAppConfig() throws IOException, SlackApiException {
         AppConfig config = AppConfig.builder().signingSecret(signingSecret).singleTeamBotToken(botToken).build();
         config.setSlack(mockSlack());

--- a/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/app/CommandsTest.java
@@ -71,8 +71,7 @@ public class CommandsTest {
         when(methods.authTest(any(RequestConfigurator.class))).thenReturn(authTestResponse);
         return slack;
     }
-
-
+    
     @Test
     public void command() {
         MutableHttpRequest<String> request = HttpRequest.POST("/slack/events", "");

--- a/bolt-micronaut/src/test/java/test_locally/app/MicronautVersionTest.java
+++ b/bolt-micronaut/src/test/java/test_locally/app/MicronautVersionTest.java
@@ -1,0 +1,18 @@
+package test_locally.app;
+
+import io.micronaut.core.version.VersionUtils;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest
+public class MicronautVersionTest {
+
+    @Test
+    public void expectedMicronautVersion() {
+       String version = VersionUtils.getMicronautVersion();
+       Assertions.assertEquals("4.3.12", version);
+    }
+
+}
+

--- a/bolt-micronaut/src/test/resources/logback.xml
+++ b/bolt-micronaut/src/test/resources/logback.xml
@@ -1,6 +1,5 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>true</withJansi>
         <encoder>
             <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
         </encoder>

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- java 9+ fix for tests, open modules in java.lang -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
     </parent>
 
     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- For these compile scope dependencies, we don't use ranges of versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,6 @@
     </parent>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- For these compile scope dependencies, we don't use ranges of versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <maven-versions-plugin.version>2.8.1</maven-versions-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <dokka.version>1.6.10</dokka.version>
     </properties>
 
@@ -243,17 +244,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <!-- java 9+ fix for tests, open modules in java.lang -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>
-                        --add-opens java.base/java.lang=ALL-UNNAMED
-                        --add-opens java.base/java.util=ALL-UNNAMED
-                    </argLine>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -408,6 +398,28 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>building-with-jdk-17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- java 9+ fix for tests, open modules in java.lang -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
+                        <configuration>
+                            <argLine>
+                                --add-opens java.base/java.lang=ALL-UNNAMED
+                                --add-opens java.base/java.util=ALL-UNNAMED
+                            </argLine>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/scripts/run_no_prep_tests.sh
+++ b/scripts/run_no_prep_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 flags()
 {
     while test $# -gt 0
@@ -12,7 +13,6 @@ flags()
         shift
     done
 }
-
 flags "$@"
 
 is_jdk_8=`echo $JAVA_HOME | grep 8.`

--- a/scripts/run_no_prep_tests.sh
+++ b/scripts/run_no_prep_tests.sh
@@ -13,9 +13,12 @@ flags()
         shift
     done
 }
+
 flags "$@"
 
 is_jdk_8=`echo $JAVA_HOME | grep 8.`
+is_jdk_14=`echo $JAVA_HOME | grep 14.`
+
 is_travis_jdk_8=`echo $TRAVIS_JDK | grep openjdk8`
 if [[ "${is_jdk_8}" != "" && "${is_travis_jdk_8}" != "" ]];
 then
@@ -25,15 +28,7 @@ then
     -pl !bolt-quarkus-examples \
     -pl !bolt-jakarta-servlet \
     -pl !bolt-jakarta-jetty \
-    clean \
-    test-compile \
-    '-Dtest=test_locally.**.*Test' -Dsurefire.failIfNoSpecifiedTests=false test ${CI_OPTIONS}\
-    -DfailIfNoTests=false \
-    -Dhttps.protocols=TLSv1.2 \
-    --no-transfer-progress && \
-    if git status --porcelain | grep .; then git --no-pager diff; exit 1; fi
-else
-  ./mvnw ${MAVEN_OPTS} \
+    -pl !bolt-micronaut \
     clean \
     test-compile \
     '-Dtest=test_locally.**.*Test' -Dsurefire.failIfNoSpecifiedTests=false test ${CI_OPTIONS} \
@@ -41,4 +36,24 @@ else
     -Dhttps.protocols=TLSv1.2 \
     --no-transfer-progress && \
     if git status --porcelain | grep .; then git --no-pager diff; exit 1; fi
+elif [[ "${is_jdk_14}" != "" ]];
+then
+  ./mvnw ${MAVEN_OPTS} \
+    -pl !bolt-micronaut \
+    clean \
+    test-compile \
+    '-Dtest=test_locally.**.*Test' -Dsurefire.failIfNoSpecifiedTests=false test ${CI_OPTIONS} \
+    -DfailIfNoTests=false \
+    -Dhttps.protocols=TLSv1.2 \
+    --no-transfer-progress && \
+    if git status --porcelain | grep .; then git --no-pager diff; exit 1; fi
+else
+    ./mvnw ${MAVEN_OPTS} \
+      clean \
+      test-compile \
+      '-Dtest=test_locally.**.*Test' -Dsurefire.failIfNoSpecifiedTests=false test ${CI_OPTIONS} \
+      -DfailIfNoTests=false \
+      -Dhttps.protocols=TLSv1.2 \
+      --no-transfer-progress && \
+      if git status --porcelain | grep .; then git --no-pager diff; exit 1; fi
 fi

--- a/scripts/run_no_prep_tests.sh
+++ b/scripts/run_no_prep_tests.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 flags()
 {
     while test $# -gt 0


### PR DESCRIPTION
(Describe the goal of this PR. Mention any related Issue numbers)

Resolving #1252 and #892

I am not very familiar with maven so unsure if test failures right now are due to Micronaut issues, compiling issues with maven / wrong jdk (MN 4 requires jdk 17), etc. Opening as draft because of this and will try to continue looking into how to get the tests all running correctly. 

Update `2024-03-28T22:42:37+00:00` - Initial test issues in `bolt-micronaut` were resolved, not exactly sure on the issue that was present but removing a `@MockBean` that was not actually returning a mock seemed to have fixed it. Since Micronaut 4 requires JDK 17, a JDK 17 build workflow was created. Since some other test modules had issues on JDK 17, created JDK 17 profile to apply maven surefire arguments to resolve those test issues which I believe would also resolve #892  

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
