### PR TITLE
Add web api response changes as of 2025-07-10

### DIFF
--- a/json-logs/raw/audit/v1/actions.json
+++ b/json-logs/raw/audit/v1/actions.json
@@ -257,7 +257,13 @@
       "search_query_audit_logs_export_completed",
       "search_query_audit_logs_export_downloaded",
       "search_query_audit_logs_export_deleted",
-      "audit_logs_ai_summary_generated"
+      "audit_logs_ai_summary_generated",
+      "pref.private_record_channel_retention_duration_changed",
+      "pref.private_record_channel_retention_changed",
+      "pref.private_record_channel_redaction_duration_changed",
+      "pref.public_record_channel_retention_duration_changed",
+      "pref.public_record_channel_retention_changed",
+      "pref.public_record_channel_redaction_duration_changed"
     ],
     "user": [
       "custom_tos_accepted",

--- a/json-logs/samples/api/admin.functions.list.json
+++ b/json-logs/samples/api/admin.functions.list.json
@@ -41,7 +41,11 @@
       "form_enabled": false,
       "date_released": 12345,
       "category_id": "A00000000",
-      "category_label": ""
+      "category_label": "",
+      "product_level_availability": {
+        "is_available": false,
+        "available_to": ""
+      }
     }
   ]
 }

--- a/json-logs/samples/api/files.completeUploadExternal.json
+++ b/json-logs/samples/api/files.completeUploadExternal.json
@@ -50,6 +50,19 @@
               "latest_reply": "0000000000.000000",
               "source": "",
               "is_silent_share": false
+            },
+            {
+              "reply_users": [
+                ""
+              ],
+              "reply_users_count": 12345,
+              "reply_count": 12345,
+              "ts": "0000000000.000000",
+              "channel_name": "",
+              "team_id": "T00000000",
+              "share_user_id": "U00000000",
+              "source": "",
+              "is_silent_share": false
             }
           ],
           "C00000001": [
@@ -65,6 +78,19 @@
               "share_user_id": "U00000000",
               "thread_ts": "0000000000.000000",
               "latest_reply": "0000000000.000000",
+              "source": "",
+              "is_silent_share": false
+            },
+            {
+              "reply_users": [
+                ""
+              ],
+              "reply_users_count": 12345,
+              "reply_count": 12345,
+              "ts": "0000000000.000000",
+              "channel_name": "",
+              "team_id": "T00000000",
+              "share_user_id": "U00000000",
               "source": "",
               "is_silent_share": false
             }

--- a/json-logs/samples/api/usergroups.create.json
+++ b/json-logs/samples/api/usergroups.create.json
@@ -28,7 +28,8 @@
     "users": [
       ""
     ],
-    "is_section": false
+    "is_section": false,
+    "is_idp_group": false
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/usergroups.list.json
+++ b/json-logs/samples/api/usergroups.list.json
@@ -32,7 +32,8 @@
         "U00000000"
       ],
       "user_count": 12345,
-      "is_section": false
+      "is_section": false,
+      "is_idp_group": false
     }
   ],
   "error": "",

--- a/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
@@ -164,6 +164,12 @@ public class Actions {
         public static final String pref_enterprise_search_connectors_changed = "pref.enterprise_search_connectors_changed";
         public static final String pref_enterprise_search_enabled_changed = "pref.enterprise_search_enabled_changed";
         public static final String pref_slack_ai_allow_translations_changed = "pref.slack_ai_allow_translations_changed";
+        public static final String pref_private_record_channel_retention_duration_changed = "pref.private_record_channel_retention_duration_changed";
+        public static final String pref_private_record_channel_retention_changed = "pref.private_record_channel_retention_changed";
+        public static final String pref_private_record_channel_redaction_duration_changed = "pref.private_record_channel_redaction_duration_changed";
+        public static final String pref_public_record_channel_retention_duration_changed = "pref.public_record_channel_retention_duration_changed";
+        public static final String pref_public_record_channel_retention_changed = "pref.public_record_channel_retention_changed";
+        public static final String pref_public_record_channel_redaction_duration_changed = "pref.public_record_channel_redaction_duration_changed";
         public static final String manual_export_downloaded = "manual_export_downloaded";
         public static final String manual_export_deleted = "manual_export_deleted";
         public static final String scheduled_export_downloaded = "scheduled_export_downloaded";

--- a/slack-api-model/src/main/java/com/slack/api/model/MatchedItem.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/MatchedItem.java
@@ -281,5 +281,6 @@ public class MatchedItem {
     private List<LayoutBlock> titleBlocks;
     private Double canvasReadtime;
     private String canvasCreatorId;
+    private String altTxt;
 
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/Usergroup.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/Usergroup.java
@@ -31,6 +31,8 @@ public class Usergroup {
     private String handle;
     @SerializedName("is_external")
     private boolean external;
+    @SerializedName("is_idp_group")
+    private boolean idpGroup;
     private boolean autoProvision;
     private Integer dateCreate;
     private Integer dateUpdate;

--- a/slack-api-model/src/main/java/com/slack/api/model/admin/AppFunction.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/admin/AppFunction.java
@@ -21,6 +21,7 @@ public class AppFunction {
     private Boolean formEnabled;
     private String categoryId;
     private String categoryLabel;
+    private ProductLevelAvailability productLevelAvailability;
 
     @Data
     public static class InputParameter {
@@ -38,5 +39,11 @@ public class AppFunction {
         private String title;
         private String description;
         private Boolean isRequired;
+    }
+
+    @Data
+    public static class ProductLevelAvailability {
+        private Boolean isAvailable;
+        private String availableTo;  // "std" etc.
     }
 }


### PR DESCRIPTION
This pull request adds a few API response data changes.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
