### PR TITLE
Fix #1311 entity.message is missing in Audit Logs API response

### DIFF
--- a/json-logs/samples/audit/v1/logs.json
+++ b/json-logs/samples/audit/v1/logs.json
@@ -75,6 +75,11 @@
           ],
           "original_connected_channel_id": ""
         },
+        "message": {
+          "channel": "",
+          "team": "",
+          "timestamp": ""
+        },
         "huddle": {
           "id": "",
           "date_start": 123,

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
@@ -59,6 +59,7 @@ public class LogsResponse implements AuditApiResponse {
         private Enterprise enterprise;
         private File file;
         private Channel channel;
+        private Message message;
         private Huddle huddle;
         private Role role;
         private AccountTypeRole accountTypeRole;
@@ -122,6 +123,13 @@ public class LogsResponse implements AuditApiResponse {
         private Boolean orgShared;
         private List<String> teamsSharedWith;
         private String originalConnectedChannelId;
+    }
+
+    @Data
+    public static class Message { // action: message_flagged
+        private String channel;
+        private String team;
+        private String timestamp;
     }
 
     @Data

--- a/slack-api-client/src/test/java/test_locally/api/audit/FieldsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/audit/FieldsTest.java
@@ -39,6 +39,7 @@ public class FieldsTest {
                 "getFile",
                 "getUsergroup",
                 "getChannel",
+                "getMessage",
                 "getWorkspace",
                 "getWorkflow",
                 "getWorkflowV2",


### PR DESCRIPTION
This pull request resolves #1311 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
