### PR TITLE
Fix #1414 botMessage handler in Assistant middleware does not work when other event listeners do not exist

### DIFF
--- a/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/Assistant.java
+++ b/bolt/src/main/java/com/slack/api/bolt/middleware/builtin/Assistant.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import static com.slack.api.bolt.util.EventsApiPayloadParser.buildEventPayload;
+import static com.slack.api.bolt.util.EventsApiPayloadParser.getEventTypeAndSubtype;
 
 public class Assistant implements Middleware {
 
@@ -50,6 +51,17 @@ public class Assistant implements Middleware {
     private AssistantEventHandler<MessageEvent> userMessage;
     private AssistantEventHandler<MessageFileShareEvent> userMessageWithFiles;
     private AssistantEventHandler<MessageEvent> botMessage;
+
+    static {
+        // *** Building event type cache data ***
+        // app.event / app.message handlers invoke getEventTypeAndSubtype method when their listeners are added.
+        // However, Assistant middleware does not, since it operates as a global middleware.
+        // This workaround ensures that the event type cache data is created before receiving requests.
+        getEventTypeAndSubtype(AssistantThreadStartedEvent.class);
+        getEventTypeAndSubtype(AssistantThreadContextChangedEvent.class);
+        getEventTypeAndSubtype(MessageEvent.class);
+        getEventTypeAndSubtype(MessageFileShareEvent.class);
+    }
 
     public Assistant() {
         this(null, buildDefaultExecutorService(), buildDefaultLogger());

--- a/bolt/src/main/java/com/slack/api/bolt/request/builtin/EventRequest.java
+++ b/bolt/src/main/java/com/slack/api/bolt/request/builtin/EventRequest.java
@@ -122,9 +122,12 @@ public class EventRequest extends Request<EventContext> {
             JsonObject context = thread.get("context").getAsJsonObject();
             if (context != null) {
                 AssistantThreadContext threadContext = AssistantThreadContext.builder()
-                        .enterpriseId(context.get("enterprise_id") != null ? context.get("enterprise_id").getAsString() : null)
-                        .teamId(context.get("team_id") != null ? context.get("team_id").getAsString() : null)
-                        .channelId(context.get("channel_id") != null ? context.get("channel_id").getAsString() : null)
+                        // enterprise_id here can be a null value
+                        // others cannot be null as of Jan 2025, but added the same logic to all for future safety
+                        .enterpriseId(context.get("enterprise_id") != null && !context.get("enterprise_id").isJsonNull() ? context.get("enterprise_id").getAsString() : null)
+                        .teamId(context.get("team_id") != null && !context.get("team_id").isJsonNull() ? context.get("team_id").getAsString() : null)
+                        .channelId(context.get("channel_id") != null && !context.get("channel_id").isJsonNull() ? context.get("channel_id").getAsString() : null)
+                        .threadEntryPoint(context.get("thread_entry_point") != null && !context.get("thread_entry_point").isJsonNull() ? context.get("thread_entry_point").getAsString() : null)
                         .build();
                 this.getContext().setThreadContext(threadContext);
             }
@@ -134,9 +137,12 @@ public class EventRequest extends Request<EventContext> {
             // message events (user replies)
             this.getContext().setAssistantThreadEvent(true);
             this.getContext().setChannelId(event.get("channel").getAsString());
-            if (event.get("thread_ts") != null) {
+            if (event.get("thread_ts") != null
+                    && !event.get("thread_ts").isJsonNull()) {
                 this.getContext().setThreadTs(event.get("thread_ts").getAsString());
-            } else if (event.get("message") != null && event.get("message").getAsJsonObject().get("thread_ts") != null) {
+            } else if (event.get("message") != null
+                    && event.get("message").getAsJsonObject().get("thread_ts") != null
+                    && !event.get("message").getAsJsonObject().get("thread_ts").isJsonNull()) {
                 // message_changed
                 this.getContext().setThreadTs(event.get("message").getAsJsonObject().get("thread_ts").getAsString());
             }

--- a/slack-api-model/src/main/java/com/slack/api/model/assistant/AssistantThreadContext.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/assistant/AssistantThreadContext.java
@@ -12,12 +12,14 @@ public class AssistantThreadContext {
     private String enterpriseId;
     private String teamId;
     private String channelId;
+    private String threadEntryPoint; // "sunroof" etc.
 
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
         map.put("enterpriseId", this.enterpriseId);
         map.put("teamId", this.teamId);
         map.put("channelId", this.channelId);
+        map.put("thread_entry_point", this.threadEntryPoint);
         return map;
     }
 }


### PR DESCRIPTION
This pull request resolves a bug reported in #1414. I overlooked this pattern because my example apps, used to verify their behavior, always had app.event listeners.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
