### PR TITLE
Add "title" filed in ConversationsCanvasesCreateRequest

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -1927,6 +1927,7 @@ public class RequestFormBuilder {
     public static FormBody.Builder toForm(ConversationsCanvasesCreateRequest req) {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("channel_id", req.getChannelId(), form);
+        setIfNotNull("title", req.getTitle(), form);
         if (req.getDocumentContent() != null) {
             setIfNotNull("document_content", GSON.toJson(req.getDocumentContent()), form);
         } else if (req.getMarkdown() != null) {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/canvases/ConversationsCanvasesCreateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/conversations/canvases/ConversationsCanvasesCreateRequest.java
@@ -19,6 +19,8 @@ public class ConversationsCanvasesCreateRequest implements SlackApiRequest {
 
     private String channelId;
 
+    private String title;
+
     private String markdown;
     private CanvasDocumentContent documentContent;
 }


### PR DESCRIPTION
Issue:
https://github.com/slackapi/java-slack-sdk/issues/1501

Parameter "title" is missing in ConversationsCanvasesCreateRequest, though it's available in API.

In my project I need to create canvases with title, therefore I suggest to expose "title" parameter in the request

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
