### PR TITLE
Run all tests using JDK 17

### DIFF
--- a/scripts/run_no_prep_tests.sh
+++ b/scripts/run_no_prep_tests.sh
@@ -47,17 +47,12 @@ then
     --no-transfer-progress && \
     if git status --porcelain | grep .; then git --no-pager diff; exit 1; fi
 else
-    # Until we resolve https://github.com/slackapi/java-slack-sdk/issues/892, most of the tests can fail with JDK 17+
-    # That's why we install jar files locally and run only the tests that work with JDK 17+
-    ./mvnw ${MAVEN_OPTS} install \
-      '-Dmaven.test.skip=true' \
-      -pl !bolt-quarkus-examples \
-    && \
-    ./mvnw ${MAVEN_OPTS} \
-      test -pl bolt-micronaut \
-      '-Dtest=test_locally.**.*Test' -Dsurefire.failIfNoSpecifiedTests=false test ${CI_OPTIONS} \
-      -DfailIfNoTests=false \
-      -Dhttps.protocols=TLSv1.2 \
-      --no-transfer-progress && \
-      if git status --porcelain | grep .; then git --no-pager diff; exit 1; fi
+  ./mvnw ${MAVEN_OPTS} \
+    clean \
+    test-compile \
+    '-Dtest=test_locally.**.*Test' -Dsurefire.failIfNoSpecifiedTests=false test ${CI_OPTIONS} \
+    -DfailIfNoTests=false \
+    -Dhttps.protocols=TLSv1.2 \
+    --no-transfer-progress && \
+    if git status --porcelain | grep .; then git --no-pager diff; exit 1; fi
 fi


### PR DESCRIPTION
As described in [comments](https://github.com/slackapi/java-slack-sdk/pull/1294#discussion_r1543961371) in #1924 - changes made to the base `pom.xml` [here](https://github.com/slackapi/java-slack-sdk/pull/1294/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R405-R426) (now also present in [main](https://github.com/slackapi/java-slack-sdk/blob/main/pom.xml#L405-L426)) should allow building all modules using JDK 17. This was tested locally using a local JDK 8 installation and JDK 17 installation, both builds pass locally. I did need to tweak the JDK 8 check locally to make sure it ran the proper JDK 8 `if` statement, but that shouldn't impact much if anything. 

Should fix #892 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
