### PR TITLE
Upgrade http4k and micronaut

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>5.26.0.0</http4k.version>
+        <http4k.version>5.27.0.0</http4k.version>
         <!-- http4k 5.26+ no longer supports Java 1.8 -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,7 +10,8 @@
     </parent>
 
     <properties>
-        <micronaut.version>4.6.1</micronaut.version>
+        <!-- TODO: holding off migrating to 4.6 due to binary compatibility issue with JDK 17; see https://github.com/slackapi/java-slack-sdk/actions/runs/10448506682/job/28929089969?pr=1350 -->
+        <micronaut.version>4.5.4</micronaut.version>
         <micronaut-test-junit5.version>4.4.0</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>3.4.0</micronaut-rxjava3.version>
         <junit5-jupiter.version>5.11.0</junit5-jupiter.version>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,10 +10,10 @@
     </parent>
 
     <properties>
-        <micronaut.version>4.5.4</micronaut.version>
+        <micronaut.version>4.6.1</micronaut.version>
         <micronaut-test-junit5.version>4.4.0</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>3.4.0</micronaut-rxjava3.version>
-        <junit5-jupiter.version>5.10.3</junit5-jupiter.version>
+        <junit5-jupiter.version>5.11.0</junit5-jupiter.version>
         <!-- Note that upgrading this library breaks other dependency resolution -->
         <mockito-all.version>1.10.19</mockito-all.version>
         <jakarta.inject.version>2.0.1.MR</jakarta.inject.version>


### PR DESCRIPTION
This pull request upgrades two optional dependencies

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
