### PR TITLE
Fix #1373 LogsResponse in AuditClient returns "ok: false" when request was a success

### DIFF
--- a/json-logs/raw/audit/v1/actions.json
+++ b/json-logs/raw/audit/v1/actions.json
@@ -323,7 +323,9 @@
       "external_shared_channel_invite_request_approved",
       "external_shared_channel_invite_request_denied",
       "channel_tab_added",
-      "channel_tab_removed"
+      "channel_tab_removed",
+      "external_shared_channel_host_transferred",
+      "channel_template_provisioned"
     ],
     "app": [
       "app_installed",
@@ -502,6 +504,11 @@
       "native_dlp_rule_reactivated",
       "native_dlp_rule_edited",
       "native_dlp_rule_action_applied"
+    ],
+    "template": [
+      "template_created",
+      "template_deleted",
+      "template_provisioned"
     ]
   }
 }

--- a/json-logs/raw/audit/v1/schemas.json
+++ b/json-logs/raw/audit/v1/schemas.json
@@ -142,6 +142,13 @@
         "template_id": "string",
         "step_configuration": "vec\u003cdict\u003cstring, mixed\u003e\u003e"
       }
+    },
+    {
+      "type": "template",
+      "template": {
+        "id": "string",
+        "template_name": "string"
+      }
     }
   ]
 }

--- a/json-logs/samples/audit/v1/actions.json
+++ b/json-logs/samples/audit/v1/actions.json
@@ -59,6 +59,9 @@
     ],
     "native_dlp": [
       ""
+    ],
+    "template": [
+      ""
     ]
   },
   "ok": false,

--- a/json-logs/samples/audit/v1/logs.json
+++ b/json-logs/samples/audit/v1/logs.json
@@ -1,5 +1,5 @@
 {
-  "ok": false,
+  "ok": true,
   "warning": "",
   "error": "",
   "needed": "",

--- a/json-logs/samples/audit/v1/schemas.json
+++ b/json-logs/samples/audit/v1/schemas.json
@@ -84,6 +84,10 @@
         "updated_by": "",
         "step_configuration": "",
         "template_id": ""
+      },
+      "template": {
+        "id": "",
+        "template_name": ""
       }
     }
   ],

--- a/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
@@ -347,6 +347,8 @@ public class Actions {
         public static final String external_shared_channel_invite_request_denied = "external_shared_channel_invite_request_denied";
         public static final String channel_tab_added = "channel_tab_added";
         public static final String channel_tab_removed = "channel_tab_removed";
+        public static final String external_shared_channel_host_transferred = "external_shared_channel_host_transferred";
+        public static final String channel_template_provisioned = "channel_template_provisioned";
     }
 
     public static class App {
@@ -590,5 +592,14 @@ public class Actions {
         public static final String native_dlp_rule_reactivated = "native_dlp_rule_reactivated";
         public static final String native_dlp_rule_edited = "native_dlp_rule_edited";
         public static final String native_dlp_rule_action_applied = "native_dlp_rule_action_applied";
+    }
+
+    public static class Template {
+        private Template() {
+        }
+
+        public static final String template_created = "template_created";
+        public static final String template_deleted = "template_deleted";
+        public static final String template_provisioned = "template_provisioned";
     }
 }

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/ActionsResponse.java
@@ -12,10 +12,15 @@ import java.util.List;
 public class ActionsResponse implements AuditApiResponse {
     private transient String rawBody;
 
-    private boolean ok;
+    @Deprecated // when an error is returned, it will be an exception instead
+    private boolean ok = true;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String warning;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String error;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String needed;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String provided;
 
     private Actions actions;
@@ -43,5 +48,6 @@ public class ActionsResponse implements AuditApiResponse {
         private List<String> function;
         private List<String> salesElevate;
         private List<String> nativeDlp;
+        private List<String> template;
     }
 }

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/LogsResponse.java
@@ -14,10 +14,15 @@ import java.util.Map;
 public class LogsResponse implements AuditApiResponse {
     private transient String rawBody;
 
-    private boolean ok;
+    @Deprecated // when an error is returned, it will be an exception instead
+    private boolean ok = true;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String warning;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String error;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String needed;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String provided;
 
     private ResponseMetadata responseMetadata;

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
@@ -11,10 +11,15 @@ import java.util.List;
 public class SchemasResponse implements AuditApiResponse {
     private transient String rawBody;
 
-    private boolean ok;
+    @Deprecated // when an error is returned, it will be an exception instead
+    private boolean ok = true;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String warning;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String error;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String needed;
+    @Deprecated // when an error is returned, it will be an exception instead
     private String provided;
 
     private List<Schema> schemas;
@@ -36,6 +41,7 @@ public class SchemasResponse implements AuditApiResponse {
         private Barrier barrier;
         private Canvas canvas;
         private WorkflowV2 workflowV2;
+        private Template template;
     }
 
     @Data
@@ -147,5 +153,11 @@ public class SchemasResponse implements AuditApiResponse {
         private String updatedBy;
         private String stepConfiguration;
         private String templateId;
+    }
+
+    @Data
+    public static class Template {
+        private String id;
+        private String templateName;
     }
 }

--- a/slack-api-client/src/test/java/test_locally/api/util/json/GsonAuditLogsDetailsChangedValueFactoryTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/util/json/GsonAuditLogsDetailsChangedValueFactoryTest.java
@@ -231,7 +231,7 @@ public class GsonAuditLogsDetailsChangedValueFactoryTest {
         List<LogsResponse.Entry> entries = Arrays.asList(entry);
         response.setEntries(entries);
         String json = gson.toJson(response);
-        assertThat(json, is("{\"ok\":false,\"entries\":[{\"details\":{" +
+        assertThat(json, is("{\"ok\":true,\"entries\":[{\"details\":{" +
                 "\"new_value\":[\"C111\",\"C222\"]," +
                 "\"previous_value\":[\"C111\",\"C222\"]" +
                 "}}]}"));
@@ -254,7 +254,7 @@ public class GsonAuditLogsDetailsChangedValueFactoryTest {
         List<LogsResponse.Entry> entries = Arrays.asList(entry);
         response.setEntries(entries);
         String json = gson.toJson(response);
-        assertThat(json, is("{\"ok\":false,\"entries\":[{\"details\":{" +
+        assertThat(json, is("{\"ok\":true,\"entries\":[{\"details\":{" +
                 "\"new_value\":{\"type\":[\"TOPLEVEL_ADMINS_AND_OWNERS_AND_SELECTED\"]}," +
                 "\"previous_value\":{\"type\":[\"TOPLEVEL_ADMINS_AND_OWNERS_AND_SELECTED\"]}" +
                 "}}]}"));

--- a/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/audit/ApiTest.java
@@ -281,6 +281,12 @@ public class ApiTest {
                 fail("Unknown action detected - " + action);
             }
         }
+        List<String> templateNames = getAllPublicStaticFieldValues(Actions.Template.class);
+        for (String action : actions.getTemplate()) {
+            if (!templateNames.contains(action)) {
+                fail("Unknown action detected - " + action);
+            }
+        }
     }
 
     @Test
@@ -329,6 +335,7 @@ public class ApiTest {
             );
             assertThat(cursor, not(equalTo(response.getResponseMetadata().getNextCursor())));
             assertThat(response, is(notNullValue()));
+            assertThat(response.isOk(), is(true));
         }
     }
 
@@ -368,6 +375,7 @@ public class ApiTest {
             try {
                 LogsResponse response = slack.auditAsync(token).getLogs(req -> req.limit(500).action(action)).get();
                 assertThat(response.getError(), is(nullValue()));
+                assertThat(response.isOk(), is(true));
             } catch (ExecutionException e) {
                 if (e.getCause() != null && e.getCause() instanceof AuditApiCompletionException) {
                     AuditApiCompletionException apiEx = ((AuditApiCompletionException) e.getCause());


### PR DESCRIPTION
This pull request resolves #1373 and marks the useless properties as deprecated for the future.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
