### PR TITLE
Upgrade gson to the latest version

### DIFF
--- a/bolt-http4k/pom.xml
+++ b/bolt-http4k/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <properties>
+        <!-- TODO: upgrade to 6.x -->
         <http4k.version>5.46.0.0</http4k.version>
         <!-- http4k 5.26+ no longer supports Java 1.8 -->
         <maven.compiler.source>11</maven.compiler.source>

--- a/bolt-ktor/pom.xml
+++ b/bolt-ktor/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
+        <!-- TODO: upgrade to 3.x -->
         <ktor.version>2.3.12</ktor.version>
     </properties>
 

--- a/bolt-micronaut/pom.xml
+++ b/bolt-micronaut/pom.xml
@@ -10,9 +10,9 @@
     </parent>
 
     <properties>
-        <micronaut.version>4.7.12</micronaut.version>
-        <micronaut-test-junit5.version>4.6.2</micronaut-test-junit5.version>
-        <micronaut-rxjava3.version>3.6.0</micronaut-rxjava3.version>
+        <micronaut.version>4.8.3</micronaut.version>
+        <micronaut-test-junit5.version>4.7.0</micronaut-test-junit5.version>
+        <micronaut-rxjava3.version>3.7.0</micronaut-rxjava3.version>
         <junit5-jupiter.version>5.11.4</junit5-jupiter.version>
         <!-- Note that upgrading this library breaks other dependency resolution -->
         <mockito-all.version>1.10.19</mockito-all.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <!-- We don't change the versions of servlet API interface to keep the backward compatibility with older versions of them -->
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <gson.version>2.11.0</gson.version>
+        <gson.version>2.12.1</gson.version>
         <!-- Upgrading to 2.0 for building this SDK modules should be safe enough,
           but we'll hold off the upgrade for a few weeks, just in case. -->
         <kotlin.version>1.9.24</kotlin.version>


### PR DESCRIPTION
This pull request upgrades gson library version to the latest one. This minor version upgrade does not bring any internal changes to our enhancement, but this affect user side dependencies, so we can release as a new minor version.

Additionaly, I've confirmed micronaut minor upgrade does not require any changes, so I've included the bump too. However, http4k and ktor major upgrades seem to require code changes. Thus, I didn't touch them this time.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
