### PR TITLE
feat: add markdown_text to chat.{postEphemeral,postMessage,scheduleMessage,update} api methods

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -1500,6 +1500,7 @@ public class RequestFormBuilder {
         warnIfEitherTextOrAttachmentFallbackIsMissing(
                 "chat.scheduleMessage",
                 req.getText(),
+                req.getMarkdownText(),
                 req.getAttachments(),
                 req.getAttachmentsAsString());
         FormBody.Builder form = new FormBody.Builder();
@@ -1531,6 +1532,7 @@ public class RequestFormBuilder {
             form.add("attachments", json);
         }
         setIfNotNull("link_names", req.isLinkNames(), form);
+        setIfNotNull("markdown_text", req.getMarkdownText(), form);
         setIfNotNull("parse", req.getParse(), form);
         setIfNotNull("reply_broadcast", req.isReplyBroadcast(), form);
         setIfNotNull("thread_ts", req.getThreadTs(), form);
@@ -1554,6 +1556,7 @@ public class RequestFormBuilder {
         warnIfEitherTextOrAttachmentFallbackIsMissing(
                 "chat.postEphemeral",
                 req.getText(),
+                req.getMarkdownText(),
                 req.getAttachments(),
                 req.getAttachmentsAsString());
         FormBody.Builder form = new FormBody.Builder();
@@ -1583,6 +1586,7 @@ public class RequestFormBuilder {
         setIfNotNull("icon_url", req.getIconUrl(), form);
         setIfNotNull("username", req.getUsername(), form);
         setIfNotNull("link_names", req.isLinkNames(), form);
+        setIfNotNull("markdown_text", req.getMarkdownText(), form);
         setIfNotNull("parse", req.getParse(), form);
         return form;
     }
@@ -1591,6 +1595,7 @@ public class RequestFormBuilder {
         warnIfEitherTextOrAttachmentFallbackIsMissing(
                 "chat.postMessage",
                 req.getText(),
+                req.getMarkdownText(),
                 req.getAttachments(),
                 req.getAttachmentsAsString());
         FormBody.Builder form = new FormBody.Builder();
@@ -1599,6 +1604,7 @@ public class RequestFormBuilder {
         setIfNotNull("text", req.getText(), form);
         setIfNotNull("parse", req.getParse(), form);
         setIfNotNull("link_names", req.isLinkNames(), form);
+        setIfNotNull("markdown_text", req.getMarkdownText(), form);
         setIfNotNull("mrkdwn", req.isMrkdwn(), form);
 
         if (req.getMetadataAsString() != null) {
@@ -1702,11 +1708,13 @@ public class RequestFormBuilder {
         warnIfEitherTextOrAttachmentFallbackIsMissing(
                 "chat.update",
                 req.getText(),
+                req.getMarkdownText(),
                 req.getAttachments(),
                 req.getAttachmentsAsString());
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("ts", req.getTs(), form);
         setIfNotNull("channel", req.getChannel(), form);
+        setIfNotNull("markdown_text", req.getMarkdownText(), form);
         setIfNotNull("text", req.getText(), form);
         setIfNotNull("parse", req.getParse(), form);
         setIfNotNull("link_names", req.isLinkNames(), form);
@@ -3153,6 +3161,7 @@ public class RequestFormBuilder {
     private static void warnIfEitherTextOrAttachmentFallbackIsMissing(
             String endpointName,
             String text,
+            String markdownText,
             List<Attachment> attachments,
             String attachmentsAsString) {
 
@@ -3165,8 +3174,8 @@ public class RequestFormBuilder {
                     endpointName,
                     Arrays.asList(GSON.fromJson(attachmentsAsString, Attachment[].class)));
         } else {
-            // when attachments do not exist, the top-level text is always required
-            if (text == null || text.trim().isEmpty()) {
+            // when attachments do not exist, the top-level text or markdown_text is always required
+            if ((text == null || text.trim().isEmpty()) && (markdownText == null || markdownText.trim().isEmpty())) {
                 log.warn(TEXT_WARN_MESSAGE_TEMPLATE, endpointName);
             }
         }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatPostEphemeralRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatPostEphemeralRequest.java
@@ -113,6 +113,11 @@ public class ChatPostEphemeralRequest implements SlackApiRequest {
     private boolean linkNames;
 
     /**
+     * Accepts message text formatted in markdown. This argument should not be used in conjunction with blocks or text. Limit this field to 12,000 characters.
+     */
+    private String markdownText;
+
+    /**
      * Change how messages are treated. Defaults to `none`. See [below](#formatting).
      */
     private String parse;

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatPostMessageRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatPostMessageRequest.java
@@ -54,6 +54,11 @@ public class ChatPostMessageRequest implements SlackApiRequest {
     private boolean linkNames;
 
     /**
+     * Accepts message text formatted in markdown. This argument should not be used in conjunction with blocks or text. Limit this field to 12,000 characters.
+     */
+    private String markdownText;
+
+    /**
      * JSON object with event_type and event_payload fields, presented as a URL-encoded string.
      * Metadata you post to Slack is accessible to any app or user who is a member of that workspace.
      */

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatScheduleMessageRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatScheduleMessageRequest.java
@@ -92,6 +92,11 @@ public class ChatScheduleMessageRequest implements SlackApiRequest {
     private boolean linkNames;
 
     /**
+     * Accepts message text formatted in markdown. This argument should not be used in conjunction with blocks or text. Limit this field to 12,000 characters.
+     */
+    private String markdownText;
+
+    /**
      * Change how messages are treated. Defaults to none. See below.
      */
     private String parse;

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUpdateRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/chat/ChatUpdateRequest.java
@@ -78,6 +78,11 @@ public class ChatUpdateRequest implements SlackApiRequest {
     }
 
     /**
+     * Accepts message text formatted in markdown. This argument should not be used in conjunction with blocks or text. Limit this field to 12,000 characters.
+     */
+    private String markdownText;
+
+    /**
      * JSON object with event_type and event_payload fields, presented as a URL-encoded string.
      * Metadata you post to Slack is accessible to any app or user who is a member of that workspace.
      */

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/chat_Test.java
@@ -201,6 +201,16 @@ public class chat_Test {
         assertThat(scopes, is(notNullValue()));
     }
 
+    @Test
+    public void postMessage_markdownText() throws Exception {
+        loadRandomChannelId();
+        ChatPostMessageResponse response = slack.methods(botToken).chatPostMessage(req -> req
+                .channel(randomChannelId)
+                .markdownText("**bold**"));
+        assertThat(response.getError(), is(nullValue()));
+        assertThat(response.getMessage().getText(), is("*bold*"));
+    }
+
     // https://github.com/slackapi/java-slack-sdk/issues/157
     @Test
     public void postMessage_blocksInAttachment_do_not_work_bot() throws Exception {
@@ -782,6 +792,19 @@ public class chat_Test {
     }
 
     @Test
+    public void chatUpdate_markdownText() throws IOException, SlackApiException {
+        loadRandomChannelId();
+        ChatPostMessageResponse creation = slack.methods(botToken)
+                .chatPostMessage(r -> r.channel(randomChannelId).text("plain"));
+        assertThat(creation.getError(), is(nullValue()));
+        assertThat(creation.getMessage().getText(), is("plain"));
+        ChatUpdateResponse modified = slack.methods(botToken)
+                .chatUpdate(r -> r.channel(randomChannelId).markdownText("**bold**").ts(creation.getTs()));
+        assertThat(modified.getError(), is(nullValue()));
+        assertThat(modified.getMessage().getText(), is("*bold*"));
+    }
+
+    @Test
     public void chatUpdateWithBotToken_issue_372() throws IOException, SlackApiException {
         loadRandomChannelId();
         ChatPostMessageResponse creation = slack.methods(botToken)
@@ -988,6 +1011,17 @@ public class chat_Test {
         assertThat(response.getError(), is(nullValue()));
     }
 
+    @Test
+    public void postEphemeral_markdownText() throws Exception {
+        loadRandomChannelId();
+        String userId = findUser();
+        ChatPostEphemeralResponse response = slack.methods(botToken).chatPostEphemeral(r -> r
+                .user(userId)
+                .channel(randomChannelId)
+                .markdownText("**bold**"));
+        assertThat(response.getError(), is(nullValue()));
+    }
+
     private String findUser() throws IOException, SlackApiException {
 
         String userId = null;
@@ -1043,10 +1077,15 @@ public class chat_Test {
                 .blocks(blocks));
         assertNull(message3.getError());
 
+        ChatScheduleMessageResponse message4 = slack.methods(botToken)
+                .chatScheduleMessage(r -> r.channel(randomChannelId).postAt(postAt)
+                .markdownText("**bold**"));
+        assertNull(message4.getError());
+
         ChatScheduledMessagesListResponse after = slack.methods(botToken)
                 .chatScheduledMessagesList(r -> r.limit(100));
         assertNull(after.getError());
-        assertTrue(after.getScheduledMessages().size() - before.getScheduledMessages().size() == 2);
+        assertTrue(after.getScheduledMessages().size() - before.getScheduledMessages().size() == 3);
     }
 
     @Test


### PR DESCRIPTION
This PR adds the `markdown_text` attribute to the following methods:

- [chat.postEphemeral](https://docs.slack.dev/reference/methods/chat.postEphemeral)
- [chat.postMessage](https://docs.slack.dev/reference/methods/chat.postMessage)
- [chat.scheduleMessage](https://docs.slack.dev/reference/methods/chat.scheduleMessage)
- [chat.update](https://docs.slack.dev/reference/methods/chat.update)

### Category

* [x] **bolt** (Bolt for Java)
* [x] **slack-api-model** (Slack API Data Models)

### Notes

These changes are surfaced with **bolt** too! Though I believe this builder pattern requires the `channel` be provided:

```java
ctx.say(r -> r.markdownText("**woah**").channel("C0123456789"));
```

https://github.com/slackapi/java-slack-sdk/blob/b08ba1248fc6857fdb70727e4cfa795cc5ab088b/bolt/src/main/java/com/slack/api/bolt/context/builtin/EventContext.java#L94-L105

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
