### PR TITLE
[1452] simplify MethodsCompletionException implementation

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsCompletionException.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsCompletionException.java
@@ -1,27 +1,13 @@
 package com.slack.api.methods;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.extern.slf4j.Slf4j;
-
-import java.io.IOException;
 
 /**
  * Wrapped exception holding the cause exception occurred in AsyncMethodsClient
  */
-@Data
-@Slf4j
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
 public class MethodsCompletionException extends RuntimeException {
-
-    private final IOException ioException;
-    private final SlackApiException slackApiException;
-    private final Exception otherException;
-
-    public MethodsCompletionException(IOException ioException, SlackApiException slackApiException, Exception otherException) {
-        this.ioException = ioException;
-        this.slackApiException = slackApiException;
-        this.otherException = otherException;
+    public MethodsCompletionException(Exception cause) {
+        super(cause);
     }
-
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncRateLimitExecutor.java
@@ -130,7 +130,7 @@ public class AsyncRateLimitExecutor {
             return handleIOException(teamId, methodName, e);
         } catch (SlackApiException e) {
             logSlackApiException(teamId, methodName, e);
-            throw new MethodsCompletionException(null, e, null);
+            throw new MethodsCompletionException(e);
         }
     }
 
@@ -171,7 +171,7 @@ public class AsyncRateLimitExecutor {
             if (e.getResponse().code() == 429) {
                 return enqueueThenRun(messageId, teamId, methodName, params, methodsSupplier);
             }
-            throw new MethodsCompletionException(null, e, null);
+            throw new MethodsCompletionException(e);
         } catch (InterruptedException e) {
             log.error("Got an InterruptedException (error: {})", e.getMessage(), e);
             throw new RuntimeException(e);
@@ -180,12 +180,12 @@ public class AsyncRateLimitExecutor {
 
     private static <T extends SlackApiTextResponse> T handleRuntimeException(String teamId, String methodName, RuntimeException e) {
         log.error("Got an exception while calling {} API (team: {}, error: {})", methodName, teamId, e.getMessage(), e);
-        throw new MethodsCompletionException(null, null, e);
+        throw new MethodsCompletionException(e);
     }
 
     private static <T extends SlackApiTextResponse> T handleIOException(String teamId, String methodName, IOException e) {
         log.error("Failed to connect to {} API (team: {}, error: {})", methodName, teamId, e.getMessage(), e);
-        throw new MethodsCompletionException(e, null, null);
+        throw new MethodsCompletionException(e);
     }
 
     private static void logSlackApiException(String teamId, String methodName, SlackApiException e) {

--- a/slack-api-client/src/test/java/test_locally/api/methods/EqualityTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/EqualityTest.java
@@ -23,7 +23,6 @@ public class EqualityTest {
                 .message("")
                 .build();
 
-        assertEquals(new MethodsCompletionException(null, null, null), new MethodsCompletionException(null, null, null));
-        assertEquals(new SlackApiException(response, ""), new SlackApiException(response, ""));
+        assertEquals(new MethodsCompletionException(new SlackApiException(response, "")), new MethodsCompletionException(new SlackApiException(response, "")));
     }
 }

--- a/slack-api-client/src/test/java/test_locally/api/methods/ExceptionsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/ExceptionsTest.java
@@ -3,13 +3,17 @@ package test_locally.api.methods;
 import com.slack.api.methods.MethodsCompletionException;
 import org.junit.Test;
 
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class ExceptionsTest {
 
     @Test
     public void createMethodsCompletionException() {
-        MethodsCompletionException exception = new MethodsCompletionException(null, null, null);
+        MethodsCompletionException exception = new MethodsCompletionException(new IOException("IO error"));
         assertNotNull(exception);
+        assertEquals("IO error", exception.getMessage());
     }
 }


### PR DESCRIPTION
MethodsCompletionException is simplified

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [X] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)


