### PR TITLE
Fix #1348 channel_convert_to_public message events

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/model/event/MessageChannelConvertToPublicEvent.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/event/MessageChannelConvertToPublicEvent.java
@@ -1,0 +1,23 @@
+package com.slack.api.model.event;
+
+import lombok.Data;
+
+/**
+ * https://api.slack.com/events/message/channel_convert_to_public
+ */
+@Data
+public class MessageChannelConvertToPublicEvent implements Event {
+
+    public static final String TYPE_NAME = "message";
+    public static final String SUBTYPE_NAME = "channel_convert_to_public";
+
+    private final String type = TYPE_NAME;
+    private final String subtype = SUBTYPE_NAME;
+
+    private String user;
+    private String text;
+    private String channel;
+    private String ts;
+    private String eventTs;
+    private String channelType; // "channel"
+}

--- a/slack-api-model/src/test/java/test_locally/api/model/event/MessageChannelConvertToPublicEventTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/event/MessageChannelConvertToPublicEventTest.java
@@ -1,0 +1,53 @@
+package test_locally.api.model.event;
+
+import com.slack.api.model.event.MessageChannelConvertToPublicEvent;
+import org.junit.Test;
+import test_locally.unit.GsonFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MessageChannelConvertToPublicEventTest {
+
+    @Test
+    public void typeName() {
+        assertThat(MessageChannelConvertToPublicEvent.TYPE_NAME, is("message"));
+        assertThat(MessageChannelConvertToPublicEvent.SUBTYPE_NAME, is("channel_convert_to_public"));
+    }
+
+    @Test
+    public void deserialize_simple() {
+        String json = "{\n" +
+                "  \"subtype\": \"channel_convert_to_public\",\n" +
+                "  \"user\": \"W013QGS7BPF\",\n" +
+                "  \"text\": \"made this channel *public*. Any member in this workspace can see and join it.\",\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"ts\": \"1728976211.166339\",\n" +
+                "  \"channel\": \"C07RP9QHR2S\",\n" +
+                "  \"event_ts\": \"1728976211.166339\",\n" +
+                "  \"channel_type\": \"channel\"\n" +
+                "}";
+        MessageChannelConvertToPublicEvent event = GsonFactory.createSnakeCase(true, true).fromJson(json, MessageChannelConvertToPublicEvent.class);
+        assertThat(event.getType(), is("message"));
+        assertThat(event.getSubtype(), is("channel_convert_to_public"));
+        assertThat(event.getUser(), is("W013QGS7BPF"));
+    }
+
+    @Test
+    public void deserialize_api_document() {
+        String json = "{\n" +
+                "  \"type\": \"message\",\n" +
+                "  \"subtype\": \"channel_convert_to_public\",\n" +
+                "  \"ts\": \"1723680078.026719\",\n" +
+                "  \"text\": \"Made this channel public. Any member in this workspace can see and join it.\",\n" +
+                "  \"user\": \"U123ABC456\",\n" +
+                "  \"channel\": \"C123ABC456\",\n" +
+                "  \"event_ts\": \"1614215651.001300\",\n" +
+                "  \"channel_type\": \"channel\"\n" +
+                "}";
+        MessageChannelConvertToPublicEvent event = GsonFactory.createSnakeCase(true, true).fromJson(json, MessageChannelConvertToPublicEvent.class);
+        assertThat(event.getType(), is("message"));
+        assertThat(event.getSubtype(), is("channel_convert_to_public"));
+        assertThat(event.getUser(), is("U123ABC456"));
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/MessageChannelConvertToPublicHandler.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/handler/MessageChannelConvertToPublicHandler.java
@@ -1,0 +1,18 @@
+package com.slack.api.app_backend.events.handler;
+
+import com.slack.api.app_backend.events.EventHandler;
+import com.slack.api.app_backend.events.payload.MessageChannelConvertToPublicPayload;
+import com.slack.api.model.event.MessageChannelConvertToPublicEvent;
+
+public abstract class MessageChannelConvertToPublicHandler extends EventHandler<MessageChannelConvertToPublicPayload> {
+
+    @Override
+    public String getEventType() {
+        return MessageChannelConvertToPublicEvent.TYPE_NAME;
+    }
+
+    @Override
+    public String getEventSubtype() {
+        return MessageChannelConvertToPublicEvent.SUBTYPE_NAME;
+    }
+}

--- a/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageChannelConvertToPublicPayload.java
+++ b/slack-app-backend/src/main/java/com/slack/api/app_backend/events/payload/MessageChannelConvertToPublicPayload.java
@@ -1,12 +1,12 @@
 package com.slack.api.app_backend.events.payload;
 
-import com.slack.api.model.event.SharedChannelInviteReceivedEvent;
+import com.slack.api.model.event.MessageChannelConvertToPublicEvent;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-public class SharedChannelInviteReceivedPayload implements EventsApiPayload<SharedChannelInviteReceivedEvent> {
+public class MessageChannelConvertToPublicPayload implements EventsApiPayload<MessageChannelConvertToPublicEvent> {
 
     private String token;
     private String enterpriseId;
@@ -21,5 +21,5 @@ public class SharedChannelInviteReceivedPayload implements EventsApiPayload<Shar
     private Integer eventTime;
     private String eventContext;
 
-    private SharedChannelInviteReceivedEvent event;
+    private MessageChannelConvertToPublicEvent event;
 }


### PR DESCRIPTION
This pull request resolves #1348 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [x] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
