### PR TITLE
fix: bump jetty version

### DIFF
--- a/bolt-jetty/pom.xml
+++ b/bolt-jetty/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <jetty.version>9.4.56.v20240826</jetty.version>
+        <jetty.version>9.4.57.v20241219</jetty.version>
     </properties>
 
     <artifactId>bolt-jetty</artifactId>


### PR DESCRIPTION
 vulnerability in jetty `9.4.56` bumping to `9.4.57` should fix the issue

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [x] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
