### PR TITLE
redis installation and oauth state services

### DIFF
--- a/bolt/pom.xml
+++ b/bolt/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <commons-text.version>1.13.0</commons-text.version>
+        <jedis.version>5.2.0</jedis.version>
     </properties>
 
     <dependencies>
@@ -43,6 +44,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
             <version>${aws.s3.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>${jedis.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
@@ -339,8 +339,8 @@ public class AmazonS3InstallationService implements InstallationService {
 
     private String getInstallerKey(Installer installer) {
         return getInstallerKey(installer.getEnterpriseId(),
-            installer.getTeamId(),
-            installer.getInstallerUserId());
+                installer.getTeamId(),
+                installer.getInstallerUserId());
     }
 
     private String getInstallerKey(String enterpriseId, String teamId, String userId) {
@@ -354,7 +354,7 @@ public class AmazonS3InstallationService implements InstallationService {
 
     private String getBotKey(Installer installer) {
         return getBotKey(installer.getEnterpriseId(),
-            installer.getTeamId());
+               installer.getTeamId());
     }
 
     private String getBotKey(String enterpriseId, String teamId) {

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3InstallationService.java
@@ -24,6 +24,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * InstallationService implementation using Amazon S3.
+ *
+ * @see <a href="https://aws.amazon.com/s3/">Amazon S3</a>
+ */
 @Slf4j
 public class AmazonS3InstallationService implements InstallationService {
 
@@ -92,16 +97,16 @@ public class AmazonS3InstallationService implements InstallationService {
     }
 
     @Override
-    public void saveInstallerAndBot(Installer i) throws Exception {
+    public void saveInstallerAndBot(Installer installer) throws Exception {
         try (S3Client s3 = this.createS3Client()) {
             if (isHistoricalDataEnabled()) {
-                save(s3, getInstallerKey(i) + "-latest", JsonOps.toJsonString(i), "AWS S3 putObject result of Installer data - {}, {}");
-                save(s3, getBotKey(i) + "-latest", JsonOps.toJsonString(i.toBot()), "AWS S3 putObject result of Bot data - {}, {}");
-                save(s3, getInstallerKey(i) + "-" + i.getInstalledAt(), JsonOps.toJsonString(i), "AWS S3 putObject result of Installer data - {}, {}");
-                save(s3, getBotKey(i) + "-" + i.getInstalledAt(), JsonOps.toJsonString(i.toBot()), "AWS S3 putObject result of Bot data - {}, {}");
+                save(s3, getInstallerKey(installer) + "-latest", JsonOps.toJsonString(installer), "AWS S3 putObject result of Installer data - {}, {}");
+                save(s3, getBotKey(installer) + "-latest", JsonOps.toJsonString(installer.toBot()), "AWS S3 putObject result of Bot data - {}, {}");
+                save(s3, getInstallerKey(installer) + "-" + installer.getInstalledAt(), JsonOps.toJsonString(installer), "AWS S3 putObject result of Installer data - {}, {}");
+                save(s3, getBotKey(installer) + "-" + installer.getInstalledAt(), JsonOps.toJsonString(installer.toBot()), "AWS S3 putObject result of Bot data - {}, {}");
             } else {
-                save(s3, getInstallerKey(i), JsonOps.toJsonString(i), "AWS S3 putObject result of Installer data - {}, {}");
-                save(s3, getBotKey(i), JsonOps.toJsonString(i.toBot()), "AWS S3 putObject result of Bot data - {}, {}");
+                save(s3, getInstallerKey(installer), JsonOps.toJsonString(installer), "AWS S3 putObject result of Installer data - {}, {}");
+                save(s3, getBotKey(installer), JsonOps.toJsonString(installer.toBot()), "AWS S3 putObject result of Bot data - {}, {}");
             }
         }
     }
@@ -332,8 +337,10 @@ public class AmazonS3InstallationService implements InstallationService {
                 .build();
     }
 
-    private String getInstallerKey(Installer i) {
-        return getInstallerKey(i.getEnterpriseId(), i.getTeamId(), i.getInstallerUserId());
+    private String getInstallerKey(Installer installer) {
+        return getInstallerKey(installer.getEnterpriseId(),
+            installer.getTeamId(),
+            installer.getInstallerUserId());
     }
 
     private String getInstallerKey(String enterpriseId, String teamId, String userId) {
@@ -345,8 +352,9 @@ public class AmazonS3InstallationService implements InstallationService {
                 + userId;
     }
 
-    private String getBotKey(Installer i) {
-        return getBotKey(i.getEnterpriseId(), i.getTeamId());
+    private String getBotKey(Installer installer) {
+        return getBotKey(installer.getEnterpriseId(),
+            installer.getTeamId());
     }
 
     private String getBotKey(String enterpriseId, String teamId) {

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3OAuthStateService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/AmazonS3OAuthStateService.java
@@ -113,8 +113,12 @@ public class AmazonS3OAuthStateService implements OAuthStateService {
 
     @Override
     public void deleteStateFromDatastore(String state) throws Exception {
+        DeleteObjectResponse deleteObjectResponse;
         try (S3Client s3 = this.createS3Client()) {
-            s3.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(getKey(state)).build());
+            deleteObjectResponse = s3.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(getKey(state)).build());
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("AWS S3 deleteObject result of state data - {}", deleteObjectResponse.toString());
         }
     }
 

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/FileInstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/FileInstallationService.java
@@ -18,6 +18,9 @@ import java.util.Optional;
 
 import static java.util.stream.Collectors.joining;
 
+/**
+ * InstallationService implementation using local file system.
+ */
 @Slf4j
 public class FileInstallationService implements InstallationService {
 
@@ -132,10 +135,12 @@ public class FileInstallationService implements InstallationService {
             if (json == null && enterpriseId != null) {
                 json = loadFileContent(getInstallerPath(null, teamId, userId));
                 if (json != null) {
-                    Installer i = JsonOps.fromJson(json, DefaultInstaller.class);
-                    i.setEnterpriseId(enterpriseId);
-                    save(getInstallerPath(enterpriseId, teamId, userId), i.getInstalledAt(), JsonOps.toJsonString(i));
-                    return i;
+                    Installer installer = JsonOps.fromJson(json, DefaultInstaller.class);
+                    installer.setEnterpriseId(enterpriseId);
+                    save(getInstallerPath(enterpriseId, teamId, userId),
+                        installer.getInstalledAt(),
+                        JsonOps.toJsonString(installer));
+                    return installer;
                 }
             }
             if (json != null) {
@@ -165,7 +170,7 @@ public class FileInstallationService implements InstallationService {
                     try {
                         Files.delete(path);
                     } catch (IOException e) {
-                        log.error("Failed to delete a file: {}", path.toString(), e);
+                        log.error("Failed to delete a file: {}", path, e);
                     }
                 }
             });
@@ -174,8 +179,10 @@ public class FileInstallationService implements InstallationService {
         }
     }
 
-    private String getInstallerPath(Installer i) throws IOException {
-        return getInstallerPath(i.getEnterpriseId(), i.getTeamId(), i.getInstallerUserId());
+    private String getInstallerPath(Installer installer) throws IOException {
+        return getInstallerPath(installer.getEnterpriseId(),
+            installer.getTeamId(),
+            installer.getInstallerUserId());
     }
 
     private String getInstallerPath(String enterpriseId, String teamId, String userId) throws IOException {

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/FileInstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/FileInstallationService.java
@@ -138,8 +138,8 @@ public class FileInstallationService implements InstallationService {
                     Installer installer = JsonOps.fromJson(json, DefaultInstaller.class);
                     installer.setEnterpriseId(enterpriseId);
                     save(getInstallerPath(enterpriseId, teamId, userId),
-                        installer.getInstalledAt(),
-                        JsonOps.toJsonString(installer));
+                            installer.getInstalledAt(),
+                            JsonOps.toJsonString(installer));
                     return installer;
                 }
             }
@@ -181,8 +181,8 @@ public class FileInstallationService implements InstallationService {
 
     private String getInstallerPath(Installer installer) throws IOException {
         return getInstallerPath(installer.getEnterpriseId(),
-            installer.getTeamId(),
-            installer.getInstallerUserId());
+                installer.getTeamId(),
+                installer.getInstallerUserId());
     }
 
     private String getInstallerPath(String enterpriseId, String teamId, String userId) throws IOException {
@@ -234,7 +234,7 @@ public class FileInstallationService implements InstallationService {
         String content = Files.readAllLines(Paths.get(filepath))
                 .stream()
                 .collect(joining());
-        if (content == null || content.trim().isEmpty() || content.trim().equals("null")) {
+        if (content.trim().isEmpty() || content.trim().equals("null")) {
             return null;
         }
         return content;

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/FileOAuthStateService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/FileOAuthStateService.java
@@ -66,8 +66,6 @@ public class FileOAuthStateService implements OAuthStateService {
             return Long.valueOf(value);
         } catch (IOException e) {
             return null;
-        } catch (NumberFormatException e) {
-            return null;
         }
     }
 

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/RedisInstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/RedisInstallationService.java
@@ -1,0 +1,209 @@
+package com.slack.api.bolt.service.builtin;
+
+import com.slack.api.bolt.Initializer;
+import com.slack.api.bolt.model.Bot;
+import com.slack.api.bolt.model.Installer;
+import com.slack.api.bolt.model.builtin.DefaultBot;
+import com.slack.api.bolt.model.builtin.DefaultInstaller;
+import com.slack.api.bolt.service.InstallationService;
+import com.slack.api.bolt.util.JsonOps;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Protocol.ResponseKeyword;
+
+/**
+ * InstallationService implementation using Redis (or ValKey)
+ *
+ * @see <a href="https://aws.amazon.com/elasticache/">Amazon ElastiCache</a>
+ */
+@Slf4j
+public class RedisInstallationService implements InstallationService {
+
+    private final JedisPool jedisPool;
+    private boolean historicalDataEnabled;
+
+    public RedisInstallationService(JedisPool jedisPool) {
+        this.jedisPool = jedisPool;
+    }
+
+    @Override
+    public Initializer initializer() {
+        return (app) -> {
+            try (Jedis jedis = jedisPool.getResource()) {
+                String pong = jedis.ping();
+                if (!pong.equals(ResponseKeyword.PONG.name())) {
+                    throw new IllegalStateException("Failed to ping redis");
+                }
+
+                log.debug("successfully initialized connection to redis");
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to access redis", e);
+            }
+        };
+    }
+
+    @Override
+    public boolean isHistoricalDataEnabled() {
+        return historicalDataEnabled;
+    }
+
+    @Override
+    public void setHistoricalDataEnabled(boolean isHistoricalDataEnabled) {
+        this.historicalDataEnabled = isHistoricalDataEnabled;
+    }
+
+    @Override
+    public void saveInstallerAndBot(Installer installer) throws Exception {
+        save(getInstallerPath(installer),
+                installer.getInstalledAt(),
+                JsonOps.toJsonString(installer));
+        save(getBotPath(installer.getEnterpriseId(), installer.getTeamId()),
+                installer.getInstalledAt(),
+                JsonOps.toJsonString(installer.toBot()));
+    }
+
+    @Override
+    public void saveBot(Bot bot) {
+        save(getBotPath(bot.getEnterpriseId(), bot.getTeamId()), bot.getInstalledAt(), JsonOps.toJsonString(bot));
+    }
+
+    @Override
+    public void deleteBot(Bot bot) throws Exception {
+        try (Jedis jedis = jedis()) {
+            jedis.del(getBotPath(bot.getEnterpriseId(), bot.getTeamId()));
+        }
+    }
+
+    @Override
+    public void deleteInstaller(Installer installer) throws Exception {
+        try (Jedis jedis = jedis()) {
+            jedis.del(getInstallerPath(installer));
+        }
+    }
+
+    @Override
+    public Bot findBot(String enterpriseId, String teamId) {
+        String json;
+        if (enterpriseId != null) {
+            // try finding org-level bot token first
+            json = loadRedisContent(getBotPath(enterpriseId, null));
+            if (json != null) {
+                return JsonOps.fromJson(json, DefaultBot.class);
+            }
+            // not found - going to find workspace level installation
+        }
+        json = loadRedisContent(getBotPath(enterpriseId, teamId));
+        if (json == null && enterpriseId != null) {
+            json = loadRedisContent(getBotPath(null, teamId));
+            if (json != null) {
+                Bot bot = JsonOps.fromJson(json, DefaultBot.class);
+                bot.setEnterpriseId(enterpriseId);
+                save(getBotPath(enterpriseId, teamId), bot.getInstalledAt(), JsonOps.toJsonString(bot));
+                return bot;
+            }
+        }
+        if (json == null) {
+            return null;
+        }
+        return JsonOps.fromJson(json, DefaultBot.class);
+    }
+
+    @Override
+    public Installer findInstaller(String enterpriseId, String teamId, String userId) {
+        String json;
+        if (enterpriseId != null) {
+            // try finding org-level user token first
+            json = loadRedisContent(getInstallerPath(enterpriseId, null, userId));
+            if (json != null) {
+                return JsonOps.fromJson(json, DefaultInstaller.class);
+            }
+            // not found - going to find workspace level installation
+        }
+        json = loadRedisContent(getInstallerPath(enterpriseId, teamId, userId));
+        if (json == null && enterpriseId != null) {
+            json = loadRedisContent(getInstallerPath(null, teamId, userId));
+            if (json != null) {
+                Installer installer = JsonOps.fromJson(json, DefaultInstaller.class);
+                installer.setEnterpriseId(enterpriseId);
+                save(getInstallerPath(enterpriseId, teamId, userId),
+                    installer.getInstalledAt(),
+                    JsonOps.toJsonString(installer));
+                return installer;
+            }
+        }
+        if (json == null) {
+            return null;
+        }
+        return JsonOps.fromJson(json, DefaultInstaller.class);
+    }
+
+    @Override
+    public void deleteAll(String enterpriseId, String teamId) {
+        String keyPrefix = Optional.ofNullable(enterpriseId).orElse("none")
+            + "-"
+            + Optional.ofNullable(teamId).orElse("none");
+        try (Jedis jedis = jedis()) {
+            jedis.keys(keyPrefix).forEach(jedis::del);
+        }
+    }
+
+    private String getInstallerPath(Installer installer) {
+        return getInstallerPath(installer.getEnterpriseId(),
+            installer.getTeamId(),
+            installer.getInstallerUserId());
+    }
+
+    private String getInstallerPath(String enterpriseId, String teamId, String userId) {
+        String key = Optional.ofNullable(enterpriseId).orElse("none")
+                + "-"
+                + Optional.ofNullable(teamId).orElse("none")
+                + "-"
+                + userId;
+        if (isHistoricalDataEnabled()) {
+            key = key + "-latest";
+        }
+        return "installer/" + key;
+    }
+
+    private String getBotPath(String enterpriseId, String teamId) {
+        String key = Optional.ofNullable(enterpriseId).orElse("none")
+                + "-"
+                + Optional.ofNullable(teamId).orElse("none");
+        if (isHistoricalDataEnabled()) {
+            key = key + "-latest";
+        }
+        return "bot/" + key;
+    }
+
+    private Jedis jedis() {
+        return jedisPool.getResource();
+    }
+
+    private void save(String path, Long installedAt, String json) {
+        try (Jedis jedis = jedis()) {
+            // latest
+            jedis.set(path, json);
+
+            if (isHistoricalDataEnabled()) {
+                // the historical data
+                jedis.set(path.replaceFirst("-latest$", "-" + installedAt), json);
+            }
+        }
+    }
+
+    private String loadRedisContent(String path) {
+        try (Jedis jedis = jedis()) {
+            if (!jedis.exists(path)) {
+                return null;
+            }
+            String content = jedis.get(path);
+            if (content.trim().isEmpty() || content.trim().equals("null")) {
+                return null;
+            }
+            return content;
+        }
+    }
+
+}

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/RedisInstallationService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/RedisInstallationService.java
@@ -128,8 +128,8 @@ public class RedisInstallationService implements InstallationService {
                 Installer installer = JsonOps.fromJson(json, DefaultInstaller.class);
                 installer.setEnterpriseId(enterpriseId);
                 save(getInstallerPath(enterpriseId, teamId, userId),
-                    installer.getInstalledAt(),
-                    JsonOps.toJsonString(installer));
+                        installer.getInstalledAt(),
+                        JsonOps.toJsonString(installer));
                 return installer;
             }
         }
@@ -142,8 +142,8 @@ public class RedisInstallationService implements InstallationService {
     @Override
     public void deleteAll(String enterpriseId, String teamId) {
         String keyPrefix = Optional.ofNullable(enterpriseId).orElse("none")
-            + "-"
-            + Optional.ofNullable(teamId).orElse("none");
+                + "-"
+                + Optional.ofNullable(teamId).orElse("none");
         try (Jedis jedis = jedis()) {
             jedis.keys(keyPrefix).forEach(jedis::del);
         }

--- a/bolt/src/main/java/com/slack/api/bolt/service/builtin/RedisOAuthStateService.java
+++ b/bolt/src/main/java/com/slack/api/bolt/service/builtin/RedisOAuthStateService.java
@@ -1,0 +1,73 @@
+package com.slack.api.bolt.service.builtin;
+
+import com.slack.api.bolt.Initializer;
+import com.slack.api.bolt.service.OAuthStateService;
+import lombok.extern.slf4j.Slf4j;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Protocol.ResponseKeyword;
+import redis.clients.jedis.params.SetParams;
+
+/**
+ * OAuthStateService implementation using Redis (or ValKey)
+ *
+ * @see <a href="https://aws.amazon.com/elasticache/">Amazon ElastiCache</a>
+ */
+@Slf4j
+public class RedisOAuthStateService implements OAuthStateService {
+
+    private final JedisPool jedisPool;
+
+    public RedisOAuthStateService(JedisPool jedisPool) {
+        this.jedisPool = jedisPool;
+    }
+
+    @Override
+    public Initializer initializer() {
+        return (app) -> {
+            try (Jedis jedis = jedisPool.getResource()) {
+                String pong = jedis.ping();
+                if (!pong.equals(ResponseKeyword.PONG.name())) {
+                    throw new IllegalStateException("Failed to ping redis");
+                }
+
+                log.debug("successfully initialized connection to redis");
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to access redis", e);
+            }
+        };
+    }
+
+    @Override
+    public void addNewStateToDatastore(String state) throws Exception {
+        try (Jedis jedis = jedis()) {
+            String key = getKey(state);
+            jedis.set(key, "", SetParams.setParams().ex(getExpirationInSeconds()));
+        }
+    }
+
+    @Override
+    public boolean isAvailableInDatabase(String state) {
+        try (Jedis jedis = jedis()) {
+            String key = getKey(state);
+            return jedis.exists(key);
+        }
+    }
+
+    @Override
+    public void deleteStateFromDatastore(String state) throws Exception {
+        try (Jedis jedis = jedis()) {
+            String key = getKey(state);
+            jedis.del(key);
+        }
+    }
+
+    Jedis jedis() {
+        return jedisPool.getResource();
+    }
+
+    String getKey(String state) {
+        return "state/" + state;
+    }
+
+}

--- a/bolt/src/test/java/test_locally/service/AmazonS3InstallationServiceTest.java
+++ b/bolt/src/test/java/test_locally/service/AmazonS3InstallationServiceTest.java
@@ -20,11 +20,14 @@ import static org.mockito.Mockito.*;
 public class AmazonS3InstallationServiceTest {
 
     static S3Client setupMocks(S3Client s3) {
-        when(s3.headBucket((HeadBucketRequest) notNull())).thenReturn(HeadBucketResponse.builder().build());
-        when(s3.headObject((HeadObjectRequest) notNull())).thenReturn(HeadObjectResponse.builder().build());
+        when(s3.headBucket((HeadBucketRequest) notNull()))
+            .thenReturn(HeadBucketResponse.builder().build());
+        when(s3.headObject((HeadObjectRequest) notNull()))
+            .thenReturn(HeadObjectResponse.builder().build());
         when(s3.getObject((GetObjectRequest) notNull(), (ResponseTransformer<GetObjectResponse, ResponseBytes<GetObjectResponse>>) notNull()))
-                .thenReturn(ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), "{}".getBytes(StandardCharsets.UTF_8)));
-        when(s3.putObject((PutObjectRequest) notNull(), (RequestBody) notNull())).thenReturn(PutObjectResponse.builder().build());
+            .thenReturn(ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), "{}".getBytes(StandardCharsets.UTF_8)));
+        when(s3.putObject((PutObjectRequest) notNull(), (RequestBody) notNull()))
+            .thenReturn(PutObjectResponse.builder().build());
         return s3;
     }
 

--- a/bolt/src/test/java/test_locally/service/AmazonS3InstallationServiceTest.java
+++ b/bolt/src/test/java/test_locally/service/AmazonS3InstallationServiceTest.java
@@ -21,13 +21,13 @@ public class AmazonS3InstallationServiceTest {
 
     static S3Client setupMocks(S3Client s3) {
         when(s3.headBucket((HeadBucketRequest) notNull()))
-            .thenReturn(HeadBucketResponse.builder().build());
+                .thenReturn(HeadBucketResponse.builder().build());
         when(s3.headObject((HeadObjectRequest) notNull()))
-            .thenReturn(HeadObjectResponse.builder().build());
+                .thenReturn(HeadObjectResponse.builder().build());
         when(s3.getObject((GetObjectRequest) notNull(), (ResponseTransformer<GetObjectResponse, ResponseBytes<GetObjectResponse>>) notNull()))
-            .thenReturn(ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), "{}".getBytes(StandardCharsets.UTF_8)));
+                .thenReturn(ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), "{}".getBytes(StandardCharsets.UTF_8)));
         when(s3.putObject((PutObjectRequest) notNull(), (RequestBody) notNull()))
-            .thenReturn(PutObjectResponse.builder().build());
+                .thenReturn(PutObjectResponse.builder().build());
         return s3;
     }
 

--- a/bolt/src/test/java/test_locally/service/AmazonS3OAuthStateServiceTest.java
+++ b/bolt/src/test/java/test_locally/service/AmazonS3OAuthStateServiceTest.java
@@ -10,18 +10,23 @@ import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
+import java.util.UUID;
 import java.nio.charset.StandardCharsets;
 
+import static junit.framework.TestCase.assertFalse;
 import static org.mockito.Mockito.*;
 
 public class AmazonS3OAuthStateServiceTest {
 
     static S3Client setupMocks(S3Client s3) {
-        when(s3.headBucket((HeadBucketRequest) notNull())).thenReturn(HeadBucketResponse.builder().build());
-        when(s3.headObject((HeadObjectRequest) notNull())).thenReturn(HeadObjectResponse.builder().build());
+        when(s3.headBucket((HeadBucketRequest) notNull()))
+            .thenReturn(HeadBucketResponse.builder().build());
         when(s3.getObject((GetObjectRequest) notNull(), (ResponseTransformer<GetObjectResponse, ResponseBytes<GetObjectResponse>>) notNull()))
-                .thenReturn(ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), "{}".getBytes(StandardCharsets.UTF_8)));
-        when(s3.putObject((PutObjectRequest) notNull(), (RequestBody) notNull())).thenReturn(PutObjectResponse.builder().build());
+            .thenReturn(ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), "42".getBytes(StandardCharsets.UTF_8)));
+        when(s3.putObject((PutObjectRequest) notNull(), (RequestBody) notNull()))
+            .thenReturn(PutObjectResponse.builder().build());
+        when(s3.deleteObject((DeleteObjectRequest) notNull()))
+            .thenReturn(DeleteObjectResponse.builder().build());
         return s3;
     }
 
@@ -81,9 +86,10 @@ public class AmazonS3OAuthStateServiceTest {
         };
         service.initializer().accept(null);
 
-        service.isAvailableInDatabase("foo");
-        service.addNewStateToDatastore("foo");
-        service.deleteStateFromDatastore("foo");
+        String uuid = UUID.randomUUID().toString();
+        assertFalse(service.isAvailableInDatabase(uuid));
+        service.addNewStateToDatastore(uuid);
+        service.deleteStateFromDatastore(uuid);
     }
 
 }

--- a/bolt/src/test/java/test_locally/service/AmazonS3OAuthStateServiceTest.java
+++ b/bolt/src/test/java/test_locally/service/AmazonS3OAuthStateServiceTest.java
@@ -20,13 +20,13 @@ public class AmazonS3OAuthStateServiceTest {
 
     static S3Client setupMocks(S3Client s3) {
         when(s3.headBucket((HeadBucketRequest) notNull()))
-            .thenReturn(HeadBucketResponse.builder().build());
+                .thenReturn(HeadBucketResponse.builder().build());
         when(s3.getObject((GetObjectRequest) notNull(), (ResponseTransformer<GetObjectResponse, ResponseBytes<GetObjectResponse>>) notNull()))
-            .thenReturn(ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), "42".getBytes(StandardCharsets.UTF_8)));
+                .thenReturn(ResponseBytes.fromByteArray(GetObjectResponse.builder().build(), "42".getBytes(StandardCharsets.UTF_8)));
         when(s3.putObject((PutObjectRequest) notNull(), (RequestBody) notNull()))
-            .thenReturn(PutObjectResponse.builder().build());
+                .thenReturn(PutObjectResponse.builder().build());
         when(s3.deleteObject((DeleteObjectRequest) notNull()))
-            .thenReturn(DeleteObjectResponse.builder().build());
+                .thenReturn(DeleteObjectResponse.builder().build());
         return s3;
     }
 

--- a/bolt/src/test/java/test_locally/service/FileOAuthStateServiceTest.java
+++ b/bolt/src/test/java/test_locally/service/FileOAuthStateServiceTest.java
@@ -2,7 +2,11 @@ package test_locally.service;
 
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.service.builtin.FileOAuthStateService;
+import java.util.UUID;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class FileOAuthStateServiceTest {
 
@@ -17,9 +21,12 @@ public class FileOAuthStateServiceTest {
         FileOAuthStateService service = new FileOAuthStateService(AppConfig.builder().build(), "target/files");
         service.initializer().accept(null);
 
-        service.isAvailableInDatabase("foo");
-        service.addNewStateToDatastore("foo");
-        service.deleteStateFromDatastore("foo");
+        String uuid = UUID.randomUUID().toString();
+        assertFalse(service.isAvailableInDatabase(uuid));
+        service.addNewStateToDatastore(uuid);
+        assertTrue(service.isAvailableInDatabase(uuid));
+        service.deleteStateFromDatastore(uuid);
+        assertFalse(service.isAvailableInDatabase(uuid));
     }
 
 }

--- a/bolt/src/test/java/test_locally/service/RedisInstallationServiceTest.java
+++ b/bolt/src/test/java/test_locally/service/RedisInstallationServiceTest.java
@@ -1,0 +1,82 @@
+package test_locally.service;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.slack.api.bolt.model.builtin.DefaultBot;
+import com.slack.api.bolt.model.builtin.DefaultInstaller;
+import com.slack.api.bolt.service.builtin.RedisInstallationService;
+import com.slack.api.bolt.service.builtin.RedisOAuthStateService;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Protocol.ResponseKeyword;
+
+public class RedisInstallationServiceTest {
+
+    static JedisPool setupJedisDongMock(JedisPool jedisPool) {
+        Jedis jedis = mock(Jedis.class);
+        when(jedis.ping()).thenReturn("DONG");
+        when(jedisPool.getResource()).thenReturn(jedis);
+        return jedisPool;
+    }
+
+    static JedisPool setupJedisPoolMock(JedisPool jedisPool) {
+        Jedis jedis = mock(Jedis.class);
+        when(jedis.ping()).thenReturn(ResponseKeyword.PONG.name());
+        when(jedis.exists(anyString())).thenReturn(true);
+        when(jedis.get(anyString())).thenReturn("{}");
+        when(jedis.set(anyString(), anyString())).thenReturn("{}");
+        when(jedis.del(anyString())).thenReturn(0L);
+        when(jedisPool.getResource()).thenReturn(jedis);
+        return jedisPool;
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void initializer_no_ping() {
+        JedisPool jedisPool = setupJedisDongMock(mock(JedisPool.class));
+        RedisOAuthStateService service = new RedisOAuthStateService(jedisPool);
+        service.initializer().accept(null);
+    }
+
+    @Test
+    public void initializer() {
+        JedisPool jedisPool = setupJedisPoolMock(mock(JedisPool.class));
+        RedisOAuthStateService service = new RedisOAuthStateService(jedisPool);
+        service.initializer().accept(null);
+    }
+
+    @Test
+    public void operations() throws Exception {
+        JedisPool jedisPool = setupJedisPoolMock(mock(JedisPool.class));
+        RedisInstallationService service = new RedisInstallationService(jedisPool);
+        service.initializer().accept(null);
+
+        service.saveInstallerAndBot(new DefaultInstaller());
+        service.deleteBot(new DefaultBot());
+        service.deleteInstaller(new DefaultInstaller());
+        service.findBot("E123", "T123");
+        service.findInstaller("E123", "T123", "U123");
+    }
+
+    @Test
+    public void operations_historical_data_enabled() throws Exception {
+        JedisPool jedisPool = setupJedisPoolMock(mock(JedisPool.class));
+        RedisInstallationService service = new RedisInstallationService(jedisPool);
+        service.setHistoricalDataEnabled(true);
+        service.initializer().accept(null);
+
+        service.saveInstallerAndBot(new DefaultInstaller());
+        service.deleteBot(new DefaultBot());
+        service.deleteInstaller(new DefaultInstaller());
+        assertNotNull(service.findBot(null, "T123"));
+        assertNotNull(service.findBot("E123", null));
+        assertNotNull(service.findBot("E123", "T123"));
+        assertNotNull(service.findInstaller(null, "T123", "U123"));
+        assertNotNull(service.findInstaller("E123", null, "U123"));
+        assertNotNull(service.findInstaller("E123", "T123", "U123"));
+    }
+
+}

--- a/bolt/src/test/java/test_locally/service/RedisOAuthStateServiceTest.java
+++ b/bolt/src/test/java/test_locally/service/RedisOAuthStateServiceTest.java
@@ -1,0 +1,59 @@
+package test_locally.service;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.slack.api.bolt.service.builtin.RedisOAuthStateService;
+import java.util.UUID;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Protocol.ResponseKeyword;
+
+public class RedisOAuthStateServiceTest {
+
+    static JedisPool setupJedisDongMock(JedisPool jedisPool) {
+        Jedis jedis = mock(Jedis.class);
+        when(jedis.ping()).thenReturn("DONG");
+        when(jedisPool.getResource()).thenReturn(jedis);
+        return jedisPool;
+    }
+
+    static JedisPool setupJedisPoolMock(JedisPool jedisPool) {
+        Jedis jedis = mock(Jedis.class);
+        when(jedis.ping()).thenReturn(ResponseKeyword.PONG.name());
+        when(jedis.exists(anyString())).thenReturn(false);
+        when(jedis.set(anyString(), anyString())).thenReturn("{}");
+        when(jedis.del(anyString())).thenReturn(0L);
+        when(jedisPool.getResource()).thenReturn(jedis);
+        return jedisPool;
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void initializer_no_ping() {
+        JedisPool jedisPool = setupJedisDongMock(mock(JedisPool.class));
+        RedisOAuthStateService service = new RedisOAuthStateService(jedisPool);
+        service.initializer().accept(null);
+    }
+
+    @Test
+    public void initializer() {
+        JedisPool jedisPool = setupJedisPoolMock(mock(JedisPool.class));
+        RedisOAuthStateService service = new RedisOAuthStateService(jedisPool);
+        service.initializer().accept(null);
+    }
+
+    @Test
+    public void operations() throws Exception {
+        JedisPool jedisPool = setupJedisPoolMock(mock(JedisPool.class));
+        RedisOAuthStateService service = new RedisOAuthStateService(jedisPool);
+        service.initializer().accept(null);
+
+        String uuid = UUID.randomUUID().toString();
+        service.isAvailableInDatabase(uuid);
+        service.addNewStateToDatastore(uuid);
+        service.deleteStateFromDatastore(uuid);
+    }
+
+}


### PR DESCRIPTION
Create a new Installation service and OAuth State service using Redis (or ValKey) storage.

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
