### PR TITLE
Fix #1378 AsyncRateLimitExecutor ignores teamId set in MethodsClientImpl provided

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
@@ -28,7 +28,7 @@ public class AsyncRateLimitExecutor {
     private AsyncRateLimitExecutor(MethodsClientImpl clientImpl, SlackConfig config) {
         this.config = config.getMethodsConfig();
         this.metricsDatastore = config.getMethodsConfig().getMetricsDatastore();
-        this.teamIdCache = new TeamIdCache(clientImpl);
+        this.teamIdCache = clientImpl.getTeamIdCache();
         this.messageIdGenerator = new MessageIdGeneratorUUIDImpl();
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -273,6 +273,7 @@ import com.slack.api.methods.response.workflows.WorkflowsUpdateStepResponse;
 import com.slack.api.rate_limits.metrics.MetricsDatastore;
 import com.slack.api.util.http.SlackHttpClient;
 import com.slack.api.util.json.GsonFactory;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 
@@ -295,6 +296,7 @@ public class MethodsClientImpl implements MethodsClient {
     // for org-level installed apps
     private final Optional<String> teamId;
     private final MetricsDatastore metricsDatastore;
+    @Getter
     private final TeamIdCache teamIdCache;
 
     public MethodsClientImpl(SlackHttpClient slackHttpClient) {


### PR DESCRIPTION
This pull request resolves #1378 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
