### PR TITLE
Add web api response changes as of 24th September, 2025

### DIFF
--- a/json-logs/raw/audit/v1/actions.json
+++ b/json-logs/raw/audit/v1/actions.json
@@ -264,7 +264,8 @@
       "pref.public_record_channel_retention_duration_changed",
       "pref.public_record_channel_retention_changed",
       "pref.public_record_channel_redaction_duration_changed",
-      "pref.enterprise_search_connectors_config_changed"
+      "pref.enterprise_search_connectors_config_changed",
+      "search_query_audit_logs_max_rows_failure"
     ],
     "user": [
       "custom_tos_accepted",
@@ -320,7 +321,9 @@
       "app_agentforce_shareable_prompt_created",
       "app_agentforce_session_created_from_prompt_link",
       "app_agentforce_execute_slack_action",
-      "user_anomaly_event_reponse_allowlist_changed"
+      "user_anomaly_event_reponse_allowlist_changed",
+      "org_owner_created",
+      "slackbot_ai_shareable_prompt_created"
     ],
     "file": [
       "file_downloaded",
@@ -402,7 +405,12 @@
       "record_channel_channel_type_conversion",
       "featured_workflow_added",
       "featured_workflow_removed",
-      "channel_huddle_properties_updated"
+      "channel_huddle_properties_updated",
+      "channel_detail_flagged",
+      "channel_detail_flag_assignment",
+      "channel_detail_flag_unassignment",
+      "channel_detail_flag_moderated",
+      "channel_detail_flag_dismissed"
     ],
     "app": [
       "app_installed",
@@ -519,7 +527,8 @@
       "usergroup_updated",
       "usergroup_update_enqueued",
       "usergroup_section_updated",
-      "user_add_to_usergroup_failed"
+      "user_add_to_usergroup_failed",
+      "usergroup_anomaly_event_response_allowlist_changed"
     ],
     "role": [
       "role_assigned",
@@ -545,7 +554,8 @@
       "workflow_v2_published",
       "workflow_trigger_permission_set",
       "workflow_trigger_permission_added",
-      "workflow_trigger_permission_removed"
+      "workflow_trigger_permission_removed",
+      "workflow_trigger_suspicious_keyword"
     ],
     "canvas": [
       "canvas_access_added",
@@ -573,7 +583,8 @@
       "canvas_restricted_sharing_enabled",
       "canvas_restricted_sharing_disabled",
       "canvas_converted_to_standalone",
-      "canvas_quip_migration_undone"
+      "canvas_quip_migration_undone",
+      "slack_ai_canvas_content_generated"
     ],
     "function": [
       "function_distribution_permission_added",

--- a/json-logs/raw/audit/v1/schemas.json
+++ b/json-logs/raw/audit/v1/schemas.json
@@ -149,6 +149,23 @@
         "id": "string",
         "template_name": "string"
       }
+    },
+    {
+      "type": "workflow_v2",
+      "workflow_v2": {
+        "id": "string",
+        "app_id": "string",
+        "date_updated": "int",
+        "callback_id": "string",
+        "name": "string",
+        "updated_by": "string",
+        "template_id": "string",
+        "step_configuration": "vec\u003cdict\u003cstring, mixed\u003e\u003e",
+        "suspicious_keywords": "vec\u003cstring\u003e",
+        "trigger_name": "string",
+        "trigger_channels": "vec\u003cstring\u003e",
+        "trigger_configuration": "dict\u003cstring, mixed\u003e"
+      }
     }
   ]
 }

--- a/json-logs/samples/api/usergroups.create.json
+++ b/json-logs/samples/api/usergroups.create.json
@@ -30,7 +30,10 @@
     ],
     "is_section": false,
     "is_idp_group": false,
-    "is_visible": false
+    "is_visible": false,
+    "is_editing_restricted": false,
+    "is_membership_locked": false,
+    "is_org_level": false
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/usergroups.disable.json
+++ b/json-logs/samples/api/usergroups.disable.json
@@ -31,7 +31,10 @@
     ],
     "is_section": false,
     "is_idp_group": false,
-    "is_visible": false
+    "is_visible": false,
+    "is_editing_restricted": false,
+    "is_membership_locked": false,
+    "is_org_level": false
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/usergroups.enable.json
+++ b/json-logs/samples/api/usergroups.enable.json
@@ -30,7 +30,10 @@
     ],
     "is_section": false,
     "is_idp_group": false,
-    "is_visible": false
+    "is_visible": false,
+    "is_editing_restricted": false,
+    "is_membership_locked": false,
+    "is_org_level": false
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/usergroups.list.json
+++ b/json-logs/samples/api/usergroups.list.json
@@ -34,7 +34,10 @@
       "user_count": 12345,
       "is_section": false,
       "is_idp_group": false,
-      "is_visible": false
+      "is_visible": false,
+      "is_editing_restricted": false,
+      "is_membership_locked": false,
+      "is_org_level": false
     }
   ],
   "error": "",

--- a/json-logs/samples/api/usergroups.update.json
+++ b/json-logs/samples/api/usergroups.update.json
@@ -30,7 +30,10 @@
     ],
     "is_section": false,
     "is_idp_group": false,
-    "is_visible": false
+    "is_visible": false,
+    "is_editing_restricted": false,
+    "is_membership_locked": false,
+    "is_org_level": false
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/usergroups.users.update.json
+++ b/json-logs/samples/api/usergroups.users.update.json
@@ -30,7 +30,10 @@
     "channel_count": 12345,
     "is_section": false,
     "is_idp_group": false,
-    "is_visible": false
+    "is_visible": false,
+    "is_editing_restricted": false,
+    "is_membership_locked": false,
+    "is_org_level": false
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/users.conversations.json
+++ b/json-logs/samples/api/users.conversations.json
@@ -89,11 +89,6 @@
               "shared_ts": "0000000000.000000"
             },
             "is_disabled": false
-          },
-          {
-            "id": "",
-            "label": "",
-            "type": ""
           }
         ],
         "tabz": [
@@ -106,9 +101,6 @@
               "shared_ts": "0000000000.000000"
             },
             "is_disabled": false
-          },
-          {
-            "type": ""
           }
         ],
         "meeting_notes": {

--- a/json-logs/samples/audit/v1/schemas.json
+++ b/json-logs/samples/audit/v1/schemas.json
@@ -83,7 +83,11 @@
         "name": "",
         "updated_by": "",
         "step_configuration": "",
-        "template_id": ""
+        "template_id": "",
+        "suspicious_keywords": "",
+        "trigger_name": "",
+        "trigger_channels": "",
+        "trigger_configuration": ""
       },
       "template": {
         "id": "",

--- a/json-logs/samples/scim/v1/Users.json
+++ b/json-logs/samples/scim/v1/Users.json
@@ -40,15 +40,15 @@
       ],
       "photos": [
         {
-          "value": "https://www.example.com/",
-          "type": ""
-        },
-        {
           "value": "",
           "type": ""
         }
       ],
       "groups": [
+        {
+          "value": "S00000000",
+          "display": ""
+        },
         {
           "value": "",
           "display": ""

--- a/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
@@ -276,6 +276,7 @@ public class Actions {
         public static final String search_query_audit_logs_export_downloaded = "search_query_audit_logs_export_downloaded";
         public static final String search_query_audit_logs_export_deleted = "search_query_audit_logs_export_deleted";
         public static final String audit_logs_ai_summary_generated = "audit_logs_ai_summary_generated";
+        public static final String search_query_audit_logs_max_rows_failure = "search_query_audit_logs_max_rows_failure";
     }
 
     public static class User {
@@ -336,6 +337,8 @@ public class Actions {
         public static final String app_agentforce_session_created_from_prompt_link = "app_agentforce_session_created_from_prompt_link";
         public static final String app_agentforce_execute_slack_action = "app_agentforce_execute_slack_action";
         public static final String user_anomaly_event_reponse_allowlist_changed = "user_anomaly_event_reponse_allowlist_changed";
+        public static final String org_owner_created = "org_owner_created";
+        public static final String slackbot_ai_shareable_prompt_created = "slackbot_ai_shareable_prompt_created";
     }
 
     public static class File {
@@ -426,6 +429,11 @@ public class Actions {
         public static final String featured_workflow_added = "featured_workflow_added";
         public static final String featured_workflow_removed = "featured_workflow_removed";
         public static final String channel_huddle_properties_updated = "channel_huddle_properties_updated";
+        public static final String channel_detail_flagged = "channel_detail_flagged";
+        public static final String channel_detail_flag_assignment = "channel_detail_flag_assignment";
+        public static final String channel_detail_flag_unassignment = "channel_detail_flag_unassignment";
+        public static final String channel_detail_flag_moderated = "channel_detail_flag_moderated";
+        public static final String channel_detail_flag_dismissed = "channel_detail_flag_dismissed";
     }
 
     public static class App {
@@ -587,6 +595,7 @@ public class Actions {
         public static final String usergroup_update_enqueued = "usergroup_update_enqueued";
         public static final String usergroup_section_updated = "usergroup_section_updated";
         public static final String user_add_to_usergroup_failed = "user_add_to_usergroup_failed";
+        public static final String usergroup_anomaly_event_response_allowlist_changed = "usergroup_anomaly_event_response_allowlist_changed";
     }
 
     public static class AccountTypeRole {
@@ -618,6 +627,7 @@ public class Actions {
         public static final String workflow_trigger_permission_set = "workflow_trigger_permission_set";
         public static final String workflow_trigger_permission_added = "workflow_trigger_permission_added";
         public static final String workflow_trigger_permission_removed = "workflow_trigger_permission_removed";
+        public static final String workflow_trigger_suspicious_keyword = "workflow_trigger_suspicious_keyword";
     }
 
     public static class Canvas {
@@ -650,6 +660,7 @@ public class Actions {
         public static final String canvas_restricted_sharing_disabled = "canvas_restricted_sharing_disabled";
         public static final String canvas_converted_to_standalone = "canvas_converted_to_standalone";
         public static final String canvas_quip_migration_undone = "canvas_quip_migration_undone";
+        public static final String slack_ai_canvas_content_generated = "slack_ai_canvas_content_generated";
     }
 
     public static class Function {

--- a/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/response/SchemasResponse.java
@@ -153,6 +153,10 @@ public class SchemasResponse implements AuditApiResponse {
         private String updatedBy;
         private String stepConfiguration;
         private String templateId;
+        private String suspiciousKeywords;
+        private String triggerName;
+        private String triggerChannels;
+        private String triggerConfiguration;
     }
 
     @Data

--- a/slack-api-model/src/main/java/com/slack/api/model/Usergroup.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/Usergroup.java
@@ -47,6 +47,12 @@ public class Usergroup {
     private Integer channelCount;
     @SerializedName("is_visible")
     private boolean visible;
+    @SerializedName("is_editing_restricted")
+    private boolean editingRestricted;
+    @SerializedName("is_membership_locked")
+    private boolean membershipLocked;
+    @SerializedName("is_org_level")
+    private boolean orgLevel;
 
     @Data
     public static class Prefs {


### PR DESCRIPTION
This pull request updates web api responses based on the production e2e test results.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
