### PR TITLE
fix: use central for publishing

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -89,8 +89,8 @@ Refer to the [README](https://github.com/slackapi/java-slack-sdk/blob/main/docs/
 * Make sure the account you are using has the permission to make releases [under com.slack groupId](https://central.sonatype.com/publishing/com.slack/users)
 
 Place `$HOME/.m2/settings.xml` with your Sonatype account information. 
-* Generate user token: https://central.sonatype.org/publish/generate-token/
-* Set the user token id/password: https://central.sonatype.org/publish/publish-manual/#signing-components
+* Generate user token: https://central.sonatype.org/publish/generate-portal-token/
+* Set the user token id/password: https://central.sonatype.org/publish/publish-portal-maven/#credentials
 
 ```xml
 <settings>
@@ -99,12 +99,7 @@ Place `$HOME/.m2/settings.xml` with your Sonatype account information.
     <server>
       <username>${your-username}</username>
       <password>${your-password}</password>
-      <id>sonatype-nexus-staging</id>
-    </server>
-    <server>
-      <username>${your-username}</username>
-      <password>${your-password}</password>
-      <id>sonatype-nexus-snapshots</id>
+      <id>central</id>
     </server>
   </servers>
   <pluginGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-versions-plugin.version>2.8.1</maven-versions-plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <dokka.version>1.6.10</dokka.version>
@@ -271,14 +271,14 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${nexus-staging-maven-plugin.version}</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>sonatype-nexus-staging</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <stagingProgressTimeoutMinutes>20</stagingProgressTimeoutMinutes>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <skipPublishing>false</skipPublishing> <!-- Set to true to perform a dry run without publishing -->
                         </configuration>
                     </plugin>
                     <plugin>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,6 +28,5 @@ else
     deploy \
     -P production-releases \
     -D maven.test.skip=true \
-    ${exclusion} \
-    nexus-staging:release
+    ${exclusion}
 fi


### PR DESCRIPTION
Following the [end of life of ossrh](https://central.sonatype.org/pages/ossrh-eol/) we were blocked from cutting releases. This PR aims update the publishing process by using [the recommended Maven plugin](https://central.sonatype.org/publish/publish-portal-maven/). It introduces changes to the release process that leverage [central-publishing-maven-plugin](https://central.sonatype.com/artifact/org.sonatype.central/central-publishing-maven-plugin) 

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
