### PR TITLE
Add assistant.threads.* APIs and related event payloads

### DIFF
--- a/bolt-socket-mode/src/test/java/samples/AssistantEventListenerApp.java
+++ b/bolt-socket-mode/src/test/java/samples/AssistantEventListenerApp.java
@@ -1,0 +1,141 @@
+package samples;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.socket_mode.SocketModeApp;
+import com.slack.api.model.assistant.SuggestedPrompt;
+import com.slack.api.model.event.*;
+
+import java.util.Collections;
+
+public class AssistantEventListenerApp {
+
+    public static void main(String[] args) throws Exception {
+        String botToken = System.getenv("SLACK_BOT_TOKEN");
+        String appToken = System.getenv("SLACK_APP_TOKEN");
+
+        App app = new App(AppConfig.builder().singleTeamBotToken(botToken).build());
+
+        app.event(AssistantThreadStartedEvent.class, (req, ctx) -> {
+            String channelId = req.getEvent().getAssistantThread().getChannelId();
+            String threadTs = req.getEvent().getAssistantThread().getThreadTs();
+            app.executorService().submit(() -> {
+                try {
+                    ctx.client().assistantThreadsSetTitle(r -> r
+                            .channelId(channelId)
+                            .threadTs(threadTs)
+                            .title("New chat")
+                    );
+                    ctx.client().chatPostMessage(r -> r
+                            .channel(channelId)
+                            .threadTs(threadTs)
+                            .text("Hi, how can I help you today?")
+                    );
+                    ctx.client().assistantThreadsSetSuggestedPrompts(r -> r
+                            .channelId(channelId)
+                            .threadTs(threadTs)
+                            .title("How are you?")
+                            .prompts(Collections.singletonList(new SuggestedPrompt("What does SLACK stand for?")))
+                    );
+                } catch (Exception e) {
+                    ctx.logger.error("Failed to handle assistant thread started event: {e}", e);
+                }
+            });
+            return ctx.ack();
+        });
+
+        app.event(AssistantThreadContextChangedEvent.class, (req, ctx) -> {
+            app.executorService().submit(() -> {
+                String channelId = req.getEvent().getAssistantThread().getChannelId();
+                String threadTs = req.getEvent().getAssistantThread().getThreadTs();
+                // TODO: Store req.getEvent().getAssistantThread() for the following conversation
+            });
+            return ctx.ack();
+        });
+
+        app.event(MessageEvent.class, (req, ctx) -> {
+            if (req.getEvent().getChannelType().equals("im") && req.getEvent().getThreadTs() != null) {
+                String channelId = req.getEvent().getChannel();
+                String threadTs = req.getEvent().getThreadTs();
+                app.executorService().submit(() -> {
+                    try {
+                        ctx.client().assistantThreadsSetStatus(r -> r
+                                .channelId(channelId)
+                                .threadTs(threadTs)
+                                .status("is typing...")
+                        );
+                        Thread.sleep(500L);
+                        ctx.client().chatPostMessage(r -> r
+                                .channel(channelId)
+                                .threadTs(threadTs)
+                                .text("Here you are!")
+                        );
+                    } catch (Exception e) {
+                        ctx.logger.error("Failed to handle assistant thread started event: {e}", e);
+                        try {
+                            ctx.client().chatPostMessage(r -> r
+                                    .channel(channelId)
+                                    .threadTs(threadTs)
+                                    .text(":warning: Sorry, something went wrong during processing your request!")
+                            );
+                        } catch (Exception ee) {
+                            ctx.logger.error("Failed to inform the error to the end-user: {ee}", ee);
+                        }
+                    }
+
+                });
+            }
+            return ctx.ack();
+        });
+
+        app.event(MessageFileShareEvent.class, (req, ctx) -> {
+            if (req.getEvent().getChannelType().equals("im") && req.getEvent().getThreadTs() != null) {
+                String channelId = req.getEvent().getChannel();
+                String threadTs = req.getEvent().getThreadTs();
+                app.executorService().submit(() -> {
+                    try {
+                        ctx.client().assistantThreadsSetStatus(r -> r
+                                .channelId(channelId)
+                                .threadTs(threadTs)
+                                .status("is analyzing the files...")
+                        );
+                        Thread.sleep(500L);
+                        ctx.client().assistantThreadsSetStatus(r -> r
+                                .channelId(channelId)
+                                .threadTs(threadTs)
+                                .status("is still checking the files...")
+                        );
+                        Thread.sleep(500L);
+                        ctx.client().chatPostMessage(r -> r
+                                .channel(channelId)
+                                .threadTs(threadTs)
+                                .text("Your files do not have any issues!")
+                        );
+                    } catch (Exception e) {
+                        ctx.logger.error("Failed to handle assistant thread started event: {e}", e);
+                        try {
+                            ctx.client().chatPostMessage(r -> r
+                                    .channel(channelId)
+                                    .threadTs(threadTs)
+                                    .text(":warning: Sorry, something went wrong during processing your request!")
+                            );
+                        } catch (Exception ee) {
+                            ctx.logger.error("Failed to inform the error to the end-user: {ee}", ee);
+                        }
+                    }
+
+                });
+            }
+            return ctx.ack();
+        });
+
+        app.event(MessageChangedEvent.class, (req, ctx) -> {
+            return ctx.ack();
+        });
+        app.event(MessageDeletedEvent.class, (payload, ctx) -> {
+            return ctx.ack();
+        });
+
+        new SocketModeApp(appToken, app).start();
+    }
+}

--- a/json-logs/samples/api/assistant.threads.setStatus.json
+++ b/json-logs/samples/api/assistant.threads.setStatus.json
@@ -1,0 +1,7 @@
+{
+  "ok": false,
+  "warning": "",
+  "error": "",
+  "needed": "",
+  "provided": ""
+}

--- a/json-logs/samples/api/assistant.threads.setSuggestedPrompts.json
+++ b/json-logs/samples/api/assistant.threads.setSuggestedPrompts.json
@@ -1,0 +1,7 @@
+{
+  "ok": false,
+  "warning": "",
+  "error": "",
+  "needed": "",
+  "provided": ""
+}

--- a/json-logs/samples/api/assistant.threads.setTitle.json
+++ b/json-logs/samples/api/assistant.threads.setTitle.json
@@ -1,0 +1,7 @@
+{
+  "ok": false,
+  "warning": "",
+  "error": "",
+  "needed": "",
+  "provided": ""
+}

--- a/json-logs/samples/api/chat.postMessage.json
+++ b/json-logs/samples/api/chat.postMessage.json
@@ -9483,7 +9483,12 @@
                 "app_id": "",
                 "call_family": ""
               },
-              "no_notifications": false
+              "no_notifications": false,
+              "assistant_app_thread": {
+                "title": "",
+                "title_blocks": [],
+                "first_user_thread_reply": ""
+              }
             }
           }
         ],
@@ -9971,7 +9976,12 @@
                     "app_id": "",
                     "call_family": ""
                   },
-                  "no_notifications": false
+                  "no_notifications": false,
+                  "assistant_app_thread": {
+                    "title": "",
+                    "title_blocks": [],
+                    "first_user_thread_reply": ""
+                  }
                 },
                 "number": [],
                 "select": [],
@@ -10504,7 +10514,12 @@
                     "app_id": "",
                     "call_family": ""
                   },
-                  "no_notifications": false
+                  "no_notifications": false,
+                  "assistant_app_thread": {
+                    "title": "",
+                    "title_blocks": [],
+                    "first_user_thread_reply": ""
+                  }
                 },
                 "number": [],
                 "select": [],
@@ -32703,7 +32718,12722 @@
         },
         "optional": false
       }
-    ]
+    ],
+    "assistant_app_thread": {
+      "title": "",
+      "title_blocks": [
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "accessibility_label": ""
+            },
+            {
+              "type": "workflow_button",
+              "action_id": "",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "workflow": {
+                "trigger": {
+                  "url": "",
+                  "customizable_input_parameters": [
+                    {
+                      "name": "",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "style": "",
+              "accessibility_label": ""
+            },
+            {
+              "type": "checkboxes",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "radio_buttons",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "channels_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channel": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "response_url_enabled": false,
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_channels_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channels": [
+                ""
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "conversations_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "response_url_enabled": false,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_conversations_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversations": [
+                ""
+              ],
+              "default_to_current_conversation": false,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "datepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_date": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "timepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_time": "",
+              "timezone": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "datetimepicker",
+              "action_id": "",
+              "initial_date_time": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "external_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_external_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "image",
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              }
+            },
+            {
+              "type": "overflow",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              }
+            },
+            {
+              "type": "static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_user": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_users": [
+                ""
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ],
+              "style": "",
+              "indent": 123,
+              "offset": 123,
+              "border": 123
+            },
+            {
+              "type": "rich_text_preformatted",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ],
+              "border": 123
+            },
+            {
+              "type": "rich_text_quote",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "block_id": "",
+          "call_id": "",
+          "api_decoration_available": false,
+          "call": {
+            "v1": {
+              "id": "",
+              "app_id": "",
+              "app_icon_urls": {
+                "image_32": "",
+                "image_36": "",
+                "image_48": "",
+                "image_64": "",
+                "image_72": "",
+                "image_96": "",
+                "image_128": "",
+                "image_192": "",
+                "image_512": "",
+                "image_1024": "",
+                "image_original": ""
+              },
+              "date_start": 123,
+              "active_participants": [
+                {
+                  "slack_id": "",
+                  "external_id": "",
+                  "display_name": "",
+                  "avatar_url": ""
+                }
+              ],
+              "all_participants": [
+                {
+                  "slack_id": "",
+                  "external_id": "",
+                  "display_name": "",
+                  "avatar_url": ""
+                }
+              ],
+              "display_id": "",
+              "join_url": "",
+              "desktop_app_join_url": "",
+              "name": "",
+              "created_by": "",
+              "date_end": 123,
+              "channels": [
+                ""
+              ],
+              "is_dm_call": false,
+              "was_rejected": false,
+              "was_missed": false,
+              "was_accepted": false,
+              "has_ended": false
+            },
+            "media_backend_type": ""
+          },
+          "external_id": "",
+          "source": "",
+          "file_id": "",
+          "file": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "name": "",
+            "title": "",
+            "subject": "",
+            "mimetype": "",
+            "filetype": "",
+            "pretty_type": "",
+            "user": "",
+            "user_team": "",
+            "source_team": "",
+            "mode": "",
+            "editable": false,
+            "non_owner_editable": false,
+            "editor": "",
+            "last_editor": "",
+            "updated": 123,
+            "file_access": "",
+            "editors": [
+              ""
+            ],
+            "edit_timestamp": 123,
+            "alt_txt": "",
+            "subtype": "",
+            "transcription": {
+              "status": "",
+              "locale": ""
+            },
+            "mp4": "",
+            "mp4_low": "",
+            "vtt": "",
+            "hls": "",
+            "hls_embed": "",
+            "duration_ms": 123,
+            "thumb_video_w": 123,
+            "thumb_video_h": 123,
+            "original_attachment_count": 123,
+            "is_external": false,
+            "external_type": "",
+            "external_id": "",
+            "external_url": "",
+            "username": "",
+            "size": 123,
+            "url_private": "",
+            "url_private_download": "",
+            "url_static_preview": "",
+            "app_id": "",
+            "app_name": "",
+            "thumb_64": "",
+            "thumb_64_gif": "",
+            "thumb_64_w": "",
+            "thumb_64_h": "",
+            "thumb_80": "",
+            "thumb_80_gif": "",
+            "thumb_80_w": "",
+            "thumb_80_h": "",
+            "thumb_160": "",
+            "thumb_160_gif": "",
+            "thumb_160_w": "",
+            "thumb_160_h": "",
+            "thumb_360": "",
+            "thumb_360_gif": "",
+            "thumb_360_w": "",
+            "thumb_360_h": "",
+            "thumb_480": "",
+            "thumb_480_gif": "",
+            "thumb_480_w": "",
+            "thumb_480_h": "",
+            "thumb_720": "",
+            "thumb_720_gif": "",
+            "thumb_720_w": "",
+            "thumb_720_h": "",
+            "thumb_800": "",
+            "thumb_800_gif": "",
+            "thumb_800_w": "",
+            "thumb_800_h": "",
+            "thumb_960": "",
+            "thumb_960_gif": "",
+            "thumb_960_w": "",
+            "thumb_960_h": "",
+            "thumb_1024": "",
+            "thumb_1024_gif": "",
+            "thumb_1024_w": "",
+            "thumb_1024_h": "",
+            "thumb_video": "",
+            "thumb_gif": "",
+            "thumb_pdf": "",
+            "thumb_pdf_w": "",
+            "thumb_pdf_h": "",
+            "thumb_tiny": "",
+            "converted_pdf": "",
+            "image_exif_rotation": 123,
+            "original_w": "",
+            "original_h": "",
+            "deanimate": "",
+            "deanimate_gif": "",
+            "pjpeg": "",
+            "permalink": "",
+            "permalink_public": "",
+            "edit_link": "",
+            "has_rich_preview": false,
+            "media_display_type": "",
+            "preview_is_truncated": false,
+            "preview": "",
+            "preview_highlight": "",
+            "plain_text": "",
+            "preview_plain_text": "",
+            "has_more": false,
+            "sent_to_self": false,
+            "lines": 123,
+            "lines_more": 123,
+            "is_public": false,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "channels": [
+              ""
+            ],
+            "groups": [
+              ""
+            ],
+            "ims": [
+              ""
+            ],
+            "shares": {
+              "public": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ]
+              },
+              "private": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ]
+              }
+            },
+            "has_more_shares": false,
+            "to": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "from": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "cc": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "channel_actions_ts": "",
+            "channel_actions_count": 123,
+            "headers": {
+              "date": "",
+              "in_reply_to": "",
+              "reply_to": "",
+              "message_id": ""
+            },
+            "simplified_html": "",
+            "media_progress": {
+              "offset_ms": 123,
+              "max_offset_ms": 123,
+              "duration_ms": 123
+            },
+            "saved": {
+              "is_archived": false,
+              "date_completed": 123,
+              "date_due": 123,
+              "state": ""
+            },
+            "quip_thread_id": "",
+            "is_channel_space": false,
+            "linked_channel_id": "",
+            "access": "",
+            "teams_shared_with": [],
+            "last_read": 123,
+            "title_blocks": [
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  },
+                  {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  },
+                  {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "divider",
+                "block_id": ""
+              },
+              {
+                "type": "image",
+                "fallback": "",
+                "image_url": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "is_animated": false,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                },
+                "alt_text": "",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "video",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "title_url": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "video_url": "",
+                "alt_text": "",
+                "thumbnail_url": "",
+                "author_name": "",
+                "provider_name": "",
+                "provider_icon_url": "",
+                "block_id": ""
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "share_shortcut",
+                "block_id": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "sales_home_workflow_app_type": 123,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "title": "",
+                "description": "",
+                "bot_user_id": "",
+                "url": "",
+                "owning_team_id": "",
+                "workflow_id": "",
+                "developer_trace_id": "",
+                "trigger_type": "",
+                "trigger_subtype": "",
+                "share_url": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "url": "",
+                  "value": "",
+                  "style": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "workflow_button",
+                  "action_id": "",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "workflow": {
+                    "trigger": {
+                      "url": "",
+                      "customizable_input_parameters": [
+                        {
+                          "name": "",
+                          "value": ""
+                        }
+                      ]
+                    }
+                  },
+                  "style": "",
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "checkboxes",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "radio_buttons",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channel": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channels": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversation": "",
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversations": [
+                    ""
+                  ],
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_date": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "timepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_time": "",
+                  "timezone": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datetimepicker",
+                  "action_id": "",
+                  "initial_date_time": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "overflow",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_user": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_users": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              }
+            ],
+            "private_channels_with_file_access_count": 123,
+            "private_file_with_access_count": 123,
+            "dm_mpdm_users_with_file_access": [
+              {
+                "user_id": "",
+                "access": ""
+              }
+            ],
+            "org_or_workspace_access": "",
+            "update_notification": 123,
+            "canvas_template_mode": "",
+            "template_conversion_ts": 123,
+            "template_name": "",
+            "template_title": "",
+            "template_description": "",
+            "template_icon": "",
+            "team_pref_version_history_enabled": false,
+            "show_badge": false,
+            "favorites": [
+              {
+                "collection_id": "",
+                "collection_name": "",
+                "position": ""
+              }
+            ],
+            "list_metadata": {
+              "icon": "",
+              "icon_url": "",
+              "icon_team_id": "",
+              "description": "",
+              "is_trial": false,
+              "creation_source": {
+                "type": "",
+                "reference_id": "",
+                "workflow_function_id": ""
+              },
+              "schema": [
+                {
+                  "id": "",
+                  "name": "",
+                  "key": "",
+                  "type": "",
+                  "is_primary_column": false,
+                  "options": {
+                    "choices": [
+                      {
+                        "value": "",
+                        "label": "",
+                        "color": ""
+                      }
+                    ],
+                    "format": "",
+                    "default_value": "",
+                    "default_value_typed": {
+                      "select": [
+                        ""
+                      ]
+                    },
+                    "emoji": "",
+                    "max": 123,
+                    "precision": 123,
+                    "show_member_name": false,
+                    "date_format": "",
+                    "time_format": "",
+                    "currency_format": "",
+                    "emoji_team_id": "",
+                    "currency": "",
+                    "rounding": "",
+                    "mark_as_done_when_checked": false,
+                    "for_assignment": false,
+                    "notify_users": false,
+                    "linked_to": [
+                      ""
+                    ],
+                    "canvas_id": "",
+                    "canvas_placeholder_mapping": [
+                      {
+                        "variable": "",
+                        "column": ""
+                      }
+                    ]
+                  }
+                }
+              ],
+              "views": [
+                {
+                  "id": "",
+                  "name": "",
+                  "type": "",
+                  "is_locked": false,
+                  "position": "",
+                  "columns": [
+                    {
+                      "visible": false,
+                      "key": "",
+                      "id": "",
+                      "position": "",
+                      "width": 123
+                    }
+                  ],
+                  "date_created": 123,
+                  "created_by": "",
+                  "stick_column_left": false,
+                  "is_all_items_view": false
+                }
+              ],
+              "integrations": [
+                ""
+              ]
+            },
+            "list_limits": {
+              "over_row_maximum": false,
+              "row_count_limit": 123,
+              "row_count": 123,
+              "over_column_maximum": false,
+              "column_count": 123,
+              "column_count_limit": 123,
+              "over_view_maximum": false,
+              "view_count": 123,
+              "view_count_limit": 123
+            },
+            "can_toggle_canvas_lock": false,
+            "bot_id": "",
+            "initial_comment": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "user": "",
+              "comment": "",
+              "channel": "",
+              "is_intro": false
+            },
+            "num_stars": 123,
+            "is_starred": false,
+            "pinned_to": [
+              ""
+            ],
+            "reactions": [
+              {
+                "name": "",
+                "count": 123,
+                "users": [
+                  ""
+                ],
+                "url": ""
+              }
+            ],
+            "comments_count": 123,
+            "attachments": [],
+            "blocks": [
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  },
+                  {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  },
+                  {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "divider",
+                "block_id": ""
+              },
+              {
+                "type": "image",
+                "fallback": "",
+                "image_url": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "is_animated": false,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                },
+                "alt_text": "",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "video",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "title_url": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "video_url": "",
+                "alt_text": "",
+                "thumbnail_url": "",
+                "author_name": "",
+                "provider_name": "",
+                "provider_icon_url": "",
+                "block_id": ""
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "share_shortcut",
+                "block_id": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "sales_home_workflow_app_type": 123,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "title": "",
+                "description": "",
+                "bot_user_id": "",
+                "url": "",
+                "owning_team_id": "",
+                "workflow_id": "",
+                "developer_trace_id": "",
+                "trigger_type": "",
+                "trigger_subtype": "",
+                "share_url": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "url": "",
+                  "value": "",
+                  "style": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "workflow_button",
+                  "action_id": "",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "workflow": {
+                    "trigger": {
+                      "url": "",
+                      "customizable_input_parameters": [
+                        {
+                          "name": "",
+                          "value": ""
+                        }
+                      ]
+                    }
+                  },
+                  "style": "",
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "checkboxes",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "radio_buttons",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channel": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channels": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversation": "",
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversations": [
+                    ""
+                  ],
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_date": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "timepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_time": "",
+                  "timezone": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datetimepicker",
+                  "action_id": "",
+                  "initial_date_time": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "overflow",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_user": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_users": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              }
+            ]
+          },
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "fallback": "",
+          "image_url": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123,
+          "is_animated": false,
+          "slack_file": {
+            "id": "",
+            "url": ""
+          },
+          "alt_text": "",
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "title_url": "",
+          "description": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "video_url": "",
+          "thumbnail_url": "",
+          "author_name": "",
+          "provider_name": "",
+          "provider_icon_url": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "sales_home_workflow_app_type": 123,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "bot_user_id": "",
+          "url": "",
+          "owning_team_id": "",
+          "workflow_id": "",
+          "developer_trace_id": "",
+          "trigger_type": "",
+          "trigger_subtype": "",
+          "share_url": "",
+          "fields": [
+            {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            {
+              "type": "mrkdwn",
+              "text": "",
+              "verbatim": false
+            }
+          ],
+          "accessory": {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "accessibility_label": "",
+            "workflow": {
+              "trigger": {
+                "url": "",
+                "customizable_input_parameters": [
+                  {
+                    "name": "",
+                    "value": ""
+                  }
+                ]
+              }
+            },
+            "options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "initial_options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "focus_on_load": false,
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_channel": "",
+            "response_url_enabled": false,
+            "initial_channels": [
+              ""
+            ],
+            "max_selected_items": 123,
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "filter": {
+              "include": [],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            },
+            "initial_conversations": [
+              ""
+            ],
+            "initial_date": "",
+            "initial_time": "",
+            "timezone": "",
+            "initial_date_time": 123,
+            "min_query_length": 123,
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "option_groups": [
+              {
+                "label": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ]
+              }
+            ],
+            "initial_user": "",
+            "initial_users": [
+              ""
+            ]
+          },
+          "label": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "element": {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "accessibility_label": "",
+            "workflow": {
+              "trigger": {
+                "url": "",
+                "customizable_input_parameters": [
+                  {
+                    "name": "",
+                    "value": ""
+                  }
+                ]
+              }
+            },
+            "options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "initial_options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "focus_on_load": false,
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_channel": "",
+            "response_url_enabled": false,
+            "initial_channels": [
+              ""
+            ],
+            "max_selected_items": 123,
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "filter": {
+              "include": [],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            },
+            "initial_conversations": [
+              ""
+            ],
+            "initial_date": "",
+            "initial_time": "",
+            "timezone": "",
+            "initial_date_time": 123,
+            "min_query_length": 123,
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "option_groups": [
+              {
+                "label": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ]
+              }
+            ],
+            "initial_user": "",
+            "initial_users": [
+              ""
+            ]
+          },
+          "dispatch_action": false,
+          "hint": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "optional": false
+        }
+      ],
+      "first_user_thread_reply": ""
+    }
   },
   "error": "",
   "deprecated_argument": "",

--- a/json-logs/samples/api/chat.scheduleMessage.json
+++ b/json-logs/samples/api/chat.scheduleMessage.json
@@ -12788,7 +12788,12722 @@
         },
         "optional": false
       }
-    ]
+    ],
+    "assistant_app_thread": {
+      "title": "",
+      "title_blocks": [
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "accessibility_label": ""
+            },
+            {
+              "type": "workflow_button",
+              "action_id": "",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "workflow": {
+                "trigger": {
+                  "url": "",
+                  "customizable_input_parameters": [
+                    {
+                      "name": "",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "style": "",
+              "accessibility_label": ""
+            },
+            {
+              "type": "checkboxes",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "radio_buttons",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "channels_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channel": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "response_url_enabled": false,
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_channels_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channels": [
+                ""
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "conversations_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "response_url_enabled": false,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_conversations_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversations": [
+                ""
+              ],
+              "default_to_current_conversation": false,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "datepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_date": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "timepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_time": "",
+              "timezone": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "datetimepicker",
+              "action_id": "",
+              "initial_date_time": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "external_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_external_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "image",
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              }
+            },
+            {
+              "type": "overflow",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              }
+            },
+            {
+              "type": "static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_user": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_users": [
+                ""
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ],
+              "style": "",
+              "indent": 123,
+              "offset": 123,
+              "border": 123
+            },
+            {
+              "type": "rich_text_preformatted",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ],
+              "border": 123
+            },
+            {
+              "type": "rich_text_quote",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "block_id": "",
+          "call_id": "",
+          "api_decoration_available": false,
+          "call": {
+            "v1": {
+              "id": "",
+              "app_id": "",
+              "app_icon_urls": {
+                "image_32": "",
+                "image_36": "",
+                "image_48": "",
+                "image_64": "",
+                "image_72": "",
+                "image_96": "",
+                "image_128": "",
+                "image_192": "",
+                "image_512": "",
+                "image_1024": "",
+                "image_original": ""
+              },
+              "date_start": 123,
+              "active_participants": [
+                {
+                  "slack_id": "",
+                  "external_id": "",
+                  "display_name": "",
+                  "avatar_url": ""
+                }
+              ],
+              "all_participants": [
+                {
+                  "slack_id": "",
+                  "external_id": "",
+                  "display_name": "",
+                  "avatar_url": ""
+                }
+              ],
+              "display_id": "",
+              "join_url": "",
+              "desktop_app_join_url": "",
+              "name": "",
+              "created_by": "",
+              "date_end": 123,
+              "channels": [
+                ""
+              ],
+              "is_dm_call": false,
+              "was_rejected": false,
+              "was_missed": false,
+              "was_accepted": false,
+              "has_ended": false
+            },
+            "media_backend_type": ""
+          },
+          "external_id": "",
+          "source": "",
+          "file_id": "",
+          "file": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "name": "",
+            "title": "",
+            "subject": "",
+            "mimetype": "",
+            "filetype": "",
+            "pretty_type": "",
+            "user": "",
+            "user_team": "",
+            "source_team": "",
+            "mode": "",
+            "editable": false,
+            "non_owner_editable": false,
+            "editor": "",
+            "last_editor": "",
+            "updated": 123,
+            "file_access": "",
+            "editors": [
+              ""
+            ],
+            "edit_timestamp": 123,
+            "alt_txt": "",
+            "subtype": "",
+            "transcription": {
+              "status": "",
+              "locale": ""
+            },
+            "mp4": "",
+            "mp4_low": "",
+            "vtt": "",
+            "hls": "",
+            "hls_embed": "",
+            "duration_ms": 123,
+            "thumb_video_w": 123,
+            "thumb_video_h": 123,
+            "original_attachment_count": 123,
+            "is_external": false,
+            "external_type": "",
+            "external_id": "",
+            "external_url": "",
+            "username": "",
+            "size": 123,
+            "url_private": "",
+            "url_private_download": "",
+            "url_static_preview": "",
+            "app_id": "",
+            "app_name": "",
+            "thumb_64": "",
+            "thumb_64_gif": "",
+            "thumb_64_w": "",
+            "thumb_64_h": "",
+            "thumb_80": "",
+            "thumb_80_gif": "",
+            "thumb_80_w": "",
+            "thumb_80_h": "",
+            "thumb_160": "",
+            "thumb_160_gif": "",
+            "thumb_160_w": "",
+            "thumb_160_h": "",
+            "thumb_360": "",
+            "thumb_360_gif": "",
+            "thumb_360_w": "",
+            "thumb_360_h": "",
+            "thumb_480": "",
+            "thumb_480_gif": "",
+            "thumb_480_w": "",
+            "thumb_480_h": "",
+            "thumb_720": "",
+            "thumb_720_gif": "",
+            "thumb_720_w": "",
+            "thumb_720_h": "",
+            "thumb_800": "",
+            "thumb_800_gif": "",
+            "thumb_800_w": "",
+            "thumb_800_h": "",
+            "thumb_960": "",
+            "thumb_960_gif": "",
+            "thumb_960_w": "",
+            "thumb_960_h": "",
+            "thumb_1024": "",
+            "thumb_1024_gif": "",
+            "thumb_1024_w": "",
+            "thumb_1024_h": "",
+            "thumb_video": "",
+            "thumb_gif": "",
+            "thumb_pdf": "",
+            "thumb_pdf_w": "",
+            "thumb_pdf_h": "",
+            "thumb_tiny": "",
+            "converted_pdf": "",
+            "image_exif_rotation": 123,
+            "original_w": "",
+            "original_h": "",
+            "deanimate": "",
+            "deanimate_gif": "",
+            "pjpeg": "",
+            "permalink": "",
+            "permalink_public": "",
+            "edit_link": "",
+            "has_rich_preview": false,
+            "media_display_type": "",
+            "preview_is_truncated": false,
+            "preview": "",
+            "preview_highlight": "",
+            "plain_text": "",
+            "preview_plain_text": "",
+            "has_more": false,
+            "sent_to_self": false,
+            "lines": 123,
+            "lines_more": 123,
+            "is_public": false,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "channels": [
+              ""
+            ],
+            "groups": [
+              ""
+            ],
+            "ims": [
+              ""
+            ],
+            "shares": {
+              "public": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ]
+              },
+              "private": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ]
+              }
+            },
+            "has_more_shares": false,
+            "to": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "from": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "cc": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "channel_actions_ts": "",
+            "channel_actions_count": 123,
+            "headers": {
+              "date": "",
+              "in_reply_to": "",
+              "reply_to": "",
+              "message_id": ""
+            },
+            "simplified_html": "",
+            "media_progress": {
+              "offset_ms": 123,
+              "max_offset_ms": 123,
+              "duration_ms": 123
+            },
+            "saved": {
+              "is_archived": false,
+              "date_completed": 123,
+              "date_due": 123,
+              "state": ""
+            },
+            "quip_thread_id": "",
+            "is_channel_space": false,
+            "linked_channel_id": "",
+            "access": "",
+            "teams_shared_with": [],
+            "last_read": 123,
+            "title_blocks": [
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  },
+                  {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  },
+                  {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "divider",
+                "block_id": ""
+              },
+              {
+                "type": "image",
+                "fallback": "",
+                "image_url": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "is_animated": false,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                },
+                "alt_text": "",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "video",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "title_url": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "video_url": "",
+                "alt_text": "",
+                "thumbnail_url": "",
+                "author_name": "",
+                "provider_name": "",
+                "provider_icon_url": "",
+                "block_id": ""
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "share_shortcut",
+                "block_id": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "sales_home_workflow_app_type": 123,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "title": "",
+                "description": "",
+                "bot_user_id": "",
+                "url": "",
+                "owning_team_id": "",
+                "workflow_id": "",
+                "developer_trace_id": "",
+                "trigger_type": "",
+                "trigger_subtype": "",
+                "share_url": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "url": "",
+                  "value": "",
+                  "style": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "workflow_button",
+                  "action_id": "",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "workflow": {
+                    "trigger": {
+                      "url": "",
+                      "customizable_input_parameters": [
+                        {
+                          "name": "",
+                          "value": ""
+                        }
+                      ]
+                    }
+                  },
+                  "style": "",
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "checkboxes",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "radio_buttons",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channel": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channels": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversation": "",
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversations": [
+                    ""
+                  ],
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_date": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "timepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_time": "",
+                  "timezone": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datetimepicker",
+                  "action_id": "",
+                  "initial_date_time": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "overflow",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_user": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_users": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              }
+            ],
+            "private_channels_with_file_access_count": 123,
+            "private_file_with_access_count": 123,
+            "dm_mpdm_users_with_file_access": [
+              {
+                "user_id": "",
+                "access": ""
+              }
+            ],
+            "org_or_workspace_access": "",
+            "update_notification": 123,
+            "canvas_template_mode": "",
+            "template_conversion_ts": 123,
+            "template_name": "",
+            "template_title": "",
+            "template_description": "",
+            "template_icon": "",
+            "team_pref_version_history_enabled": false,
+            "show_badge": false,
+            "favorites": [
+              {
+                "collection_id": "",
+                "collection_name": "",
+                "position": ""
+              }
+            ],
+            "list_metadata": {
+              "icon": "",
+              "icon_url": "",
+              "icon_team_id": "",
+              "description": "",
+              "is_trial": false,
+              "creation_source": {
+                "type": "",
+                "reference_id": "",
+                "workflow_function_id": ""
+              },
+              "schema": [
+                {
+                  "id": "",
+                  "name": "",
+                  "key": "",
+                  "type": "",
+                  "is_primary_column": false,
+                  "options": {
+                    "choices": [
+                      {
+                        "value": "",
+                        "label": "",
+                        "color": ""
+                      }
+                    ],
+                    "format": "",
+                    "default_value": "",
+                    "default_value_typed": {
+                      "select": [
+                        ""
+                      ]
+                    },
+                    "emoji": "",
+                    "max": 123,
+                    "precision": 123,
+                    "show_member_name": false,
+                    "date_format": "",
+                    "time_format": "",
+                    "currency_format": "",
+                    "emoji_team_id": "",
+                    "currency": "",
+                    "rounding": "",
+                    "mark_as_done_when_checked": false,
+                    "for_assignment": false,
+                    "notify_users": false,
+                    "linked_to": [
+                      ""
+                    ],
+                    "canvas_id": "",
+                    "canvas_placeholder_mapping": [
+                      {
+                        "variable": "",
+                        "column": ""
+                      }
+                    ]
+                  }
+                }
+              ],
+              "views": [
+                {
+                  "id": "",
+                  "name": "",
+                  "type": "",
+                  "is_locked": false,
+                  "position": "",
+                  "columns": [
+                    {
+                      "visible": false,
+                      "key": "",
+                      "id": "",
+                      "position": "",
+                      "width": 123
+                    }
+                  ],
+                  "date_created": 123,
+                  "created_by": "",
+                  "stick_column_left": false,
+                  "is_all_items_view": false
+                }
+              ],
+              "integrations": [
+                ""
+              ]
+            },
+            "list_limits": {
+              "over_row_maximum": false,
+              "row_count_limit": 123,
+              "row_count": 123,
+              "over_column_maximum": false,
+              "column_count": 123,
+              "column_count_limit": 123,
+              "over_view_maximum": false,
+              "view_count": 123,
+              "view_count_limit": 123
+            },
+            "can_toggle_canvas_lock": false,
+            "bot_id": "",
+            "initial_comment": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "user": "",
+              "comment": "",
+              "channel": "",
+              "is_intro": false
+            },
+            "num_stars": 123,
+            "is_starred": false,
+            "pinned_to": [
+              ""
+            ],
+            "reactions": [
+              {
+                "name": "",
+                "count": 123,
+                "users": [
+                  ""
+                ],
+                "url": ""
+              }
+            ],
+            "comments_count": 123,
+            "attachments": [],
+            "blocks": [
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  },
+                  {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  },
+                  {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "divider",
+                "block_id": ""
+              },
+              {
+                "type": "image",
+                "fallback": "",
+                "image_url": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "is_animated": false,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                },
+                "alt_text": "",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "video",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "title_url": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "video_url": "",
+                "alt_text": "",
+                "thumbnail_url": "",
+                "author_name": "",
+                "provider_name": "",
+                "provider_icon_url": "",
+                "block_id": ""
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "share_shortcut",
+                "block_id": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "sales_home_workflow_app_type": 123,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "title": "",
+                "description": "",
+                "bot_user_id": "",
+                "url": "",
+                "owning_team_id": "",
+                "workflow_id": "",
+                "developer_trace_id": "",
+                "trigger_type": "",
+                "trigger_subtype": "",
+                "share_url": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "url": "",
+                  "value": "",
+                  "style": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "workflow_button",
+                  "action_id": "",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "workflow": {
+                    "trigger": {
+                      "url": "",
+                      "customizable_input_parameters": [
+                        {
+                          "name": "",
+                          "value": ""
+                        }
+                      ]
+                    }
+                  },
+                  "style": "",
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "checkboxes",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "radio_buttons",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channel": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channels": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversation": "",
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversations": [
+                    ""
+                  ],
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_date": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "timepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_time": "",
+                  "timezone": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datetimepicker",
+                  "action_id": "",
+                  "initial_date_time": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "overflow",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_user": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_users": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              }
+            ]
+          },
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "fallback": "",
+          "image_url": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123,
+          "is_animated": false,
+          "slack_file": {
+            "id": "",
+            "url": ""
+          },
+          "alt_text": "",
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "title_url": "",
+          "description": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "video_url": "",
+          "thumbnail_url": "",
+          "author_name": "",
+          "provider_name": "",
+          "provider_icon_url": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "sales_home_workflow_app_type": 123,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "bot_user_id": "",
+          "url": "",
+          "owning_team_id": "",
+          "workflow_id": "",
+          "developer_trace_id": "",
+          "trigger_type": "",
+          "trigger_subtype": "",
+          "share_url": "",
+          "fields": [
+            {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            {
+              "type": "mrkdwn",
+              "text": "",
+              "verbatim": false
+            }
+          ],
+          "accessory": {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "accessibility_label": "",
+            "workflow": {
+              "trigger": {
+                "url": "",
+                "customizable_input_parameters": [
+                  {
+                    "name": "",
+                    "value": ""
+                  }
+                ]
+              }
+            },
+            "options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "initial_options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "focus_on_load": false,
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_channel": "",
+            "response_url_enabled": false,
+            "initial_channels": [
+              ""
+            ],
+            "max_selected_items": 123,
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "filter": {
+              "include": [],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            },
+            "initial_conversations": [
+              ""
+            ],
+            "initial_date": "",
+            "initial_time": "",
+            "timezone": "",
+            "initial_date_time": 123,
+            "min_query_length": 123,
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "option_groups": [
+              {
+                "label": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ]
+              }
+            ],
+            "initial_user": "",
+            "initial_users": [
+              ""
+            ]
+          },
+          "label": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "element": {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "accessibility_label": "",
+            "workflow": {
+              "trigger": {
+                "url": "",
+                "customizable_input_parameters": [
+                  {
+                    "name": "",
+                    "value": ""
+                  }
+                ]
+              }
+            },
+            "options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "initial_options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "focus_on_load": false,
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_channel": "",
+            "response_url_enabled": false,
+            "initial_channels": [
+              ""
+            ],
+            "max_selected_items": 123,
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "filter": {
+              "include": [],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            },
+            "initial_conversations": [
+              ""
+            ],
+            "initial_date": "",
+            "initial_time": "",
+            "timezone": "",
+            "initial_date_time": 123,
+            "min_query_length": 123,
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "option_groups": [
+              {
+                "label": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ]
+              }
+            ],
+            "initial_user": "",
+            "initial_users": [
+              ""
+            ]
+          },
+          "dispatch_action": false,
+          "hint": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "optional": false
+        }
+      ],
+      "first_user_thread_reply": ""
+    }
   },
   "error": "",
   "response_metadata": {

--- a/json-logs/samples/api/chat.update.json
+++ b/json-logs/samples/api/chat.update.json
@@ -17607,7 +17607,12722 @@
         },
         "optional": false
       }
-    ]
+    ],
+    "assistant_app_thread": {
+      "title": "",
+      "title_blocks": [
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "accessibility_label": ""
+            },
+            {
+              "type": "workflow_button",
+              "action_id": "",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "workflow": {
+                "trigger": {
+                  "url": "",
+                  "customizable_input_parameters": [
+                    {
+                      "name": "",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "style": "",
+              "accessibility_label": ""
+            },
+            {
+              "type": "checkboxes",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "radio_buttons",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "channels_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channel": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "response_url_enabled": false,
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_channels_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channels": [
+                ""
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "conversations_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "response_url_enabled": false,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_conversations_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversations": [
+                ""
+              ],
+              "default_to_current_conversation": false,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "datepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_date": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "timepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_time": "",
+              "timezone": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "datetimepicker",
+              "action_id": "",
+              "initial_date_time": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "external_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_external_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "image",
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              }
+            },
+            {
+              "type": "overflow",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              }
+            },
+            {
+              "type": "static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_user": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_users": [
+                ""
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ],
+              "style": "",
+              "indent": 123,
+              "offset": 123,
+              "border": 123
+            },
+            {
+              "type": "rich_text_preformatted",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ],
+              "border": 123
+            },
+            {
+              "type": "rich_text_quote",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "block_id": "",
+          "call_id": "",
+          "api_decoration_available": false,
+          "call": {
+            "v1": {
+              "id": "",
+              "app_id": "",
+              "app_icon_urls": {
+                "image_32": "",
+                "image_36": "",
+                "image_48": "",
+                "image_64": "",
+                "image_72": "",
+                "image_96": "",
+                "image_128": "",
+                "image_192": "",
+                "image_512": "",
+                "image_1024": "",
+                "image_original": ""
+              },
+              "date_start": 123,
+              "active_participants": [
+                {
+                  "slack_id": "",
+                  "external_id": "",
+                  "display_name": "",
+                  "avatar_url": ""
+                }
+              ],
+              "all_participants": [
+                {
+                  "slack_id": "",
+                  "external_id": "",
+                  "display_name": "",
+                  "avatar_url": ""
+                }
+              ],
+              "display_id": "",
+              "join_url": "",
+              "desktop_app_join_url": "",
+              "name": "",
+              "created_by": "",
+              "date_end": 123,
+              "channels": [
+                ""
+              ],
+              "is_dm_call": false,
+              "was_rejected": false,
+              "was_missed": false,
+              "was_accepted": false,
+              "has_ended": false
+            },
+            "media_backend_type": ""
+          },
+          "external_id": "",
+          "source": "",
+          "file_id": "",
+          "file": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "name": "",
+            "title": "",
+            "subject": "",
+            "mimetype": "",
+            "filetype": "",
+            "pretty_type": "",
+            "user": "",
+            "user_team": "",
+            "source_team": "",
+            "mode": "",
+            "editable": false,
+            "non_owner_editable": false,
+            "editor": "",
+            "last_editor": "",
+            "updated": 123,
+            "file_access": "",
+            "editors": [
+              ""
+            ],
+            "edit_timestamp": 123,
+            "alt_txt": "",
+            "subtype": "",
+            "transcription": {
+              "status": "",
+              "locale": ""
+            },
+            "mp4": "",
+            "mp4_low": "",
+            "vtt": "",
+            "hls": "",
+            "hls_embed": "",
+            "duration_ms": 123,
+            "thumb_video_w": 123,
+            "thumb_video_h": 123,
+            "original_attachment_count": 123,
+            "is_external": false,
+            "external_type": "",
+            "external_id": "",
+            "external_url": "",
+            "username": "",
+            "size": 123,
+            "url_private": "",
+            "url_private_download": "",
+            "url_static_preview": "",
+            "app_id": "",
+            "app_name": "",
+            "thumb_64": "",
+            "thumb_64_gif": "",
+            "thumb_64_w": "",
+            "thumb_64_h": "",
+            "thumb_80": "",
+            "thumb_80_gif": "",
+            "thumb_80_w": "",
+            "thumb_80_h": "",
+            "thumb_160": "",
+            "thumb_160_gif": "",
+            "thumb_160_w": "",
+            "thumb_160_h": "",
+            "thumb_360": "",
+            "thumb_360_gif": "",
+            "thumb_360_w": "",
+            "thumb_360_h": "",
+            "thumb_480": "",
+            "thumb_480_gif": "",
+            "thumb_480_w": "",
+            "thumb_480_h": "",
+            "thumb_720": "",
+            "thumb_720_gif": "",
+            "thumb_720_w": "",
+            "thumb_720_h": "",
+            "thumb_800": "",
+            "thumb_800_gif": "",
+            "thumb_800_w": "",
+            "thumb_800_h": "",
+            "thumb_960": "",
+            "thumb_960_gif": "",
+            "thumb_960_w": "",
+            "thumb_960_h": "",
+            "thumb_1024": "",
+            "thumb_1024_gif": "",
+            "thumb_1024_w": "",
+            "thumb_1024_h": "",
+            "thumb_video": "",
+            "thumb_gif": "",
+            "thumb_pdf": "",
+            "thumb_pdf_w": "",
+            "thumb_pdf_h": "",
+            "thumb_tiny": "",
+            "converted_pdf": "",
+            "image_exif_rotation": 123,
+            "original_w": "",
+            "original_h": "",
+            "deanimate": "",
+            "deanimate_gif": "",
+            "pjpeg": "",
+            "permalink": "",
+            "permalink_public": "",
+            "edit_link": "",
+            "has_rich_preview": false,
+            "media_display_type": "",
+            "preview_is_truncated": false,
+            "preview": "",
+            "preview_highlight": "",
+            "plain_text": "",
+            "preview_plain_text": "",
+            "has_more": false,
+            "sent_to_self": false,
+            "lines": 123,
+            "lines_more": 123,
+            "is_public": false,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "channels": [
+              ""
+            ],
+            "groups": [
+              ""
+            ],
+            "ims": [
+              ""
+            ],
+            "shares": {
+              "public": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ]
+              },
+              "private": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ]
+              }
+            },
+            "has_more_shares": false,
+            "to": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "from": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "cc": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "channel_actions_ts": "",
+            "channel_actions_count": 123,
+            "headers": {
+              "date": "",
+              "in_reply_to": "",
+              "reply_to": "",
+              "message_id": ""
+            },
+            "simplified_html": "",
+            "media_progress": {
+              "offset_ms": 123,
+              "max_offset_ms": 123,
+              "duration_ms": 123
+            },
+            "saved": {
+              "is_archived": false,
+              "date_completed": 123,
+              "date_due": 123,
+              "state": ""
+            },
+            "quip_thread_id": "",
+            "is_channel_space": false,
+            "linked_channel_id": "",
+            "access": "",
+            "teams_shared_with": [],
+            "last_read": 123,
+            "title_blocks": [
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  },
+                  {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  },
+                  {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "divider",
+                "block_id": ""
+              },
+              {
+                "type": "image",
+                "fallback": "",
+                "image_url": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "is_animated": false,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                },
+                "alt_text": "",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "video",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "title_url": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "video_url": "",
+                "alt_text": "",
+                "thumbnail_url": "",
+                "author_name": "",
+                "provider_name": "",
+                "provider_icon_url": "",
+                "block_id": ""
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "share_shortcut",
+                "block_id": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "sales_home_workflow_app_type": 123,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "title": "",
+                "description": "",
+                "bot_user_id": "",
+                "url": "",
+                "owning_team_id": "",
+                "workflow_id": "",
+                "developer_trace_id": "",
+                "trigger_type": "",
+                "trigger_subtype": "",
+                "share_url": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "url": "",
+                  "value": "",
+                  "style": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "workflow_button",
+                  "action_id": "",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "workflow": {
+                    "trigger": {
+                      "url": "",
+                      "customizable_input_parameters": [
+                        {
+                          "name": "",
+                          "value": ""
+                        }
+                      ]
+                    }
+                  },
+                  "style": "",
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "checkboxes",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "radio_buttons",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channel": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channels": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversation": "",
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversations": [
+                    ""
+                  ],
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_date": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "timepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_time": "",
+                  "timezone": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datetimepicker",
+                  "action_id": "",
+                  "initial_date_time": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "overflow",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_user": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_users": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              }
+            ],
+            "private_channels_with_file_access_count": 123,
+            "private_file_with_access_count": 123,
+            "dm_mpdm_users_with_file_access": [
+              {
+                "user_id": "",
+                "access": ""
+              }
+            ],
+            "org_or_workspace_access": "",
+            "update_notification": 123,
+            "canvas_template_mode": "",
+            "template_conversion_ts": 123,
+            "template_name": "",
+            "template_title": "",
+            "template_description": "",
+            "template_icon": "",
+            "team_pref_version_history_enabled": false,
+            "show_badge": false,
+            "favorites": [
+              {
+                "collection_id": "",
+                "collection_name": "",
+                "position": ""
+              }
+            ],
+            "list_metadata": {
+              "icon": "",
+              "icon_url": "",
+              "icon_team_id": "",
+              "description": "",
+              "is_trial": false,
+              "creation_source": {
+                "type": "",
+                "reference_id": "",
+                "workflow_function_id": ""
+              },
+              "schema": [
+                {
+                  "id": "",
+                  "name": "",
+                  "key": "",
+                  "type": "",
+                  "is_primary_column": false,
+                  "options": {
+                    "choices": [
+                      {
+                        "value": "",
+                        "label": "",
+                        "color": ""
+                      }
+                    ],
+                    "format": "",
+                    "default_value": "",
+                    "default_value_typed": {
+                      "select": [
+                        ""
+                      ]
+                    },
+                    "emoji": "",
+                    "max": 123,
+                    "precision": 123,
+                    "show_member_name": false,
+                    "date_format": "",
+                    "time_format": "",
+                    "currency_format": "",
+                    "emoji_team_id": "",
+                    "currency": "",
+                    "rounding": "",
+                    "mark_as_done_when_checked": false,
+                    "for_assignment": false,
+                    "notify_users": false,
+                    "linked_to": [
+                      ""
+                    ],
+                    "canvas_id": "",
+                    "canvas_placeholder_mapping": [
+                      {
+                        "variable": "",
+                        "column": ""
+                      }
+                    ]
+                  }
+                }
+              ],
+              "views": [
+                {
+                  "id": "",
+                  "name": "",
+                  "type": "",
+                  "is_locked": false,
+                  "position": "",
+                  "columns": [
+                    {
+                      "visible": false,
+                      "key": "",
+                      "id": "",
+                      "position": "",
+                      "width": 123
+                    }
+                  ],
+                  "date_created": 123,
+                  "created_by": "",
+                  "stick_column_left": false,
+                  "is_all_items_view": false
+                }
+              ],
+              "integrations": [
+                ""
+              ]
+            },
+            "list_limits": {
+              "over_row_maximum": false,
+              "row_count_limit": 123,
+              "row_count": 123,
+              "over_column_maximum": false,
+              "column_count": 123,
+              "column_count_limit": 123,
+              "over_view_maximum": false,
+              "view_count": 123,
+              "view_count_limit": 123
+            },
+            "can_toggle_canvas_lock": false,
+            "bot_id": "",
+            "initial_comment": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "user": "",
+              "comment": "",
+              "channel": "",
+              "is_intro": false
+            },
+            "num_stars": 123,
+            "is_starred": false,
+            "pinned_to": [
+              ""
+            ],
+            "reactions": [
+              {
+                "name": "",
+                "count": 123,
+                "users": [
+                  ""
+                ],
+                "url": ""
+              }
+            ],
+            "comments_count": 123,
+            "attachments": [],
+            "blocks": [
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  },
+                  {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  },
+                  {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "divider",
+                "block_id": ""
+              },
+              {
+                "type": "image",
+                "fallback": "",
+                "image_url": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "is_animated": false,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                },
+                "alt_text": "",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "video",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "title_url": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "video_url": "",
+                "alt_text": "",
+                "thumbnail_url": "",
+                "author_name": "",
+                "provider_name": "",
+                "provider_icon_url": "",
+                "block_id": ""
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "share_shortcut",
+                "block_id": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "sales_home_workflow_app_type": 123,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "title": "",
+                "description": "",
+                "bot_user_id": "",
+                "url": "",
+                "owning_team_id": "",
+                "workflow_id": "",
+                "developer_trace_id": "",
+                "trigger_type": "",
+                "trigger_subtype": "",
+                "share_url": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "url": "",
+                  "value": "",
+                  "style": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "workflow_button",
+                  "action_id": "",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "workflow": {
+                    "trigger": {
+                      "url": "",
+                      "customizable_input_parameters": [
+                        {
+                          "name": "",
+                          "value": ""
+                        }
+                      ]
+                    }
+                  },
+                  "style": "",
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "checkboxes",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "radio_buttons",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channel": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channels": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversation": "",
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversations": [
+                    ""
+                  ],
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_date": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "timepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_time": "",
+                  "timezone": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datetimepicker",
+                  "action_id": "",
+                  "initial_date_time": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "overflow",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_user": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_users": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              }
+            ]
+          },
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "fallback": "",
+          "image_url": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123,
+          "is_animated": false,
+          "slack_file": {
+            "id": "",
+            "url": ""
+          },
+          "alt_text": "",
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "title_url": "",
+          "description": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "video_url": "",
+          "thumbnail_url": "",
+          "author_name": "",
+          "provider_name": "",
+          "provider_icon_url": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "sales_home_workflow_app_type": 123,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "bot_user_id": "",
+          "url": "",
+          "owning_team_id": "",
+          "workflow_id": "",
+          "developer_trace_id": "",
+          "trigger_type": "",
+          "trigger_subtype": "",
+          "share_url": "",
+          "fields": [
+            {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            {
+              "type": "mrkdwn",
+              "text": "",
+              "verbatim": false
+            }
+          ],
+          "accessory": {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "accessibility_label": "",
+            "workflow": {
+              "trigger": {
+                "url": "",
+                "customizable_input_parameters": [
+                  {
+                    "name": "",
+                    "value": ""
+                  }
+                ]
+              }
+            },
+            "options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "initial_options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "focus_on_load": false,
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_channel": "",
+            "response_url_enabled": false,
+            "initial_channels": [
+              ""
+            ],
+            "max_selected_items": 123,
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "filter": {
+              "include": [],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            },
+            "initial_conversations": [
+              ""
+            ],
+            "initial_date": "",
+            "initial_time": "",
+            "timezone": "",
+            "initial_date_time": 123,
+            "min_query_length": 123,
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "option_groups": [
+              {
+                "label": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ]
+              }
+            ],
+            "initial_user": "",
+            "initial_users": [
+              ""
+            ]
+          },
+          "label": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "element": {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "accessibility_label": "",
+            "workflow": {
+              "trigger": {
+                "url": "",
+                "customizable_input_parameters": [
+                  {
+                    "name": "",
+                    "value": ""
+                  }
+                ]
+              }
+            },
+            "options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "initial_options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "focus_on_load": false,
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_channel": "",
+            "response_url_enabled": false,
+            "initial_channels": [
+              ""
+            ],
+            "max_selected_items": 123,
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "filter": {
+              "include": [],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            },
+            "initial_conversations": [
+              ""
+            ],
+            "initial_date": "",
+            "initial_time": "",
+            "timezone": "",
+            "initial_date_time": 123,
+            "min_query_length": 123,
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "option_groups": [
+              {
+                "label": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ]
+              }
+            ],
+            "initial_user": "",
+            "initial_users": [
+              ""
+            ]
+          },
+          "dispatch_action": false,
+          "hint": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "optional": false
+        }
+      ],
+      "first_user_thread_reply": ""
+    }
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -26985,7 +26985,12 @@
                   "app_id": "",
                   "call_family": ""
                 },
-                "no_notifications": false
+                "no_notifications": false,
+                "assistant_app_thread": {
+                  "title": "",
+                  "title_blocks": [],
+                  "first_user_thread_reply": ""
+                }
               }
             }
           ],
@@ -27473,7 +27478,12 @@
                       "app_id": "",
                       "call_family": ""
                     },
-                    "no_notifications": false
+                    "no_notifications": false,
+                    "assistant_app_thread": {
+                      "title": "",
+                      "title_blocks": [],
+                      "first_user_thread_reply": ""
+                    }
                   },
                   "number": [],
                   "select": [],
@@ -28006,7 +28016,12 @@
                       "app_id": "",
                       "call_family": ""
                     },
-                    "no_notifications": false
+                    "no_notifications": false,
+                    "assistant_app_thread": {
+                      "title": "",
+                      "title_blocks": [],
+                      "first_user_thread_reply": ""
+                    }
                   },
                   "number": [],
                   "select": [],
@@ -37494,7 +37509,12722 @@
           },
           "is_file_attachment": false
         }
-      ]
+      ],
+      "assistant_app_thread": {
+        "title": "",
+        "title_blocks": [
+          {
+            "type": "actions",
+            "elements": [
+              {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "url": "",
+                "value": "",
+                "style": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "accessibility_label": ""
+              },
+              {
+                "type": "workflow_button",
+                "action_id": "",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "workflow": {
+                  "trigger": {
+                    "url": "",
+                    "customizable_input_parameters": [
+                      {
+                        "name": "",
+                        "value": ""
+                      }
+                    ]
+                  }
+                },
+                "style": "",
+                "accessibility_label": ""
+              },
+              {
+                "type": "checkboxes",
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "radio_buttons",
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "channels_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_channel": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "response_url_enabled": false,
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_channels_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_channels": [
+                  ""
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "conversations_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_conversation": "",
+                "default_to_current_conversation": false,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "response_url_enabled": false,
+                "filter": {
+                  "include": [],
+                  "exclude_external_shared_channels": false,
+                  "exclude_bot_users": false
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_conversations_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_conversations": [
+                  ""
+                ],
+                "default_to_current_conversation": false,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "filter": {
+                  "include": [],
+                  "exclude_external_shared_channels": false,
+                  "exclude_bot_users": false
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "datepicker",
+                "action_id": "",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "initial_date": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "timepicker",
+                "action_id": "",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "initial_time": "",
+                "timezone": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "datetimepicker",
+                "action_id": "",
+                "initial_date_time": 123,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "external_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "min_query_length": 123,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_external_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "min_query_length": 123,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "image",
+                "image_url": "",
+                "alt_text": "",
+                "fallback": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                }
+              },
+              {
+                "type": "overflow",
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                }
+              },
+              {
+                "type": "static_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "option_groups": [
+                  {
+                    "label": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ]
+                  }
+                ],
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_static_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "option_groups": [
+                  {
+                    "label": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ]
+                  }
+                ],
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "users_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_user": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_users_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_users": [
+                  ""
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "rich_text_list",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "style": "",
+                "indent": 123,
+                "offset": 123,
+                "border": 123
+              },
+              {
+                "type": "rich_text_preformatted",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "border": 123
+              },
+              {
+                "type": "rich_text_quote",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "block_id": "",
+            "call_id": "",
+            "api_decoration_available": false,
+            "call": {
+              "v1": {
+                "id": "",
+                "app_id": "",
+                "app_icon_urls": {
+                  "image_32": "",
+                  "image_36": "",
+                  "image_48": "",
+                  "image_64": "",
+                  "image_72": "",
+                  "image_96": "",
+                  "image_128": "",
+                  "image_192": "",
+                  "image_512": "",
+                  "image_1024": "",
+                  "image_original": ""
+                },
+                "date_start": 123,
+                "active_participants": [
+                  {
+                    "slack_id": "",
+                    "external_id": "",
+                    "display_name": "",
+                    "avatar_url": ""
+                  }
+                ],
+                "all_participants": [
+                  {
+                    "slack_id": "",
+                    "external_id": "",
+                    "display_name": "",
+                    "avatar_url": ""
+                  }
+                ],
+                "display_id": "",
+                "join_url": "",
+                "desktop_app_join_url": "",
+                "name": "",
+                "created_by": "",
+                "date_end": 123,
+                "channels": [
+                  ""
+                ],
+                "is_dm_call": false,
+                "was_rejected": false,
+                "was_missed": false,
+                "was_accepted": false,
+                "has_ended": false
+              },
+              "media_backend_type": ""
+            },
+            "external_id": "",
+            "source": "",
+            "file_id": "",
+            "file": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "name": "",
+              "title": "",
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "source_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "editors": [
+                ""
+              ],
+              "edit_timestamp": 123,
+              "alt_txt": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "mp4_low": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "url_static_preview": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ]
+                }
+              },
+              "has_more_shares": false,
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "media_progress": {
+                "offset_ms": 123,
+                "max_offset_ms": 123,
+                "duration_ms": 123
+              },
+              "saved": {
+                "is_archived": false,
+                "date_completed": 123,
+                "date_due": 123,
+                "state": ""
+              },
+              "quip_thread_id": "",
+              "is_channel_space": false,
+              "linked_channel_id": "",
+              "access": "",
+              "teams_shared_with": [],
+              "last_read": 123,
+              "title_blocks": [
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "url": "",
+                      "value": "",
+                      "style": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "workflow_button",
+                      "action_id": "",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "workflow": {
+                        "trigger": {
+                          "url": "",
+                          "customizable_input_parameters": [
+                            {
+                              "name": "",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      "style": "",
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "checkboxes",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "radio_buttons",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channel": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channels": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversation": "",
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversations": [
+                        ""
+                      ],
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_date": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "timepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_time": "",
+                      "timezone": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datetimepicker",
+                      "action_id": "",
+                      "initial_date_time": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "type": "overflow",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      }
+                    },
+                    {
+                      "type": "static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_user": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_users": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "divider",
+                  "block_id": ""
+                },
+                {
+                  "type": "image",
+                  "fallback": "",
+                  "image_url": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "is_animated": false,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  },
+                  "alt_text": "",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "video",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "title_url": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "video_url": "",
+                  "alt_text": "",
+                  "thumbnail_url": "",
+                  "author_name": "",
+                  "provider_name": "",
+                  "provider_icon_url": "",
+                  "block_id": ""
+                },
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_list",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "style": "",
+                      "indent": 123,
+                      "offset": 123,
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_quote",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "share_shortcut",
+                  "block_id": "",
+                  "function_trigger_id": "",
+                  "app_id": "",
+                  "is_workflow_app": false,
+                  "sales_home_workflow_app_type": 123,
+                  "app_collaborators": [
+                    ""
+                  ],
+                  "button_label": "",
+                  "title": "",
+                  "description": "",
+                  "bot_user_id": "",
+                  "url": "",
+                  "owning_team_id": "",
+                  "workflow_id": "",
+                  "developer_trace_id": "",
+                  "trigger_type": "",
+                  "trigger_subtype": "",
+                  "share_url": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                }
+              ],
+              "private_channels_with_file_access_count": 123,
+              "private_file_with_access_count": 123,
+              "dm_mpdm_users_with_file_access": [
+                {
+                  "user_id": "",
+                  "access": ""
+                }
+              ],
+              "org_or_workspace_access": "",
+              "update_notification": 123,
+              "canvas_template_mode": "",
+              "template_conversion_ts": 123,
+              "template_name": "",
+              "template_title": "",
+              "template_description": "",
+              "template_icon": "",
+              "team_pref_version_history_enabled": false,
+              "show_badge": false,
+              "favorites": [
+                {
+                  "collection_id": "",
+                  "collection_name": "",
+                  "position": ""
+                }
+              ],
+              "list_metadata": {
+                "icon": "",
+                "icon_url": "",
+                "icon_team_id": "",
+                "description": "",
+                "is_trial": false,
+                "creation_source": {
+                  "type": "",
+                  "reference_id": "",
+                  "workflow_function_id": ""
+                },
+                "schema": [
+                  {
+                    "id": "",
+                    "name": "",
+                    "key": "",
+                    "type": "",
+                    "is_primary_column": false,
+                    "options": {
+                      "choices": [
+                        {
+                          "value": "",
+                          "label": "",
+                          "color": ""
+                        }
+                      ],
+                      "format": "",
+                      "default_value": "",
+                      "default_value_typed": {
+                        "select": [
+                          ""
+                        ]
+                      },
+                      "emoji": "",
+                      "max": 123,
+                      "precision": 123,
+                      "show_member_name": false,
+                      "date_format": "",
+                      "time_format": "",
+                      "currency_format": "",
+                      "emoji_team_id": "",
+                      "currency": "",
+                      "rounding": "",
+                      "mark_as_done_when_checked": false,
+                      "for_assignment": false,
+                      "notify_users": false,
+                      "linked_to": [
+                        ""
+                      ],
+                      "canvas_id": "",
+                      "canvas_placeholder_mapping": [
+                        {
+                          "variable": "",
+                          "column": ""
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "views": [
+                  {
+                    "id": "",
+                    "name": "",
+                    "type": "",
+                    "is_locked": false,
+                    "position": "",
+                    "columns": [
+                      {
+                        "visible": false,
+                        "key": "",
+                        "id": "",
+                        "position": "",
+                        "width": 123
+                      }
+                    ],
+                    "date_created": 123,
+                    "created_by": "",
+                    "stick_column_left": false,
+                    "is_all_items_view": false
+                  }
+                ],
+                "integrations": [
+                  ""
+                ]
+              },
+              "list_limits": {
+                "over_row_maximum": false,
+                "row_count_limit": 123,
+                "row_count": 123,
+                "over_column_maximum": false,
+                "column_count": 123,
+                "column_count_limit": 123,
+                "over_view_maximum": false,
+                "view_count": 123,
+                "view_count_limit": 123
+              },
+              "can_toggle_canvas_lock": false,
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
+              "attachments": [],
+              "blocks": [
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "url": "",
+                      "value": "",
+                      "style": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "workflow_button",
+                      "action_id": "",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "workflow": {
+                        "trigger": {
+                          "url": "",
+                          "customizable_input_parameters": [
+                            {
+                              "name": "",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      "style": "",
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "checkboxes",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "radio_buttons",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channel": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channels": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversation": "",
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversations": [
+                        ""
+                      ],
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_date": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "timepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_time": "",
+                      "timezone": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datetimepicker",
+                      "action_id": "",
+                      "initial_date_time": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "type": "overflow",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      }
+                    },
+                    {
+                      "type": "static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_user": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_users": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "divider",
+                  "block_id": ""
+                },
+                {
+                  "type": "image",
+                  "fallback": "",
+                  "image_url": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "is_animated": false,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  },
+                  "alt_text": "",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "video",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "title_url": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "video_url": "",
+                  "alt_text": "",
+                  "thumbnail_url": "",
+                  "author_name": "",
+                  "provider_name": "",
+                  "provider_icon_url": "",
+                  "block_id": ""
+                },
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_list",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "style": "",
+                      "indent": 123,
+                      "offset": 123,
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_quote",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "share_shortcut",
+                  "block_id": "",
+                  "function_trigger_id": "",
+                  "app_id": "",
+                  "is_workflow_app": false,
+                  "sales_home_workflow_app_type": 123,
+                  "app_collaborators": [
+                    ""
+                  ],
+                  "button_label": "",
+                  "title": "",
+                  "description": "",
+                  "bot_user_id": "",
+                  "url": "",
+                  "owning_team_id": "",
+                  "workflow_id": "",
+                  "developer_trace_id": "",
+                  "trigger_type": "",
+                  "trigger_subtype": "",
+                  "share_url": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                }
+              ]
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "fallback": "",
+            "image_url": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "is_animated": false,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "alt_text": "",
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "title_url": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "video_url": "",
+            "thumbnail_url": "",
+            "author_name": "",
+            "provider_name": "",
+            "provider_icon_url": "",
+            "function_trigger_id": "",
+            "app_id": "",
+            "is_workflow_app": false,
+            "sales_home_workflow_app_type": 123,
+            "app_collaborators": [
+              ""
+            ],
+            "button_label": "",
+            "bot_user_id": "",
+            "url": "",
+            "owning_team_id": "",
+            "workflow_id": "",
+            "developer_trace_id": "",
+            "trigger_type": "",
+            "trigger_subtype": "",
+            "share_url": "",
+            "fields": [
+              {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              {
+                "type": "mrkdwn",
+                "text": "",
+                "verbatim": false
+              }
+            ],
+            "accessory": {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "accessibility_label": "",
+              "workflow": {
+                "trigger": {
+                  "url": "",
+                  "customizable_input_parameters": [
+                    {
+                      "name": "",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "focus_on_load": false,
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_channel": "",
+              "response_url_enabled": false,
+              "initial_channels": [
+                ""
+              ],
+              "max_selected_items": 123,
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "initial_conversations": [
+                ""
+              ],
+              "initial_date": "",
+              "initial_time": "",
+              "timezone": "",
+              "initial_date_time": 123,
+              "min_query_length": 123,
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              },
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_user": "",
+              "initial_users": [
+                ""
+              ]
+            },
+            "label": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "element": {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "accessibility_label": "",
+              "workflow": {
+                "trigger": {
+                  "url": "",
+                  "customizable_input_parameters": [
+                    {
+                      "name": "",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "focus_on_load": false,
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_channel": "",
+              "response_url_enabled": false,
+              "initial_channels": [
+                ""
+              ],
+              "max_selected_items": 123,
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "initial_conversations": [
+                ""
+              ],
+              "initial_date": "",
+              "initial_time": "",
+              "timezone": "",
+              "initial_date_time": 123,
+              "min_query_length": 123,
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              },
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_user": "",
+              "initial_users": [
+                ""
+              ]
+            },
+            "dispatch_action": false,
+            "hint": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "optional": false
+          }
+        ],
+        "first_user_thread_reply": ""
+      }
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/conversations.open.json
+++ b/json-logs/samples/api/conversations.open.json
@@ -12741,7 +12741,12722 @@
           },
           "optional": false
         }
-      ]
+      ],
+      "assistant_app_thread": {
+        "title": "",
+        "title_blocks": [
+          {
+            "type": "actions",
+            "elements": [
+              {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "url": "",
+                "value": "",
+                "style": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "accessibility_label": ""
+              },
+              {
+                "type": "workflow_button",
+                "action_id": "",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "workflow": {
+                  "trigger": {
+                    "url": "",
+                    "customizable_input_parameters": [
+                      {
+                        "name": "",
+                        "value": ""
+                      }
+                    ]
+                  }
+                },
+                "style": "",
+                "accessibility_label": ""
+              },
+              {
+                "type": "checkboxes",
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "radio_buttons",
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "channels_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_channel": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "response_url_enabled": false,
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_channels_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_channels": [
+                  ""
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "conversations_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_conversation": "",
+                "default_to_current_conversation": false,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "response_url_enabled": false,
+                "filter": {
+                  "include": [],
+                  "exclude_external_shared_channels": false,
+                  "exclude_bot_users": false
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_conversations_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_conversations": [
+                  ""
+                ],
+                "default_to_current_conversation": false,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "filter": {
+                  "include": [],
+                  "exclude_external_shared_channels": false,
+                  "exclude_bot_users": false
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "datepicker",
+                "action_id": "",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "initial_date": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "timepicker",
+                "action_id": "",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "initial_time": "",
+                "timezone": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "datetimepicker",
+                "action_id": "",
+                "initial_date_time": 123,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "external_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "min_query_length": 123,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_external_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "min_query_length": 123,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "image",
+                "image_url": "",
+                "alt_text": "",
+                "fallback": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                }
+              },
+              {
+                "type": "overflow",
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                }
+              },
+              {
+                "type": "static_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "option_groups": [
+                  {
+                    "label": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ]
+                  }
+                ],
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_static_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "option_groups": [
+                  {
+                    "label": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ]
+                  }
+                ],
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "users_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_user": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_users_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_users": [
+                  ""
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "rich_text_list",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "style": "",
+                "indent": 123,
+                "offset": 123,
+                "border": 123
+              },
+              {
+                "type": "rich_text_preformatted",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "border": 123
+              },
+              {
+                "type": "rich_text_quote",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "block_id": "",
+            "call_id": "",
+            "api_decoration_available": false,
+            "call": {
+              "v1": {
+                "id": "",
+                "app_id": "",
+                "app_icon_urls": {
+                  "image_32": "",
+                  "image_36": "",
+                  "image_48": "",
+                  "image_64": "",
+                  "image_72": "",
+                  "image_96": "",
+                  "image_128": "",
+                  "image_192": "",
+                  "image_512": "",
+                  "image_1024": "",
+                  "image_original": ""
+                },
+                "date_start": 123,
+                "active_participants": [
+                  {
+                    "slack_id": "",
+                    "external_id": "",
+                    "display_name": "",
+                    "avatar_url": ""
+                  }
+                ],
+                "all_participants": [
+                  {
+                    "slack_id": "",
+                    "external_id": "",
+                    "display_name": "",
+                    "avatar_url": ""
+                  }
+                ],
+                "display_id": "",
+                "join_url": "",
+                "desktop_app_join_url": "",
+                "name": "",
+                "created_by": "",
+                "date_end": 123,
+                "channels": [
+                  ""
+                ],
+                "is_dm_call": false,
+                "was_rejected": false,
+                "was_missed": false,
+                "was_accepted": false,
+                "has_ended": false
+              },
+              "media_backend_type": ""
+            },
+            "external_id": "",
+            "source": "",
+            "file_id": "",
+            "file": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "name": "",
+              "title": "",
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "source_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "editors": [
+                ""
+              ],
+              "edit_timestamp": 123,
+              "alt_txt": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "mp4_low": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "url_static_preview": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ]
+                }
+              },
+              "has_more_shares": false,
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "media_progress": {
+                "offset_ms": 123,
+                "max_offset_ms": 123,
+                "duration_ms": 123
+              },
+              "saved": {
+                "is_archived": false,
+                "date_completed": 123,
+                "date_due": 123,
+                "state": ""
+              },
+              "quip_thread_id": "",
+              "is_channel_space": false,
+              "linked_channel_id": "",
+              "access": "",
+              "teams_shared_with": [],
+              "last_read": 123,
+              "title_blocks": [
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "url": "",
+                      "value": "",
+                      "style": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "workflow_button",
+                      "action_id": "",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "workflow": {
+                        "trigger": {
+                          "url": "",
+                          "customizable_input_parameters": [
+                            {
+                              "name": "",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      "style": "",
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "checkboxes",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "radio_buttons",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channel": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channels": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversation": "",
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversations": [
+                        ""
+                      ],
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_date": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "timepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_time": "",
+                      "timezone": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datetimepicker",
+                      "action_id": "",
+                      "initial_date_time": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "type": "overflow",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      }
+                    },
+                    {
+                      "type": "static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_user": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_users": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "divider",
+                  "block_id": ""
+                },
+                {
+                  "type": "image",
+                  "fallback": "",
+                  "image_url": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "is_animated": false,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  },
+                  "alt_text": "",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "video",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "title_url": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "video_url": "",
+                  "alt_text": "",
+                  "thumbnail_url": "",
+                  "author_name": "",
+                  "provider_name": "",
+                  "provider_icon_url": "",
+                  "block_id": ""
+                },
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_list",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "style": "",
+                      "indent": 123,
+                      "offset": 123,
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_quote",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "share_shortcut",
+                  "block_id": "",
+                  "function_trigger_id": "",
+                  "app_id": "",
+                  "is_workflow_app": false,
+                  "sales_home_workflow_app_type": 123,
+                  "app_collaborators": [
+                    ""
+                  ],
+                  "button_label": "",
+                  "title": "",
+                  "description": "",
+                  "bot_user_id": "",
+                  "url": "",
+                  "owning_team_id": "",
+                  "workflow_id": "",
+                  "developer_trace_id": "",
+                  "trigger_type": "",
+                  "trigger_subtype": "",
+                  "share_url": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                }
+              ],
+              "private_channels_with_file_access_count": 123,
+              "private_file_with_access_count": 123,
+              "dm_mpdm_users_with_file_access": [
+                {
+                  "user_id": "",
+                  "access": ""
+                }
+              ],
+              "org_or_workspace_access": "",
+              "update_notification": 123,
+              "canvas_template_mode": "",
+              "template_conversion_ts": 123,
+              "template_name": "",
+              "template_title": "",
+              "template_description": "",
+              "template_icon": "",
+              "team_pref_version_history_enabled": false,
+              "show_badge": false,
+              "favorites": [
+                {
+                  "collection_id": "",
+                  "collection_name": "",
+                  "position": ""
+                }
+              ],
+              "list_metadata": {
+                "icon": "",
+                "icon_url": "",
+                "icon_team_id": "",
+                "description": "",
+                "is_trial": false,
+                "creation_source": {
+                  "type": "",
+                  "reference_id": "",
+                  "workflow_function_id": ""
+                },
+                "schema": [
+                  {
+                    "id": "",
+                    "name": "",
+                    "key": "",
+                    "type": "",
+                    "is_primary_column": false,
+                    "options": {
+                      "choices": [
+                        {
+                          "value": "",
+                          "label": "",
+                          "color": ""
+                        }
+                      ],
+                      "format": "",
+                      "default_value": "",
+                      "default_value_typed": {
+                        "select": [
+                          ""
+                        ]
+                      },
+                      "emoji": "",
+                      "max": 123,
+                      "precision": 123,
+                      "show_member_name": false,
+                      "date_format": "",
+                      "time_format": "",
+                      "currency_format": "",
+                      "emoji_team_id": "",
+                      "currency": "",
+                      "rounding": "",
+                      "mark_as_done_when_checked": false,
+                      "for_assignment": false,
+                      "notify_users": false,
+                      "linked_to": [
+                        ""
+                      ],
+                      "canvas_id": "",
+                      "canvas_placeholder_mapping": [
+                        {
+                          "variable": "",
+                          "column": ""
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "views": [
+                  {
+                    "id": "",
+                    "name": "",
+                    "type": "",
+                    "is_locked": false,
+                    "position": "",
+                    "columns": [
+                      {
+                        "visible": false,
+                        "key": "",
+                        "id": "",
+                        "position": "",
+                        "width": 123
+                      }
+                    ],
+                    "date_created": 123,
+                    "created_by": "",
+                    "stick_column_left": false,
+                    "is_all_items_view": false
+                  }
+                ],
+                "integrations": [
+                  ""
+                ]
+              },
+              "list_limits": {
+                "over_row_maximum": false,
+                "row_count_limit": 123,
+                "row_count": 123,
+                "over_column_maximum": false,
+                "column_count": 123,
+                "column_count_limit": 123,
+                "over_view_maximum": false,
+                "view_count": 123,
+                "view_count_limit": 123
+              },
+              "can_toggle_canvas_lock": false,
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
+              "attachments": [],
+              "blocks": [
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "url": "",
+                      "value": "",
+                      "style": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "workflow_button",
+                      "action_id": "",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "workflow": {
+                        "trigger": {
+                          "url": "",
+                          "customizable_input_parameters": [
+                            {
+                              "name": "",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      "style": "",
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "checkboxes",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "radio_buttons",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channel": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channels": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversation": "",
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversations": [
+                        ""
+                      ],
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_date": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "timepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_time": "",
+                      "timezone": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datetimepicker",
+                      "action_id": "",
+                      "initial_date_time": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "type": "overflow",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      }
+                    },
+                    {
+                      "type": "static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_user": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_users": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "divider",
+                  "block_id": ""
+                },
+                {
+                  "type": "image",
+                  "fallback": "",
+                  "image_url": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "is_animated": false,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  },
+                  "alt_text": "",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "video",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "title_url": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "video_url": "",
+                  "alt_text": "",
+                  "thumbnail_url": "",
+                  "author_name": "",
+                  "provider_name": "",
+                  "provider_icon_url": "",
+                  "block_id": ""
+                },
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_list",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "style": "",
+                      "indent": 123,
+                      "offset": 123,
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_quote",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "share_shortcut",
+                  "block_id": "",
+                  "function_trigger_id": "",
+                  "app_id": "",
+                  "is_workflow_app": false,
+                  "sales_home_workflow_app_type": 123,
+                  "app_collaborators": [
+                    ""
+                  ],
+                  "button_label": "",
+                  "title": "",
+                  "description": "",
+                  "bot_user_id": "",
+                  "url": "",
+                  "owning_team_id": "",
+                  "workflow_id": "",
+                  "developer_trace_id": "",
+                  "trigger_type": "",
+                  "trigger_subtype": "",
+                  "share_url": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                }
+              ]
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "fallback": "",
+            "image_url": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "is_animated": false,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "alt_text": "",
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "title_url": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "video_url": "",
+            "thumbnail_url": "",
+            "author_name": "",
+            "provider_name": "",
+            "provider_icon_url": "",
+            "function_trigger_id": "",
+            "app_id": "",
+            "is_workflow_app": false,
+            "sales_home_workflow_app_type": 123,
+            "app_collaborators": [
+              ""
+            ],
+            "button_label": "",
+            "bot_user_id": "",
+            "url": "",
+            "owning_team_id": "",
+            "workflow_id": "",
+            "developer_trace_id": "",
+            "trigger_type": "",
+            "trigger_subtype": "",
+            "share_url": "",
+            "fields": [
+              {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              {
+                "type": "mrkdwn",
+                "text": "",
+                "verbatim": false
+              }
+            ],
+            "accessory": {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "accessibility_label": "",
+              "workflow": {
+                "trigger": {
+                  "url": "",
+                  "customizable_input_parameters": [
+                    {
+                      "name": "",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "focus_on_load": false,
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_channel": "",
+              "response_url_enabled": false,
+              "initial_channels": [
+                ""
+              ],
+              "max_selected_items": 123,
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "initial_conversations": [
+                ""
+              ],
+              "initial_date": "",
+              "initial_time": "",
+              "timezone": "",
+              "initial_date_time": 123,
+              "min_query_length": 123,
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              },
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_user": "",
+              "initial_users": [
+                ""
+              ]
+            },
+            "label": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "element": {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "accessibility_label": "",
+              "workflow": {
+                "trigger": {
+                  "url": "",
+                  "customizable_input_parameters": [
+                    {
+                      "name": "",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "focus_on_load": false,
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_channel": "",
+              "response_url_enabled": false,
+              "initial_channels": [
+                ""
+              ],
+              "max_selected_items": 123,
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "initial_conversations": [
+                ""
+              ],
+              "initial_date": "",
+              "initial_time": "",
+              "timezone": "",
+              "initial_date_time": 123,
+              "min_query_length": 123,
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              },
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_user": "",
+              "initial_users": [
+                ""
+              ]
+            },
+            "dispatch_action": false,
+            "hint": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "optional": false
+          }
+        ],
+        "first_user_thread_reply": ""
+      }
     },
     "unread_count": 12345,
     "unread_count_display": 12345,

--- a/json-logs/samples/api/conversations.replies.json
+++ b/json-logs/samples/api/conversations.replies.json
@@ -22141,7 +22141,12 @@
                   "app_id": "",
                   "call_family": ""
                 },
-                "no_notifications": false
+                "no_notifications": false,
+                "assistant_app_thread": {
+                  "title": "",
+                  "title_blocks": [],
+                  "first_user_thread_reply": ""
+                }
               }
             }
           ],
@@ -22629,7 +22634,12 @@
                       "app_id": "",
                       "call_family": ""
                     },
-                    "no_notifications": false
+                    "no_notifications": false,
+                    "assistant_app_thread": {
+                      "title": "",
+                      "title_blocks": [],
+                      "first_user_thread_reply": ""
+                    }
                   },
                   "number": [],
                   "select": [],
@@ -23162,7 +23172,12 @@
                       "app_id": "",
                       "call_family": ""
                     },
-                    "no_notifications": false
+                    "no_notifications": false,
+                    "assistant_app_thread": {
+                      "title": "",
+                      "title_blocks": [],
+                      "first_user_thread_reply": ""
+                    }
                   },
                   "number": [],
                   "select": [],
@@ -37460,7 +37475,12722 @@
           ],
           "comments_count": 123
         }
-      ]
+      ],
+      "assistant_app_thread": {
+        "title": "",
+        "title_blocks": [
+          {
+            "type": "actions",
+            "elements": [
+              {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "url": "",
+                "value": "",
+                "style": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "accessibility_label": ""
+              },
+              {
+                "type": "workflow_button",
+                "action_id": "",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "workflow": {
+                  "trigger": {
+                    "url": "",
+                    "customizable_input_parameters": [
+                      {
+                        "name": "",
+                        "value": ""
+                      }
+                    ]
+                  }
+                },
+                "style": "",
+                "accessibility_label": ""
+              },
+              {
+                "type": "checkboxes",
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "radio_buttons",
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "channels_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_channel": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "response_url_enabled": false,
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_channels_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_channels": [
+                  ""
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "conversations_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_conversation": "",
+                "default_to_current_conversation": false,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "response_url_enabled": false,
+                "filter": {
+                  "include": [],
+                  "exclude_external_shared_channels": false,
+                  "exclude_bot_users": false
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_conversations_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_conversations": [
+                  ""
+                ],
+                "default_to_current_conversation": false,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "filter": {
+                  "include": [],
+                  "exclude_external_shared_channels": false,
+                  "exclude_bot_users": false
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "datepicker",
+                "action_id": "",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "initial_date": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "timepicker",
+                "action_id": "",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "initial_time": "",
+                "timezone": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "datetimepicker",
+                "action_id": "",
+                "initial_date_time": 123,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "external_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "min_query_length": 123,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_external_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "min_query_length": 123,
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "image",
+                "image_url": "",
+                "alt_text": "",
+                "fallback": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                }
+              },
+              {
+                "type": "overflow",
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                }
+              },
+              {
+                "type": "static_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "option_groups": [
+                  {
+                    "label": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ]
+                  }
+                ],
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_static_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "option_groups": [
+                  {
+                    "label": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ]
+                  }
+                ],
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "users_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_user": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "focus_on_load": false
+              },
+              {
+                "type": "multi_users_select",
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "initial_users": [
+                  ""
+                ],
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "max_selected_items": 123,
+                "focus_on_load": false
+              },
+              {
+                "type": "rich_text_list",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "style": "",
+                "indent": 123,
+                "offset": 123,
+                "border": 123
+              },
+              {
+                "type": "rich_text_preformatted",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ],
+                "border": 123
+              },
+              {
+                "type": "rich_text_quote",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "rich_text_section",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "broadcast",
+                        "range": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "text",
+                        "text": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "channel",
+                        "channel_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "color",
+                        "value": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "date",
+                        "timestamp": "",
+                        "format": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        },
+                        "url": "",
+                        "fallback": ""
+                      },
+                      {
+                        "type": "link",
+                        "url": "",
+                        "text": "",
+                        "unsafe": false,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false,
+                          "code": false
+                        }
+                      },
+                      {
+                        "type": "team",
+                        "team_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "user",
+                        "user_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "usergroup",
+                        "usergroup_id": "",
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        }
+                      },
+                      {
+                        "type": "emoji",
+                        "name": "",
+                        "skin_tone": 123,
+                        "style": {
+                          "bold": false,
+                          "italic": false,
+                          "strike": false,
+                          "highlight": false,
+                          "client_highlight": false,
+                          "unlink": false
+                        },
+                        "unicode": ""
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "block_id": "",
+            "call_id": "",
+            "api_decoration_available": false,
+            "call": {
+              "v1": {
+                "id": "",
+                "app_id": "",
+                "app_icon_urls": {
+                  "image_32": "",
+                  "image_36": "",
+                  "image_48": "",
+                  "image_64": "",
+                  "image_72": "",
+                  "image_96": "",
+                  "image_128": "",
+                  "image_192": "",
+                  "image_512": "",
+                  "image_1024": "",
+                  "image_original": ""
+                },
+                "date_start": 123,
+                "active_participants": [
+                  {
+                    "slack_id": "",
+                    "external_id": "",
+                    "display_name": "",
+                    "avatar_url": ""
+                  }
+                ],
+                "all_participants": [
+                  {
+                    "slack_id": "",
+                    "external_id": "",
+                    "display_name": "",
+                    "avatar_url": ""
+                  }
+                ],
+                "display_id": "",
+                "join_url": "",
+                "desktop_app_join_url": "",
+                "name": "",
+                "created_by": "",
+                "date_end": 123,
+                "channels": [
+                  ""
+                ],
+                "is_dm_call": false,
+                "was_rejected": false,
+                "was_missed": false,
+                "was_accepted": false,
+                "has_ended": false
+              },
+              "media_backend_type": ""
+            },
+            "external_id": "",
+            "source": "",
+            "file_id": "",
+            "file": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "name": "",
+              "title": "",
+              "subject": "",
+              "mimetype": "",
+              "filetype": "",
+              "pretty_type": "",
+              "user": "",
+              "user_team": "",
+              "source_team": "",
+              "mode": "",
+              "editable": false,
+              "non_owner_editable": false,
+              "editor": "",
+              "last_editor": "",
+              "updated": 123,
+              "file_access": "",
+              "editors": [
+                ""
+              ],
+              "edit_timestamp": 123,
+              "alt_txt": "",
+              "subtype": "",
+              "transcription": {
+                "status": "",
+                "locale": ""
+              },
+              "mp4": "",
+              "mp4_low": "",
+              "vtt": "",
+              "hls": "",
+              "hls_embed": "",
+              "duration_ms": 123,
+              "thumb_video_w": 123,
+              "thumb_video_h": 123,
+              "original_attachment_count": 123,
+              "is_external": false,
+              "external_type": "",
+              "external_id": "",
+              "external_url": "",
+              "username": "",
+              "size": 123,
+              "url_private": "",
+              "url_private_download": "",
+              "url_static_preview": "",
+              "app_id": "",
+              "app_name": "",
+              "thumb_64": "",
+              "thumb_64_gif": "",
+              "thumb_64_w": "",
+              "thumb_64_h": "",
+              "thumb_80": "",
+              "thumb_80_gif": "",
+              "thumb_80_w": "",
+              "thumb_80_h": "",
+              "thumb_160": "",
+              "thumb_160_gif": "",
+              "thumb_160_w": "",
+              "thumb_160_h": "",
+              "thumb_360": "",
+              "thumb_360_gif": "",
+              "thumb_360_w": "",
+              "thumb_360_h": "",
+              "thumb_480": "",
+              "thumb_480_gif": "",
+              "thumb_480_w": "",
+              "thumb_480_h": "",
+              "thumb_720": "",
+              "thumb_720_gif": "",
+              "thumb_720_w": "",
+              "thumb_720_h": "",
+              "thumb_800": "",
+              "thumb_800_gif": "",
+              "thumb_800_w": "",
+              "thumb_800_h": "",
+              "thumb_960": "",
+              "thumb_960_gif": "",
+              "thumb_960_w": "",
+              "thumb_960_h": "",
+              "thumb_1024": "",
+              "thumb_1024_gif": "",
+              "thumb_1024_w": "",
+              "thumb_1024_h": "",
+              "thumb_video": "",
+              "thumb_gif": "",
+              "thumb_pdf": "",
+              "thumb_pdf_w": "",
+              "thumb_pdf_h": "",
+              "thumb_tiny": "",
+              "converted_pdf": "",
+              "image_exif_rotation": 123,
+              "original_w": "",
+              "original_h": "",
+              "deanimate": "",
+              "deanimate_gif": "",
+              "pjpeg": "",
+              "permalink": "",
+              "permalink_public": "",
+              "edit_link": "",
+              "has_rich_preview": false,
+              "media_display_type": "",
+              "preview_is_truncated": false,
+              "preview": "",
+              "preview_highlight": "",
+              "plain_text": "",
+              "preview_plain_text": "",
+              "has_more": false,
+              "sent_to_self": false,
+              "lines": 123,
+              "lines_more": 123,
+              "is_public": false,
+              "public_url_shared": false,
+              "display_as_bot": false,
+              "channels": [
+                ""
+              ],
+              "groups": [
+                ""
+              ],
+              "ims": [
+                ""
+              ],
+              "shares": {
+                "public": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ]
+                },
+                "private": {
+                  "C03E94MKU": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ],
+                  "C03E94MKU_": [
+                    {
+                      "share_user_id": "",
+                      "reply_users": [
+                        ""
+                      ],
+                      "reply_users_count": 123,
+                      "reply_count": 123,
+                      "ts": "",
+                      "thread_ts": "",
+                      "latest_reply": "",
+                      "channel_name": "",
+                      "team_id": "",
+                      "access": "",
+                      "source": "",
+                      "date_last_shared": 123
+                    }
+                  ]
+                }
+              },
+              "has_more_shares": false,
+              "to": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "from": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "cc": [
+                {
+                  "address": "",
+                  "name": "",
+                  "original": ""
+                }
+              ],
+              "channel_actions_ts": "",
+              "channel_actions_count": 123,
+              "headers": {
+                "date": "",
+                "in_reply_to": "",
+                "reply_to": "",
+                "message_id": ""
+              },
+              "simplified_html": "",
+              "media_progress": {
+                "offset_ms": 123,
+                "max_offset_ms": 123,
+                "duration_ms": 123
+              },
+              "saved": {
+                "is_archived": false,
+                "date_completed": 123,
+                "date_due": 123,
+                "state": ""
+              },
+              "quip_thread_id": "",
+              "is_channel_space": false,
+              "linked_channel_id": "",
+              "access": "",
+              "teams_shared_with": [],
+              "last_read": 123,
+              "title_blocks": [
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "url": "",
+                      "value": "",
+                      "style": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "workflow_button",
+                      "action_id": "",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "workflow": {
+                        "trigger": {
+                          "url": "",
+                          "customizable_input_parameters": [
+                            {
+                              "name": "",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      "style": "",
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "checkboxes",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "radio_buttons",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channel": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channels": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversation": "",
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversations": [
+                        ""
+                      ],
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_date": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "timepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_time": "",
+                      "timezone": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datetimepicker",
+                      "action_id": "",
+                      "initial_date_time": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "type": "overflow",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      }
+                    },
+                    {
+                      "type": "static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_user": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_users": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "divider",
+                  "block_id": ""
+                },
+                {
+                  "type": "image",
+                  "fallback": "",
+                  "image_url": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "is_animated": false,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  },
+                  "alt_text": "",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "video",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "title_url": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "video_url": "",
+                  "alt_text": "",
+                  "thumbnail_url": "",
+                  "author_name": "",
+                  "provider_name": "",
+                  "provider_icon_url": "",
+                  "block_id": ""
+                },
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_list",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "style": "",
+                      "indent": 123,
+                      "offset": 123,
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_quote",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "share_shortcut",
+                  "block_id": "",
+                  "function_trigger_id": "",
+                  "app_id": "",
+                  "is_workflow_app": false,
+                  "sales_home_workflow_app_type": 123,
+                  "app_collaborators": [
+                    ""
+                  ],
+                  "button_label": "",
+                  "title": "",
+                  "description": "",
+                  "bot_user_id": "",
+                  "url": "",
+                  "owning_team_id": "",
+                  "workflow_id": "",
+                  "developer_trace_id": "",
+                  "trigger_type": "",
+                  "trigger_subtype": "",
+                  "share_url": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                }
+              ],
+              "private_channels_with_file_access_count": 123,
+              "private_file_with_access_count": 123,
+              "dm_mpdm_users_with_file_access": [
+                {
+                  "user_id": "",
+                  "access": ""
+                }
+              ],
+              "org_or_workspace_access": "",
+              "update_notification": 123,
+              "canvas_template_mode": "",
+              "template_conversion_ts": 123,
+              "template_name": "",
+              "template_title": "",
+              "template_description": "",
+              "template_icon": "",
+              "team_pref_version_history_enabled": false,
+              "show_badge": false,
+              "favorites": [
+                {
+                  "collection_id": "",
+                  "collection_name": "",
+                  "position": ""
+                }
+              ],
+              "list_metadata": {
+                "icon": "",
+                "icon_url": "",
+                "icon_team_id": "",
+                "description": "",
+                "is_trial": false,
+                "creation_source": {
+                  "type": "",
+                  "reference_id": "",
+                  "workflow_function_id": ""
+                },
+                "schema": [
+                  {
+                    "id": "",
+                    "name": "",
+                    "key": "",
+                    "type": "",
+                    "is_primary_column": false,
+                    "options": {
+                      "choices": [
+                        {
+                          "value": "",
+                          "label": "",
+                          "color": ""
+                        }
+                      ],
+                      "format": "",
+                      "default_value": "",
+                      "default_value_typed": {
+                        "select": [
+                          ""
+                        ]
+                      },
+                      "emoji": "",
+                      "max": 123,
+                      "precision": 123,
+                      "show_member_name": false,
+                      "date_format": "",
+                      "time_format": "",
+                      "currency_format": "",
+                      "emoji_team_id": "",
+                      "currency": "",
+                      "rounding": "",
+                      "mark_as_done_when_checked": false,
+                      "for_assignment": false,
+                      "notify_users": false,
+                      "linked_to": [
+                        ""
+                      ],
+                      "canvas_id": "",
+                      "canvas_placeholder_mapping": [
+                        {
+                          "variable": "",
+                          "column": ""
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "views": [
+                  {
+                    "id": "",
+                    "name": "",
+                    "type": "",
+                    "is_locked": false,
+                    "position": "",
+                    "columns": [
+                      {
+                        "visible": false,
+                        "key": "",
+                        "id": "",
+                        "position": "",
+                        "width": 123
+                      }
+                    ],
+                    "date_created": 123,
+                    "created_by": "",
+                    "stick_column_left": false,
+                    "is_all_items_view": false
+                  }
+                ],
+                "integrations": [
+                  ""
+                ]
+              },
+              "list_limits": {
+                "over_row_maximum": false,
+                "row_count_limit": 123,
+                "row_count": 123,
+                "over_column_maximum": false,
+                "column_count": 123,
+                "column_count_limit": 123,
+                "over_view_maximum": false,
+                "view_count": 123,
+                "view_count_limit": 123
+              },
+              "can_toggle_canvas_lock": false,
+              "bot_id": "",
+              "initial_comment": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "user": "",
+                "comment": "",
+                "channel": "",
+                "is_intro": false
+              },
+              "num_stars": 123,
+              "is_starred": false,
+              "pinned_to": [
+                ""
+              ],
+              "reactions": [
+                {
+                  "name": "",
+                  "count": 123,
+                  "users": [
+                    ""
+                  ],
+                  "url": ""
+                }
+              ],
+              "comments_count": 123,
+              "attachments": [],
+              "blocks": [
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "url": "",
+                      "value": "",
+                      "style": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "workflow_button",
+                      "action_id": "",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "workflow": {
+                        "trigger": {
+                          "url": "",
+                          "customizable_input_parameters": [
+                            {
+                              "name": "",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      "style": "",
+                      "accessibility_label": ""
+                    },
+                    {
+                      "type": "checkboxes",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "radio_buttons",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channel": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channels": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversation": "",
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversations": [
+                        ""
+                      ],
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_date": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "timepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_time": "",
+                      "timezone": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "datetimepicker",
+                      "action_id": "",
+                      "initial_date_time": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    },
+                    {
+                      "type": "overflow",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      }
+                    },
+                    {
+                      "type": "static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_user": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    },
+                    {
+                      "type": "multi_users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_users": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "divider",
+                  "block_id": ""
+                },
+                {
+                  "type": "image",
+                  "fallback": "",
+                  "image_url": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "is_animated": false,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  },
+                  "alt_text": "",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "video",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "title_url": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "video_url": "",
+                  "alt_text": "",
+                  "thumbnail_url": "",
+                  "author_name": "",
+                  "provider_name": "",
+                  "provider_icon_url": "",
+                  "block_id": ""
+                },
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_list",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "style": "",
+                      "indent": 123,
+                      "offset": 123,
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_quote",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "rich_text_list",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "style": "",
+                          "indent": 123,
+                          "offset": 123,
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_preformatted",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ],
+                          "border": 123
+                        },
+                        {
+                          "type": "rich_text_quote",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        },
+                        {
+                          "type": "rich_text_section",
+                          "elements": [
+                            {
+                              "type": "broadcast",
+                              "range": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "text",
+                              "text": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "channel",
+                              "channel_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "color",
+                              "value": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "date",
+                              "timestamp": "",
+                              "format": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              },
+                              "url": "",
+                              "fallback": ""
+                            },
+                            {
+                              "type": "link",
+                              "url": "",
+                              "text": "",
+                              "unsafe": false,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false,
+                                "code": false
+                              }
+                            },
+                            {
+                              "type": "team",
+                              "team_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "user",
+                              "user_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "usergroup",
+                              "usergroup_id": "",
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              }
+                            },
+                            {
+                              "type": "emoji",
+                              "name": "",
+                              "skin_tone": 123,
+                              "style": {
+                                "bold": false,
+                                "italic": false,
+                                "strike": false,
+                                "highlight": false,
+                                "client_highlight": false,
+                                "unlink": false
+                              },
+                              "unicode": ""
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "block_id": ""
+                },
+                {
+                  "type": "share_shortcut",
+                  "block_id": "",
+                  "function_trigger_id": "",
+                  "app_id": "",
+                  "is_workflow_app": false,
+                  "sales_home_workflow_app_type": 123,
+                  "app_collaborators": [
+                    ""
+                  ],
+                  "button_label": "",
+                  "title": "",
+                  "description": "",
+                  "bot_user_id": "",
+                  "url": "",
+                  "owning_team_id": "",
+                  "workflow_id": "",
+                  "developer_trace_id": "",
+                  "trigger_type": "",
+                  "trigger_subtype": "",
+                  "share_url": ""
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "block_id": "",
+                  "fields": [
+                    {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "",
+                      "verbatim": false
+                    }
+                  ],
+                  "accessory": {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                }
+              ]
+            },
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "fallback": "",
+            "image_url": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "is_animated": false,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "alt_text": "",
+            "title": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "title_url": "",
+            "description": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "video_url": "",
+            "thumbnail_url": "",
+            "author_name": "",
+            "provider_name": "",
+            "provider_icon_url": "",
+            "function_trigger_id": "",
+            "app_id": "",
+            "is_workflow_app": false,
+            "sales_home_workflow_app_type": 123,
+            "app_collaborators": [
+              ""
+            ],
+            "button_label": "",
+            "bot_user_id": "",
+            "url": "",
+            "owning_team_id": "",
+            "workflow_id": "",
+            "developer_trace_id": "",
+            "trigger_type": "",
+            "trigger_subtype": "",
+            "share_url": "",
+            "fields": [
+              {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              {
+                "type": "mrkdwn",
+                "text": "",
+                "verbatim": false
+              }
+            ],
+            "accessory": {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "accessibility_label": "",
+              "workflow": {
+                "trigger": {
+                  "url": "",
+                  "customizable_input_parameters": [
+                    {
+                      "name": "",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "focus_on_load": false,
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_channel": "",
+              "response_url_enabled": false,
+              "initial_channels": [
+                ""
+              ],
+              "max_selected_items": 123,
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "initial_conversations": [
+                ""
+              ],
+              "initial_date": "",
+              "initial_time": "",
+              "timezone": "",
+              "initial_date_time": 123,
+              "min_query_length": 123,
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              },
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_user": "",
+              "initial_users": [
+                ""
+              ]
+            },
+            "label": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "element": {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "accessibility_label": "",
+              "workflow": {
+                "trigger": {
+                  "url": "",
+                  "customizable_input_parameters": [
+                    {
+                      "name": "",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "focus_on_load": false,
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_channel": "",
+              "response_url_enabled": false,
+              "initial_channels": [
+                ""
+              ],
+              "max_selected_items": 123,
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "initial_conversations": [
+                ""
+              ],
+              "initial_date": "",
+              "initial_time": "",
+              "timezone": "",
+              "initial_date_time": 123,
+              "min_query_length": 123,
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              },
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_user": "",
+              "initial_users": [
+                ""
+              ]
+            },
+            "dispatch_action": false,
+            "hint": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "optional": false
+          }
+        ],
+        "first_user_thread_reply": ""
+      }
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/reactions.get.json
+++ b/json-logs/samples/api/reactions.get.json
@@ -12794,7 +12794,12722 @@
         },
         "optional": false
       }
-    ]
+    ],
+    "assistant_app_thread": {
+      "title": "",
+      "title_blocks": [
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "url": "",
+              "value": "",
+              "style": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "accessibility_label": ""
+            },
+            {
+              "type": "workflow_button",
+              "action_id": "",
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "workflow": {
+                "trigger": {
+                  "url": "",
+                  "customizable_input_parameters": [
+                    {
+                      "name": "",
+                      "value": ""
+                    }
+                  ]
+                }
+              },
+              "style": "",
+              "accessibility_label": ""
+            },
+            {
+              "type": "checkboxes",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "radio_buttons",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "channels_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channel": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "response_url_enabled": false,
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_channels_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_channels": [
+                ""
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "conversations_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversation": "",
+              "default_to_current_conversation": false,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "response_url_enabled": false,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_conversations_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_conversations": [
+                ""
+              ],
+              "default_to_current_conversation": false,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "filter": {
+                "include": [],
+                "exclude_external_shared_channels": false,
+                "exclude_bot_users": false
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "datepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_date": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "timepicker",
+              "action_id": "",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "initial_time": "",
+              "timezone": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "datetimepicker",
+              "action_id": "",
+              "initial_date_time": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "external_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_external_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "min_query_length": 123,
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "image",
+              "image_url": "",
+              "alt_text": "",
+              "fallback": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              }
+            },
+            {
+              "type": "overflow",
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              }
+            },
+            {
+              "type": "static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_option": {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              },
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_static_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "option_groups": [
+                {
+                  "label": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ]
+                }
+              ],
+              "initial_options": [
+                {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                }
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_user": "",
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "focus_on_load": false
+            },
+            {
+              "type": "multi_users_select",
+              "placeholder": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "action_id": "",
+              "initial_users": [
+                ""
+              ],
+              "confirm": {
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "confirm": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "deny": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "style": ""
+              },
+              "max_selected_items": 123,
+              "focus_on_load": false
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ],
+              "style": "",
+              "indent": 123,
+              "offset": 123,
+              "border": 123
+            },
+            {
+              "type": "rich_text_preformatted",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ],
+              "border": 123
+            },
+            {
+              "type": "rich_text_quote",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "broadcast",
+                      "range": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "text": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "channel",
+                      "channel_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "color",
+                      "value": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "date",
+                      "timestamp": "",
+                      "format": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      },
+                      "url": "",
+                      "fallback": ""
+                    },
+                    {
+                      "type": "link",
+                      "url": "",
+                      "text": "",
+                      "unsafe": false,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false,
+                        "code": false
+                      }
+                    },
+                    {
+                      "type": "team",
+                      "team_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "user_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "usergroup",
+                      "usergroup_id": "",
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      }
+                    },
+                    {
+                      "type": "emoji",
+                      "name": "",
+                      "skin_tone": 123,
+                      "style": {
+                        "bold": false,
+                        "italic": false,
+                        "strike": false,
+                        "highlight": false,
+                        "client_highlight": false,
+                        "unlink": false
+                      },
+                      "unicode": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "block_id": "",
+          "call_id": "",
+          "api_decoration_available": false,
+          "call": {
+            "v1": {
+              "id": "",
+              "app_id": "",
+              "app_icon_urls": {
+                "image_32": "",
+                "image_36": "",
+                "image_48": "",
+                "image_64": "",
+                "image_72": "",
+                "image_96": "",
+                "image_128": "",
+                "image_192": "",
+                "image_512": "",
+                "image_1024": "",
+                "image_original": ""
+              },
+              "date_start": 123,
+              "active_participants": [
+                {
+                  "slack_id": "",
+                  "external_id": "",
+                  "display_name": "",
+                  "avatar_url": ""
+                }
+              ],
+              "all_participants": [
+                {
+                  "slack_id": "",
+                  "external_id": "",
+                  "display_name": "",
+                  "avatar_url": ""
+                }
+              ],
+              "display_id": "",
+              "join_url": "",
+              "desktop_app_join_url": "",
+              "name": "",
+              "created_by": "",
+              "date_end": 123,
+              "channels": [
+                ""
+              ],
+              "is_dm_call": false,
+              "was_rejected": false,
+              "was_missed": false,
+              "was_accepted": false,
+              "has_ended": false
+            },
+            "media_backend_type": ""
+          },
+          "external_id": "",
+          "source": "",
+          "file_id": "",
+          "file": {
+            "id": "",
+            "created": 123,
+            "timestamp": 123,
+            "name": "",
+            "title": "",
+            "subject": "",
+            "mimetype": "",
+            "filetype": "",
+            "pretty_type": "",
+            "user": "",
+            "user_team": "",
+            "source_team": "",
+            "mode": "",
+            "editable": false,
+            "non_owner_editable": false,
+            "editor": "",
+            "last_editor": "",
+            "updated": 123,
+            "file_access": "",
+            "editors": [
+              ""
+            ],
+            "edit_timestamp": 123,
+            "alt_txt": "",
+            "subtype": "",
+            "transcription": {
+              "status": "",
+              "locale": ""
+            },
+            "mp4": "",
+            "mp4_low": "",
+            "vtt": "",
+            "hls": "",
+            "hls_embed": "",
+            "duration_ms": 123,
+            "thumb_video_w": 123,
+            "thumb_video_h": 123,
+            "original_attachment_count": 123,
+            "is_external": false,
+            "external_type": "",
+            "external_id": "",
+            "external_url": "",
+            "username": "",
+            "size": 123,
+            "url_private": "",
+            "url_private_download": "",
+            "url_static_preview": "",
+            "app_id": "",
+            "app_name": "",
+            "thumb_64": "",
+            "thumb_64_gif": "",
+            "thumb_64_w": "",
+            "thumb_64_h": "",
+            "thumb_80": "",
+            "thumb_80_gif": "",
+            "thumb_80_w": "",
+            "thumb_80_h": "",
+            "thumb_160": "",
+            "thumb_160_gif": "",
+            "thumb_160_w": "",
+            "thumb_160_h": "",
+            "thumb_360": "",
+            "thumb_360_gif": "",
+            "thumb_360_w": "",
+            "thumb_360_h": "",
+            "thumb_480": "",
+            "thumb_480_gif": "",
+            "thumb_480_w": "",
+            "thumb_480_h": "",
+            "thumb_720": "",
+            "thumb_720_gif": "",
+            "thumb_720_w": "",
+            "thumb_720_h": "",
+            "thumb_800": "",
+            "thumb_800_gif": "",
+            "thumb_800_w": "",
+            "thumb_800_h": "",
+            "thumb_960": "",
+            "thumb_960_gif": "",
+            "thumb_960_w": "",
+            "thumb_960_h": "",
+            "thumb_1024": "",
+            "thumb_1024_gif": "",
+            "thumb_1024_w": "",
+            "thumb_1024_h": "",
+            "thumb_video": "",
+            "thumb_gif": "",
+            "thumb_pdf": "",
+            "thumb_pdf_w": "",
+            "thumb_pdf_h": "",
+            "thumb_tiny": "",
+            "converted_pdf": "",
+            "image_exif_rotation": 123,
+            "original_w": "",
+            "original_h": "",
+            "deanimate": "",
+            "deanimate_gif": "",
+            "pjpeg": "",
+            "permalink": "",
+            "permalink_public": "",
+            "edit_link": "",
+            "has_rich_preview": false,
+            "media_display_type": "",
+            "preview_is_truncated": false,
+            "preview": "",
+            "preview_highlight": "",
+            "plain_text": "",
+            "preview_plain_text": "",
+            "has_more": false,
+            "sent_to_self": false,
+            "lines": 123,
+            "lines_more": 123,
+            "is_public": false,
+            "public_url_shared": false,
+            "display_as_bot": false,
+            "channels": [
+              ""
+            ],
+            "groups": [
+              ""
+            ],
+            "ims": [
+              ""
+            ],
+            "shares": {
+              "public": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ]
+              },
+              "private": {
+                "C03E94MKU": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ],
+                "C03E94MKU_": [
+                  {
+                    "share_user_id": "",
+                    "reply_users": [
+                      ""
+                    ],
+                    "reply_users_count": 123,
+                    "reply_count": 123,
+                    "ts": "",
+                    "thread_ts": "",
+                    "latest_reply": "",
+                    "channel_name": "",
+                    "team_id": "",
+                    "access": "",
+                    "source": "",
+                    "date_last_shared": 123
+                  }
+                ]
+              }
+            },
+            "has_more_shares": false,
+            "to": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "from": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "cc": [
+              {
+                "address": "",
+                "name": "",
+                "original": ""
+              }
+            ],
+            "channel_actions_ts": "",
+            "channel_actions_count": 123,
+            "headers": {
+              "date": "",
+              "in_reply_to": "",
+              "reply_to": "",
+              "message_id": ""
+            },
+            "simplified_html": "",
+            "media_progress": {
+              "offset_ms": 123,
+              "max_offset_ms": 123,
+              "duration_ms": 123
+            },
+            "saved": {
+              "is_archived": false,
+              "date_completed": 123,
+              "date_due": 123,
+              "state": ""
+            },
+            "quip_thread_id": "",
+            "is_channel_space": false,
+            "linked_channel_id": "",
+            "access": "",
+            "teams_shared_with": [],
+            "last_read": 123,
+            "title_blocks": [
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  },
+                  {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  },
+                  {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "divider",
+                "block_id": ""
+              },
+              {
+                "type": "image",
+                "fallback": "",
+                "image_url": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "is_animated": false,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                },
+                "alt_text": "",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "video",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "title_url": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "video_url": "",
+                "alt_text": "",
+                "thumbnail_url": "",
+                "author_name": "",
+                "provider_name": "",
+                "provider_icon_url": "",
+                "block_id": ""
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "share_shortcut",
+                "block_id": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "sales_home_workflow_app_type": 123,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "title": "",
+                "description": "",
+                "bot_user_id": "",
+                "url": "",
+                "owning_team_id": "",
+                "workflow_id": "",
+                "developer_trace_id": "",
+                "trigger_type": "",
+                "trigger_subtype": "",
+                "share_url": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "url": "",
+                  "value": "",
+                  "style": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "workflow_button",
+                  "action_id": "",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "workflow": {
+                    "trigger": {
+                      "url": "",
+                      "customizable_input_parameters": [
+                        {
+                          "name": "",
+                          "value": ""
+                        }
+                      ]
+                    }
+                  },
+                  "style": "",
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "checkboxes",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "radio_buttons",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channel": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channels": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversation": "",
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversations": [
+                    ""
+                  ],
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_date": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "timepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_time": "",
+                  "timezone": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datetimepicker",
+                  "action_id": "",
+                  "initial_date_time": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "overflow",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_user": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_users": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              }
+            ],
+            "private_channels_with_file_access_count": 123,
+            "private_file_with_access_count": 123,
+            "dm_mpdm_users_with_file_access": [
+              {
+                "user_id": "",
+                "access": ""
+              }
+            ],
+            "org_or_workspace_access": "",
+            "update_notification": 123,
+            "canvas_template_mode": "",
+            "template_conversion_ts": 123,
+            "template_name": "",
+            "template_title": "",
+            "template_description": "",
+            "template_icon": "",
+            "team_pref_version_history_enabled": false,
+            "show_badge": false,
+            "favorites": [
+              {
+                "collection_id": "",
+                "collection_name": "",
+                "position": ""
+              }
+            ],
+            "list_metadata": {
+              "icon": "",
+              "icon_url": "",
+              "icon_team_id": "",
+              "description": "",
+              "is_trial": false,
+              "creation_source": {
+                "type": "",
+                "reference_id": "",
+                "workflow_function_id": ""
+              },
+              "schema": [
+                {
+                  "id": "",
+                  "name": "",
+                  "key": "",
+                  "type": "",
+                  "is_primary_column": false,
+                  "options": {
+                    "choices": [
+                      {
+                        "value": "",
+                        "label": "",
+                        "color": ""
+                      }
+                    ],
+                    "format": "",
+                    "default_value": "",
+                    "default_value_typed": {
+                      "select": [
+                        ""
+                      ]
+                    },
+                    "emoji": "",
+                    "max": 123,
+                    "precision": 123,
+                    "show_member_name": false,
+                    "date_format": "",
+                    "time_format": "",
+                    "currency_format": "",
+                    "emoji_team_id": "",
+                    "currency": "",
+                    "rounding": "",
+                    "mark_as_done_when_checked": false,
+                    "for_assignment": false,
+                    "notify_users": false,
+                    "linked_to": [
+                      ""
+                    ],
+                    "canvas_id": "",
+                    "canvas_placeholder_mapping": [
+                      {
+                        "variable": "",
+                        "column": ""
+                      }
+                    ]
+                  }
+                }
+              ],
+              "views": [
+                {
+                  "id": "",
+                  "name": "",
+                  "type": "",
+                  "is_locked": false,
+                  "position": "",
+                  "columns": [
+                    {
+                      "visible": false,
+                      "key": "",
+                      "id": "",
+                      "position": "",
+                      "width": 123
+                    }
+                  ],
+                  "date_created": 123,
+                  "created_by": "",
+                  "stick_column_left": false,
+                  "is_all_items_view": false
+                }
+              ],
+              "integrations": [
+                ""
+              ]
+            },
+            "list_limits": {
+              "over_row_maximum": false,
+              "row_count_limit": 123,
+              "row_count": 123,
+              "over_column_maximum": false,
+              "column_count": 123,
+              "column_count_limit": 123,
+              "over_view_maximum": false,
+              "view_count": 123,
+              "view_count_limit": 123
+            },
+            "can_toggle_canvas_lock": false,
+            "bot_id": "",
+            "initial_comment": {
+              "id": "",
+              "created": 123,
+              "timestamp": 123,
+              "user": "",
+              "comment": "",
+              "channel": "",
+              "is_intro": false
+            },
+            "num_stars": 123,
+            "is_starred": false,
+            "pinned_to": [
+              ""
+            ],
+            "reactions": [
+              {
+                "name": "",
+                "count": 123,
+                "users": [
+                  ""
+                ],
+                "url": ""
+              }
+            ],
+            "comments_count": 123,
+            "attachments": [],
+            "blocks": [
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "url": "",
+                    "value": "",
+                    "style": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "workflow_button",
+                    "action_id": "",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "workflow": {
+                      "trigger": {
+                        "url": "",
+                        "customizable_input_parameters": [
+                          {
+                            "name": "",
+                            "value": ""
+                          }
+                        ]
+                      }
+                    },
+                    "style": "",
+                    "accessibility_label": ""
+                  },
+                  {
+                    "type": "checkboxes",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "radio_buttons",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channel": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_channels_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_channels": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversation": "",
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "response_url_enabled": false,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_conversations_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_conversations": [
+                      ""
+                    ],
+                    "default_to_current_conversation": false,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "filter": {
+                      "include": [],
+                      "exclude_external_shared_channels": false,
+                      "exclude_bot_users": false
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_date": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "timepicker",
+                    "action_id": "",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "initial_time": "",
+                    "timezone": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "datetimepicker",
+                    "action_id": "",
+                    "initial_date_time": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_external_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "min_query_length": 123,
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  },
+                  {
+                    "type": "overflow",
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    }
+                  },
+                  {
+                    "type": "static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_option": {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    },
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_static_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "option_groups": [
+                      {
+                        "label": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "initial_options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_user": "",
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "focus_on_load": false
+                  },
+                  {
+                    "type": "multi_users_select",
+                    "placeholder": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "action_id": "",
+                    "initial_users": [
+                      ""
+                    ],
+                    "confirm": {
+                      "title": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "confirm": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "deny": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "style": ""
+                    },
+                    "max_selected_items": 123,
+                    "focus_on_load": false
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "image",
+                    "image_url": "",
+                    "alt_text": "",
+                    "fallback": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    }
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "divider",
+                "block_id": ""
+              },
+              {
+                "type": "image",
+                "fallback": "",
+                "image_url": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "is_animated": false,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                },
+                "alt_text": "",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "video",
+                "title": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "title_url": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "video_url": "",
+                "alt_text": "",
+                "thumbnail_url": "",
+                "author_name": "",
+                "provider_name": "",
+                "provider_icon_url": "",
+                "block_id": ""
+              },
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_list",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "style": "",
+                    "indent": 123,
+                    "offset": 123,
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ],
+                    "border": 123
+                  },
+                  {
+                    "type": "rich_text_quote",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "broadcast",
+                            "range": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "text",
+                            "text": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "channel",
+                            "channel_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "color",
+                            "value": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "date",
+                            "timestamp": "",
+                            "format": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            },
+                            "url": "",
+                            "fallback": ""
+                          },
+                          {
+                            "type": "link",
+                            "url": "",
+                            "text": "",
+                            "unsafe": false,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false,
+                              "code": false
+                            }
+                          },
+                          {
+                            "type": "team",
+                            "team_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "user",
+                            "user_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "usergroup",
+                            "usergroup_id": "",
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            }
+                          },
+                          {
+                            "type": "emoji",
+                            "name": "",
+                            "skin_tone": 123,
+                            "style": {
+                              "bold": false,
+                              "italic": false,
+                              "strike": false,
+                              "highlight": false,
+                              "client_highlight": false,
+                              "unlink": false
+                            },
+                            "unicode": ""
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "block_id": ""
+              },
+              {
+                "type": "share_shortcut",
+                "block_id": "",
+                "function_trigger_id": "",
+                "app_id": "",
+                "is_workflow_app": false,
+                "sales_home_workflow_app_type": 123,
+                "app_collaborators": [
+                  ""
+                ],
+                "button_label": "",
+                "title": "",
+                "description": "",
+                "bot_user_id": "",
+                "url": "",
+                "owning_team_id": "",
+                "workflow_id": "",
+                "developer_trace_id": "",
+                "trigger_type": "",
+                "trigger_subtype": "",
+                "share_url": ""
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "url": "",
+                  "value": "",
+                  "style": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "workflow_button",
+                  "action_id": "",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "workflow": {
+                    "trigger": {
+                      "url": "",
+                      "customizable_input_parameters": [
+                        {
+                          "name": "",
+                          "value": ""
+                        }
+                      ]
+                    }
+                  },
+                  "style": "",
+                  "accessibility_label": ""
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "checkboxes",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "radio_buttons",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channel": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channels": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversation": "",
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversations": [
+                    ""
+                  ],
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_date": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "timepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_time": "",
+                  "timezone": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "datetimepicker",
+                  "action_id": "",
+                  "initial_date_time": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "overflow",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  }
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_user": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "block_id": "",
+                "fields": [
+                  {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
+                    "verbatim": false
+                  }
+                ],
+                "accessory": {
+                  "type": "multi_users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_users": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                }
+              }
+            ]
+          },
+          "text": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "fallback": "",
+          "image_url": "",
+          "image_width": 123,
+          "image_height": 123,
+          "image_bytes": 123,
+          "is_animated": false,
+          "slack_file": {
+            "id": "",
+            "url": ""
+          },
+          "alt_text": "",
+          "title": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "title_url": "",
+          "description": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "video_url": "",
+          "thumbnail_url": "",
+          "author_name": "",
+          "provider_name": "",
+          "provider_icon_url": "",
+          "function_trigger_id": "",
+          "app_id": "",
+          "is_workflow_app": false,
+          "sales_home_workflow_app_type": 123,
+          "app_collaborators": [
+            ""
+          ],
+          "button_label": "",
+          "bot_user_id": "",
+          "url": "",
+          "owning_team_id": "",
+          "workflow_id": "",
+          "developer_trace_id": "",
+          "trigger_type": "",
+          "trigger_subtype": "",
+          "share_url": "",
+          "fields": [
+            {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            {
+              "type": "mrkdwn",
+              "text": "",
+              "verbatim": false
+            }
+          ],
+          "accessory": {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "accessibility_label": "",
+            "workflow": {
+              "trigger": {
+                "url": "",
+                "customizable_input_parameters": [
+                  {
+                    "name": "",
+                    "value": ""
+                  }
+                ]
+              }
+            },
+            "options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "initial_options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "focus_on_load": false,
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_channel": "",
+            "response_url_enabled": false,
+            "initial_channels": [
+              ""
+            ],
+            "max_selected_items": 123,
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "filter": {
+              "include": [],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            },
+            "initial_conversations": [
+              ""
+            ],
+            "initial_date": "",
+            "initial_time": "",
+            "timezone": "",
+            "initial_date_time": 123,
+            "min_query_length": 123,
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "option_groups": [
+              {
+                "label": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ]
+              }
+            ],
+            "initial_user": "",
+            "initial_users": [
+              ""
+            ]
+          },
+          "label": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "element": {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "action_id": "",
+            "url": "",
+            "value": "",
+            "style": "",
+            "confirm": {
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "confirm": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "deny": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "style": ""
+            },
+            "accessibility_label": "",
+            "workflow": {
+              "trigger": {
+                "url": "",
+                "customizable_input_parameters": [
+                  {
+                    "name": "",
+                    "value": ""
+                  }
+                ]
+              }
+            },
+            "options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "initial_options": [
+              {
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "value": "",
+                "description": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "url": ""
+              }
+            ],
+            "focus_on_load": false,
+            "initial_option": {
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "value": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "url": ""
+            },
+            "placeholder": {
+              "type": "plain_text",
+              "text": "",
+              "emoji": false
+            },
+            "initial_channel": "",
+            "response_url_enabled": false,
+            "initial_channels": [
+              ""
+            ],
+            "max_selected_items": 123,
+            "initial_conversation": "",
+            "default_to_current_conversation": false,
+            "filter": {
+              "include": [],
+              "exclude_external_shared_channels": false,
+              "exclude_bot_users": false
+            },
+            "initial_conversations": [
+              ""
+            ],
+            "initial_date": "",
+            "initial_time": "",
+            "timezone": "",
+            "initial_date_time": 123,
+            "min_query_length": 123,
+            "image_url": "",
+            "alt_text": "",
+            "fallback": "",
+            "image_width": 123,
+            "image_height": 123,
+            "image_bytes": 123,
+            "slack_file": {
+              "id": "",
+              "url": ""
+            },
+            "option_groups": [
+              {
+                "label": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ]
+              }
+            ],
+            "initial_user": "",
+            "initial_users": [
+              ""
+            ]
+          },
+          "dispatch_action": false,
+          "hint": {
+            "type": "plain_text",
+            "text": "",
+            "emoji": false
+          },
+          "optional": false
+        }
+      ],
+      "first_user_thread_reply": ""
+    }
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/reactions.list.json
+++ b/json-logs/samples/api/reactions.list.json
@@ -27011,7 +27011,12 @@
                     "app_id": "",
                     "call_family": ""
                   },
-                  "no_notifications": false
+                  "no_notifications": false,
+                  "assistant_app_thread": {
+                    "title": "",
+                    "title_blocks": [],
+                    "first_user_thread_reply": ""
+                  }
                 }
               }
             ],
@@ -27499,7 +27504,12 @@
                         "app_id": "",
                         "call_family": ""
                       },
-                      "no_notifications": false
+                      "no_notifications": false,
+                      "assistant_app_thread": {
+                        "title": "",
+                        "title_blocks": [],
+                        "first_user_thread_reply": ""
+                      }
                     },
                     "number": [],
                     "select": [],
@@ -28032,7 +28042,12 @@
                         "app_id": "",
                         "call_family": ""
                       },
-                      "no_notifications": false
+                      "no_notifications": false,
+                      "assistant_app_thread": {
+                        "title": "",
+                        "title_blocks": [],
+                        "first_user_thread_reply": ""
+                      }
                     },
                     "number": [],
                     "select": [],
@@ -37520,7 +37535,12722 @@
             },
             "is_file_attachment": false
           }
-        ]
+        ],
+        "assistant_app_thread": {
+          "title": "",
+          "title_blocks": [
+            {
+              "type": "actions",
+              "elements": [
+                {
+                  "type": "button",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "url": "",
+                  "value": "",
+                  "style": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "accessibility_label": ""
+                },
+                {
+                  "type": "workflow_button",
+                  "action_id": "",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "workflow": {
+                    "trigger": {
+                      "url": "",
+                      "customizable_input_parameters": [
+                        {
+                          "name": "",
+                          "value": ""
+                        }
+                      ]
+                    }
+                  },
+                  "style": "",
+                  "accessibility_label": ""
+                },
+                {
+                  "type": "checkboxes",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                },
+                {
+                  "type": "radio_buttons",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                },
+                {
+                  "type": "channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channel": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "focus_on_load": false
+                },
+                {
+                  "type": "multi_channels_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_channels": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                },
+                {
+                  "type": "conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversation": "",
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "response_url_enabled": false,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                },
+                {
+                  "type": "multi_conversations_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_conversations": [
+                    ""
+                  ],
+                  "default_to_current_conversation": false,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "filter": {
+                    "include": [],
+                    "exclude_external_shared_channels": false,
+                    "exclude_bot_users": false
+                  },
+                  "focus_on_load": false
+                },
+                {
+                  "type": "datepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_date": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                },
+                {
+                  "type": "timepicker",
+                  "action_id": "",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "initial_time": "",
+                  "timezone": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                },
+                {
+                  "type": "datetimepicker",
+                  "action_id": "",
+                  "initial_date_time": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                },
+                {
+                  "type": "external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                },
+                {
+                  "type": "multi_external_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "min_query_length": 123,
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                },
+                {
+                  "type": "image",
+                  "image_url": "",
+                  "alt_text": "",
+                  "fallback": "",
+                  "image_width": 123,
+                  "image_height": 123,
+                  "image_bytes": 123,
+                  "slack_file": {
+                    "id": "",
+                    "url": ""
+                  }
+                },
+                {
+                  "type": "overflow",
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  }
+                },
+                {
+                  "type": "static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_option": {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  },
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                },
+                {
+                  "type": "multi_static_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "option_groups": [
+                    {
+                      "label": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "initial_options": [
+                    {
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "value": "",
+                      "description": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "url": ""
+                    }
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                },
+                {
+                  "type": "users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_user": "",
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "focus_on_load": false
+                },
+                {
+                  "type": "multi_users_select",
+                  "placeholder": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "action_id": "",
+                  "initial_users": [
+                    ""
+                  ],
+                  "confirm": {
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "confirm": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "deny": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "style": ""
+                  },
+                  "max_selected_items": 123,
+                  "focus_on_load": false
+                },
+                {
+                  "type": "rich_text_list",
+                  "elements": [
+                    {
+                      "type": "rich_text_list",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ],
+                      "style": "",
+                      "indent": 123,
+                      "offset": 123,
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ],
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_quote",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "style": "",
+                  "indent": 123,
+                  "offset": 123,
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_preformatted",
+                  "elements": [
+                    {
+                      "type": "rich_text_list",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ],
+                      "style": "",
+                      "indent": 123,
+                      "offset": 123,
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ],
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_quote",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ]
+                    }
+                  ],
+                  "border": 123
+                },
+                {
+                  "type": "rich_text_quote",
+                  "elements": [
+                    {
+                      "type": "rich_text_list",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ],
+                      "style": "",
+                      "indent": 123,
+                      "offset": 123,
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ],
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_quote",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "rich_text_list",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ],
+                      "style": "",
+                      "indent": 123,
+                      "offset": 123,
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ],
+                      "border": 123
+                    },
+                    {
+                      "type": "rich_text_quote",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "broadcast",
+                          "range": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "text": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "channel",
+                          "channel_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "color",
+                          "value": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "date",
+                          "timestamp": "",
+                          "format": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          },
+                          "url": "",
+                          "fallback": ""
+                        },
+                        {
+                          "type": "link",
+                          "url": "",
+                          "text": "",
+                          "unsafe": false,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false,
+                            "code": false
+                          }
+                        },
+                        {
+                          "type": "team",
+                          "team_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "user",
+                          "user_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "usergroup",
+                          "usergroup_id": "",
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          }
+                        },
+                        {
+                          "type": "emoji",
+                          "name": "",
+                          "skin_tone": 123,
+                          "style": {
+                            "bold": false,
+                            "italic": false,
+                            "strike": false,
+                            "highlight": false,
+                            "client_highlight": false,
+                            "unlink": false
+                          },
+                          "unicode": ""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "block_id": "",
+              "call_id": "",
+              "api_decoration_available": false,
+              "call": {
+                "v1": {
+                  "id": "",
+                  "app_id": "",
+                  "app_icon_urls": {
+                    "image_32": "",
+                    "image_36": "",
+                    "image_48": "",
+                    "image_64": "",
+                    "image_72": "",
+                    "image_96": "",
+                    "image_128": "",
+                    "image_192": "",
+                    "image_512": "",
+                    "image_1024": "",
+                    "image_original": ""
+                  },
+                  "date_start": 123,
+                  "active_participants": [
+                    {
+                      "slack_id": "",
+                      "external_id": "",
+                      "display_name": "",
+                      "avatar_url": ""
+                    }
+                  ],
+                  "all_participants": [
+                    {
+                      "slack_id": "",
+                      "external_id": "",
+                      "display_name": "",
+                      "avatar_url": ""
+                    }
+                  ],
+                  "display_id": "",
+                  "join_url": "",
+                  "desktop_app_join_url": "",
+                  "name": "",
+                  "created_by": "",
+                  "date_end": 123,
+                  "channels": [
+                    ""
+                  ],
+                  "is_dm_call": false,
+                  "was_rejected": false,
+                  "was_missed": false,
+                  "was_accepted": false,
+                  "has_ended": false
+                },
+                "media_backend_type": ""
+              },
+              "external_id": "",
+              "source": "",
+              "file_id": "",
+              "file": {
+                "id": "",
+                "created": 123,
+                "timestamp": 123,
+                "name": "",
+                "title": "",
+                "subject": "",
+                "mimetype": "",
+                "filetype": "",
+                "pretty_type": "",
+                "user": "",
+                "user_team": "",
+                "source_team": "",
+                "mode": "",
+                "editable": false,
+                "non_owner_editable": false,
+                "editor": "",
+                "last_editor": "",
+                "updated": 123,
+                "file_access": "",
+                "editors": [
+                  ""
+                ],
+                "edit_timestamp": 123,
+                "alt_txt": "",
+                "subtype": "",
+                "transcription": {
+                  "status": "",
+                  "locale": ""
+                },
+                "mp4": "",
+                "mp4_low": "",
+                "vtt": "",
+                "hls": "",
+                "hls_embed": "",
+                "duration_ms": 123,
+                "thumb_video_w": 123,
+                "thumb_video_h": 123,
+                "original_attachment_count": 123,
+                "is_external": false,
+                "external_type": "",
+                "external_id": "",
+                "external_url": "",
+                "username": "",
+                "size": 123,
+                "url_private": "",
+                "url_private_download": "",
+                "url_static_preview": "",
+                "app_id": "",
+                "app_name": "",
+                "thumb_64": "",
+                "thumb_64_gif": "",
+                "thumb_64_w": "",
+                "thumb_64_h": "",
+                "thumb_80": "",
+                "thumb_80_gif": "",
+                "thumb_80_w": "",
+                "thumb_80_h": "",
+                "thumb_160": "",
+                "thumb_160_gif": "",
+                "thumb_160_w": "",
+                "thumb_160_h": "",
+                "thumb_360": "",
+                "thumb_360_gif": "",
+                "thumb_360_w": "",
+                "thumb_360_h": "",
+                "thumb_480": "",
+                "thumb_480_gif": "",
+                "thumb_480_w": "",
+                "thumb_480_h": "",
+                "thumb_720": "",
+                "thumb_720_gif": "",
+                "thumb_720_w": "",
+                "thumb_720_h": "",
+                "thumb_800": "",
+                "thumb_800_gif": "",
+                "thumb_800_w": "",
+                "thumb_800_h": "",
+                "thumb_960": "",
+                "thumb_960_gif": "",
+                "thumb_960_w": "",
+                "thumb_960_h": "",
+                "thumb_1024": "",
+                "thumb_1024_gif": "",
+                "thumb_1024_w": "",
+                "thumb_1024_h": "",
+                "thumb_video": "",
+                "thumb_gif": "",
+                "thumb_pdf": "",
+                "thumb_pdf_w": "",
+                "thumb_pdf_h": "",
+                "thumb_tiny": "",
+                "converted_pdf": "",
+                "image_exif_rotation": 123,
+                "original_w": "",
+                "original_h": "",
+                "deanimate": "",
+                "deanimate_gif": "",
+                "pjpeg": "",
+                "permalink": "",
+                "permalink_public": "",
+                "edit_link": "",
+                "has_rich_preview": false,
+                "media_display_type": "",
+                "preview_is_truncated": false,
+                "preview": "",
+                "preview_highlight": "",
+                "plain_text": "",
+                "preview_plain_text": "",
+                "has_more": false,
+                "sent_to_self": false,
+                "lines": 123,
+                "lines_more": 123,
+                "is_public": false,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "channels": [
+                  ""
+                ],
+                "groups": [
+                  ""
+                ],
+                "ims": [
+                  ""
+                ],
+                "shares": {
+                  "public": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": "",
+                        "access": "",
+                        "source": "",
+                        "date_last_shared": 123
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": "",
+                        "access": "",
+                        "source": "",
+                        "date_last_shared": 123
+                      }
+                    ]
+                  },
+                  "private": {
+                    "C03E94MKU": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": "",
+                        "access": "",
+                        "source": "",
+                        "date_last_shared": 123
+                      }
+                    ],
+                    "C03E94MKU_": [
+                      {
+                        "share_user_id": "",
+                        "reply_users": [
+                          ""
+                        ],
+                        "reply_users_count": 123,
+                        "reply_count": 123,
+                        "ts": "",
+                        "thread_ts": "",
+                        "latest_reply": "",
+                        "channel_name": "",
+                        "team_id": "",
+                        "access": "",
+                        "source": "",
+                        "date_last_shared": 123
+                      }
+                    ]
+                  }
+                },
+                "has_more_shares": false,
+                "to": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "from": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "cc": [
+                  {
+                    "address": "",
+                    "name": "",
+                    "original": ""
+                  }
+                ],
+                "channel_actions_ts": "",
+                "channel_actions_count": 123,
+                "headers": {
+                  "date": "",
+                  "in_reply_to": "",
+                  "reply_to": "",
+                  "message_id": ""
+                },
+                "simplified_html": "",
+                "media_progress": {
+                  "offset_ms": 123,
+                  "max_offset_ms": 123,
+                  "duration_ms": 123
+                },
+                "saved": {
+                  "is_archived": false,
+                  "date_completed": 123,
+                  "date_due": 123,
+                  "state": ""
+                },
+                "quip_thread_id": "",
+                "is_channel_space": false,
+                "linked_channel_id": "",
+                "access": "",
+                "teams_shared_with": [],
+                "last_read": 123,
+                "title_blocks": [
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "url": "",
+                        "value": "",
+                        "style": "",
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "accessibility_label": ""
+                      },
+                      {
+                        "type": "workflow_button",
+                        "action_id": "",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "workflow": {
+                          "trigger": {
+                            "url": "",
+                            "customizable_input_parameters": [
+                              {
+                                "name": "",
+                                "value": ""
+                              }
+                            ]
+                          }
+                        },
+                        "style": "",
+                        "accessibility_label": ""
+                      },
+                      {
+                        "type": "checkboxes",
+                        "action_id": "",
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "initial_options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "radio_buttons",
+                        "action_id": "",
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "initial_option": {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        },
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "channels_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_channel": "",
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "response_url_enabled": false,
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "multi_channels_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_channels": [
+                          ""
+                        ],
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "max_selected_items": 123,
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "conversations_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_conversation": "",
+                        "default_to_current_conversation": false,
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "response_url_enabled": false,
+                        "filter": {
+                          "include": [],
+                          "exclude_external_shared_channels": false,
+                          "exclude_bot_users": false
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "multi_conversations_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_conversations": [
+                          ""
+                        ],
+                        "default_to_current_conversation": false,
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "max_selected_items": 123,
+                        "filter": {
+                          "include": [],
+                          "exclude_external_shared_channels": false,
+                          "exclude_bot_users": false
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "datepicker",
+                        "action_id": "",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "initial_date": "",
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "timepicker",
+                        "action_id": "",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "initial_time": "",
+                        "timezone": "",
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "datetimepicker",
+                        "action_id": "",
+                        "initial_date_time": 123,
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "external_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_option": {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        },
+                        "min_query_length": 123,
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "multi_external_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "min_query_length": 123,
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "max_selected_items": 123,
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "image",
+                        "image_url": "",
+                        "alt_text": "",
+                        "fallback": "",
+                        "image_width": 123,
+                        "image_height": 123,
+                        "image_bytes": 123,
+                        "slack_file": {
+                          "id": "",
+                          "url": ""
+                        }
+                      },
+                      {
+                        "type": "overflow",
+                        "action_id": "",
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        }
+                      },
+                      {
+                        "type": "static_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "option_groups": [
+                          {
+                            "label": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "options": [
+                              {
+                                "text": {
+                                  "type": "plain_text",
+                                  "text": "",
+                                  "emoji": false
+                                },
+                                "value": "",
+                                "description": {
+                                  "type": "plain_text",
+                                  "text": "",
+                                  "emoji": false
+                                },
+                                "url": ""
+                              }
+                            ]
+                          }
+                        ],
+                        "initial_option": {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        },
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "multi_static_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "option_groups": [
+                          {
+                            "label": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "options": [
+                              {
+                                "text": {
+                                  "type": "plain_text",
+                                  "text": "",
+                                  "emoji": false
+                                },
+                                "value": "",
+                                "description": {
+                                  "type": "plain_text",
+                                  "text": "",
+                                  "emoji": false
+                                },
+                                "url": ""
+                              }
+                            ]
+                          }
+                        ],
+                        "initial_options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "max_selected_items": 123,
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "users_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_user": "",
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "multi_users_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_users": [
+                          ""
+                        ],
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "max_selected_items": 123,
+                        "focus_on_load": false
+                      }
+                    ],
+                    "block_id": ""
+                  },
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "image",
+                        "image_url": "",
+                        "alt_text": "",
+                        "fallback": "",
+                        "image_width": 123,
+                        "image_height": 123,
+                        "image_bytes": 123,
+                        "slack_file": {
+                          "id": "",
+                          "url": ""
+                        }
+                      }
+                    ],
+                    "block_id": ""
+                  },
+                  {
+                    "type": "divider",
+                    "block_id": ""
+                  },
+                  {
+                    "type": "image",
+                    "fallback": "",
+                    "image_url": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "is_animated": false,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    },
+                    "alt_text": "",
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": ""
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    }
+                  },
+                  {
+                    "type": "video",
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "title_url": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "video_url": "",
+                    "alt_text": "",
+                    "thumbnail_url": "",
+                    "author_name": "",
+                    "provider_name": "",
+                    "provider_icon_url": "",
+                    "block_id": ""
+                  },
+                  {
+                    "type": "rich_text",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "rich_text_list",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "style": "",
+                            "indent": 123,
+                            "offset": 123,
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_preformatted",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_quote",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "rich_text_section",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "rich_text_list",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "style": "",
+                            "indent": 123,
+                            "offset": 123,
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_preformatted",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_quote",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "rich_text_section",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "rich_text_list",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "style": "",
+                            "indent": 123,
+                            "offset": 123,
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_preformatted",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_quote",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "rich_text_section",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "rich_text_list",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "style": "",
+                            "indent": 123,
+                            "offset": 123,
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_preformatted",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_quote",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "rich_text_section",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "block_id": ""
+                  },
+                  {
+                    "type": "share_shortcut",
+                    "block_id": "",
+                    "function_trigger_id": "",
+                    "app_id": "",
+                    "is_workflow_app": false,
+                    "sales_home_workflow_app_type": 123,
+                    "app_collaborators": [
+                      ""
+                    ],
+                    "button_label": "",
+                    "title": "",
+                    "description": "",
+                    "bot_user_id": "",
+                    "url": "",
+                    "owning_team_id": "",
+                    "workflow_id": "",
+                    "developer_trace_id": "",
+                    "trigger_type": "",
+                    "trigger_subtype": "",
+                    "share_url": ""
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "url": "",
+                      "value": "",
+                      "style": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "accessibility_label": ""
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "workflow_button",
+                      "action_id": "",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "workflow": {
+                        "trigger": {
+                          "url": "",
+                          "customizable_input_parameters": [
+                            {
+                              "name": "",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      "style": "",
+                      "accessibility_label": ""
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "checkboxes",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "radio_buttons",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channel": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "multi_channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channels": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversation": "",
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "multi_conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversations": [
+                        ""
+                      ],
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "datepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_date": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "timepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_time": "",
+                      "timezone": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "datetimepicker",
+                      "action_id": "",
+                      "initial_date_time": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "multi_external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "overflow",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      }
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "multi_static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_user": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "multi_users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_users": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  }
+                ],
+                "private_channels_with_file_access_count": 123,
+                "private_file_with_access_count": 123,
+                "dm_mpdm_users_with_file_access": [
+                  {
+                    "user_id": "",
+                    "access": ""
+                  }
+                ],
+                "org_or_workspace_access": "",
+                "update_notification": 123,
+                "canvas_template_mode": "",
+                "template_conversion_ts": 123,
+                "template_name": "",
+                "template_title": "",
+                "template_description": "",
+                "template_icon": "",
+                "team_pref_version_history_enabled": false,
+                "show_badge": false,
+                "favorites": [
+                  {
+                    "collection_id": "",
+                    "collection_name": "",
+                    "position": ""
+                  }
+                ],
+                "list_metadata": {
+                  "icon": "",
+                  "icon_url": "",
+                  "icon_team_id": "",
+                  "description": "",
+                  "is_trial": false,
+                  "creation_source": {
+                    "type": "",
+                    "reference_id": "",
+                    "workflow_function_id": ""
+                  },
+                  "schema": [
+                    {
+                      "id": "",
+                      "name": "",
+                      "key": "",
+                      "type": "",
+                      "is_primary_column": false,
+                      "options": {
+                        "choices": [
+                          {
+                            "value": "",
+                            "label": "",
+                            "color": ""
+                          }
+                        ],
+                        "format": "",
+                        "default_value": "",
+                        "default_value_typed": {
+                          "select": [
+                            ""
+                          ]
+                        },
+                        "emoji": "",
+                        "max": 123,
+                        "precision": 123,
+                        "show_member_name": false,
+                        "date_format": "",
+                        "time_format": "",
+                        "currency_format": "",
+                        "emoji_team_id": "",
+                        "currency": "",
+                        "rounding": "",
+                        "mark_as_done_when_checked": false,
+                        "for_assignment": false,
+                        "notify_users": false,
+                        "linked_to": [
+                          ""
+                        ],
+                        "canvas_id": "",
+                        "canvas_placeholder_mapping": [
+                          {
+                            "variable": "",
+                            "column": ""
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "views": [
+                    {
+                      "id": "",
+                      "name": "",
+                      "type": "",
+                      "is_locked": false,
+                      "position": "",
+                      "columns": [
+                        {
+                          "visible": false,
+                          "key": "",
+                          "id": "",
+                          "position": "",
+                          "width": 123
+                        }
+                      ],
+                      "date_created": 123,
+                      "created_by": "",
+                      "stick_column_left": false,
+                      "is_all_items_view": false
+                    }
+                  ],
+                  "integrations": [
+                    ""
+                  ]
+                },
+                "list_limits": {
+                  "over_row_maximum": false,
+                  "row_count_limit": 123,
+                  "row_count": 123,
+                  "over_column_maximum": false,
+                  "column_count": 123,
+                  "column_count_limit": 123,
+                  "over_view_maximum": false,
+                  "view_count": 123,
+                  "view_count_limit": 123
+                },
+                "can_toggle_canvas_lock": false,
+                "bot_id": "",
+                "initial_comment": {
+                  "id": "",
+                  "created": 123,
+                  "timestamp": 123,
+                  "user": "",
+                  "comment": "",
+                  "channel": "",
+                  "is_intro": false
+                },
+                "num_stars": 123,
+                "is_starred": false,
+                "pinned_to": [
+                  ""
+                ],
+                "reactions": [
+                  {
+                    "name": "",
+                    "count": 123,
+                    "users": [
+                      ""
+                    ],
+                    "url": ""
+                  }
+                ],
+                "comments_count": 123,
+                "attachments": [],
+                "blocks": [
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "url": "",
+                        "value": "",
+                        "style": "",
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "accessibility_label": ""
+                      },
+                      {
+                        "type": "workflow_button",
+                        "action_id": "",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "workflow": {
+                          "trigger": {
+                            "url": "",
+                            "customizable_input_parameters": [
+                              {
+                                "name": "",
+                                "value": ""
+                              }
+                            ]
+                          }
+                        },
+                        "style": "",
+                        "accessibility_label": ""
+                      },
+                      {
+                        "type": "checkboxes",
+                        "action_id": "",
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "initial_options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "radio_buttons",
+                        "action_id": "",
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "initial_option": {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        },
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "channels_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_channel": "",
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "response_url_enabled": false,
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "multi_channels_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_channels": [
+                          ""
+                        ],
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "max_selected_items": 123,
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "conversations_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_conversation": "",
+                        "default_to_current_conversation": false,
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "response_url_enabled": false,
+                        "filter": {
+                          "include": [],
+                          "exclude_external_shared_channels": false,
+                          "exclude_bot_users": false
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "multi_conversations_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_conversations": [
+                          ""
+                        ],
+                        "default_to_current_conversation": false,
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "max_selected_items": 123,
+                        "filter": {
+                          "include": [],
+                          "exclude_external_shared_channels": false,
+                          "exclude_bot_users": false
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "datepicker",
+                        "action_id": "",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "initial_date": "",
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "timepicker",
+                        "action_id": "",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "initial_time": "",
+                        "timezone": "",
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "datetimepicker",
+                        "action_id": "",
+                        "initial_date_time": 123,
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "external_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_option": {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        },
+                        "min_query_length": 123,
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "multi_external_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "min_query_length": 123,
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "max_selected_items": 123,
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "image",
+                        "image_url": "",
+                        "alt_text": "",
+                        "fallback": "",
+                        "image_width": 123,
+                        "image_height": 123,
+                        "image_bytes": 123,
+                        "slack_file": {
+                          "id": "",
+                          "url": ""
+                        }
+                      },
+                      {
+                        "type": "overflow",
+                        "action_id": "",
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        }
+                      },
+                      {
+                        "type": "static_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "option_groups": [
+                          {
+                            "label": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "options": [
+                              {
+                                "text": {
+                                  "type": "plain_text",
+                                  "text": "",
+                                  "emoji": false
+                                },
+                                "value": "",
+                                "description": {
+                                  "type": "plain_text",
+                                  "text": "",
+                                  "emoji": false
+                                },
+                                "url": ""
+                              }
+                            ]
+                          }
+                        ],
+                        "initial_option": {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        },
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "multi_static_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "option_groups": [
+                          {
+                            "label": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "options": [
+                              {
+                                "text": {
+                                  "type": "plain_text",
+                                  "text": "",
+                                  "emoji": false
+                                },
+                                "value": "",
+                                "description": {
+                                  "type": "plain_text",
+                                  "text": "",
+                                  "emoji": false
+                                },
+                                "url": ""
+                              }
+                            ]
+                          }
+                        ],
+                        "initial_options": [
+                          {
+                            "text": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "value": "",
+                            "description": {
+                              "type": "plain_text",
+                              "text": "",
+                              "emoji": false
+                            },
+                            "url": ""
+                          }
+                        ],
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "max_selected_items": 123,
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "users_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_user": "",
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "focus_on_load": false
+                      },
+                      {
+                        "type": "multi_users_select",
+                        "placeholder": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "action_id": "",
+                        "initial_users": [
+                          ""
+                        ],
+                        "confirm": {
+                          "title": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "confirm": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "deny": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "style": ""
+                        },
+                        "max_selected_items": 123,
+                        "focus_on_load": false
+                      }
+                    ],
+                    "block_id": ""
+                  },
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "image",
+                        "image_url": "",
+                        "alt_text": "",
+                        "fallback": "",
+                        "image_width": 123,
+                        "image_height": 123,
+                        "image_bytes": 123,
+                        "slack_file": {
+                          "id": "",
+                          "url": ""
+                        }
+                      }
+                    ],
+                    "block_id": ""
+                  },
+                  {
+                    "type": "divider",
+                    "block_id": ""
+                  },
+                  {
+                    "type": "image",
+                    "fallback": "",
+                    "image_url": "",
+                    "image_width": 123,
+                    "image_height": 123,
+                    "image_bytes": 123,
+                    "is_animated": false,
+                    "slack_file": {
+                      "id": "",
+                      "url": ""
+                    },
+                    "alt_text": "",
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": ""
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    }
+                  },
+                  {
+                    "type": "video",
+                    "title": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "title_url": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "video_url": "",
+                    "alt_text": "",
+                    "thumbnail_url": "",
+                    "author_name": "",
+                    "provider_name": "",
+                    "provider_icon_url": "",
+                    "block_id": ""
+                  },
+                  {
+                    "type": "rich_text",
+                    "elements": [
+                      {
+                        "type": "rich_text_list",
+                        "elements": [
+                          {
+                            "type": "rich_text_list",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "style": "",
+                            "indent": 123,
+                            "offset": 123,
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_preformatted",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_quote",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "rich_text_section",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          }
+                        ],
+                        "style": "",
+                        "indent": 123,
+                        "offset": 123,
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_preformatted",
+                        "elements": [
+                          {
+                            "type": "rich_text_list",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "style": "",
+                            "indent": 123,
+                            "offset": 123,
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_preformatted",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_quote",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "rich_text_section",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          }
+                        ],
+                        "border": 123
+                      },
+                      {
+                        "type": "rich_text_quote",
+                        "elements": [
+                          {
+                            "type": "rich_text_list",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "style": "",
+                            "indent": 123,
+                            "offset": 123,
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_preformatted",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_quote",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "rich_text_section",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "rich_text_section",
+                        "elements": [
+                          {
+                            "type": "rich_text_list",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "style": "",
+                            "indent": 123,
+                            "offset": 123,
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_preformatted",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ],
+                            "border": 123
+                          },
+                          {
+                            "type": "rich_text_quote",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          },
+                          {
+                            "type": "rich_text_section",
+                            "elements": [
+                              {
+                                "type": "broadcast",
+                                "range": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "text",
+                                "text": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "channel",
+                                "channel_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "color",
+                                "value": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "date",
+                                "timestamp": "",
+                                "format": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                },
+                                "url": "",
+                                "fallback": ""
+                              },
+                              {
+                                "type": "link",
+                                "url": "",
+                                "text": "",
+                                "unsafe": false,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false,
+                                  "code": false
+                                }
+                              },
+                              {
+                                "type": "team",
+                                "team_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "user",
+                                "user_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "usergroup",
+                                "usergroup_id": "",
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                }
+                              },
+                              {
+                                "type": "emoji",
+                                "name": "",
+                                "skin_tone": 123,
+                                "style": {
+                                  "bold": false,
+                                  "italic": false,
+                                  "strike": false,
+                                  "highlight": false,
+                                  "client_highlight": false,
+                                  "unlink": false
+                                },
+                                "unicode": ""
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "block_id": ""
+                  },
+                  {
+                    "type": "share_shortcut",
+                    "block_id": "",
+                    "function_trigger_id": "",
+                    "app_id": "",
+                    "is_workflow_app": false,
+                    "sales_home_workflow_app_type": 123,
+                    "app_collaborators": [
+                      ""
+                    ],
+                    "button_label": "",
+                    "title": "",
+                    "description": "",
+                    "bot_user_id": "",
+                    "url": "",
+                    "owning_team_id": "",
+                    "workflow_id": "",
+                    "developer_trace_id": "",
+                    "trigger_type": "",
+                    "trigger_subtype": "",
+                    "share_url": ""
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "url": "",
+                      "value": "",
+                      "style": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "accessibility_label": ""
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "workflow_button",
+                      "action_id": "",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "workflow": {
+                        "trigger": {
+                          "url": "",
+                          "customizable_input_parameters": [
+                            {
+                              "name": "",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      "style": "",
+                      "accessibility_label": ""
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "checkboxes",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "radio_buttons",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channel": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "multi_channels_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_channels": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversation": "",
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "response_url_enabled": false,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "multi_conversations_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_conversations": [
+                        ""
+                      ],
+                      "default_to_current_conversation": false,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "filter": {
+                        "include": [],
+                        "exclude_external_shared_channels": false,
+                        "exclude_bot_users": false
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "datepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_date": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "timepicker",
+                      "action_id": "",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "initial_time": "",
+                      "timezone": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "datetimepicker",
+                      "action_id": "",
+                      "initial_date_time": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "multi_external_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "min_query_length": 123,
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "image",
+                      "image_url": "",
+                      "alt_text": "",
+                      "fallback": "",
+                      "image_width": 123,
+                      "image_height": 123,
+                      "image_bytes": 123,
+                      "slack_file": {
+                        "id": "",
+                        "url": ""
+                      }
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "overflow",
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      }
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_option": {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      },
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "multi_static_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "option_groups": [
+                        {
+                          "label": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "options": [
+                            {
+                              "text": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "value": "",
+                              "description": {
+                                "type": "plain_text",
+                                "text": "",
+                                "emoji": false
+                              },
+                              "url": ""
+                            }
+                          ]
+                        }
+                      ],
+                      "initial_options": [
+                        {
+                          "text": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "value": "",
+                          "description": {
+                            "type": "plain_text",
+                            "text": "",
+                            "emoji": false
+                          },
+                          "url": ""
+                        }
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_user": "",
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "focus_on_load": false
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "block_id": "",
+                    "fields": [
+                      {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "",
+                        "verbatim": false
+                      }
+                    ],
+                    "accessory": {
+                      "type": "multi_users_select",
+                      "placeholder": {
+                        "type": "plain_text",
+                        "text": "",
+                        "emoji": false
+                      },
+                      "action_id": "",
+                      "initial_users": [
+                        ""
+                      ],
+                      "confirm": {
+                        "title": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "confirm": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "deny": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "style": ""
+                      },
+                      "max_selected_items": 123,
+                      "focus_on_load": false
+                    }
+                  }
+                ]
+              },
+              "text": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "fallback": "",
+              "image_url": "",
+              "image_width": 123,
+              "image_height": 123,
+              "image_bytes": 123,
+              "is_animated": false,
+              "slack_file": {
+                "id": "",
+                "url": ""
+              },
+              "alt_text": "",
+              "title": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "title_url": "",
+              "description": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "video_url": "",
+              "thumbnail_url": "",
+              "author_name": "",
+              "provider_name": "",
+              "provider_icon_url": "",
+              "function_trigger_id": "",
+              "app_id": "",
+              "is_workflow_app": false,
+              "sales_home_workflow_app_type": 123,
+              "app_collaborators": [
+                ""
+              ],
+              "button_label": "",
+              "bot_user_id": "",
+              "url": "",
+              "owning_team_id": "",
+              "workflow_id": "",
+              "developer_trace_id": "",
+              "trigger_type": "",
+              "trigger_subtype": "",
+              "share_url": "",
+              "fields": [
+                {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                {
+                  "type": "mrkdwn",
+                  "text": "",
+                  "verbatim": false
+                }
+              ],
+              "accessory": {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "url": "",
+                "value": "",
+                "style": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "accessibility_label": "",
+                "workflow": {
+                  "trigger": {
+                    "url": "",
+                    "customizable_input_parameters": [
+                      {
+                        "name": "",
+                        "value": ""
+                      }
+                    ]
+                  }
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "focus_on_load": false,
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "initial_channel": "",
+                "response_url_enabled": false,
+                "initial_channels": [
+                  ""
+                ],
+                "max_selected_items": 123,
+                "initial_conversation": "",
+                "default_to_current_conversation": false,
+                "filter": {
+                  "include": [],
+                  "exclude_external_shared_channels": false,
+                  "exclude_bot_users": false
+                },
+                "initial_conversations": [
+                  ""
+                ],
+                "initial_date": "",
+                "initial_time": "",
+                "timezone": "",
+                "initial_date_time": 123,
+                "min_query_length": 123,
+                "image_url": "",
+                "alt_text": "",
+                "fallback": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                },
+                "option_groups": [
+                  {
+                    "label": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ]
+                  }
+                ],
+                "initial_user": "",
+                "initial_users": [
+                  ""
+                ]
+              },
+              "label": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "element": {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "action_id": "",
+                "url": "",
+                "value": "",
+                "style": "",
+                "confirm": {
+                  "title": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "confirm": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "deny": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "style": ""
+                },
+                "accessibility_label": "",
+                "workflow": {
+                  "trigger": {
+                    "url": "",
+                    "customizable_input_parameters": [
+                      {
+                        "name": "",
+                        "value": ""
+                      }
+                    ]
+                  }
+                },
+                "options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "initial_options": [
+                  {
+                    "text": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "value": "",
+                    "description": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "url": ""
+                  }
+                ],
+                "focus_on_load": false,
+                "initial_option": {
+                  "text": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "value": "",
+                  "description": {
+                    "type": "plain_text",
+                    "text": "",
+                    "emoji": false
+                  },
+                  "url": ""
+                },
+                "placeholder": {
+                  "type": "plain_text",
+                  "text": "",
+                  "emoji": false
+                },
+                "initial_channel": "",
+                "response_url_enabled": false,
+                "initial_channels": [
+                  ""
+                ],
+                "max_selected_items": 123,
+                "initial_conversation": "",
+                "default_to_current_conversation": false,
+                "filter": {
+                  "include": [],
+                  "exclude_external_shared_channels": false,
+                  "exclude_bot_users": false
+                },
+                "initial_conversations": [
+                  ""
+                ],
+                "initial_date": "",
+                "initial_time": "",
+                "timezone": "",
+                "initial_date_time": 123,
+                "min_query_length": 123,
+                "image_url": "",
+                "alt_text": "",
+                "fallback": "",
+                "image_width": 123,
+                "image_height": 123,
+                "image_bytes": 123,
+                "slack_file": {
+                  "id": "",
+                  "url": ""
+                },
+                "option_groups": [
+                  {
+                    "label": {
+                      "type": "plain_text",
+                      "text": "",
+                      "emoji": false
+                    },
+                    "options": [
+                      {
+                        "text": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "value": "",
+                        "description": {
+                          "type": "plain_text",
+                          "text": "",
+                          "emoji": false
+                        },
+                        "url": ""
+                      }
+                    ]
+                  }
+                ],
+                "initial_user": "",
+                "initial_users": [
+                  ""
+                ]
+              },
+              "dispatch_action": false,
+              "hint": {
+                "type": "plain_text",
+                "text": "",
+                "emoji": false
+              },
+              "optional": false
+            }
+          ],
+          "first_user_thread_reply": ""
+        }
       }
     }
   ],

--- a/json-logs/samples/api/rtm.start.json
+++ b/json-logs/samples/api/rtm.start.json
@@ -10444,7 +10444,12 @@
                     "app_id": "",
                     "call_family": ""
                   },
-                  "no_notifications": false
+                  "no_notifications": false,
+                  "assistant_app_thread": {
+                    "title": "",
+                    "title_blocks": [],
+                    "first_user_thread_reply": ""
+                  }
                 }
               }
             ],
@@ -10932,7 +10937,12 @@
                         "app_id": "",
                         "call_family": ""
                       },
-                      "no_notifications": false
+                      "no_notifications": false,
+                      "assistant_app_thread": {
+                        "title": "",
+                        "title_blocks": [],
+                        "first_user_thread_reply": ""
+                      }
                     },
                     "number": [],
                     "select": [],
@@ -11465,7 +11475,12 @@
                         "app_id": "",
                         "call_family": ""
                       },
-                      "no_notifications": false
+                      "no_notifications": false,
+                      "assistant_app_thread": {
+                        "title": "",
+                        "title_blocks": [],
+                        "first_user_thread_reply": ""
+                      }
                     },
                     "number": [],
                     "select": [],
@@ -48035,7 +48050,12 @@
                             "app_id": "",
                             "call_family": ""
                           },
-                          "no_notifications": false
+                          "no_notifications": false,
+                          "assistant_app_thread": {
+                            "title": "",
+                            "title_blocks": [],
+                            "first_user_thread_reply": ""
+                          }
                         }
                       }
                     ],
@@ -48523,7 +48543,12 @@
                                 "app_id": "",
                                 "call_family": ""
                               },
-                              "no_notifications": false
+                              "no_notifications": false,
+                              "assistant_app_thread": {
+                                "title": "",
+                                "title_blocks": [],
+                                "first_user_thread_reply": ""
+                              }
                             },
                             "number": [],
                             "select": [],
@@ -49056,7 +49081,12 @@
                                 "app_id": "",
                                 "call_family": ""
                               },
-                              "no_notifications": false
+                              "no_notifications": false,
+                              "assistant_app_thread": {
+                                "title": "",
+                                "title_blocks": [],
+                                "first_user_thread_reply": ""
+                              }
                             },
                             "number": [],
                             "select": [],

--- a/json-logs/samples/api/search.files.json
+++ b/json-logs/samples/api/search.files.json
@@ -9580,7 +9580,12 @@
                     "app_id": "",
                     "call_family": ""
                   },
-                  "no_notifications": false
+                  "no_notifications": false,
+                  "assistant_app_thread": {
+                    "title": "",
+                    "title_blocks": [],
+                    "first_user_thread_reply": ""
+                  }
                 }
               }
             ],
@@ -10068,7 +10073,12 @@
                         "app_id": "",
                         "call_family": ""
                       },
-                      "no_notifications": false
+                      "no_notifications": false,
+                      "assistant_app_thread": {
+                        "title": "",
+                        "title_blocks": [],
+                        "first_user_thread_reply": ""
+                      }
                     },
                     "number": [],
                     "select": [],
@@ -10601,7 +10611,12 @@
                         "app_id": "",
                         "call_family": ""
                       },
-                      "no_notifications": false
+                      "no_notifications": false,
+                      "assistant_app_thread": {
+                        "title": "",
+                        "title_blocks": [],
+                        "first_user_thread_reply": ""
+                      }
                     },
                     "number": [],
                     "select": [],

--- a/json-logs/samples/api/search.messages.json
+++ b/json-logs/samples/api/search.messages.json
@@ -9431,7 +9431,12 @@
                       "app_id": "",
                       "call_family": ""
                     },
-                    "no_notifications": false
+                    "no_notifications": false,
+                    "assistant_app_thread": {
+                      "title": "",
+                      "title_blocks": [],
+                      "first_user_thread_reply": ""
+                    }
                   }
                 }
               ],
@@ -9919,7 +9924,12 @@
                           "app_id": "",
                           "call_family": ""
                         },
-                        "no_notifications": false
+                        "no_notifications": false,
+                        "assistant_app_thread": {
+                          "title": "",
+                          "title_blocks": [],
+                          "first_user_thread_reply": ""
+                        }
                       },
                       "number": [],
                       "select": [],
@@ -10452,7 +10462,12 @@
                           "app_id": "",
                           "call_family": ""
                         },
-                        "no_notifications": false
+                        "no_notifications": false,
+                        "assistant_app_thread": {
+                          "title": "",
+                          "title_blocks": [],
+                          "first_user_thread_reply": ""
+                        }
                       },
                       "number": [],
                       "select": [],
@@ -42037,7 +42052,12 @@
                       "app_id": "",
                       "call_family": ""
                     },
-                    "no_notifications": false
+                    "no_notifications": false,
+                    "assistant_app_thread": {
+                      "title": "",
+                      "title_blocks": [],
+                      "first_user_thread_reply": ""
+                    }
                   }
                 }
               ],
@@ -42525,7 +42545,12 @@
                           "app_id": "",
                           "call_family": ""
                         },
-                        "no_notifications": false
+                        "no_notifications": false,
+                        "assistant_app_thread": {
+                          "title": "",
+                          "title_blocks": [],
+                          "first_user_thread_reply": ""
+                        }
                       },
                       "number": [],
                       "select": [],
@@ -43058,7 +43083,12 @@
                           "app_id": "",
                           "call_family": ""
                         },
-                        "no_notifications": false
+                        "no_notifications": false,
+                        "assistant_app_thread": {
+                          "title": "",
+                          "title_blocks": [],
+                          "first_user_thread_reply": ""
+                        }
                       },
                       "number": [],
                       "select": [],
@@ -87348,7 +87378,12 @@
                     "app_id": "",
                     "call_family": ""
                   },
-                  "no_notifications": false
+                  "no_notifications": false,
+                  "assistant_app_thread": {
+                    "title": "",
+                    "title_blocks": [],
+                    "first_user_thread_reply": ""
+                  }
                 }
               }
             ],
@@ -87836,7 +87871,12 @@
                         "app_id": "",
                         "call_family": ""
                       },
-                      "no_notifications": false
+                      "no_notifications": false,
+                      "assistant_app_thread": {
+                        "title": "",
+                        "title_blocks": [],
+                        "first_user_thread_reply": ""
+                      }
                     },
                     "number": [],
                     "select": [],
@@ -88369,7 +88409,12 @@
                         "app_id": "",
                         "call_family": ""
                       },
-                      "no_notifications": false
+                      "no_notifications": false,
+                      "assistant_app_thread": {
+                        "title": "",
+                        "title_blocks": [],
+                        "first_user_thread_reply": ""
+                      }
                     },
                     "number": [],
                     "select": [],

--- a/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/BlockActionPayload.json
@@ -1579,7 +1579,11 @@
       "app_id": "",
       "call_family": ""
     },
-    "no_notifications": false
+    "no_notifications": false,
+    "assistant_app_thread": {
+      "title": "",
+      "first_user_thread_reply": ""
+    }
   },
   "response_url": "",
   "view": {

--- a/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
+++ b/json-logs/samples/app-backend/interactive-components/MessageShortcutPayload.json
@@ -1548,7 +1548,11 @@
       "app_id": "",
       "call_family": ""
     },
-    "no_notifications": false
+    "no_notifications": false,
+    "assistant_app_thread": {
+      "title": "",
+      "first_user_thread_reply": ""
+    }
   },
   "enterprise": {
     "id": "",

--- a/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
@@ -43,6 +43,9 @@ import com.slack.api.methods.request.apps.AppsUninstallRequest;
 import com.slack.api.methods.request.apps.connections.AppsConnectionsOpenRequest;
 import com.slack.api.methods.request.apps.event.authorizations.AppsEventAuthorizationsListRequest;
 import com.slack.api.methods.request.apps.manifest.*;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetStatusRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetSuggestedPromptsRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetTitleRequest;
 import com.slack.api.methods.request.auth.AuthRevokeRequest;
 import com.slack.api.methods.request.auth.AuthTestRequest;
 import com.slack.api.methods.request.auth.teams.AuthTeamsListRequest;
@@ -160,6 +163,9 @@ import com.slack.api.methods.response.apps.AppsUninstallResponse;
 import com.slack.api.methods.response.apps.connections.AppsConnectionsOpenResponse;
 import com.slack.api.methods.response.apps.event.authorizations.AppsEventAuthorizationsListResponse;
 import com.slack.api.methods.response.apps.manifest.*;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetStatusResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetSuggestedPromptsResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetTitleResponse;
 import com.slack.api.methods.response.auth.AuthRevokeResponse;
 import com.slack.api.methods.response.auth.AuthTestResponse;
 import com.slack.api.methods.response.auth.teams.AuthTeamsListResponse;
@@ -802,6 +808,22 @@ public interface AsyncMethodsClient {
     CompletableFuture<AppsManifestValidateResponse> appsManifestValidate(AppsManifestValidateRequest req);
 
     CompletableFuture<AppsManifestValidateResponse> appsManifestValidate(RequestConfigurator<AppsManifestValidateRequest.AppsManifestValidateRequestBuilder> req);
+
+    // ------------------------------
+    // assistant.threads
+    // ------------------------------
+
+    CompletableFuture<AssistantThreadsSetStatusResponse> assistantThreadsSetStatus(AssistantThreadsSetStatusRequest req);
+
+    CompletableFuture<AssistantThreadsSetStatusResponse> assistantThreadsSetStatus(RequestConfigurator<AssistantThreadsSetStatusRequest.AssistantThreadsSetStatusRequestBuilder> req);
+
+    CompletableFuture<AssistantThreadsSetSuggestedPromptsResponse> assistantThreadsSetSuggestedPrompts(AssistantThreadsSetSuggestedPromptsRequest req);
+
+    CompletableFuture<AssistantThreadsSetSuggestedPromptsResponse> assistantThreadsSetSuggestedPrompts(RequestConfigurator<AssistantThreadsSetSuggestedPromptsRequest.AssistantThreadsSetSuggestedPromptsRequestBuilder> req);
+
+    CompletableFuture<AssistantThreadsSetTitleResponse> assistantThreadsSetTitle(AssistantThreadsSetTitleRequest req);
+
+    CompletableFuture<AssistantThreadsSetTitleResponse> assistantThreadsSetTitle(RequestConfigurator<AssistantThreadsSetTitleRequest.AssistantThreadsSetTitleRequestBuilder> req);
 
     // ------------------------------
     // auth

--- a/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
@@ -277,6 +277,14 @@ public class Methods {
     public static final String APPS_PERMISSIONS_USERS_REQUEST = "apps.permissions.users.request";
 
     // ------------------------------
+    // assistant.threads
+    // ------------------------------
+
+    public static final String ASSISTANT_THREADS_SET_STATUS = "assistant.threads.setStatus";
+    public static final String ASSISTANT_THREADS_SET_SUGGESTED_PROMPTS = "assistant.threads.setSuggestedPrompts";
+    public static final String ASSISTANT_THREADS_SET_TITLE = "assistant.threads.setTitle";
+
+    // ------------------------------
     // auth
     // ------------------------------
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
@@ -49,6 +49,9 @@ import com.slack.api.methods.request.apps.permissions.resources.AppsPermissionsR
 import com.slack.api.methods.request.apps.permissions.scopes.AppsPermissionsScopesListRequest;
 import com.slack.api.methods.request.apps.permissions.users.AppsPermissionsUsersListRequest;
 import com.slack.api.methods.request.apps.permissions.users.AppsPermissionsUsersRequestRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetStatusRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetSuggestedPromptsRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetTitleRequest;
 import com.slack.api.methods.request.auth.AuthRevokeRequest;
 import com.slack.api.methods.request.auth.AuthTestRequest;
 import com.slack.api.methods.request.auth.teams.AuthTeamsListRequest;
@@ -179,6 +182,9 @@ import com.slack.api.methods.response.apps.permissions.resources.AppsPermissions
 import com.slack.api.methods.response.apps.permissions.scopes.AppsPermissionsScopesListResponse;
 import com.slack.api.methods.response.apps.permissions.users.AppsPermissionsUsersListResponse;
 import com.slack.api.methods.response.apps.permissions.users.AppsPermissionsUsersRequestResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetStatusResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetSuggestedPromptsResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetTitleResponse;
 import com.slack.api.methods.response.auth.AuthRevokeResponse;
 import com.slack.api.methods.response.auth.AuthTestResponse;
 import com.slack.api.methods.response.auth.teams.AuthTeamsListResponse;
@@ -964,6 +970,22 @@ public interface MethodsClient {
     // and the Conversations API will become available to classic Slack apps over the coming months.
     @Deprecated
     AppsPermissionsUsersRequestResponse appsPermissionsUsersRequest(AppsPermissionsUsersRequestRequest req) throws IOException, SlackApiException;
+
+    // ------------------------------
+    // assistant.threads
+    // ------------------------------
+
+    AssistantThreadsSetStatusResponse assistantThreadsSetStatus(AssistantThreadsSetStatusRequest req) throws IOException, SlackApiException;
+
+    AssistantThreadsSetStatusResponse assistantThreadsSetStatus(RequestConfigurator<AssistantThreadsSetStatusRequest.AssistantThreadsSetStatusRequestBuilder> req) throws IOException, SlackApiException;
+
+    AssistantThreadsSetSuggestedPromptsResponse assistantThreadsSetSuggestedPrompts(AssistantThreadsSetSuggestedPromptsRequest req) throws IOException, SlackApiException;
+
+    AssistantThreadsSetSuggestedPromptsResponse assistantThreadsSetSuggestedPrompts(RequestConfigurator<AssistantThreadsSetSuggestedPromptsRequest.AssistantThreadsSetSuggestedPromptsRequestBuilder> req) throws IOException, SlackApiException;
+
+    AssistantThreadsSetTitleResponse assistantThreadsSetTitle(AssistantThreadsSetTitleRequest req) throws IOException, SlackApiException;
+
+    AssistantThreadsSetTitleResponse assistantThreadsSetTitle(RequestConfigurator<AssistantThreadsSetTitleRequest.AssistantThreadsSetTitleRequestBuilder> req) throws IOException, SlackApiException;
 
     // ------------------------------
     // auth

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
@@ -227,6 +227,10 @@ public class MethodsRateLimits {
         setRateLimitTier(APPS_UNINSTALL, Tier1);
         setRateLimitTier(APPS_EVENT_AUTHORIZATIONS_LIST, Tier4);
 
+        setRateLimitTier(ASSISTANT_THREADS_SET_STATUS, Tier3);
+        setRateLimitTier(ASSISTANT_THREADS_SET_SUGGESTED_PROMPTS, Tier3);
+        setRateLimitTier(ASSISTANT_THREADS_SET_TITLE, Tier3);
+
         setRateLimitTier(AUTH_REVOKE, Tier3);
         setRateLimitTier(AUTH_TEST, SpecialTier_auth_test);
         setRateLimitTier(AUTH_TEAMS_LIST, Tier2);

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -49,6 +49,9 @@ import com.slack.api.methods.request.apps.permissions.resources.AppsPermissionsR
 import com.slack.api.methods.request.apps.permissions.scopes.AppsPermissionsScopesListRequest;
 import com.slack.api.methods.request.apps.permissions.users.AppsPermissionsUsersListRequest;
 import com.slack.api.methods.request.apps.permissions.users.AppsPermissionsUsersRequestRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetStatusRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetSuggestedPromptsRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetTitleRequest;
 import com.slack.api.methods.request.auth.AuthRevokeRequest;
 import com.slack.api.methods.request.auth.AuthTestRequest;
 import com.slack.api.methods.request.auth.teams.AuthTeamsListRequest;
@@ -1121,6 +1124,31 @@ public class RequestFormBuilder {
             setIfNotNull("scopes", req.getScopes().stream().collect(joining(",")), form);
         }
         setIfNotNull("user", req.getUser(), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AssistantThreadsSetStatusRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("channel_id", req.getChannelId(), form);
+        setIfNotNull("thread_ts", req.getThreadTs(), form);
+        setIfNotNull("status", req.getStatus(), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AssistantThreadsSetSuggestedPromptsRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("channel_id", req.getChannelId(), form);
+        setIfNotNull("thread_ts", req.getThreadTs(), form);
+        setIfNotNull("title", req.getTitle(), form);
+        setIfNotNull("prompts", GSON.toJson(req.getPrompts()), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AssistantThreadsSetTitleRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("channel_id", req.getChannelId(), form);
+        setIfNotNull("thread_ts", req.getThreadTs(), form);
+        setIfNotNull("title", req.getTitle(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
@@ -47,6 +47,9 @@ import com.slack.api.methods.request.apps.AppsUninstallRequest;
 import com.slack.api.methods.request.apps.connections.AppsConnectionsOpenRequest;
 import com.slack.api.methods.request.apps.event.authorizations.AppsEventAuthorizationsListRequest;
 import com.slack.api.methods.request.apps.manifest.*;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetStatusRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetSuggestedPromptsRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetTitleRequest;
 import com.slack.api.methods.request.auth.AuthRevokeRequest;
 import com.slack.api.methods.request.auth.AuthTestRequest;
 import com.slack.api.methods.request.auth.teams.AuthTeamsListRequest;
@@ -164,6 +167,9 @@ import com.slack.api.methods.response.apps.AppsUninstallResponse;
 import com.slack.api.methods.response.apps.connections.AppsConnectionsOpenResponse;
 import com.slack.api.methods.response.apps.event.authorizations.AppsEventAuthorizationsListResponse;
 import com.slack.api.methods.response.apps.manifest.*;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetStatusResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetSuggestedPromptsResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetTitleResponse;
 import com.slack.api.methods.response.auth.AuthRevokeResponse;
 import com.slack.api.methods.response.auth.AuthTestResponse;
 import com.slack.api.methods.response.auth.teams.AuthTeamsListResponse;
@@ -1351,6 +1357,36 @@ public class AsyncMethodsClientImpl implements AsyncMethodsClient {
     @Override
     public CompletableFuture<AppsManifestValidateResponse> appsManifestValidate(RequestConfigurator<AppsManifestValidateRequest.AppsManifestValidateRequestBuilder> req) {
         return appsManifestValidate(req.configure(AppsManifestValidateRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<AssistantThreadsSetStatusResponse> assistantThreadsSetStatus(AssistantThreadsSetStatusRequest req) {
+        return executor.execute(ASSISTANT_THREADS_SET_STATUS, toMap(req), () -> methods.assistantThreadsSetStatus(req));
+    }
+
+    @Override
+    public CompletableFuture<AssistantThreadsSetStatusResponse> assistantThreadsSetStatus(RequestConfigurator<AssistantThreadsSetStatusRequest.AssistantThreadsSetStatusRequestBuilder> req) {
+        return assistantThreadsSetStatus(req.configure(AssistantThreadsSetStatusRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<AssistantThreadsSetSuggestedPromptsResponse> assistantThreadsSetSuggestedPrompts(AssistantThreadsSetSuggestedPromptsRequest req) {
+        return executor.execute(ASSISTANT_THREADS_SET_SUGGESTED_PROMPTS, toMap(req), () -> methods.assistantThreadsSetSuggestedPrompts(req));
+    }
+
+    @Override
+    public CompletableFuture<AssistantThreadsSetSuggestedPromptsResponse> assistantThreadsSetSuggestedPrompts(RequestConfigurator<AssistantThreadsSetSuggestedPromptsRequest.AssistantThreadsSetSuggestedPromptsRequestBuilder> req) {
+        return assistantThreadsSetSuggestedPrompts(req.configure(AssistantThreadsSetSuggestedPromptsRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<AssistantThreadsSetTitleResponse> assistantThreadsSetTitle(AssistantThreadsSetTitleRequest req) {
+        return executor.execute(ASSISTANT_THREADS_SET_TITLE, toMap(req), () -> methods.assistantThreadsSetTitle(req));
+    }
+
+    @Override
+    public CompletableFuture<AssistantThreadsSetTitleResponse> assistantThreadsSetTitle(RequestConfigurator<AssistantThreadsSetTitleRequest.AssistantThreadsSetTitleRequestBuilder> req) {
+        return assistantThreadsSetTitle(req.configure(AssistantThreadsSetTitleRequest.builder()).build());
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -51,6 +51,9 @@ import com.slack.api.methods.request.apps.permissions.resources.AppsPermissionsR
 import com.slack.api.methods.request.apps.permissions.scopes.AppsPermissionsScopesListRequest;
 import com.slack.api.methods.request.apps.permissions.users.AppsPermissionsUsersListRequest;
 import com.slack.api.methods.request.apps.permissions.users.AppsPermissionsUsersRequestRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetStatusRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetSuggestedPromptsRequest;
+import com.slack.api.methods.request.assistant.threads.AssistantThreadsSetTitleRequest;
 import com.slack.api.methods.request.auth.AuthRevokeRequest;
 import com.slack.api.methods.request.auth.AuthTestRequest;
 import com.slack.api.methods.request.auth.teams.AuthTeamsListRequest;
@@ -181,6 +184,9 @@ import com.slack.api.methods.response.apps.permissions.resources.AppsPermissions
 import com.slack.api.methods.response.apps.permissions.scopes.AppsPermissionsScopesListResponse;
 import com.slack.api.methods.response.apps.permissions.users.AppsPermissionsUsersListResponse;
 import com.slack.api.methods.response.apps.permissions.users.AppsPermissionsUsersRequestResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetStatusResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetSuggestedPromptsResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetTitleResponse;
 import com.slack.api.methods.response.auth.AuthRevokeResponse;
 import com.slack.api.methods.response.auth.AuthTestResponse;
 import com.slack.api.methods.response.auth.teams.AuthTeamsListResponse;
@@ -1432,6 +1438,36 @@ public class MethodsClientImpl implements MethodsClient {
     @Override
     public AppsPermissionsUsersRequestResponse appsPermissionsUsersRequest(AppsPermissionsUsersRequestRequest req) throws IOException, SlackApiException {
         return postFormWithTokenAndParseResponse(toForm(req), Methods.APPS_PERMISSIONS_USERS_REQUEST, getToken(req), AppsPermissionsUsersRequestResponse.class);
+    }
+
+    @Override
+    public AssistantThreadsSetStatusResponse assistantThreadsSetStatus(AssistantThreadsSetStatusRequest req) throws IOException, SlackApiException {
+        return postFormWithTokenAndParseResponse(toForm(req), Methods.ASSISTANT_THREADS_SET_STATUS, getToken(req), AssistantThreadsSetStatusResponse.class);
+    }
+
+    @Override
+    public AssistantThreadsSetStatusResponse assistantThreadsSetStatus(RequestConfigurator<AssistantThreadsSetStatusRequest.AssistantThreadsSetStatusRequestBuilder> req) throws IOException, SlackApiException {
+        return assistantThreadsSetStatus(req.configure(AssistantThreadsSetStatusRequest.builder()).build());
+    }
+
+    @Override
+    public AssistantThreadsSetSuggestedPromptsResponse assistantThreadsSetSuggestedPrompts(AssistantThreadsSetSuggestedPromptsRequest req) throws IOException, SlackApiException {
+        return postFormWithTokenAndParseResponse(toForm(req), Methods.ASSISTANT_THREADS_SET_SUGGESTED_PROMPTS, getToken(req), AssistantThreadsSetSuggestedPromptsResponse.class);
+    }
+
+    @Override
+    public AssistantThreadsSetSuggestedPromptsResponse assistantThreadsSetSuggestedPrompts(RequestConfigurator<AssistantThreadsSetSuggestedPromptsRequest.AssistantThreadsSetSuggestedPromptsRequestBuilder> req) throws IOException, SlackApiException {
+        return assistantThreadsSetSuggestedPrompts(req.configure(AssistantThreadsSetSuggestedPromptsRequest.builder()).build());
+    }
+
+    @Override
+    public AssistantThreadsSetTitleResponse assistantThreadsSetTitle(AssistantThreadsSetTitleRequest req) throws IOException, SlackApiException {
+        return postFormWithTokenAndParseResponse(toForm(req), Methods.ASSISTANT_THREADS_SET_TITLE, getToken(req), AssistantThreadsSetTitleResponse.class);
+    }
+
+    @Override
+    public AssistantThreadsSetTitleResponse assistantThreadsSetTitle(RequestConfigurator<AssistantThreadsSetTitleRequest.AssistantThreadsSetTitleRequestBuilder> req) throws IOException, SlackApiException {
+        return assistantThreadsSetTitle(req.configure(AssistantThreadsSetTitleRequest.builder()).build());
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/assistant/threads/AssistantThreadsSetStatusRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/assistant/threads/AssistantThreadsSetStatusRequest.java
@@ -1,0 +1,30 @@
+package com.slack.api.methods.request.assistant.threads;
+
+import com.slack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/methods/assistant.threads.setStatus
+ */
+@Data
+@Builder
+public class AssistantThreadsSetStatusRequest implements SlackApiRequest {
+
+    private String token;
+
+    /**
+     * Channel ID containing the assistant thread.
+     */
+    private String channelId;
+
+    /**
+     * Message timestamp of the thread of where to set the status.
+     */
+    private String threadTs;
+
+    /**
+     * Status of the specified bot user, e.g. 'is thinking...'
+     */
+    private String status;
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/assistant/threads/AssistantThreadsSetSuggestedPromptsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/assistant/threads/AssistantThreadsSetSuggestedPromptsRequest.java
@@ -1,0 +1,41 @@
+package com.slack.api.methods.request.assistant.threads;
+
+import com.slack.api.methods.SlackApiRequest;
+import com.slack.api.model.assistant.SuggestedPrompt;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * https://api.slack.com/methods/assistant.threads.setSuggestedPrompts
+ */
+@Data
+@Builder
+public class AssistantThreadsSetSuggestedPromptsRequest implements SlackApiRequest {
+
+    private String token;
+
+    /**
+     * Channel ID containing the assistant thread.
+     */
+    private String channelId;
+
+    /**
+     * Message timestamp of the thread of where to set the status.
+     */
+    private String threadTs;
+
+    /**
+     * Title for the prompts. Like Suggested Prompts, Related questions
+     */
+    private String title;
+
+    /**
+     * The suggested prompts.
+     */
+    private List<SuggestedPrompt> prompts;
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/assistant/threads/AssistantThreadsSetTitleRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/assistant/threads/AssistantThreadsSetTitleRequest.java
@@ -1,0 +1,31 @@
+package com.slack.api.methods.request.assistant.threads;
+
+import com.slack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://api.slack.com/methods/assistant.threads.setTitle
+ */
+@Data
+@Builder
+public class AssistantThreadsSetTitleRequest implements SlackApiRequest {
+
+    private String token;
+
+    /**
+     * Channel ID containing the assistant thread.
+     */
+    private String channelId;
+
+    /**
+     * Message timestamp of the thread of where to set the status.
+     */
+    private String threadTs;
+
+    /**
+     * The title to use for the thread.
+     */
+    private String title;
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/asssistant/threads/AssistantThreadsSetStatusResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/asssistant/threads/AssistantThreadsSetStatusResponse.java
@@ -1,0 +1,18 @@
+package com.slack.api.methods.response.asssistant.threads;
+
+import com.slack.api.methods.SlackApiTextResponse;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class AssistantThreadsSetStatusResponse implements SlackApiTextResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/asssistant/threads/AssistantThreadsSetSuggestedPromptsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/asssistant/threads/AssistantThreadsSetSuggestedPromptsResponse.java
@@ -1,0 +1,18 @@
+package com.slack.api.methods.response.asssistant.threads;
+
+import com.slack.api.methods.SlackApiTextResponse;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class AssistantThreadsSetSuggestedPromptsResponse implements SlackApiTextResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/asssistant/threads/AssistantThreadsSetTitleResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/asssistant/threads/AssistantThreadsSetTitleResponse.java
@@ -1,0 +1,18 @@
+package com.slack.api.methods.response.asssistant.threads;
+
+import com.slack.api.methods.SlackApiTextResponse;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class AssistantThreadsSetTitleResponse implements SlackApiTextResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+    private transient Map<String, List<String>> httpResponseHeaders;
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatScheduleMessageResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/chat/ChatScheduleMessageResponse.java
@@ -1,10 +1,7 @@
 package com.slack.api.methods.response.chat;
 
 import com.slack.api.methods.SlackApiTextResponse;
-import com.slack.api.model.Attachment;
-import com.slack.api.model.BotProfile;
-import com.slack.api.model.ErrorResponseMetadata;
-import com.slack.api.model.Message;
+import com.slack.api.model.*;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.Data;
 
@@ -42,5 +39,6 @@ public class ChatScheduleMessageResponse implements SlackApiTextResponse {
         private List<Attachment> attachments;
         private List<LayoutBlock> blocks;
         private Message.Metadata metadata;
+        private Message.AssistantAppThread assistantAppThread;
     }
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsGetResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsGetResponse.java
@@ -3,6 +3,7 @@ package com.slack.api.methods.response.reactions;
 import com.slack.api.methods.SlackApiTextResponse;
 import com.slack.api.model.Attachment;
 import com.slack.api.model.BotProfile;
+import com.slack.api.model.Message;
 import com.slack.api.model.Reaction;
 import com.slack.api.model.block.LayoutBlock;
 import lombok.Data;
@@ -39,6 +40,7 @@ public class ReactionsGetResponse implements SlackApiTextResponse {
         private List<Attachment> attachments;
         private List<LayoutBlock> blocks;
         private com.slack.api.model.Message.Metadata metadata;
+        private com.slack.api.model.Message.AssistantAppThread assistantAppThread;
         private String permalink;
         private List<Reaction> reactions;
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsListResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/reactions/ReactionsListResponse.java
@@ -38,6 +38,7 @@ public class ReactionsListResponse implements SlackApiTextResponse {
             private List<Attachment> attachments;
             private List<LayoutBlock> blocks;
             private com.slack.api.model.Message.Metadata metadata;
+            private com.slack.api.model.Message.AssistantAppThread assistantAppThread;
             private String ts;
             private String team;
             private String user;

--- a/slack-api-client/src/test/java/test_locally/sample_json_generation/MethodsResponseDumpTest.java
+++ b/slack-api-client/src/test/java/test_locally/sample_json_generation/MethodsResponseDumpTest.java
@@ -1,6 +1,9 @@
 package test_locally.sample_json_generation;
 
 import com.slack.api.methods.response.admin.apps.*;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetStatusResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetSuggestedPromptsResponse;
+import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetTitleResponse;
 import com.slack.api.methods.response.dialog.DialogOpenResponse;
 import com.slack.api.methods.response.migration.MigrationExchangeResponse;
 import com.slack.api.methods.response.users.UsersGetPresenceResponse;
@@ -164,5 +167,18 @@ public class MethodsResponseDumpTest {
             ObjectInitializer.initProperties(response);
             dumper.dump("admin.apps.uninstall", response);
         }
+    }
+
+    @Test
+    public void assistant_threads() throws Exception {
+        AssistantThreadsSetStatusResponse setStatus = new AssistantThreadsSetStatusResponse();
+        ObjectInitializer.initProperties(setStatus);
+        dumper.dump("assistant.threads.setStatus", setStatus);
+        AssistantThreadsSetSuggestedPromptsResponse setSuggestedPrompts = new AssistantThreadsSetSuggestedPromptsResponse();
+        ObjectInitializer.initProperties(setSuggestedPrompts);
+        dumper.dump("assistant.threads.setSuggestedPrompts", setSuggestedPrompts);
+        AssistantThreadsSetTitleResponse setTitle = new AssistantThreadsSetTitleResponse();
+        ObjectInitializer.initProperties(setTitle);
+        dumper.dump("assistant.threads.setTitle", setTitle);
     }
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/Latest.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/Latest.java
@@ -35,6 +35,9 @@ public class Latest {
     private List<String> xFiles;
     private Edited edited;
 
+    private Message.Metadata metadata;
+    private Message.AssistantAppThread assistantAppThread;
+
     @Data
     public static class Edited {
         private String user;

--- a/slack-api-model/src/main/java/com/slack/api/model/Message.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/Message.java
@@ -234,10 +234,6 @@ public class Message {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    /**
-     * Message metadata is in open beta as of May 2, 2022
-     * https://api.slack.com/metadata
-     */
     public static class Metadata {
         private String eventType;
         private Map<String, Object> eventPayload;
@@ -245,4 +241,16 @@ public class Message {
 
     private Room room; // Huddle
     private boolean noNotifications;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AssistantAppThread {
+        private String title;
+        private List<LayoutBlock> titleBlocks;
+        private String firstUserThreadReply;
+    }
+
+    private AssistantAppThread assistantAppThread;
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/assistant/AssistantThread.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/assistant/AssistantThread.java
@@ -1,0 +1,11 @@
+package com.slack.api.model.assistant;
+
+import lombok.Data;
+
+@Data
+public class AssistantThread {
+    private String userId;
+    private AssistantThreadContext context;
+    private String channelId;
+    private String threadTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/assistant/AssistantThreadContext.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/assistant/AssistantThreadContext.java
@@ -1,0 +1,23 @@
+package com.slack.api.model.assistant;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+@Builder
+public class AssistantThreadContext {
+    private String enterpriseId;
+    private String teamId;
+    private String channelId;
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("enterpriseId", this.enterpriseId);
+        map.put("teamId", this.teamId);
+        map.put("channelId", this.channelId);
+        return map;
+    }
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/assistant/SuggestedPrompt.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/assistant/SuggestedPrompt.java
@@ -1,0 +1,21 @@
+package com.slack.api.model.assistant;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SuggestedPrompt {
+    private String title;
+    private String message;
+
+    public SuggestedPrompt(String title, String message) {
+        setTitle(title);
+        setMessage(message);
+    }
+
+    public SuggestedPrompt(String message) {
+        setTitle(message);
+        setMessage(message);
+    }
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/AssistantThreadContextChangedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/AssistantThreadContextChangedEvent.java
@@ -1,0 +1,14 @@
+package com.slack.api.model.event;
+
+import com.slack.api.model.assistant.AssistantThread;
+import lombok.Data;
+
+@Data
+public class AssistantThreadContextChangedEvent implements Event {
+
+    public static final String TYPE_NAME = "assistant_thread_context_changed";
+
+    private final String type = TYPE_NAME;
+    private AssistantThread assistantThread;
+    private String eventTs;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/event/AssistantThreadStartedEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/AssistantThreadStartedEvent.java
@@ -1,0 +1,14 @@
+package com.slack.api.model.event;
+
+import com.slack.api.model.assistant.AssistantThread;
+import lombok.Data;
+
+@Data
+public class AssistantThreadStartedEvent implements Event {
+
+    public static final String TYPE_NAME = "assistant_thread_started";
+
+    private final String type = TYPE_NAME;
+    private AssistantThread assistantThread;
+    private String eventTs;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/AssistantThreadContextChangedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/AssistantThreadContextChangedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.AssistantThreadContextChangedPayload;
+import com.slack.api.model.event.AssistantThreadContextChangedEvent;
+
+public abstract class AssistantThreadContextChangedHandler extends EventHandler<AssistantThreadContextChangedPayload> {
+
+    @Override
+    public String getEventType() {
+        return AssistantThreadContextChangedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/AssistantThreadStartedHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/AssistantThreadStartedHandler.java
@@ -1,0 +1,13 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.AssistantThreadStartedPayload;
+import com.slack.api.model.event.AssistantThreadStartedEvent;
+
+public abstract class AssistantThreadStartedHandler extends EventHandler<AssistantThreadStartedPayload> {
+
+    @Override
+    public String getEventType() {
+        return AssistantThreadStartedEvent.TYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AssistantThreadContextChangedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AssistantThreadContextChangedPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.AssistantThreadContextChangedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AssistantThreadContextChangedPayload implements EventsApiPayload<AssistantThreadContextChangedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private AssistantThreadContextChangedEvent event;
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AssistantThreadStartedPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/AssistantThreadStartedPayload.java
@@ -1,0 +1,25 @@
+package com.slack.api.app_backend.events.payload;
+
+import com.slack.api.model.event.AssistantThreadStartedEvent;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AssistantThreadStartedPayload implements EventsApiPayload<AssistantThreadStartedEvent> {
+
+    private String token;
+    private String enterpriseId;
+    private String teamId;
+    private String apiAppId;
+    private String type;
+    private List<String> authedUsers;
+    private List<String> authedTeams;
+    private List<Authorization> authorizations;
+    private boolean isExtSharedChannel;
+    private String eventId;
+    private Integer eventTime;
+    private String eventContext;
+
+    private AssistantThreadStartedEvent event;
+}


### PR DESCRIPTION
This pull request adds the following APIs and Events API payloads:
- https://api.slack.com/methods?query=assistant.threads
- https://api.slack.com/events?filter=Events&query=assistant_thread

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
