### PR TITLE
Fix #1402 Migrating AWS S3 SDK to v2

### DIFF
--- a/bolt-jakarta-servlet/pom.xml
+++ b/bolt-jakarta-servlet/pom.xml
@@ -61,8 +61,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <version>${aws.s3.version}</version>
             <scope>test</scope>
         </dependency>

--- a/bolt-kotlin-examples/pom.xml
+++ b/bolt-kotlin-examples/pom.xml
@@ -41,8 +41,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <version>${aws.s3.version}</version>
         </dependency>
 

--- a/bolt-servlet/pom.xml
+++ b/bolt-servlet/pom.xml
@@ -66,8 +66,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <version>${aws.s3.version}</version>
             <scope>test</scope>
         </dependency>

--- a/bolt/pom.xml
+++ b/bolt/pom.xml
@@ -41,8 +41,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <version>${aws.s3.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3OAuthStateService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3OAuthStateService.java
@@ -1,19 +1,18 @@
 package com.slack.api.bolt.service.builtin;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.PutObjectResult;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.util.IOUtils;
 import com.slack.api.bolt.Initializer;
 import com.slack.api.bolt.service.OAuthStateService;
-import com.slack.api.bolt.util.JsonOps;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
 
-import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * OAuthStateService implementation using Amazon S3.
@@ -24,6 +23,7 @@ import java.io.IOException;
 public class AmazonS3OAuthStateService implements OAuthStateService {
 
     private final String bucketName;
+    private AwsCredentialsProvider credentialsProvider;
 
     public AmazonS3OAuthStateService(String bucketName) {
         this.bucketName = bucketName;
@@ -33,74 +33,92 @@ public class AmazonS3OAuthStateService implements OAuthStateService {
     public Initializer initializer() {
         return (app) -> {
             // The first access to S3 tends to be slow on AWS Lambda.
-            AWSCredentials credentials = getCredentials();
-            if (credentials == null || credentials.getAWSAccessKeyId() == null) {
+            this.credentialsProvider = DefaultCredentialsProvider.create();
+            AwsCredentials credentials = createCredentials(credentialsProvider);
+            if (credentials == null || credentials.accessKeyId() == null) {
                 throw new IllegalStateException("AWS credentials not found");
             }
             if (log.isDebugEnabled()) {
-                log.debug("AWS credentials loaded (access key id: {})", credentials.getAWSAccessKeyId());
+                log.debug("AWS credentials loaded (access key id: {})", credentials.accessKeyId());
             }
-            boolean bucketExists = createS3Client().doesBucketExistV2(bucketName);
+            boolean bucketExists = false;
+            Exception ex = null;
+            try (S3Client s3 = createS3Client()) {
+                bucketExists = s3.headBucket(HeadBucketRequest.builder().bucket(bucketName).build()) != null;
+            } catch (Exception e) { // NoSuchBucketException etc.
+                ex = e;
+            }
             if (!bucketExists) {
-                throw new IllegalStateException("Failed to access the Amazon S3 bucket (name: " + bucketName + ")");
+                String error = ex != null ? ex.getClass().getName() + ":" + ex.getMessage() : "-";
+                String message = "Failed to access the Amazon S3 bucket (name: " + bucketName + ", error: " + error + ")";
+                throw new IllegalStateException(message);
             }
         };
     }
 
     @Override
     public void addNewStateToDatastore(String state) throws Exception {
-        AmazonS3 s3 = this.createS3Client();
-        String value = "" + (System.currentTimeMillis() + getExpirationInSeconds() * 1000);
-        PutObjectResult putObjectResult = s3.putObject(bucketName, getKey(state), value);
+        PutObjectResponse putObjectResult;
+        try (S3Client s3 = this.createS3Client()) {
+            String value = "" + (System.currentTimeMillis() + getExpirationInSeconds() * 1000);
+            putObjectResult = s3.putObject(
+                    PutObjectRequest.builder().bucket(bucketName).key(getKey(state)).build(),
+                    RequestBody.fromString(value)
+            );
+        }
         if (log.isDebugEnabled()) {
-            log.debug("AWS S3 putObject result of state data - {}", JsonOps.toJsonString(putObjectResult));
+            log.debug("AWS S3 putObject result of state data - {}", putObjectResult.toString());
         }
     }
 
     @Override
     public boolean isAvailableInDatabase(String state) {
-        AmazonS3 s3 = this.createS3Client();
-        S3Object s3Object = getObject(s3, getKey(state));
+        S3Client s3 = this.createS3Client();
+        ResponseBytes<GetObjectResponse> s3Object = getObject(s3, getKey(state));
         if (s3Object == null) {
             return false;
         }
         String millisToExpire = null;
         try {
-            millisToExpire = IOUtils.toString(s3Object.getObjectContent());
-            return Long.valueOf(millisToExpire) > System.currentTimeMillis();
-        } catch (IOException e) {
-            log.error("Failed to load a state data for state: {}", state, e);
-            return false;
+            millisToExpire = s3Object.asString(StandardCharsets.UTF_8);
+            return Long.parseLong(millisToExpire) > System.currentTimeMillis();
         } catch (NumberFormatException ne) {
             log.error("Invalid state value detected - state: {}, millisToExpire: {}", state, millisToExpire);
+            return false;
+        } catch (Exception e) {
+            log.error("Failed to load a state data for state: {}", state, e);
             return false;
         }
     }
 
     @Override
     public void deleteStateFromDatastore(String state) throws Exception {
-        AmazonS3 s3 = this.createS3Client();
-        s3.deleteObject(bucketName, getKey(state));
+        try (S3Client s3 = this.createS3Client()) {
+            s3.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(getKey(state)).build());
+        }
     }
 
-    protected AWSCredentials getCredentials() {
-        return DefaultAWSCredentialsProviderChain.getInstance().getCredentials();
+    protected AwsCredentials createCredentials(AwsCredentialsProvider provider) {
+        return provider.resolveCredentials();
     }
 
-    protected AmazonS3 createS3Client() {
-        return AmazonS3ClientBuilder.defaultClient();
+    protected S3Client createS3Client() {
+        return S3Client.builder().credentialsProvider(this.credentialsProvider).build();
     }
 
     private String getKey(String state) {
         return "state/" + state;
     }
 
-    private S3Object getObject(AmazonS3 s3, String fullKey) {
+    private ResponseBytes<GetObjectResponse> getObject(S3Client s3, String fullKey) {
         try {
-            return s3.getObject(bucketName, fullKey);
-        } catch (AmazonS3Exception e) {
+            return s3.getObject(
+                    GetObjectRequest.builder().bucket(bucketName).key(fullKey).build(),
+                    ResponseTransformer.toBytes()
+            );
+        } catch (Exception e) {
             if (log.isDebugEnabled()) {
-                log.debug("Amazon S3 object metadata not found (key: {}, AmazonS3Exception: {})", fullKey, e.toString());
+                log.debug("Amazon S3 object metadata not found (key: {}, Exception: {})", fullKey, e.toString());
             }
             return null;
         }

--- a/bolt/src/test/java/test_with_remote_apis/service/aws/AmazonS3InstallationServiceTest.java
+++ b/bolt/src/test/java/test_with_remote_apis/service/aws/AmazonS3InstallationServiceTest.java
@@ -9,6 +9,7 @@ public class AmazonS3InstallationServiceTest {
 
     @Test(expected = IllegalStateException.class)
     public void init() {
+        // To avoid accessing existing buckets
         String bucketName = "java-slack-sdk-test-dummy-bucket" + UUID.randomUUID();
         AmazonS3InstallationService service = new AmazonS3InstallationService(bucketName);
         service.initializer().accept(null);

--- a/bolt/src/test/java/test_with_remote_apis/service/aws/AmazonS3OAuthStateServiceTest.java
+++ b/bolt/src/test/java/test_with_remote_apis/service/aws/AmazonS3OAuthStateServiceTest.java
@@ -9,6 +9,7 @@ public class AmazonS3OAuthStateServiceTest {
 
     @Test(expected = IllegalStateException.class)
     public void init() {
+        // To avoid accessing existing buckets
         String bucketName = "java-slack-sdk-test-dummy-bucket" + UUID.randomUUID();
         AmazonS3OAuthStateService service = new AmazonS3OAuthStateService(bucketName);
         service.initializer().accept(null);

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <!-- Note that "[11.0,12.0)" does not exclude jetty-xxx 12.0.0.alpha0 -->
         <jakarta.jetty.version>[11.0,11.1)</jakarta.jetty.version>
         <java-jwt.version>[4.0,5.0)</java-jwt.version>
-        <aws.s3.version>[1.12.62,1.13.0)</aws.s3.version>
+        <aws.s3.version>[2.29.24,3)</aws.s3.version>
         <junit.version>4.13.2</junit.version>
         <logback-slf4j-v1.version>1.2.11</logback-slf4j-v1.version>
         <logback-slf4j-v2.version>1.4.7</logback-slf4j-v2.version>


### PR DESCRIPTION
This pull request resolves #1402

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
