### PR TITLE
Pin GitHub Actions workflow step hashes and use minimum permission

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -5,23 +5,26 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**'
+      - "docs/**"
   push:
     branches:
       - main
     paths:
-      - 'docs/**'
+      - "docs/**"
   workflow_dispatch:
 
 jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm
@@ -82,7 +85,7 @@ jobs:
         working-directory: ./docs
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./docs/build
 
@@ -105,4 +108,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -17,7 +17,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9.1.0
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 10

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -4,18 +4,17 @@
 
 name: Close stale issues and PRs
 
-on: 
+on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 1'
-  
-permissions:
-  issues: write
-  pull-requests: write
+    - cron: "0 0 * * 1"
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
@@ -31,4 +30,3 @@ jobs:
           remove-stale-when-updated: true
           enable-statistics: true
           operations-per-run: 60
-

--- a/.github/workflows/unit-tests-jdk-14.yml
+++ b/.github/workflows/unit-tests-jdk-14.yml
@@ -2,7 +2,8 @@ name: JDK 14 Build & Tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -11,21 +12,24 @@ jobs:
     timeout-minutes: 12
     strategy:
       matrix:
-        java-version: ['14']
-
+        java-version: ["14"]
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
-    - name: Install JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ matrix.java-version }}
-        distribution: 'adopt'
-    - name: Run all tests
-      run: |
-        ./scripts/run_no_prep_tests.sh -ci
-      env:
-        SKIP_UNSTABLE_TESTS: 1
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install JDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: "adopt"
+      - name: Run all tests
+        run: |
+          ./scripts/run_no_prep_tests.sh -ci
+        env:
+          SKIP_UNSTABLE_TESTS: 1
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests-jdk-17.yml
+++ b/.github/workflows/unit-tests-jdk-17.yml
@@ -2,7 +2,8 @@ name: JDK 17 Build & Tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -11,17 +12,20 @@ jobs:
     timeout-minutes: 12
     strategy:
       matrix:
-        java-version: ['17']
-
+        java-version: ["17"]
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
-    - name: Install JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ matrix.java-version }}
-        distribution: 'adopt'
-    - name: Run all tests
-      run: |
-        ./scripts/run_no_prep_tests.sh -ci
-      env:
-        SKIP_UNSTABLE_TESTS: 1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install JDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: "adopt"
+      - name: Run all tests
+        run: |
+          ./scripts/run_no_prep_tests.sh -ci
+        env:
+          SKIP_UNSTABLE_TESTS: 1

--- a/.github/workflows/unit-tests-jdk-8.yml
+++ b/.github/workflows/unit-tests-jdk-8.yml
@@ -2,7 +2,8 @@ name: JDK 1.8 Build & Tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -11,20 +12,23 @@ jobs:
     timeout-minutes: 12
     strategy:
       matrix:
-        java-version: ['8']
-
+        java-version: ["8"]
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
-    - name: Install JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ matrix.java-version }}
-        distribution: 'adopt'
-    - name: Run all tests
-      run: |
-        if [ ${{ matrix.java-version }} == "8" ]; then
-          export TRAVIS_JDK=openjdk8
-        fi
-        ./scripts/run_no_prep_tests.sh -ci
-      env:
-        SKIP_UNSTABLE_TESTS: 1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install JDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: "adopt"
+      - name: Run all tests
+        run: |
+          if [ ${{ matrix.java-version }} == "8" ]; then
+            export TRAVIS_JDK=openjdk8
+          fi
+          ./scripts/run_no_prep_tests.sh -ci
+        env:
+          SKIP_UNSTABLE_TESTS: 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ A cheat-sheet:
 
 ## Running locally
 
-Docusaurus requires at least Node 18. You can update Node however you want. `nvm` is one way. 
+Docusaurus requires at least Node 18. You can update Node however you want. `nvm` is one way.
 
 Install `nvm` if you don't have it:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ A cheat-sheet:
 
 ## Running locally
 
-Docusaurus requires at least Node 18. You can update Node however you want. `nvm` is one way.
+Docusaurus requires at least Node 18. You can update Node however you want. `nvm` is one way. 
 
 Install `nvm` if you don't have it:
 


### PR DESCRIPTION
### Summary

This PR uses the wonderful [`zizmor`](https://github.com/zizmorcore/zizmor) tool to audit our own workflows and [`pinact`](https://github.com/suzuki-shunsuke/pinact) for pinned versioning 👾 

### Category

* [x] **Other**

### Reviewers

A similar audit can be performed with the `zizmor` tool:

```sh
$ zizmor .
...
No findings to report. Good job! (6 suppressed)
```

> The suppressed findings are expected permission blocks at the top-level of a workflow, but we set this for each job.

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
