### PR TITLE
Fix codecov CI errors

### DIFF
--- a/.github/workflows/unit-tests-jdk-14.yml
+++ b/.github/workflows/unit-tests-jdk-14.yml
@@ -26,6 +26,6 @@ jobs:
       env:
         SKIP_UNSTABLE_TESTS: 1
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This pull request resolves the CI error caused by the outdated codecov integration

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
