### PR TITLE
Mark files.upload / rtm.connect as deprecated

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
@@ -1070,8 +1070,10 @@ public interface AsyncMethodsClient {
 
     CompletableFuture<FilesSharedPublicURLResponse> filesSharedPublicURL(RequestConfigurator<FilesSharedPublicURLRequest.FilesSharedPublicURLRequestBuilder> req);
 
+    @Deprecated // https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay
     CompletableFuture<FilesUploadResponse> filesUpload(FilesUploadRequest req);
 
+    @Deprecated // https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay
     CompletableFuture<FilesUploadResponse> filesUpload(RequestConfigurator<FilesUploadRequest.FilesUploadRequestBuilder> req);
 
     CompletableFuture<FilesGetUploadURLExternalResponse> filesGetUploadURLExternal(FilesGetUploadURLExternalRequest req);
@@ -1230,8 +1232,10 @@ public interface AsyncMethodsClient {
     // rtm
     // ------------------------------
 
+    @Deprecated // https://api.slack.com/changelog/2024-04-discontinuing-new-creation-of-classic-slack-apps-and-custom-bots
     CompletableFuture<RTMConnectResponse> rtmConnect(RTMConnectRequest req);
 
+    @Deprecated // https://api.slack.com/changelog/2024-04-discontinuing-new-creation-of-classic-slack-apps-and-custom-bots
     CompletableFuture<RTMConnectResponse> rtmConnect(RequestConfigurator<RTMConnectRequest.RTMConnectRequestBuilder> req);
 
     @Deprecated

--- a/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
@@ -447,6 +447,7 @@ public class Methods {
     public static final String FILES_LIST = "files.list";
     public static final String FILES_REVOKE_PUBLIC_URL = "files.revokePublicURL";
     public static final String FILES_SHARED_PUBLIC_URL = "files.sharedPublicURL";
+    @Deprecated // https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay
     public static final String FILES_UPLOAD = "files.upload";
 
     public static final String FILES_GET_UPLOAD_URL_EXTERNAL = "files.getUploadURLExternal";
@@ -598,6 +599,7 @@ public class Methods {
     // rtm
     // ------------------------------
 
+    @Deprecated // https://api.slack.com/changelog/2024-04-discontinuing-new-creation-of-classic-slack-apps-and-custom-bots
     public static final String RTM_CONNECT = "rtm.connect";
     @Deprecated // https://api.slack.com/changelog/2021-10-rtm-start-to-stop
     public static final String RTM_START = "rtm.start";

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
@@ -1356,8 +1356,10 @@ public interface MethodsClient {
 
     FilesSharedPublicURLResponse filesSharedPublicURL(RequestConfigurator<FilesSharedPublicURLRequest.FilesSharedPublicURLRequestBuilder> req) throws IOException, SlackApiException;
 
+    @Deprecated // https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay
     FilesUploadResponse filesUpload(FilesUploadRequest req) throws IOException, SlackApiException;
 
+    @Deprecated // https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay
     FilesUploadResponse filesUpload(RequestConfigurator<FilesUploadRequest.FilesUploadRequestBuilder> req) throws IOException, SlackApiException;
 
     FilesGetUploadURLExternalResponse filesGetUploadURLExternal(FilesGetUploadURLExternalRequest req) throws IOException, SlackApiException;
@@ -1772,8 +1774,10 @@ public interface MethodsClient {
     // rtm
     // ------------------------------
 
+    @Deprecated // https://api.slack.com/changelog/2024-04-discontinuing-new-creation-of-classic-slack-apps-and-custom-bots
     RTMConnectResponse rtmConnect(RTMConnectRequest req) throws IOException, SlackApiException;
 
+    @Deprecated // https://api.slack.com/changelog/2024-04-discontinuing-new-creation-of-classic-slack-apps-and-custom-bots
     RTMConnectResponse rtmConnect(RequestConfigurator<RTMConnectRequest.RTMConnectRequestBuilder> req) throws IOException, SlackApiException;
 
     @Deprecated

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
@@ -1923,11 +1923,13 @@ public class AsyncMethodsClientImpl implements AsyncMethodsClient {
     }
 
     @Override
+    @Deprecated
     public CompletableFuture<FilesUploadResponse> filesUpload(FilesUploadRequest req) {
         return executor.execute(FILES_UPLOAD, toMap(req), () -> methods.filesUpload(req));
     }
 
     @Override
+    @Deprecated
     public CompletableFuture<FilesUploadResponse> filesUpload(RequestConfigurator<FilesUploadRequest.FilesUploadRequestBuilder> req) {
         return filesUpload(req.configure(FilesUploadRequest.builder()).build());
     }
@@ -2237,11 +2239,13 @@ public class AsyncMethodsClientImpl implements AsyncMethodsClient {
     }
 
     @Override
+    @Deprecated
     public CompletableFuture<RTMConnectResponse> rtmConnect(RTMConnectRequest req) {
         return executor.execute(RTM_CONNECT, toMap(req), () -> methods.rtmConnect(req));
     }
 
     @Override
+    @Deprecated
     public CompletableFuture<RTMConnectResponse> rtmConnect(RequestConfigurator<RTMConnectRequest.RTMConnectRequestBuilder> req) {
         return rtmConnect(req.configure(RTMConnectRequest.builder()).build());
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -2906,11 +2906,13 @@ public class MethodsClientImpl implements MethodsClient {
     }
 
     @Override
+    @Deprecated
     public RTMConnectResponse rtmConnect(RTMConnectRequest req) throws IOException, SlackApiException {
         return postFormWithTokenAndParseResponse(toForm(req), Methods.RTM_CONNECT, getToken(req), RTMConnectResponse.class);
     }
 
     @Override
+    @Deprecated
     public RTMConnectResponse rtmConnect(RequestConfigurator<RTMConnectRequest.RTMConnectRequestBuilder> req) throws IOException, SlackApiException {
         return rtmConnect(req.configure(RTMConnectRequest.builder()).build());
     }


### PR DESCRIPTION
See the following announcements:
* https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay
* https://api.slack.com/changelog/2024-04-discontinuing-new-creation-of-classic-slack-apps-and-custom-bots

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
