### PR TITLE
Upgrade a few optional dependencies

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <http4k.version>5.31.0.0</http4k.version>
+        <http4k.version>5.32.4.0</http4k.version>
         <!-- http4k 5.26+ no longer supports Java 1.8 -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/bolt-jetty/pom.xml
+++ b/bolt-jetty/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <jetty.version>9.4.55.v20240627</jetty.version>
+        <jetty.version>9.4.56.v20240826</jetty.version>
     </properties>
 
     <artifactId>bolt-jetty</artifactId>

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,11 +10,10 @@
     </parent>
 
     <properties>
-        <!-- TODO: holding off migrating to 4.6 due to binary compatibility issue with JDK 17; see https://github.com/slackapi/java-slack-sdk/actions/runs/10448506682/job/28929089969?pr=1350 -->
-        <micronaut.version>4.5.4</micronaut.version>
+        <micronaut.version>4.7.0</micronaut.version>
         <micronaut-test-junit5.version>4.5.0</micronaut-test-junit5.version>
         <micronaut-rxjava3.version>3.5.0</micronaut-rxjava3.version>
-        <junit5-jupiter.version>5.11.0</junit5-jupiter.version>
+        <junit5-jupiter.version>5.11.2</junit5-jupiter.version>
         <!-- Note that upgrading this library breaks other dependency resolution -->
         <mockito-all.version>1.10.19</mockito-all.version>
         <jakarta.inject.version>2.0.1.MR</jakarta.inject.version>

--- a/slack-api-client/pom.xml
+++ b/slack-api-client/pom.xml
@@ -20,7 +20,7 @@
          -->
         <tyrus-standalone-client.version>1.20</tyrus-standalone-client.version>
         <java-websocket.version>1.5.7</java-websocket.version>
-        <jedis.version>5.1.5</jedis.version>
+        <jedis.version>5.2.0</jedis.version>
         <jedis-mock.version>1.1.4</jedis-mock.version>
     </properties>
 


### PR DESCRIPTION
If the micronaut upgrade fails, I will revert it

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
