### PR TITLE
Consistently use the same OkHttpClient for files.slack.com requests

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/FilesUploadV2Helper.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/FilesUploadV2Helper.java
@@ -31,7 +31,7 @@ public class FilesUploadV2Helper implements AutoCloseable {
 
     public FilesUploadV2Helper(MethodsClient client) {
         this.client = client;
-        this.okHttpClient = SlackHttpClient.buildOkHttpClient(client.getSlackHttpClient().getConfig());
+        this.okHttpClient = client.getSlackHttpClient().getOkHttpClient();
     }
 
     public String uploadFile(

--- a/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/http/SlackHttpClient.java
@@ -123,6 +123,10 @@ public class SlackHttpClient implements AutoCloseable {
         this.config = config;
     }
 
+    public OkHttpClient getOkHttpClient() {
+        return this.okHttpClient;
+    }
+
     public Response get(String url, Map<String, String> query, String token) throws IOException {
         if (query != null) {
             HttpUrl.Builder u = HttpUrl.parse(url).newBuilder();


### PR DESCRIPTION
This pull request resolves a bug where the files.slack.com requests fail when a developer passes OkHttpClient to SlackHttpClient when initializing the API clients to handle specific SSL conditions. This pull request tweak the internal FilesUploadV2Helper class to use the given OkHttpClient rather than creating a new once only using SlackConfig properties. 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
