### PR TITLE
fix: Empty user list for updating usergroup users sets usergroup as having no members

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -3086,7 +3086,12 @@ public class RequestFormBuilder {
         FormBody.Builder form = new FormBody.Builder();
         setIfNotNull("usergroup", req.getUsergroup(), form);
         if (req.getUsers() != null) {
-            setIfNotNull("users", req.getUsers().stream().collect(joining(",")), form);
+            if (!req.getUsers().isEmpty()) {
+                setIfNotNull("users", req.getUsers().stream().collect(joining(",")), form);
+            }
+            else {
+                setIfNotNull("users", "[]", form);
+            }
         }
         setIfNotNull("include_count", req.isIncludeCount(), form);
         setIfNotNull("team_id", req.getTeamId(), form);

--- a/slack-api-client/src/test/java/test_locally/api/methods/UsergroupsTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/UsergroupsTest.java
@@ -7,6 +7,9 @@ import org.junit.Before;
 import org.junit.Test;
 import util.MockSlackApiServer;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static util.MockSlackApi.ValidToken;
@@ -44,6 +47,10 @@ public class UsergroupsTest {
                 .isOk(), is(true));
         assertThat(slack.methods(ValidToken).usergroupsUsersUpdate(r -> r.usergroup("xxx"))
                 .isOk(), is(true));
+        assertThat(slack.methods(ValidToken).usergroupsUsersUpdate(r -> r.usergroup("xxx").users(Stream.<String>of().collect(Collectors.toList())))
+                .isOk(), is(true));
+        assertThat(slack.methods(ValidToken).usergroupsUsersUpdate(r -> r.usergroup("xxx").users(Stream.of("user").collect(Collectors.toList())))
+                .isOk(), is(true));
     }
 
     @Test
@@ -61,6 +68,10 @@ public class UsergroupsTest {
         assertThat(slack.methodsAsync(ValidToken).usergroupsUsersList(r -> r.includeDisabled(true))
                 .get().isOk(), is(true));
         assertThat(slack.methodsAsync(ValidToken).usergroupsUsersUpdate(r -> r.usergroup("xxx"))
+                .get().isOk(), is(true));
+        assertThat(slack.methodsAsync(ValidToken).usergroupsUsersUpdate(r -> r.usergroup("xxx").users(Stream.<String>of().collect(Collectors.toList())))
+                .get().isOk(), is(true));
+        assertThat(slack.methodsAsync(ValidToken).usergroupsUsersUpdate(r -> r.usergroup("xxx").users(Stream.of("user").collect(Collectors.toList())))
                 .get().isOk(), is(true));
     }
 

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/usergroups_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/usergroups_Test.java
@@ -2,6 +2,7 @@ package test_with_remote_apis.methods;
 
 import com.slack.api.Slack;
 import com.slack.api.methods.request.usergroups.users.UsergroupsUsersListRequest;
+import com.slack.api.methods.request.usergroups.users.UsergroupsUsersUpdateRequest;
 import com.slack.api.methods.response.usergroups.*;
 import com.slack.api.methods.response.usergroups.users.UsergroupsUsersListResponse;
 import com.slack.api.methods.response.usergroups.users.UsergroupsUsersUpdateResponse;
@@ -17,6 +18,8 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -145,6 +148,42 @@ public class usergroups_Test {
 //            assertThat(response.getError(), is("missing_required_argument"));
         // As of 2018/05, the error message has been changed
         assertThat(response.getError(), is("no_such_subteam"));
+    }
+
+    @Test
+    public void usergroups_users_update_null_property() throws Exception {
+        UsergroupsCreateResponse creation = slack.methods().usergroupsCreate(r -> r
+                .token(userToken)
+                .name("usergroup-" + System.currentTimeMillis())
+                .description("Something wrong"));
+        assertThat(creation.getError(), is(nullValue()));
+        final Usergroup usergroup = creation.getUsergroup();
+
+        UsergroupsUsersUpdateResponse response = slack.methods().usergroupsUsersUpdate(
+                UsergroupsUsersUpdateRequest.builder()
+                        .token(userToken)
+                        .usergroup(usergroup.getId())
+                        .build());
+        assertThat(response.isOk(), is(false));
+        assertThat(response.getError(), is("missing_required_argument"));
+    }
+
+    @Test
+    public void usergroups_users_update_empty_list() throws Exception {
+        UsergroupsCreateResponse creation = slack.methods().usergroupsCreate(r -> r
+                .token(userToken)
+                .name("usergroup-" + System.currentTimeMillis())
+                .description("Should have 0 members"));
+        assertThat(creation.getError(), is(nullValue()));
+        final Usergroup usergroup = creation.getUsergroup();
+
+        UsergroupsUsersUpdateResponse response = slack.methods().usergroupsUsersUpdate(
+                UsergroupsUsersUpdateRequest.builder()
+                        .token(userToken)
+                        .usergroup(usergroup.getId())
+                        .users(Stream.<String>of().collect(Collectors.toList()))
+                        .build());
+        assertThat(response.getError(), is(nullValue()));
     }
 
 }


### PR DESCRIPTION
Currently when an empty list is provided within `UsergroupsUsersUpdateRequest`, it is sent in the request as `users=`, which is not supported by the Slack API to denote a usergroup as having 0 members. This adds a case for checking an empty list, and using the accepted value of `[]` in the request if so.

Fixes #1573.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
