### PR TITLE
Speedup slow tests due to rate limit

### DIFF
--- a/slack-api-client/src/test/java/test_locally/api/methods/TeamTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/TeamTest.java
@@ -2,10 +2,14 @@ package test_locally.api.methods;
 
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
+import com.slack.api.methods.MethodsConfig;
+import com.slack.api.methods.MethodsCustomRateLimitResolver;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import util.MockSlackApiServer;
+
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,6 +25,19 @@ public class TeamTest {
     public void setup() throws Exception {
         server.start();
         config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+        MethodsConfig methodsConfig = new MethodsConfig();
+        methodsConfig.setCustomRateLimitResolver(new MethodsCustomRateLimitResolver() {
+            @Override
+            public Optional<Integer> getCustomAllowedRequestsPerMinute(String teamId, String methodName) {
+                return Optional.of(20);
+            }
+
+            @Override
+            public Optional<Integer> getCustomAllowedRequestsForChatPostMessagePerMinute(String teamId, String channel) {
+                return Optional.empty();
+            }
+        });
+        config.setMethodsConfig(methodsConfig);
     }
 
     @After

--- a/slack-api-client/src/test/java/test_locally/api/methods_admin_api/AdminApiAsyncTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods_admin_api/AdminApiAsyncTest.java
@@ -3,6 +3,8 @@ package test_locally.api.methods_admin_api;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.methods.AsyncMethodsClient;
+import com.slack.api.methods.MethodsConfig;
+import com.slack.api.methods.MethodsCustomRateLimitResolver;
 import com.slack.api.model.admin.AppConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -11,6 +13,7 @@ import util.MockSlackApiServer;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -26,6 +29,19 @@ public class AdminApiAsyncTest {
     public void setup() throws Exception {
         server.start();
         config.setMethodsEndpointUrlPrefix(server.getMethodsEndpointPrefix());
+        MethodsConfig methodsConfig = new MethodsConfig();
+        methodsConfig.setCustomRateLimitResolver(new MethodsCustomRateLimitResolver() {
+            @Override
+            public Optional<Integer> getCustomAllowedRequestsPerMinute(String teamId, String methodName) {
+                return Optional.of(50);
+            }
+
+            @Override
+            public Optional<Integer> getCustomAllowedRequestsForChatPostMessagePerMinute(String teamId, String channel) {
+                return Optional.empty();
+            }
+        });
+        config.setMethodsConfig(methodsConfig);
     }
 
     @After


### PR DESCRIPTION
Speedup slow tests due to rate limit.
Total execution time is reduced from 10 minutes to 4 minutes, which is 2.5x faster or saving 6 minutes each.

Reference: https://github.com/KENNYSOFT/java-slack-sdk/actions/runs/10939043557/job/30368464798

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
