### PR TITLE
test: exercise number/date/rating list columns for options property detection

### DIFF
--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/slacklists_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/slacklists_Test.java
@@ -63,10 +63,35 @@ public class slacklists_Test {
                 .primaryColumn(true)
                 .build();
 
+        // A date column with a dateFormat option so the response echoes back date_format
         ListColumn dueDateCol = ListColumn.builder()
                 .key("due_date")
                 .name("Due Date")
                 .type("date")
+                .options(ListColumnOptions.builder()
+                        .dateFormat("MM/DD/YYYY")
+                        .build())
+                .build();
+
+        // A number column with precision so the response echoes back precision
+        ListColumn estimateCol = ListColumn.builder()
+                .key("estimate")
+                .name("Estimate")
+                .type("number")
+                .options(ListColumnOptions.builder()
+                        .precision(2)
+                        .build())
+                .build();
+
+        // A rating column with emoji/max so the response echoes back emoji and max
+        ListColumn ratingCol = ListColumn.builder()
+                .key("priority")
+                .name("Priority")
+                .type("rating")
+                .options(ListColumnOptions.builder()
+                        .emoji(":star:")
+                        .max(5)
+                        .build())
                 .build();
 
         ListColumnOptions.Choice choice1 = ListColumnOptions.Choice.builder()
@@ -115,7 +140,7 @@ public class slacklists_Test {
                                         .build()))
                                 .build()))
                         .build()))
-                .schema(Arrays.asList(taskNameCol, dueDateCol, statusCol, assigneeCol)));
+                .schema(Arrays.asList(taskNameCol, dueDateCol, estimateCol, ratingCol, statusCol, assigneeCol)));
 
         assertThat(createResponse.getError(), is(nullValue()));
         assertThat(createResponse.isOk(), is(true));


### PR DESCRIPTION
This pull request extends the Slack Lists remote-API test to create column types whose `options` sub-properties were never being recorded, so the automatic property-detection mechanism picks them up.

### Context

`fullSlackListsWorkflow` only created `text` / `date` / `select` / `user` columns, and none set the option variants that Slack echoes back per column type. As a result the recorded `slackLists.*` samples never contained:

- `options.precision` (number columns)
- `options.date_format` (date columns with a format)
- `options.emoji` / `options.max` (rating columns)

Downstream, the [node-slack-sdk](https://github.com/slackapi/node-slack-sdk) response-type generator infers types from these samples, so it produced a thinner `SchemaOptions` that dropped those documented fields — a consumer-facing regression on `slackLists.create` / `slackLists.items.info`.

### Changes

- Give the existing `due_date` column a `dateFormat` option → records `date_format`.
- Add a `number` column (`estimate`) with `precision` → records `precision`.
- Add a `rating` column (`priority`) with `emoji` and `max` → records `emoji` and `max`.
- Wire the new columns into the create-list schema.

The `ListColumnOptions` model already supports all of these fields; this only exercises them.

### Category

* [x] **slack-api-client** (Slack API Clients)

### Testing

- Run the Slack Lists remote-API flow against a test workspace (via the java-slack-sdk-runner `workflow_dispatch`), then confirm the regenerated `json-logs/samples/api/slackLists.create.json` now contains `options.precision`, `options.date_format`, `options.emoji`, and `options.max`.

### Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.