### PR TITLE
Update commons-text to 1.14.0 (CVE-2025-48924)

### DIFF
--- a/bolt/pom.xml
+++ b/bolt/pom.xml
@@ -17,7 +17,7 @@
     <url>${project.url}</url>
 
     <properties>
-        <commons-text.version>1.13.0</commons-text.version>
+        <commons-text.version>1.14.0</commons-text.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Changes

This PR updates the commons-text from 1.13.0 to 1.14.0.

Version 1.13.0 includes `commons-lang3:3.17` which contains a security vulnerability.
See: https://mvnrepository.com/artifact/org.apache.commons/commons-text/1.13.0

Version 1.14.0 patches this, by updating to `commons-lang3:3.18`.
See: https://mvnrepository.com/artifact/org.apache.commons/commons-text/1.14.0

### Short description of vulnerability
```
Uncontrolled Recursion vulnerability in Apache Commons Lang. 
This issue affects Apache Commons Lang: Starting with commons-lang:commons-lang 2.0 to 2.6, and, 
from org.apache.commons:commons-lang3 3.0 before 3.18.0. 
The methods ClassUtils.getClass(...) can throw StackOverflowError on very long inputs. 
Because an Error is usually not handled by applications and libraries, 
a StackOverflowError could cause an application to stop. 
Users are recommended to upgrade to version 3.18.0, which fixes the issue. 
Mend Note: The description of this vulnerability differs from MITRE.
```

For additional info, see [CVE-2025-48924](https://www.mend.io/vulnerability-database/CVE-2025-48924).

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)


