### PR TITLE
Fix #1343 block_suggestion response does not support description in an option

### DIFF
--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/response/Option.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/response/Option.java
@@ -14,4 +14,9 @@ public class Option {
     private TextObject text;
     private String value;
     private TextObject description;
+
+    // For backward-compatibility
+    public Option(TextObject text, String value) {
+        this(text, value, null);
+    }
 }

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/response/Option.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/interactive_components/response/Option.java
@@ -13,4 +13,5 @@ import lombok.NoArgsConstructor;
 public class Option {
     private TextObject text;
     private String value;
+    private TextObject description;
 }


### PR DESCRIPTION
This pull  request resolves #1343

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
