### PR TITLE
feat: add highlight_type to files.completeUploadExternal and filesUploadV2

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -2520,6 +2520,7 @@ public class MethodsClientImpl implements MethodsClient {
                     FilesCompleteUploadExternalRequest.FileDetails file = new FilesCompleteUploadExternalRequest.FileDetails();
                     file.setId(fileId);
                     file.setTitle(uploadFile.getTitle());
+                    file.setHighlightType(uploadFile.getHighlightType());
 
                     files.add(file);
                 }
@@ -2542,12 +2543,14 @@ public class MethodsClientImpl implements MethodsClient {
 
                 uploadFile.setAltTxt(req.getAltTxt());
                 uploadFile.setSnippetType(req.getSnippetType());
+                uploadFile.setHighlightType(req.getHighlightType());
 
                 String fileId = helper.uploadFile(req, uploadFile);
 
                 FilesCompleteUploadExternalRequest.FileDetails file = new FilesCompleteUploadExternalRequest.FileDetails();
                 file.setId(fileId);
                 file.setTitle(uploadFile.getTitle());
+                file.setHighlightType(uploadFile.getHighlightType());
                 files.add(file);
             }
             return helper.completeUploads(req, files);

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -2543,14 +2543,13 @@ public class MethodsClientImpl implements MethodsClient {
 
                 uploadFile.setAltTxt(req.getAltTxt());
                 uploadFile.setSnippetType(req.getSnippetType());
-                uploadFile.setHighlightType(req.getHighlightType());
 
                 String fileId = helper.uploadFile(req, uploadFile);
 
                 FilesCompleteUploadExternalRequest.FileDetails file = new FilesCompleteUploadExternalRequest.FileDetails();
                 file.setId(fileId);
                 file.setTitle(uploadFile.getTitle());
-                file.setHighlightType(uploadFile.getHighlightType());
+                file.setHighlightType(req.getHighlightType());
                 files.add(file);
             }
             return helper.completeUploads(req, files);

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesCompleteUploadExternalRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesCompleteUploadExternalRequest.java
@@ -53,7 +53,10 @@ public class FilesCompleteUploadExternalRequest implements SlackApiRequest {
     public static class FileDetails {
         private String id; // required
         private String title; // optional
-        private String highlightType; // optional - file type hint for optimistic rendering
+        /**
+         * Optional highlight type hint for the file. The upload processing job may overwrite this value.
+         */
+        private String highlightType;
     }
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesCompleteUploadExternalRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesCompleteUploadExternalRequest.java
@@ -53,6 +53,7 @@ public class FilesCompleteUploadExternalRequest implements SlackApiRequest {
     public static class FileDetails {
         private String id; // required
         private String title; // optional
+        private String highlightType; // optional - file type hint for optimistic rendering
     }
 
 }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadV2Request.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadV2Request.java
@@ -71,7 +71,7 @@ public class FilesUploadV2Request implements SlackApiRequest {
      */
     private String snippetType;
     /**
-     * File type hint for optimistic rendering (e.g. "png", "jpg", "gif").
+     * Optional highlight type hint for the file. The upload processing job may overwrite this value.
      * (this is mainly for backward compatibility - using uploadFiles instead is recommended)
      */
     private String highlightType;
@@ -119,7 +119,7 @@ public class FilesUploadV2Request implements SlackApiRequest {
          */
         private String snippetType;
         /**
-         * File type hint for optimistic rendering (e.g. "png", "jpg", "gif").
+         * Optional highlight type hint for the file. The upload processing job may overwrite this value.
          */
         private String highlightType;
     }

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadV2Request.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadV2Request.java
@@ -70,6 +70,11 @@ public class FilesUploadV2Request implements SlackApiRequest {
      * (this is mainly for backward compatibility - using uploadFiles instead is recommended)
      */
     private String snippetType;
+    /**
+     * File type hint for optimistic rendering (e.g. "png", "jpg", "gif").
+     * (this is mainly for backward compatibility - using uploadFiles instead is recommended)
+     */
+    private String highlightType;
 
     /**
      * Fetches all the file metadata for better v1 compatibility when this property is true.
@@ -113,6 +118,10 @@ public class FilesUploadV2Request implements SlackApiRequest {
          * Syntax type of the snippet being uploaded.
          */
         private String snippetType;
+        /**
+         * File type hint for optimistic rendering (e.g. "png", "jpg", "gif").
+         */
+        private String highlightType;
     }
 
     /**


### PR DESCRIPTION
This pull request adds `highlight_type` support to `files.completeUploadExternal` and the `filesUploadV2` method.

The `highlight_type` parameter allows specifying the file type hint for uploads (e.g. `png`, `jpg`, `gif`), enabling optimistic rendering before the async upload processing job completes.

📚 https://docs.slack.dev/reference/methods/files.completeUploadExternal

#### Changes

- Added `highlightType` to `FilesCompleteUploadExternalRequest.FileDetails` (per-file in the `files` array)
- Added `highlightType` to `FilesUploadV2Request` (top-level for single-file uploads) and `FilesUploadV2Request.UploadFile` (for multi-file uploads)
- Updated `MethodsClientImpl.filesUploadV2` to pass `highlightType` through to each `FileDetails` object in the completion step

#### Usage

```java
import com.slack.api.Slack;
import com.slack.api.methods.response.files.FilesUploadV2Response;

Slack slack = Slack.getInstance();

// Single file upload with highlight_type
FilesUploadV2Response response = slack.methods(token).filesUploadV2(r -> r
    .channel("C0123456789")
    .file(new File("./image.png"))
    .filename("image.png")
    .title("Image Upload")
    .highlightType("png")
    .initialComment("Uploaded with highlight_type for optimistic rendering")
);

// Multiple file uploads with highlight_type
FilesUploadV2Response response = slack.methods(token).filesUploadV2(r -> r
    .channel("C0123456789")
    .uploadFiles(Arrays.asList(
        FilesUploadV2Request.UploadFile.builder()
            .file(new File("./photo.jpg"))
            .filename("photo.jpg")
            .title("Photo")
            .highlightType("jpg")
            .build(),
        FilesUploadV2Request.UploadFile.builder()
            .file(new File("./diagram.png"))
            .filename("diagram.png")
            .title("Diagram")
            .highlightType("png")
            .build()
    ))
    .initialComment("Multiple files with highlight_type")
);
```

#### Related PRs

- Node SDK: https://github.com/slackapi/node-slack-sdk/pull/2594
- Python SDK: https://github.com/slackapi/python-slack-sdk/pull/1875

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.