### PR TITLE
feat(model): add markdown block

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
@@ -87,6 +87,12 @@ public class Blocks {
         return configurator.configure(InputBlock.builder()).build();
     }
 
+    // MarkdownBlock
+
+    public static MarkdownBlock markdown(ModelConfigurator<MarkdownBlock.MarkdownBlockBuilder> configurator) {
+        return configurator.configure(MarkdownBlock.builder()).build();
+    }
+
     // RichTextBlock
 
     public static RichTextBlock richText(ModelConfigurator<RichTextBlock.RichTextBlockBuilder> configurator) {

--- a/slack-api-model/src/main/java/com/slack/api/model/block/MarkdownBlock.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/MarkdownBlock.java
@@ -1,0 +1,30 @@
+package com.slack.api.model.block;
+
+import com.slack.api.model.File;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://docs.slack.dev/reference/block-kit/blocks/markdown-block
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarkdownBlock implements LayoutBlock {
+    public static final String TYPE = "markdown";
+    /**
+     * The type of block. For a markdown block, type is always markdown.
+     */
+    private final String type = TYPE;
+    /**
+     * The standard markdown-formatted text. Limit 12,000 characters max.
+     */
+    private String text;
+    /**
+     * The block_id is ignored in markdown blocks and will not be retained.
+     */
+    private String blockId;
+}

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
@@ -51,6 +51,8 @@ public class GsonLayoutBlockFactory implements JsonDeserializer<LayoutBlock>, Js
                 return InputBlock.class;
             case HeaderBlock.TYPE:
                 return HeaderBlock.class;
+            case MarkdownBlock.TYPE:
+                return MarkdownBlock.class;
             case VideoBlock.TYPE:
                 return VideoBlock.class;
             case RichTextBlock.TYPE:

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -56,6 +56,20 @@ public class BlockKitTest {
     }
 
     @Test
+    public void parseMarkdownBlock() {
+        String blocks = "[{\n" +
+                "  \"type\": \"markdown\",\n" +
+                "  \"text\": \"**this is bold**\"\n" +
+                "}]";
+        String json = "{blocks: " + blocks + "}";
+        Message message = GsonFactory.createSnakeCase().fromJson(json, Message.class);
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getBlocks().size(), is(1));
+        MarkdownBlock markdownBlock = (MarkdownBlock) message.getBlocks().get(0);
+        assertThat(markdownBlock.getText(), is("**this is bold**"));
+    }
+
+    @Test
     public void parseMultiSelectOnes() {
         String blocks = "[\n" +
                 "    {\n" +

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -87,6 +87,11 @@ public class BlocksTest {
     }
 
     @Test
+    public void testMarkdown() {
+        assertThat(markdown(h -> h.text("**this is bold**")), is(notNullValue()));
+    }
+
+    @Test
     public void testRichText() {
         assertThat(richText(i -> i
                 .blockId("block-id")


### PR DESCRIPTION
This PR adds the [`markdown`](https://docs.slack.dev/reference/block-kit/blocks/markdown-block) block.

### Reviewers

The following code snippets can post markdown messages:

```java
import com.slack.api.model.block.Blocks.*;
import static com.slack.api.model.block.Blocks.*;

var markdownBlock = MarkdownBlock.builder()
    .text("**this is bold**")
    .build();
var response = slack.methods().chatPostMessage(r -> r.token(token).blocks(asBlocks(markdownBlock)).channel("C0123456789"));

var response2 = slack.methods().chatPostMessage(r -> r.token(token).blocks(asBlocks(markdown(m -> m.text("**epic**")))).channel("C0123456789"));
```

### Category

* [x] **slack-api-model** (Slack API Data Models)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
