### PR TITLE
Remove extra double quotes from the "Add to Slack" OAuth image alt text

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/default_impl/OAuthDefaultInstallPageRenderer.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/oauth/view/default_impl/OAuthDefaultInstallPageRenderer.java
@@ -18,7 +18,7 @@ public class OAuthDefaultInstallPageRenderer implements OAuthInstallPageRenderer
             "</head>\n" +
             "<body>\n" +
             "<h2>Slack App Installation</h2>\n" +
-            "<p><a href=\"__URL__\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
+            "<p><a href=\"__URL__\"><img alt=\"Add to Slack\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
             "</body>\n" +
             "</html>";
 

--- a/bolt/src/test/java/test_locally/app/OAuthStartTest.java
+++ b/bolt/src/test/java/test_locally/app/OAuthStartTest.java
@@ -48,7 +48,7 @@ public class OAuthStartTest {
                 "</head>\n" +
                 "<body>\n" +
                 "<h2>Slack App Installation</h2>\n" +
-                "<p><a href=\"https://slack.com/oauth/v2/authorize?client_id=111.222&amp;scope=commands%2Cchat%3Awrite&amp;user_scope=&amp;state=generated-state-value\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
+                "<p><a href=\"https://slack.com/oauth/v2/authorize?client_id=111.222&amp;scope=commands%2Cchat%3Awrite&amp;user_scope=&amp;state=generated-state-value\"><img alt=\"Add to Slack\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
                 "</body>\n" +
                 "</html>", response.getBody());
     }
@@ -78,7 +78,7 @@ public class OAuthStartTest {
                 "</head>\n" +
                 "<body>\n" +
                 "<h2>Slack App Installation</h2>\n" +
-                "<p><a href=\"https://slack.com/oauth/v2/authorize?client_id=111.222&amp;scope=commands%2Cchat%3Awrite&amp;user_scope=&amp;state=\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
+                "<p><a href=\"https://slack.com/oauth/v2/authorize?client_id=111.222&amp;scope=commands%2Cchat%3Awrite&amp;user_scope=&amp;state=\"><img alt=\"Add to Slack\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
                 "</body>\n" +
                 "</html>", response.getBody());
     }

--- a/bolt/src/test/java/test_locally/app/OpenIDConnectTest.java
+++ b/bolt/src/test/java/test_locally/app/OpenIDConnectTest.java
@@ -66,7 +66,7 @@ public class OpenIDConnectTest {
             "</head>\n" +
             "<body>\n" +
             "<h2>Slack App Installation</h2>\n" +
-            "<p><a href=\"https://slack.com/openid/connect/authorize?client_id=111.222&amp;response_type=code&amp;scope=openid%2Cemail%2Cprofile&amp;state=generated-state-value&amp;nonce=generated-nonce-value\"><img alt=\"\"Add to Slack\"\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
+            "<p><a href=\"https://slack.com/openid/connect/authorize?client_id=111.222&amp;response_type=code&amp;scope=openid%2Cemail%2Cprofile&amp;state=generated-state-value&amp;nonce=generated-nonce-value\"><img alt=\"Add to Slack\" height=\"40\" width=\"139\" src=\"https://platform.slack-edge.com/img/add_to_slack.png\" srcset=\"https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x\" /></a></p>\n" +
             "</body>\n" +
             "</html>";
 


### PR DESCRIPTION
### Summary

This PR removes extra double quotes from the "Add to Slack" OAuth image alt text to match similar changes made in https://github.com/slackapi/bolt-python/pull/1170 and https://github.com/slackapi/node-slack-sdk/pull/2044 🔍

From [another comment](https://github.com/slackapi/node-slack-sdk/pull/2044#issuecomment-2380389913), I believe the current snippet is changing the following in browser:

```diff
- <img alt=""example"" />
+ <img alt="" />
```

But using the single set of double quotes brings the `alt` text back 🙏 :sparkles:

### Category

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
