### PR TITLE
docs: clarify thread_ts is optional for assistant.threads.setSuggestedPrompts

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/request/assistant/threads/AssistantThreadsSetSuggestedPromptsRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/assistant/threads/AssistantThreadsSetSuggestedPromptsRequest.java
@@ -24,7 +24,7 @@ public class AssistantThreadsSetSuggestedPromptsRequest implements SlackApiReque
     private String channelId;
 
     /**
-     * Message timestamp of the thread of where to set the status.
+     * Message timestamp of the thread. Optional.
      */
     private String threadTs;
 


### PR DESCRIPTION
This pull request clarifies that the `thread_ts` argument of `assistant.threads.setSuggestedPrompts` is optional.

- `thread_ts` is no longer required by the API. In the Messages tab agent experience, suggested prompts live at the top of the Messages tab rather than within a thread, so a `thread_ts` is not needed.
- `AssistantThreadsSetSuggestedPromptsRequest.threadTs` is a Lombok builder field already sent via `setIfNotNull`, so it was already optional at runtime — this updates the Javadoc to say so.
- Removes a stale copy-paste reference to "where to set the status" (carried over from `setStatus`).

### Category

* [x] **slack-api-client** (Slack API Clients)

## Requirements

I've read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).