### PR TITLE
Add missing event data types

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/model/connect/ConnectRequestActor.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/connect/ConnectRequestActor.java
@@ -1,0 +1,16 @@
+package com.slack.api.model.connect;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class ConnectRequestActor {
+    private String id;
+    private String name;
+    @SerializedName("is_bot")
+    private boolean bot;
+    private String teamId;
+    private String timezone;
+    private String realName;
+    private String displayName;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/AppDeletedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/AppDeletedEvent.java
@@ -1,0 +1,20 @@
+package com.slack.api.model.event;
+
+import lombok.Data;
+
+/**
+ * https://api.slack.com/events/app_deleted
+ */
+@Data
+public class AppDeletedEvent implements Event {
+
+    public static final String TYPE_NAME = "app_deleted";
+
+    private final String type = TYPE_NAME;
+    private String appId;
+    private String appName;
+    private String appOwnerId;
+    private String teamId;
+    private String teamDomain;
+    private String eventTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/AppInstalledEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/AppInstalledEvent.java
@@ -1,0 +1,21 @@
+package com.slack.api.model.event;
+
+import lombok.Data;
+
+/**
+ * https://api.slack.com/events/app_installed
+ */
+@Data
+public class AppInstalledEvent implements Event {
+
+    public static final String TYPE_NAME = "app_installed";
+
+    private final String type = TYPE_NAME;
+    private String appId;
+    private String appName;
+    private String appOwnerId;
+    private String user_id;
+    private String teamId;
+    private String teamDomain;
+    private String eventTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/AppUninstalledTeamEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/AppUninstalledTeamEvent.java
@@ -1,0 +1,21 @@
+package com.slack.api.model.event;
+
+import lombok.Data;
+
+/**
+ * https://api.slack.com/events/app_uninstalled_team
+ */
+@Data
+public class AppUninstalledTeamEvent implements Event {
+
+    public static final String TYPE_NAME = "app_uninstalled_team";
+
+    private final String type = TYPE_NAME;
+    private String appId;
+    private String appName;
+    private String appOwnerId;
+    private String user_id;
+    private String teamId;
+    private String teamDomain;
+    private String eventTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/SharedChannelInviteRequestedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/SharedChannelInviteRequestedEvent.java
@@ -1,0 +1,37 @@
+package com.slack.api.model.event;
+
+import com.google.gson.annotations.SerializedName;
+import com.slack.api.model.connect.ConnectRequestActor;
+import com.slack.api.model.connect.ConnectTeam;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/events/shared_channel_invite_requested
+ */
+@Data
+public class SharedChannelInviteRequestedEvent implements Event {
+
+    public static final String TYPE_NAME = "shared_channel_invite_requested";
+
+    private final String type = TYPE_NAME;
+    private ConnectRequestActor actor;
+    private String channelId;
+    private String eventType;
+    private String channelName;
+    private String channelType;
+    private List<TargetUser> targetUsers;
+    private List<ConnectTeam> teamsInChannel;
+    @SerializedName("is_external_limited")
+    private boolean externalLimited;
+    private Integer channelDateCreated;
+    private Integer channelMessageLatestCountedTimestamp;
+    private String eventTs;
+
+    @Data
+    public static class TargetUser {
+        private String email;
+        private String inviteId;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/AppDeletedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/AppDeletedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.AppDeletedPayload;
+import com.slack.api.model.event.AppDeletedEvent;
+
+public abstract class AppDeletedHandler extends EventHandler<AppDeletedPayload> {
+
+    @Override
+    public String getEventType() {
+        return AppDeletedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/AppInstalledHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/AppInstalledHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.AppInstalledPayload;
+import com.slack.api.model.event.AppInstalledEvent;
+
+public abstract class AppInstalledHandler extends EventHandler<AppInstalledPayload> {
+
+    @Override
+    public String getEventType() {
+        return AppInstalledEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/AppUninstalledTeamHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/AppUninstalledTeamHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.AppUninstalledTeamPayload;
+import com.slack.api.model.event.AppUninstalledTeamEvent;
+
+public abstract class AppUninstalledTeamHandler extends EventHandler<AppUninstalledTeamPayload> {
+
+    @Override
+    public String getEventType() {
+        return AppUninstalledTeamEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/FunctionExecutedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/FunctionExecutedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.FunctionExecutedPayload;
+import com.slack.api.model.event.FunctionExecutedEvent;
+
+public abstract class FunctionExecutedHandler extends EventHandler<FunctionExecutedPayload> {
+
+    @Override
+    public String getEventType() {
+        return FunctionExecutedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/SharedChannelInviteRequestedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/SharedChannelInviteRequestedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.SharedChannelInviteRequestedPayload;
+import com.slack.api.model.event.SharedChannelInviteRequestedEvent;
+
+public abstract class SharedChannelInviteRequestedHandler extends EventHandler<SharedChannelInviteRequestedPayload> {
+
+    @Override
+    public String getEventType() {
+        return SharedChannelInviteRequestedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppDeletedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppDeletedPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.AppDeletedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AppDeletedPayload implements EventsApiPayload<AppDeletedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private AppDeletedEvent event;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppInstalledPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppInstalledPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.AppInstalledEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AppInstalledPayload implements EventsApiPayload<AppInstalledEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private AppInstalledEvent event;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppUninstalledTeamPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AppUninstalledTeamPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.AppUninstalledTeamEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AppUninstalledTeamPayload implements EventsApiPayload<AppUninstalledTeamEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private AppUninstalledTeamEvent event;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SharedChannelInviteRequestedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/SharedChannelInviteRequestedPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.SharedChannelInviteRequestedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SharedChannelInviteRequestedPayload implements EventsApiPayload<SharedChannelInviteRequestedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private SharedChannelInviteRequestedEvent event;
+}


### PR DESCRIPTION
While auditing the latest updates on the platform, I found that a few events are not yet supported in this SDK.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
