### PR TITLE
fix filename & title getting improperly defaulted in filesUploadV2

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -2333,20 +2333,19 @@ public class MethodsClientImpl implements MethodsClient {
             if (req.getUploadFiles() != null && req.getUploadFiles().size() > 0) {
                 // upload multiple files
                 for (FilesUploadV2Request.UploadFile uploadFile : req.getUploadFiles()) {
-                    if (uploadFile.getTitle() != null) {
-                        uploadFile.setTitle(uploadFile.getTitle());
-                    } else {
-                        String filename = req.getFilename();
-                        if (filename == null) {
-                            if (uploadFile.getFile() != null && uploadFile.getFile().getName() != null) {
-                                filename = uploadFile.getFile().getName();
-                            } else {
-                                filename = "Uploaded file";
-                            }
+                    String filename = uploadFile.getFilename();
+                    if (filename == null) {
+                        if (uploadFile.getFile() != null && uploadFile.getFile().getName() != null) {
+                            filename = uploadFile.getFile().getName();
+                        } else {
+                            filename = "Uploaded file";
                         }
-                        uploadFile.setFilename(filename);
+                    }
+                    uploadFile.setFilename(filename);
+                    if (uploadFile.getTitle() == null) {
                         uploadFile.setTitle(filename);
                     }
+
                     String fileId = helper.uploadFile(req, uploadFile);
 
                     FilesCompleteUploadExternalRequest.FileDetails file = new FilesCompleteUploadExternalRequest.FileDetails();

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
@@ -1176,7 +1176,7 @@ public class files_Test {
         byte[] fileData = Files.readAllBytes(Paths.get("src/test/resources/sample.txt"));
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
-        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().filename("issue1345_test.txt").title("issue1345 test").fileData(fileData);
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().filename("issue1345_test.txt").title("issue1345 test").fileData(fileData).build();
         FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));
@@ -1192,7 +1192,7 @@ public class files_Test {
         byte[] fileData = Files.readAllBytes(Paths.get("src/test/resources/sample.txt"));
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
-        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().filename("issue1345_test.txt").fileData(fileData);
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().filename("issue1345_test.txt").fileData(fileData).build();
         FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));
@@ -1209,7 +1209,7 @@ public class files_Test {
         byte[] fileData = Files.readAllBytes(Paths.get("src/test/resources/sample.txt"));
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
-        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().title("issue1345 test").fileData(fileData);
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().title("issue1345 test").fileData(fileData).build();
         FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));
@@ -1227,7 +1227,7 @@ public class files_Test {
         File file = new File("src/test/resources/sample.txt");
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
-        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().file(fileData);
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().file(fileData).build();
         FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));
@@ -1245,7 +1245,7 @@ public class files_Test {
         byte[] fileData = Files.readAllBytes(Paths.get("src/test/resources/sample.txt"));
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
-        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().fileData(fileData);
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().fileData(fileData).build();
         FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
@@ -1167,4 +1167,91 @@ public class files_Test {
         FilesInfoResponse file1info = client.filesInfo(r -> r.file(file1Upload.getFileId()));
         assertThat(file1info.getFile().getShares().getPublicChannels().get(randomChannelId), is(notNullValue()));
     }
+
+    @Test
+    public void issue1345_filesUploadV2_multiple() throws IOException, SlackApiException {
+        loadRandomChannelId();
+        MethodsClient slackMethods = slack.methods(userToken);
+
+        byte[] fileData = Files.readAllBytes(Paths.get("src/test/resources/sample.txt"));
+
+        // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().filename("issue1345_test.txt").title("issue1345 test").fileData(fileData);
+        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
+
+        assertThat(response.getError(), is(nullValue()));
+        assertThat(response.getFiles().get(0).getName(), is("issue1345_test.txt"));
+        assertThat(response.getFiles().get(0).getTitle(), is("issue1345 test"));
+    }
+
+    @Test
+    public void issue1345_filesUploadV2_multiple_no_title() throws IOException, SlackApiException {
+        loadRandomChannelId();
+        MethodsClient slackMethods = slack.methods(userToken);
+
+        byte[] fileData = Files.readAllBytes(Paths.get("src/test/resources/sample.txt"));
+
+        // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().filename("issue1345_test.txt").fileData(fileData);
+        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
+
+        assertThat(response.getError(), is(nullValue()));
+        assertThat(response.getFiles().get(0).getName(), is("issue1345_test.txt"));
+        // title should default to filename
+        assertThat(response.getFiles().get(0).getTitle(), is("issue1345_test.txt"));
+    }
+
+    @Test
+    public void issue1345_filesUploadV2_multiple_no_filename() throws IOException, SlackApiException {
+        loadRandomChannelId();
+        MethodsClient slackMethods = slack.methods(userToken);
+
+        byte[] fileData = Files.readAllBytes(Paths.get("src/test/resources/sample.txt"));
+
+        // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().title("issue1345 test").fileData(fileData);
+        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
+
+        assertThat(response.getError(), is(nullValue()));
+        // filename defaults to "Uploaded file", which will be converted by slack servers to be lowercase only, contain no special characters but underscores, dots and dashes, etc.
+        assertThat(response.getFiles().get(0).getName(), is("uploaded_file"));
+        // title should be unaffected if it has a value set
+        assertThat(response.getFiles().get(0).getTitle(), is("issue1345 test"));
+    }
+
+    @Test
+    public void issue1345_filesUploadV2_multiple_no_filename_no_title_file() throws IOException, SlackApiException {
+        loadRandomChannelId();
+        MethodsClient slackMethods = slack.methods(userToken);
+
+        File file = new File("src/test/resources/sample.txt");
+
+        // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().file(fileData);
+        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
+
+        assertThat(response.getError(), is(nullValue()));
+        // filename defaults to "Uploaded file", which will be converted by slack servers to be lowercase only, contain no special characters but underscores, dots and dashes, etc.
+        assertThat(response.getFiles().get(0).getName(), is(file.getName()));
+        // title should be unaffected if it has a value set
+        assertThat(response.getFiles().get(0).getTitle(), is(file.getName()));
+    }
+
+    @Test
+    public void issue1345_filesUploadV2_multiple_no_filename_no_title() throws IOException, SlackApiException {
+        loadRandomChannelId();
+        MethodsClient slackMethods = slack.methods(userToken);
+
+        byte[] fileData = Files.readAllBytes(Paths.get("src/test/resources/sample.txt"));
+
+        // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().fileData(fileData);
+        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
+
+        assertThat(response.getError(), is(nullValue()));
+        // filename defaults to "Uploaded file", which will be converted by slack servers to be lowercase only, contain no special characters but underscores, dots and dashes, etc.
+        assertThat(response.getFiles().get(0).getName(), is("uploaded_file"));
+        // title defaults to filename, which is (as this is defaulted on the client side) "Uploaded file"
+        assertThat(response.getFiles().get(0).getTitle(), is("Uploaded file"));
+    }
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
@@ -1227,7 +1227,7 @@ public class files_Test {
         File file = new File("src/test/resources/sample.txt");
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
-        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().file(fileData).build();
+        FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().file(file).build();
         FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
@@ -1177,7 +1177,7 @@ public class files_Test {
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
         FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().filename("issue1345_test.txt").title("issue1345 test").fileData(fileData).build();
-        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
+        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(Arrays.asList(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.getFiles().get(0).getName(), is("issue1345_test.txt"));
@@ -1193,7 +1193,7 @@ public class files_Test {
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
         FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().filename("issue1345_test.txt").fileData(fileData).build();
-        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
+        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(Arrays.asList(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));
         assertThat(response.getFiles().get(0).getName(), is("issue1345_test.txt"));
@@ -1210,7 +1210,7 @@ public class files_Test {
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
         FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().title("issue1345 test").fileData(fileData).build();
-        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
+        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(Arrays.asList(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));
         // filename defaults to "Uploaded file", which will be converted by slack servers to be lowercase only, contain no special characters but underscores, dots and dashes, etc.
@@ -1228,7 +1228,7 @@ public class files_Test {
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
         FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().file(file).build();
-        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
+        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(Arrays.asList(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));
         // filename defaults to "Uploaded file", which will be converted by slack servers to be lowercase only, contain no special characters but underscores, dots and dashes, etc.
@@ -1246,7 +1246,7 @@ public class files_Test {
 
         // note: this test can be done using only one file as everything tested applies to each file individually - the only important thing is to use "uploadFiles" instead of direct values
         FilesUploadV2Request.UploadFile uploadFile = FilesUploadV2Request.UploadFile.builder().fileData(fileData).build();
-        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(List.of(uploadFile)));
+        FilesUploadV2Response response = slackMethods.filesUploadV2(r -> r.uploadFiles(Arrays.asList(uploadFile)));
 
         assertThat(response.getError(), is(nullValue()));
         // filename defaults to "Uploaded file", which will be converted by slack servers to be lowercase only, contain no special characters but underscores, dots and dashes, etc.

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
@@ -1232,9 +1232,9 @@ public class files_Test {
 
         assertThat(response.getError(), is(nullValue()));
         // filename defaults to "Uploaded file", which will be converted by slack servers to be lowercase only, contain no special characters but underscores, dots and dashes, etc.
-        assertThat(response.getFiles().get(0).getName(), is(file.getName()));
+        assertThat(response.getFiles().get(0).getName(), is("sample.txt"));
         // title should be unaffected if it has a value set
-        assertThat(response.getFiles().get(0).getTitle(), is(file.getName()));
+        assertThat(response.getFiles().get(0).getTitle(), is("sample.txt"));
     }
 
     @Test


### PR DESCRIPTION
fix filename & title getting improperly defaulted when uploading multiple files using MethodsClientImpl#filesUploadV2

fixes #1345

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
