### PR TITLE
chore: Add .github/CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Salesforce Open Source project configuration
+# Learn more: https://github.com/salesforce/oss-template
+#ECCN:Open Source
+#GUSINFO:Open Source,Open Source Workflow
+
+# @slackapi/slack-platform-java
+# are code reviewers for all changes in this repo.
+* @slackapi/slack-platform-java
+
+# @slackapi/developer-education
+# are code reviewers for changes in the `/docs` directory.
+/docs/ @slackapi/developer-education


### PR DESCRIPTION
This pull request adds a `.github/CODEOWNERS` file to adhere to the Salesforce Open Source project requirements. 

I've also added the Education team for the `docs/` directory and comments to match https://github.com/slackapi/python-slack-sdk and other projects.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)
* [x] **Other**

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
