### PR TITLE
feat(model): add minLines/maxLines to RichTextInputElement

### DIFF
--- a/json-logs/samples/api/views.open.json
+++ b/json-logs/samples/api/views.open.json
@@ -2421,7 +2421,9 @@
             "type": "plain_text",
             "text": "",
             "emoji": false
-          }
+          },
+          "min_lines": 123,
+          "max_lines": 123
         },
         "dispatch_action": false,
         "hint": {

--- a/json-logs/samples/api/views.publish.json
+++ b/json-logs/samples/api/views.publish.json
@@ -2421,7 +2421,9 @@
             "type": "plain_text",
             "text": "",
             "emoji": false
-          }
+          },
+          "min_lines": 123,
+          "max_lines": 123
         },
         "dispatch_action": false,
         "hint": {

--- a/json-logs/samples/api/views.push.json
+++ b/json-logs/samples/api/views.push.json
@@ -2421,7 +2421,9 @@
             "type": "plain_text",
             "text": "",
             "emoji": false
-          }
+          },
+          "min_lines": 123,
+          "max_lines": 123
         },
         "dispatch_action": false,
         "hint": {

--- a/json-logs/samples/api/views.update.json
+++ b/json-logs/samples/api/views.update.json
@@ -2421,7 +2421,9 @@
             "type": "plain_text",
             "text": "",
             "emoji": false
-          }
+          },
+          "min_lines": 123,
+          "max_lines": 123
         },
         "dispatch_action": false,
         "hint": {

--- a/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
+++ b/slack-api-client/src/test/java/util/sample_json_generation/SampleObjects.java
@@ -253,6 +253,8 @@ public class SampleObjects {
             .placeholder(initProperties(PlainTextObject.builder().build()))
             .initialValue(RichTextBlock)
             .dispatchActionConfig(initProperties(DispatchActionConfig.builder().triggerActionsOn(Arrays.asList("")).build()))
+            .minLines(3)
+            .maxLines(20)
             .build());
 
     public static RadioButtonsElement radioButtonsElement = initProperties(RadioButtonsElement.builder()

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/RichTextInputElementBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/element/RichTextInputElementBuilder.kt
@@ -15,6 +15,8 @@ class RichTextInputElementBuilder : Builder<RichTextInputElement> {
     private var initialValue: RichTextBlock? = null
     private var dispatchActionConfig: DispatchActionConfig? = null
     private var _focusOnLoad: Boolean? = null
+    private var minLines: Int? = null
+    private var maxLines: Int? = null
 
     /**
      * An identifier for the input value when the parent modal is submitted. You can use this when you receive a
@@ -62,6 +64,25 @@ class RichTextInputElementBuilder : Builder<RichTextInputElement> {
         _focusOnLoad = focusOnLoad
     }
 
+    /**
+     * The minimum number of lines of text shown in the input. Must be between 1 and 100.
+     *
+     * @see <a href="https://docs.slack.dev/reference/block-kit/block-elements/rich-text-input-element/">Rich text input documentation</a>
+     */
+    fun minLines(lines: Int) {
+        minLines = lines
+    }
+
+    /**
+     * The maximum number of lines of text shown in the input before it scrolls.
+     * Must be between 1 and 100. Defaults to 8 when not specified.
+     *
+     * @see <a href="https://docs.slack.dev/reference/block-kit/block-elements/rich-text-input-element/">Rich text input documentation</a>
+     */
+    fun maxLines(lines: Int) {
+        maxLines = lines
+    }
+
     override fun build(): RichTextInputElement {
         return RichTextInputElement.builder()
             .actionId(actionId)
@@ -69,6 +90,8 @@ class RichTextInputElementBuilder : Builder<RichTextInputElement> {
             .initialValue(initialValue)
             .dispatchActionConfig(dispatchActionConfig)
             .focusOnLoad(_focusOnLoad)
+            .minLines(minLines)
+            .maxLines(maxLines)
             .build()
     }
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextInputElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/RichTextInputElement.java
@@ -47,4 +47,15 @@ public class RichTextInputElement extends BlockElement {
      * Maximum length for the text in this field is 150 characters.
      */
     private PlainTextObject placeholder;
+
+    /**
+     * The minimum number of lines of text shown in the input. Must be between 1 and 100.
+     */
+    private Integer minLines;
+
+    /**
+     * The maximum number of lines of text shown in the input before it scrolls.
+     * Must be between 1 and 100. Defaults to 8 when not specified.
+     */
+    private Integer maxLines;
 }


### PR DESCRIPTION
### Summary
Adds optional `minLines` and `maxLines` Integer fields to the `RichTextInputElement` Block Kit model, allowing developers to control the visible height of `rich_text_input` elements.

- `minLines` → `min_lines` in JSON — minimum number of visible lines (1–100)
- `maxLines` → `max_lines` in JSON — maximum number of visible lines before scrolling (1–100, defaults to 8 on the platform when unset)

Both fields are optional (nullable `Integer`), preserving full backward compatibility. The Kotlin DSL builder is also updated.

### Testing
<details><summary> Test App.java</summary>


```java
package blockkit;

import com.slack.api.bolt.AppConfig;
import com.slack.api.bolt.socket_mode.SocketModeApp;
import com.slack.api.model.block.element.RichTextInputElement;

import static com.slack.api.model.block.Blocks.*;
import static com.slack.api.model.block.composition.BlockCompositions.plainText;
import static com.slack.api.model.view.Views.*;

public class App {

    public static void main(String[] args) throws Exception {
        var app = new com.slack.api.bolt.App(AppConfig.builder()
                .singleTeamBotToken(System.getenv("SLACK_BOT_TOKEN"))
                .build());

        // /test-rich-text — opens a modal with rich_text_input elements using min_lines/max_lines
        app.command("/test-rich-text", (req, ctx) -> {
            ctx.client().viewsOpen(r -> r
                    .triggerId(req.getPayload().getTriggerId())
                    .view(view(v -> v
                            .type("modal")
                            .title(viewTitle(vt -> vt.type("plain_text").text("Rich Text Test")))
                            .submit(viewSubmit(vs -> vs.type("plain_text").text("Submit")))
                            .blocks(asBlocks(
                                    input(i -> i
                                            .blockId("rich_text_block")
                                            .label(plainText("Default (no min/max — should be 8 max)"))
                                            .element(RichTextInputElement.builder()
                                                    .actionId("default_input")
                                                    .build())
                                    ),
                                    input(i -> i
                                            .blockId("rich_text_min_block")
                                            .label(plainText("min_lines: 5"))
                                            .element(RichTextInputElement.builder()
                                                    .actionId("min_input")
                                                    .minLines(5)
                                                    .build())
                                    ),
                                    input(i -> i
                                            .blockId("rich_text_max_block")
                                            .label(plainText("max_lines: 16"))
                                            .element(RichTextInputElement.builder()
                                                    .actionId("max_input")
                                                    .maxLines(16)
                                                    .build())
                                    ),
                                    input(i -> i
                                            .blockId("rich_text_both_block")
                                            .label(plainText("min_lines: 3, max_lines: 20"))
                                            .element(RichTextInputElement.builder()
                                                    .actionId("both_input")
                                                    .minLines(3)
                                                    .maxLines(20)
                                                    .build())
                                    )
                            ))
                    ))
            );
            return ctx.ack();
        });

        String appToken = System.getenv("SLACK_APP_TOKEN");
        SocketModeApp socketModeApp = new SocketModeApp(appToken, app);
        socketModeApp.start();
    }
}
```


</details>

### Category

* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.