### PR TITLE
docs: removing external links for unified nav

### DIFF
--- a/docs/english/_sidebar.json
+++ b/docs/english/_sidebar.json
@@ -137,21 +137,5 @@
 			},
 			"tools/java-slack-sdk/ja-jp/reference"
 		]
-	},
-	{ "type": "html", "value": "<hr>" },
-	{
-		"type": "link",
-		"label": "Release notes",
-		"href": "https://github.com/SlackAPI/java-slack-sdk/releases"
-	},
-	{
-		"type": "link",
-		"label": "Code on GitHub",
-		"href": "https://github.com/SlackAPI/java-slack-sdk"
-	},
-	{
-		"type": "link",
-		"label": "Contributors Guide",
-		"href": "https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md"
 	}
 ]

--- a/docs/english/index.md
+++ b/docs/english/index.md
@@ -24,6 +24,10 @@ If you get stuck, we're here to help. The following are the best ways to get ass
 * Visit the [Slack Developer Community](https://slackcommunity.com/) for getting help or for bonding with your fellow Slack developers.
 * [Email](mailto:support@slack.com) our developer support team: `support@slack.com`.
 
+## Release notes
+
+Check out the [Java Slack SDK release notes](https://github.com/SlackAPI/java-slack-sdk/releases) for all the latest happenings.
+
 ## Contributing
 
 These docs live within the [Java Slack SDK](https://github.com/slackapi/java-slack-sdk/) repository and are open source.


### PR DESCRIPTION
I'm working on uniting the nav bar for all of the tools so that you don't lose the context of the rest of the nav when you click on one of the tools. In this PR, I'm removing the external links (release notes, github repo, contributor's guide) to cut down on bloat in the nav menu when they are all united. Since the github repo and contributor's guide are already mentioned in the landing page, I just added the release notes link to that. 

Preview for one nav here: https://docs-slack-d-unified-na-idfrpr.herokuapp.com/tools
PR for unified nav here: https://github.com/slackapi/docs/pull/605

### Category (place an `x` in each of the `[ ]`)

* [x] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
