### PR TITLE
Add channels param to files.upload v2 method (and its underlying files.completeUploadExternal)

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -2086,7 +2086,11 @@ public class RequestFormBuilder {
         if (req.getFiles() != null) {
             setIfNotNull("files", GSON.toJson(req.getFiles()), form);
         }
-        setIfNotNull("channel_id", req.getChannelId(), form);
+        if (req.getChannels() != null) {
+            setIfNotNull("channels", req.getChannels().stream().collect(joining(",")), form);
+        } else {
+            setIfNotNull("channel_id", req.getChannelId(), form);
+        }
         setIfNotNull("initial_comment", req.getInitialComment(), form);
         setIfNotNull("thread_ts", req.getThreadTs(), form);
         return form;

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/FilesUploadV2Helper.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/FilesUploadV2Helper.java
@@ -94,6 +94,7 @@ public class FilesUploadV2Helper implements AutoCloseable {
                 .token(v2Request.getToken())
                 .files(files)
                 .channelId(v2Request.getChannel())
+                .channels(v2Request.getChannels())
                 .initialComment(v2Request.getInitialComment())
                 .threadTs(v2Request.getThreadTs())
         );

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesCompleteUploadExternalRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesCompleteUploadExternalRequest.java
@@ -31,6 +31,11 @@ public class FilesCompleteUploadExternalRequest implements SlackApiRequest {
     private String channelId;
 
     /**
+     * Comma-separated string of channel IDs where the file will be shared.
+     */
+    private List<String> channels;
+
+    /**
      * The message text introducing the file in specified channels.
      */
     private String initialComment;

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadV2Request.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadV2Request.java
@@ -131,6 +131,11 @@ public class FilesUploadV2Request implements SlackApiRequest {
     private String channel;
 
     /**
+     * Comma-separated string of channel IDs where the file will be shared.
+     */
+    private List<String> channels;
+
+    /**
      * Provide another message's ts value to upload this file as a reply.
      * Never use a reply's ts value; use its parent instead.
      */


### PR DESCRIPTION
This pull request adds the `channels` parameter to files.completeUploadExternal API method and the wrapper v2 method.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
