### PR TITLE
feat: add webapi response changes as of 2026-08-21

### DIFF
--- a/json-logs/raw/audit/v1/actions.json
+++ b/json-logs/raw/audit/v1/actions.json
@@ -341,7 +341,8 @@
       "mcp_slack_update_list_record_tool_called",
       "mcp_slack_delete_list_record_tool_called",
       "pref.ai_feature_default_access_changed",
-      "mcp_slack_activity_list_tool_called"
+      "mcp_slack_activity_list_tool_called",
+      "mcp_slack_todos_list_tool_called"
     ],
     "user": [
       "custom_tos_accepted",
@@ -824,7 +825,9 @@
       "salesforce_mcp_server_workspace_granted",
       "salesforce_mcp_server_workspace_revoked",
       "salesforce_mcp_server_acl_updated",
-      "salesforce_mcp_server_tool_acl_updated"
+      "salesforce_mcp_server_tool_acl_updated",
+      "salesforce_mcp_server_tool_default_updated",
+      "salesforce_mcp_server_tool_permissions_deleted"
     ],
     "work_object_record": [
       "enterprise_search_email_attachment_downloaded"

--- a/json-logs/raw/audit/v1/actions.json
+++ b/json-logs/raw/audit/v1/actions.json
@@ -342,7 +342,8 @@
       "mcp_slack_delete_list_record_tool_called",
       "pref.ai_feature_default_access_changed",
       "mcp_slack_activity_list_tool_called",
-      "mcp_slack_todos_list_tool_called"
+      "mcp_slack_todos_list_tool_called",
+      "slack_ai_mcp_model_context_updated"
     ],
     "user": [
       "custom_tos_accepted",

--- a/json-logs/samples/api/bots.info.json
+++ b/json-logs/samples/api/bots.info.json
@@ -11,7 +11,9 @@
       "image_36": "https://www.example.com/",
       "image_48": "https://www.example.com/",
       "image_72": "https://www.example.com/"
-    }
+    },
+    "is_workflow_bot": false,
+    "is_legacy_workflow_bot": false
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/bots.info.json
+++ b/json-logs/samples/api/bots.info.json
@@ -13,7 +13,8 @@
       "image_72": "https://www.example.com/"
     },
     "is_workflow_bot": false,
-    "is_legacy_workflow_bot": false
+    "is_legacy_workflow_bot": false,
+    "is_connector_bot": false
   },
   "error": "",
   "needed": "",

--- a/json-logs/samples/api/chat.postMessage.json
+++ b/json-logs/samples/api/chat.postMessage.json
@@ -11187,7 +11187,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -11326,7 +11327,8 @@
           "show_completed_items": false,
           "grouping": {
             "group_by": "",
-            "group_by_column_id": ""
+            "group_by_column_id": "",
+            "order": ""
           },
           "filters": [
             {
@@ -16315,7 +16317,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {
@@ -33831,7 +33834,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -51721,7 +51725,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {

--- a/json-logs/samples/api/chat.postMessage.json
+++ b/json-logs/samples/api/chat.postMessage.json
@@ -9913,6 +9913,13 @@
               "language": {
                 "locale": "",
                 "is_reliable": false
+              },
+              "agent_session": {
+                "status": "",
+                "agent_bot_user_ids": [],
+                "agent_statuses": [],
+                "title": "",
+                "date_status_processing_expire": 123
               }
             }
           }
@@ -10452,6 +10459,13 @@
                   "language": {
                     "locale": "",
                     "is_reliable": false
+                  },
+                  "agent_session": {
+                    "status": "",
+                    "agent_bot_user_ids": [],
+                    "agent_statuses": [],
+                    "title": "",
+                    "date_status_processing_expire": 123
                   }
                 },
                 "number": [],
@@ -11040,6 +11054,13 @@
                   "language": {
                     "locale": "",
                     "is_reliable": false
+                  },
+                  "agent_session": {
+                    "status": "",
+                    "agent_bot_user_ids": [],
+                    "agent_statuses": [],
+                    "title": "",
+                    "date_status_processing_expire": 123
                   }
                 },
                 "number": [],

--- a/json-logs/samples/api/chat.postMessage.json
+++ b/json-logs/samples/api/chat.postMessage.json
@@ -10495,6 +10495,7 @@
                   "channel": []
                 },
                 "emoji": "",
+                "emoji_url": "",
                 "max": 123,
                 "precision": 123,
                 "show_member_name": false,
@@ -11134,6 +11135,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -11274,6 +11276,7 @@
                 "channel": []
               },
               "emoji": "",
+              "emoji_url": "",
               "max": 123,
               "precision": 123,
               "show_member_name": false,
@@ -16260,6 +16263,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -33775,6 +33779,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -51664,6 +51669,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,

--- a/json-logs/samples/api/chat.postMessage.json
+++ b/json-logs/samples/api/chat.postMessage.json
@@ -11188,7 +11188,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -11200,7 +11200,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               }
             ],
             "integrations": [
@@ -11328,7 +11338,7 @@
           "grouping": {
             "group_by": "",
             "group_by_column_id": "",
-            "order": ""
+            "order": []
           },
           "filters": [
             {
@@ -11340,7 +11350,17 @@
               "typed_values": [],
               "column_id": ""
             }
-          ]
+          ],
+          "sorts": [],
+          "info_column_filters": [],
+          "calculations": [],
+          "options": {
+            "cover_field": "",
+            "cover_fit": "",
+            "calendar_field": ""
+          },
+          "is_template_initial_view": false,
+          "row_height": 123
         },
         "files": [
           {
@@ -16318,7 +16338,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -16330,7 +16350,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [
@@ -33835,7 +33865,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -33847,7 +33877,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               }
             ],
             "integrations": [
@@ -51726,7 +51766,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -51738,7 +51778,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [

--- a/json-logs/samples/api/chat.scheduleMessage.json
+++ b/json-logs/samples/api/chat.scheduleMessage.json
@@ -8328,7 +8328,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -26218,7 +26219,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {

--- a/json-logs/samples/api/chat.scheduleMessage.json
+++ b/json-logs/samples/api/chat.scheduleMessage.json
@@ -8329,7 +8329,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -8341,7 +8341,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               }
             ],
             "integrations": [
@@ -26220,7 +26230,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -26232,7 +26242,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [

--- a/json-logs/samples/api/chat.scheduleMessage.json
+++ b/json-logs/samples/api/chat.scheduleMessage.json
@@ -8276,6 +8276,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -26165,6 +26166,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,

--- a/json-logs/samples/api/chat.stopStream.json
+++ b/json-logs/samples/api/chat.stopStream.json
@@ -8270,7 +8270,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {

--- a/json-logs/samples/api/chat.stopStream.json
+++ b/json-logs/samples/api/chat.stopStream.json
@@ -8271,7 +8271,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -8283,7 +8283,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               }
             ],
             "integrations": [

--- a/json-logs/samples/api/chat.stopStream.json
+++ b/json-logs/samples/api/chat.stopStream.json
@@ -8218,6 +8218,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,

--- a/json-logs/samples/api/chat.update.json
+++ b/json-logs/samples/api/chat.update.json
@@ -5019,6 +5019,7 @@
                   "channel": []
                 },
                 "emoji": "",
+                "emoji_url": "",
                 "max": 123,
                 "precision": 123,
                 "show_member_name": false,
@@ -17920,6 +17921,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -35809,6 +35811,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,

--- a/json-logs/samples/api/chat.update.json
+++ b/json-logs/samples/api/chat.update.json
@@ -5071,7 +5071,8 @@
               "show_completed_items": false,
               "grouping": {
                 "group_by": "",
-                "group_by_column_id": ""
+                "group_by_column_id": "",
+                "order": ""
               },
               "filters": [
                 {
@@ -17973,7 +17974,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -35863,7 +35865,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {

--- a/json-logs/samples/api/chat.update.json
+++ b/json-logs/samples/api/chat.update.json
@@ -5072,7 +5072,7 @@
               "grouping": {
                 "group_by": "",
                 "group_by_column_id": "",
-                "order": ""
+                "order": []
               },
               "filters": [
                 {
@@ -5084,7 +5084,17 @@
                   "typed_values": [],
                   "column_id": ""
                 }
-              ]
+              ],
+              "sorts": [],
+              "info_column_filters": [],
+              "calculations": [],
+              "options": {
+                "cover_field": "",
+                "cover_fit": "",
+                "calendar_field": ""
+              },
+              "is_template_initial_view": false,
+              "row_height": 123
             }
           ],
           "integrations": [
@@ -17975,7 +17985,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -17987,7 +17997,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               }
             ],
             "integrations": [
@@ -35866,7 +35886,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -35878,7 +35898,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -37432,6 +37432,13 @@
                 "language": {
                   "locale": "",
                   "is_reliable": false
+                },
+                "agent_session": {
+                  "status": "",
+                  "agent_bot_user_ids": [],
+                  "agent_statuses": [],
+                  "title": "",
+                  "date_status_processing_expire": 123
                 }
               }
             }
@@ -37971,6 +37978,13 @@
                     "language": {
                       "locale": "",
                       "is_reliable": false
+                    },
+                    "agent_session": {
+                      "status": "",
+                      "agent_bot_user_ids": [],
+                      "agent_statuses": [],
+                      "title": "",
+                      "date_status_processing_expire": 123
                     }
                   },
                   "number": [],
@@ -38559,6 +38573,13 @@
                     "language": {
                       "locale": "",
                       "is_reliable": false
+                    },
+                    "agent_session": {
+                      "status": "",
+                      "agent_bot_user_ids": [],
+                      "agent_statuses": [],
+                      "title": "",
+                      "date_status_processing_expire": 123
                     }
                   },
                   "number": [],

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -5064,7 +5064,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -17966,7 +17967,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {
@@ -38684,7 +38686,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {
@@ -38823,7 +38826,8 @@
             "show_completed_items": false,
             "grouping": {
               "group_by": "",
-              "group_by_column_id": ""
+              "group_by_column_id": "",
+              "order": ""
             },
             "filters": [
               {
@@ -43812,7 +43816,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -61330,7 +61335,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -71061,6 +71061,11 @@
             "status": "",
             "is_stoppable": false,
             "date_status_processing_expire": 12345
+          },
+          {
+            "agent_bot_user_id": "U00000000",
+            "status": "",
+            "is_stoppable": false
           }
         ],
         "title": "",

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -70975,7 +70975,8 @@
       "language": {
         "locale": "",
         "is_reliable": false
-      }
+      },
+      "hidden": false
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -5065,7 +5065,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -5077,7 +5077,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               }
             ],
             "integrations": [
@@ -17968,7 +17978,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -17980,7 +17990,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [
@@ -38687,7 +38707,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -38699,7 +38719,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [
@@ -38827,7 +38857,7 @@
             "grouping": {
               "group_by": "",
               "group_by_column_id": "",
-              "order": ""
+              "order": []
             },
             "filters": [
               {
@@ -38839,7 +38869,17 @@
                 "typed_values": [],
                 "column_id": ""
               }
-            ]
+            ],
+            "sorts": [],
+            "info_column_filters": [],
+            "calculations": [],
+            "options": {
+              "cover_field": "",
+              "cover_fit": "",
+              "calendar_field": ""
+            },
+            "is_template_initial_view": false,
+            "row_height": 123
           },
           "files": [
             {
@@ -43817,7 +43857,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -43829,7 +43869,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -61336,7 +61386,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -61348,7 +61398,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -70989,7 +71049,23 @@
         "locale": "",
         "is_reliable": false
       },
-      "hidden": false
+      "hidden": false,
+      "agent_session": {
+        "status": "",
+        "agent_bot_user_ids": [
+          "U00000000"
+        ],
+        "agent_statuses": [
+          {
+            "agent_bot_user_id": "U00000000",
+            "status": "",
+            "is_stoppable": false,
+            "date_status_processing_expire": 12345
+          }
+        ],
+        "title": "",
+        "date_status_processing_expire": 12345
+      }
     }
   ],
   "has_more": false,

--- a/json-logs/samples/api/conversations.history.json
+++ b/json-logs/samples/api/conversations.history.json
@@ -5012,6 +5012,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -17913,6 +17914,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -37990,6 +37992,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -38629,6 +38632,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -38769,6 +38773,7 @@
                   "channel": []
                 },
                 "emoji": "",
+                "emoji_url": "",
                 "max": 123,
                 "precision": 123,
                 "show_member_name": false,
@@ -43755,6 +43760,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -61272,6 +61278,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,

--- a/json-logs/samples/api/conversations.open.json
+++ b/json-logs/samples/api/conversations.open.json
@@ -8272,7 +8272,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {
@@ -26162,7 +26163,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {

--- a/json-logs/samples/api/conversations.open.json
+++ b/json-logs/samples/api/conversations.open.json
@@ -8220,6 +8220,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -26109,6 +26110,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,

--- a/json-logs/samples/api/conversations.open.json
+++ b/json-logs/samples/api/conversations.open.json
@@ -8273,7 +8273,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -8285,7 +8285,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [
@@ -26164,7 +26174,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -26176,7 +26186,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [

--- a/json-logs/samples/api/conversations.replies.json
+++ b/json-logs/samples/api/conversations.replies.json
@@ -8296,7 +8296,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {
@@ -29014,7 +29015,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {
@@ -29153,7 +29155,8 @@
             "show_completed_items": false,
             "grouping": {
               "group_by": "",
-              "group_by_column_id": ""
+              "group_by_column_id": "",
+              "order": ""
             },
             "filters": [
               {
@@ -34142,7 +34145,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -48392,7 +48396,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -61296,7 +61301,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {

--- a/json-logs/samples/api/conversations.replies.json
+++ b/json-logs/samples/api/conversations.replies.json
@@ -27751,6 +27751,13 @@
                 "language": {
                   "locale": "",
                   "is_reliable": false
+                },
+                "agent_session": {
+                  "status": "",
+                  "agent_bot_user_ids": [],
+                  "agent_statuses": [],
+                  "title": "",
+                  "date_status_processing_expire": 123
                 }
               }
             }
@@ -28290,6 +28297,13 @@
                     "language": {
                       "locale": "",
                       "is_reliable": false
+                    },
+                    "agent_session": {
+                      "status": "",
+                      "agent_bot_user_ids": [],
+                      "agent_statuses": [],
+                      "title": "",
+                      "date_status_processing_expire": 123
                     }
                   },
                   "number": [],
@@ -28878,6 +28892,13 @@
                     "language": {
                       "locale": "",
                       "is_reliable": false
+                    },
+                    "agent_session": {
+                      "status": "",
+                      "agent_bot_user_ids": [],
+                      "agent_statuses": [],
+                      "title": "",
+                      "date_status_processing_expire": 123
                     }
                   },
                   "number": [],

--- a/json-logs/samples/api/conversations.replies.json
+++ b/json-logs/samples/api/conversations.replies.json
@@ -8244,6 +8244,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -28321,6 +28322,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -28960,6 +28962,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -29100,6 +29103,7 @@
                   "channel": []
                 },
                 "emoji": "",
+                "emoji_url": "",
                 "max": 123,
                 "precision": 123,
                 "show_member_name": false,
@@ -34086,6 +34090,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -48335,6 +48340,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -61238,6 +61244,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,

--- a/json-logs/samples/api/conversations.replies.json
+++ b/json-logs/samples/api/conversations.replies.json
@@ -8297,7 +8297,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -8309,7 +8309,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [
@@ -29016,7 +29026,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -29028,7 +29038,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [
@@ -29156,7 +29176,7 @@
             "grouping": {
               "group_by": "",
               "group_by_column_id": "",
-              "order": ""
+              "order": []
             },
             "filters": [
               {
@@ -29168,7 +29188,17 @@
                 "typed_values": [],
                 "column_id": ""
               }
-            ]
+            ],
+            "sorts": [],
+            "info_column_filters": [],
+            "calculations": [],
+            "options": {
+              "cover_field": "",
+              "cover_fit": "",
+              "calendar_field": ""
+            },
+            "is_template_initial_view": false,
+            "row_height": 123
           },
           "files": [
             {
@@ -34146,7 +34176,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -34158,7 +34188,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -48397,7 +48437,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -48409,7 +48449,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               }
             ],
             "integrations": [
@@ -61302,7 +61352,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -61314,7 +61364,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [

--- a/json-logs/samples/api/files.completeUploadExternal.json
+++ b/json-logs/samples/api/files.completeUploadExternal.json
@@ -50,19 +50,6 @@
               "latest_reply": "0000000000.000000",
               "source": "",
               "is_silent_share": false
-            },
-            {
-              "ts": "0000000000.000000",
-              "channel_name": "",
-              "team_id": "T00000000",
-              "share_user_id": "U00000000",
-              "source": "",
-              "is_silent_share": false,
-              "reply_users": [
-                ""
-              ],
-              "reply_users_count": 12345,
-              "reply_count": 12345
             }
           ],
           "C00000001": [
@@ -80,25 +67,13 @@
               "latest_reply": "0000000000.000000",
               "source": "",
               "is_silent_share": false
-            },
-            {
-              "ts": "0000000000.000000",
-              "channel_name": "",
-              "team_id": "T00000000",
-              "share_user_id": "U00000000",
-              "source": "",
-              "is_silent_share": false,
-              "reply_users": [
-                ""
-              ],
-              "reply_users_count": 12345,
-              "reply_count": 12345
             }
           ]
         }
       },
       "channels": [
-        "C00000000"
+        "C00000000",
+        ""
       ],
       "groups": [
         ""

--- a/json-logs/samples/api/files.completeUploadExternal.json
+++ b/json-logs/samples/api/files.completeUploadExternal.json
@@ -50,6 +50,19 @@
               "latest_reply": "0000000000.000000",
               "source": "",
               "is_silent_share": false
+            },
+            {
+              "ts": "0000000000.000000",
+              "channel_name": "",
+              "team_id": "T00000000",
+              "share_user_id": "U00000000",
+              "source": "",
+              "is_silent_share": false,
+              "reply_users": [
+                ""
+              ],
+              "reply_users_count": 12345,
+              "reply_count": 12345
             }
           ],
           "C00000001": [
@@ -67,13 +80,25 @@
               "latest_reply": "0000000000.000000",
               "source": "",
               "is_silent_share": false
+            },
+            {
+              "ts": "0000000000.000000",
+              "channel_name": "",
+              "team_id": "T00000000",
+              "share_user_id": "U00000000",
+              "source": "",
+              "is_silent_share": false,
+              "reply_users": [
+                ""
+              ],
+              "reply_users_count": 12345,
+              "reply_count": 12345
             }
           ]
         }
       },
       "channels": [
-        "C00000000",
-        ""
+        "C00000000"
       ],
       "groups": [
         ""

--- a/json-logs/samples/api/files.delete.json
+++ b/json-logs/samples/api/files.delete.json
@@ -2,5 +2,6 @@
   "ok": false,
   "error": "",
   "needed": "",
-  "provided": ""
+  "provided": "",
+  "warning": ""
 }

--- a/json-logs/samples/api/files.info.json
+++ b/json-logs/samples/api/files.info.json
@@ -4974,7 +4974,8 @@
           "show_completed_items": false,
           "grouping": {
             "group_by": "",
-            "group_by_column_id": ""
+            "group_by_column_id": "",
+            "order": ""
           },
           "filters": [
             {

--- a/json-logs/samples/api/files.info.json
+++ b/json-logs/samples/api/files.info.json
@@ -4975,7 +4975,7 @@
           "grouping": {
             "group_by": "",
             "group_by_column_id": "",
-            "order": ""
+            "order": []
           },
           "filters": [
             {
@@ -4987,7 +4987,17 @@
               "typed_values": [],
               "column_id": ""
             }
-          ]
+          ],
+          "sorts": [],
+          "info_column_filters": [],
+          "calculations": [],
+          "options": {
+            "cover_field": "",
+            "cover_fit": "",
+            "calendar_field": ""
+          },
+          "is_template_initial_view": false,
+          "row_height": 123
         }
       ],
       "integrations": [

--- a/json-logs/samples/api/files.info.json
+++ b/json-logs/samples/api/files.info.json
@@ -4922,6 +4922,7 @@
               "channel": []
             },
             "emoji": "",
+            "emoji_url": "",
             "max": 123,
             "precision": 123,
             "show_member_name": false,

--- a/json-logs/samples/api/files.list.json
+++ b/json-logs/samples/api/files.list.json
@@ -4923,6 +4923,7 @@
                 "channel": []
               },
               "emoji": "",
+              "emoji_url": "",
               "max": 123,
               "precision": 123,
               "show_member_name": false,

--- a/json-logs/samples/api/files.list.json
+++ b/json-logs/samples/api/files.list.json
@@ -4975,7 +4975,8 @@
             "show_completed_items": false,
             "grouping": {
               "group_by": "",
-              "group_by_column_id": ""
+              "group_by_column_id": "",
+              "order": ""
             },
             "filters": [
               {

--- a/json-logs/samples/api/files.list.json
+++ b/json-logs/samples/api/files.list.json
@@ -4976,7 +4976,7 @@
             "grouping": {
               "group_by": "",
               "group_by_column_id": "",
-              "order": ""
+              "order": []
             },
             "filters": [
               {
@@ -4988,7 +4988,17 @@
                 "typed_values": [],
                 "column_id": ""
               }
-            ]
+            ],
+            "sorts": [],
+            "info_column_filters": [],
+            "calculations": [],
+            "options": {
+              "cover_field": "",
+              "cover_fit": "",
+              "calendar_field": ""
+            },
+            "is_template_initial_view": false,
+            "row_height": 123
           }
         ],
         "integrations": [

--- a/json-logs/samples/api/files.remote.add.json
+++ b/json-logs/samples/api/files.remote.add.json
@@ -4974,7 +4974,8 @@
           "show_completed_items": false,
           "grouping": {
             "group_by": "",
-            "group_by_column_id": ""
+            "group_by_column_id": "",
+            "order": ""
           },
           "filters": [
             {

--- a/json-logs/samples/api/files.remote.add.json
+++ b/json-logs/samples/api/files.remote.add.json
@@ -4975,7 +4975,7 @@
           "grouping": {
             "group_by": "",
             "group_by_column_id": "",
-            "order": ""
+            "order": []
           },
           "filters": [
             {
@@ -4987,7 +4987,17 @@
               "typed_values": [],
               "column_id": ""
             }
-          ]
+          ],
+          "sorts": [],
+          "info_column_filters": [],
+          "calculations": [],
+          "options": {
+            "cover_field": "",
+            "cover_fit": "",
+            "calendar_field": ""
+          },
+          "is_template_initial_view": false,
+          "row_height": 123
         }
       ],
       "integrations": [

--- a/json-logs/samples/api/files.remote.add.json
+++ b/json-logs/samples/api/files.remote.add.json
@@ -4922,6 +4922,7 @@
               "channel": []
             },
             "emoji": "",
+            "emoji_url": "",
             "max": 123,
             "precision": 123,
             "show_member_name": false,

--- a/json-logs/samples/api/files.remote.info.json
+++ b/json-logs/samples/api/files.remote.info.json
@@ -4974,7 +4974,8 @@
           "show_completed_items": false,
           "grouping": {
             "group_by": "",
-            "group_by_column_id": ""
+            "group_by_column_id": "",
+            "order": ""
           },
           "filters": [
             {

--- a/json-logs/samples/api/files.remote.info.json
+++ b/json-logs/samples/api/files.remote.info.json
@@ -4975,7 +4975,7 @@
           "grouping": {
             "group_by": "",
             "group_by_column_id": "",
-            "order": ""
+            "order": []
           },
           "filters": [
             {
@@ -4987,7 +4987,17 @@
               "typed_values": [],
               "column_id": ""
             }
-          ]
+          ],
+          "sorts": [],
+          "info_column_filters": [],
+          "calculations": [],
+          "options": {
+            "cover_field": "",
+            "cover_fit": "",
+            "calendar_field": ""
+          },
+          "is_template_initial_view": false,
+          "row_height": 123
         }
       ],
       "integrations": [

--- a/json-logs/samples/api/files.remote.info.json
+++ b/json-logs/samples/api/files.remote.info.json
@@ -4922,6 +4922,7 @@
               "channel": []
             },
             "emoji": "",
+            "emoji_url": "",
             "max": 123,
             "precision": 123,
             "show_member_name": false,

--- a/json-logs/samples/api/files.remote.list.json
+++ b/json-logs/samples/api/files.remote.list.json
@@ -4923,6 +4923,7 @@
                 "channel": []
               },
               "emoji": "",
+              "emoji_url": "",
               "max": 123,
               "precision": 123,
               "show_member_name": false,

--- a/json-logs/samples/api/files.remote.list.json
+++ b/json-logs/samples/api/files.remote.list.json
@@ -4975,7 +4975,8 @@
             "show_completed_items": false,
             "grouping": {
               "group_by": "",
-              "group_by_column_id": ""
+              "group_by_column_id": "",
+              "order": ""
             },
             "filters": [
               {

--- a/json-logs/samples/api/files.remote.list.json
+++ b/json-logs/samples/api/files.remote.list.json
@@ -4976,7 +4976,7 @@
             "grouping": {
               "group_by": "",
               "group_by_column_id": "",
-              "order": ""
+              "order": []
             },
             "filters": [
               {
@@ -4988,7 +4988,17 @@
                 "typed_values": [],
                 "column_id": ""
               }
-            ]
+            ],
+            "sorts": [],
+            "info_column_filters": [],
+            "calculations": [],
+            "options": {
+              "cover_field": "",
+              "cover_fit": "",
+              "calendar_field": ""
+            },
+            "is_template_initial_view": false,
+            "row_height": 123
           }
         ],
         "integrations": [

--- a/json-logs/samples/api/files.remote.share.json
+++ b/json-logs/samples/api/files.remote.share.json
@@ -4974,7 +4974,8 @@
           "show_completed_items": false,
           "grouping": {
             "group_by": "",
-            "group_by_column_id": ""
+            "group_by_column_id": "",
+            "order": ""
           },
           "filters": [
             {

--- a/json-logs/samples/api/files.remote.share.json
+++ b/json-logs/samples/api/files.remote.share.json
@@ -4975,7 +4975,7 @@
           "grouping": {
             "group_by": "",
             "group_by_column_id": "",
-            "order": ""
+            "order": []
           },
           "filters": [
             {
@@ -4987,7 +4987,17 @@
               "typed_values": [],
               "column_id": ""
             }
-          ]
+          ],
+          "sorts": [],
+          "info_column_filters": [],
+          "calculations": [],
+          "options": {
+            "cover_field": "",
+            "cover_fit": "",
+            "calendar_field": ""
+          },
+          "is_template_initial_view": false,
+          "row_height": 123
         }
       ],
       "integrations": [

--- a/json-logs/samples/api/files.remote.share.json
+++ b/json-logs/samples/api/files.remote.share.json
@@ -4922,6 +4922,7 @@
               "channel": []
             },
             "emoji": "",
+            "emoji_url": "",
             "max": 123,
             "precision": 123,
             "show_member_name": false,

--- a/json-logs/samples/api/files.remote.update.json
+++ b/json-logs/samples/api/files.remote.update.json
@@ -4974,7 +4974,8 @@
           "show_completed_items": false,
           "grouping": {
             "group_by": "",
-            "group_by_column_id": ""
+            "group_by_column_id": "",
+            "order": ""
           },
           "filters": [
             {

--- a/json-logs/samples/api/files.remote.update.json
+++ b/json-logs/samples/api/files.remote.update.json
@@ -4975,7 +4975,7 @@
           "grouping": {
             "group_by": "",
             "group_by_column_id": "",
-            "order": ""
+            "order": []
           },
           "filters": [
             {
@@ -4987,7 +4987,17 @@
               "typed_values": [],
               "column_id": ""
             }
-          ]
+          ],
+          "sorts": [],
+          "info_column_filters": [],
+          "calculations": [],
+          "options": {
+            "cover_field": "",
+            "cover_fit": "",
+            "calendar_field": ""
+          },
+          "is_template_initial_view": false,
+          "row_height": 123
         }
       ],
       "integrations": [

--- a/json-logs/samples/api/files.remote.update.json
+++ b/json-logs/samples/api/files.remote.update.json
@@ -4922,6 +4922,7 @@
               "channel": []
             },
             "emoji": "",
+            "emoji_url": "",
             "max": 123,
             "precision": 123,
             "show_member_name": false,

--- a/json-logs/samples/api/pins.list.json
+++ b/json-logs/samples/api/pins.list.json
@@ -47085,6 +47085,13 @@
                   "language": {
                     "locale": "",
                     "is_reliable": false
+                  },
+                  "agent_session": {
+                    "status": "",
+                    "agent_bot_user_ids": [],
+                    "agent_statuses": [],
+                    "title": "",
+                    "date_status_processing_expire": 123
                   }
                 }
               }
@@ -47624,6 +47631,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],
@@ -48212,6 +48226,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],

--- a/json-logs/samples/api/pins.list.json
+++ b/json-logs/samples/api/pins.list.json
@@ -4979,7 +4979,8 @@
               "show_completed_items": false,
               "grouping": {
                 "group_by": "",
-                "group_by_column_id": ""
+                "group_by_column_id": "",
+                "order": ""
               },
               "filters": [
                 {
@@ -17889,7 +17890,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -32592,7 +32594,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {
@@ -48326,7 +48329,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -48465,7 +48469,8 @@
               "show_completed_items": false,
               "grouping": {
                 "group_by": "",
-                "group_by_column_id": ""
+                "group_by_column_id": "",
+                "order": ""
               },
               "filters": [
                 {
@@ -53454,7 +53459,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {

--- a/json-logs/samples/api/pins.list.json
+++ b/json-logs/samples/api/pins.list.json
@@ -4927,6 +4927,7 @@
                   "channel": []
                 },
                 "emoji": "",
+                "emoji_url": "",
                 "max": 123,
                 "precision": 123,
                 "show_member_name": false,
@@ -17836,6 +17837,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -32538,6 +32540,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -47631,6 +47634,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -48270,6 +48274,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -48410,6 +48415,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -53396,6 +53402,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,

--- a/json-logs/samples/api/pins.list.json
+++ b/json-logs/samples/api/pins.list.json
@@ -4980,7 +4980,7 @@
               "grouping": {
                 "group_by": "",
                 "group_by_column_id": "",
-                "order": ""
+                "order": []
               },
               "filters": [
                 {
@@ -4992,7 +4992,17 @@
                   "typed_values": [],
                   "column_id": ""
                 }
-              ]
+              ],
+              "sorts": [],
+              "info_column_filters": [],
+              "calculations": [],
+              "options": {
+                "cover_field": "",
+                "cover_fit": "",
+                "calendar_field": ""
+              },
+              "is_template_initial_view": false,
+              "row_height": 123
             }
           ],
           "integrations": [
@@ -17891,7 +17901,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -17903,7 +17913,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -32595,7 +32615,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -32607,7 +32627,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [
@@ -48330,7 +48360,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -48342,7 +48372,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -48470,7 +48510,7 @@
               "grouping": {
                 "group_by": "",
                 "group_by_column_id": "",
-                "order": ""
+                "order": []
               },
               "filters": [
                 {
@@ -48482,7 +48522,17 @@
                   "typed_values": [],
                   "column_id": ""
                 }
-              ]
+              ],
+              "sorts": [],
+              "info_column_filters": [],
+              "calculations": [],
+              "options": {
+                "cover_field": "",
+                "cover_fit": "",
+                "calendar_field": ""
+              },
+              "is_template_initial_view": false,
+              "row_height": 123
             },
             "files": [
               {
@@ -53460,7 +53510,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -53472,7 +53522,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [

--- a/json-logs/samples/api/reactions.get.json
+++ b/json-logs/samples/api/reactions.get.json
@@ -8335,7 +8335,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -8347,7 +8347,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               }
             ],
             "integrations": [
@@ -26226,7 +26236,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -26238,7 +26248,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [

--- a/json-logs/samples/api/reactions.get.json
+++ b/json-logs/samples/api/reactions.get.json
@@ -8334,7 +8334,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -26224,7 +26225,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {

--- a/json-logs/samples/api/reactions.get.json
+++ b/json-logs/samples/api/reactions.get.json
@@ -8282,6 +8282,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -26171,6 +26172,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,

--- a/json-logs/samples/api/reactions.list.json
+++ b/json-logs/samples/api/reactions.list.json
@@ -5097,7 +5097,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -5109,7 +5109,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [
@@ -18000,7 +18010,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -18012,7 +18022,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -38719,7 +38739,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -38731,7 +38751,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -38859,7 +38889,7 @@
               "grouping": {
                 "group_by": "",
                 "group_by_column_id": "",
-                "order": ""
+                "order": []
               },
               "filters": [
                 {
@@ -38871,7 +38901,17 @@
                   "typed_values": [],
                   "column_id": ""
                 }
-              ]
+              ],
+              "sorts": [],
+              "info_column_filters": [],
+              "calculations": [],
+              "options": {
+                "cover_field": "",
+                "cover_fit": "",
+                "calendar_field": ""
+              },
+              "is_template_initial_view": false,
+              "row_height": 123
             },
             "files": [
               {
@@ -43849,7 +43889,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -43861,7 +43901,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -61368,7 +61418,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -61380,7 +61430,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [

--- a/json-logs/samples/api/reactions.list.json
+++ b/json-logs/samples/api/reactions.list.json
@@ -5044,6 +5044,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -17945,6 +17946,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -38022,6 +38024,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -38661,6 +38664,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -38801,6 +38805,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -43787,6 +43792,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -61304,6 +61310,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,

--- a/json-logs/samples/api/reactions.list.json
+++ b/json-logs/samples/api/reactions.list.json
@@ -37464,6 +37464,13 @@
                   "language": {
                     "locale": "",
                     "is_reliable": false
+                  },
+                  "agent_session": {
+                    "status": "",
+                    "agent_bot_user_ids": [],
+                    "agent_statuses": [],
+                    "title": "",
+                    "date_status_processing_expire": 123
                   }
                 }
               }
@@ -38003,6 +38010,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],
@@ -38591,6 +38605,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],

--- a/json-logs/samples/api/reactions.list.json
+++ b/json-logs/samples/api/reactions.list.json
@@ -5096,7 +5096,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {
@@ -17998,7 +17999,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -38716,7 +38718,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -38855,7 +38858,8 @@
               "show_completed_items": false,
               "grouping": {
                 "group_by": "",
-                "group_by_column_id": ""
+                "group_by_column_id": "",
+                "order": ""
               },
               "filters": [
                 {
@@ -43844,7 +43848,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -61362,7 +61367,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {

--- a/json-logs/samples/api/search.all.json
+++ b/json-logs/samples/api/search.all.json
@@ -10436,6 +10436,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -11075,6 +11076,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -11215,6 +11217,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -16201,6 +16204,7 @@
                             "channel": []
                           },
                           "emoji": "",
+                          "emoji_url": "",
                           "max": 123,
                           "precision": 123,
                           "show_member_name": false,
@@ -33716,6 +33720,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -53802,6 +53807,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -54441,6 +54447,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -54581,6 +54588,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -59567,6 +59575,7 @@
                             "channel": []
                           },
                           "emoji": "",
+                          "emoji_url": "",
                           "max": 123,
                           "precision": 123,
                           "show_member_name": false,
@@ -77082,6 +77091,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -94972,6 +94982,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -115049,6 +115060,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -115688,6 +115700,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -115828,6 +115841,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -120814,6 +120828,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -135063,6 +135078,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -150348,6 +150364,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -150987,6 +151004,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -151127,6 +151145,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -156113,6 +156132,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -173628,6 +173648,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,

--- a/json-logs/samples/api/search.all.json
+++ b/json-logs/samples/api/search.all.json
@@ -11128,7 +11128,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -11267,7 +11268,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -16256,7 +16258,8 @@
                         "show_completed_items": false,
                         "grouping": {
                           "group_by": "",
-                          "group_by_column_id": ""
+                          "group_by_column_id": "",
+                          "order": ""
                         },
                         "filters": [
                           {
@@ -33772,7 +33775,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -54499,7 +54503,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -54638,7 +54643,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -59627,7 +59633,8 @@
                         "show_completed_items": false,
                         "grouping": {
                           "group_by": "",
-                          "group_by_column_id": ""
+                          "group_by_column_id": "",
+                          "order": ""
                         },
                         "filters": [
                           {
@@ -77143,7 +77150,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -95034,7 +95042,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -115752,7 +115761,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -115891,7 +115901,8 @@
               "show_completed_items": false,
               "grouping": {
                 "group_by": "",
-                "group_by_column_id": ""
+                "group_by_column_id": "",
+                "order": ""
               },
               "filters": [
                 {
@@ -120880,7 +120891,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -135130,7 +135142,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {
@@ -151056,7 +151069,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -151195,7 +151209,8 @@
               "show_completed_items": false,
               "grouping": {
                 "group_by": "",
-                "group_by_column_id": ""
+                "group_by_column_id": "",
+                "order": ""
               },
               "filters": [
                 {
@@ -156184,7 +156199,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -173700,7 +173716,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {

--- a/json-logs/samples/api/search.all.json
+++ b/json-logs/samples/api/search.all.json
@@ -11129,7 +11129,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -11141,7 +11141,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -11269,7 +11279,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -11281,7 +11291,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               },
               "files": [
                 {
@@ -16259,7 +16279,7 @@
                         "grouping": {
                           "group_by": "",
                           "group_by_column_id": "",
-                          "order": ""
+                          "order": []
                         },
                         "filters": [
                           {
@@ -16271,7 +16291,17 @@
                             "typed_values": [],
                             "column_id": ""
                           }
-                        ]
+                        ],
+                        "sorts": [],
+                        "info_column_filters": [],
+                        "calculations": [],
+                        "options": {
+                          "cover_field": "",
+                          "cover_fit": "",
+                          "calendar_field": ""
+                        },
+                        "is_template_initial_view": false,
+                        "row_height": 123
                       }
                     ],
                     "integrations": [
@@ -33776,7 +33806,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -33788,7 +33818,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -54504,7 +54544,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -54516,7 +54556,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -54644,7 +54694,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -54656,7 +54706,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               },
               "files": [
                 {
@@ -59634,7 +59694,7 @@
                         "grouping": {
                           "group_by": "",
                           "group_by_column_id": "",
-                          "order": ""
+                          "order": []
                         },
                         "filters": [
                           {
@@ -59646,7 +59706,17 @@
                             "typed_values": [],
                             "column_id": ""
                           }
-                        ]
+                        ],
+                        "sorts": [],
+                        "info_column_filters": [],
+                        "calculations": [],
+                        "options": {
+                          "cover_field": "",
+                          "cover_fit": "",
+                          "calendar_field": ""
+                        },
+                        "is_template_initial_view": false,
+                        "row_height": 123
                       }
                     ],
                     "integrations": [
@@ -77151,7 +77221,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -77163,7 +77233,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -95043,7 +95123,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -95055,7 +95135,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -115762,7 +115852,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -115774,7 +115864,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -115902,7 +116002,7 @@
               "grouping": {
                 "group_by": "",
                 "group_by_column_id": "",
-                "order": ""
+                "order": []
               },
               "filters": [
                 {
@@ -115914,7 +116014,17 @@
                   "typed_values": [],
                   "column_id": ""
                 }
-              ]
+              ],
+              "sorts": [],
+              "info_column_filters": [],
+              "calculations": [],
+              "options": {
+                "cover_field": "",
+                "cover_fit": "",
+                "calendar_field": ""
+              },
+              "is_template_initial_view": false,
+              "row_height": 123
             },
             "files": [
               {
@@ -120892,7 +121002,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -120904,7 +121014,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -135143,7 +135263,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -135155,7 +135275,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [
@@ -151070,7 +151200,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -151082,7 +151212,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -151210,7 +151350,7 @@
               "grouping": {
                 "group_by": "",
                 "group_by_column_id": "",
-                "order": ""
+                "order": []
               },
               "filters": [
                 {
@@ -151222,7 +151362,17 @@
                   "typed_values": [],
                   "column_id": ""
                 }
-              ]
+              ],
+              "sorts": [],
+              "info_column_filters": [],
+              "calculations": [],
+              "options": {
+                "cover_field": "",
+                "cover_fit": "",
+                "calendar_field": ""
+              },
+              "is_template_initial_view": false,
+              "row_height": 123
             },
             "files": [
               {
@@ -156200,7 +156350,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -156212,7 +156362,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -173717,7 +173877,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -173729,7 +173889,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [

--- a/json-logs/samples/api/search.all.json
+++ b/json-logs/samples/api/search.all.json
@@ -9854,6 +9854,13 @@
                     "language": {
                       "locale": "",
                       "is_reliable": false
+                    },
+                    "agent_session": {
+                      "status": "",
+                      "agent_bot_user_ids": [],
+                      "agent_statuses": [],
+                      "title": "",
+                      "date_status_processing_expire": 123
                     }
                   }
                 }
@@ -10393,6 +10400,13 @@
                         "language": {
                           "locale": "",
                           "is_reliable": false
+                        },
+                        "agent_session": {
+                          "status": "",
+                          "agent_bot_user_ids": [],
+                          "agent_statuses": [],
+                          "title": "",
+                          "date_status_processing_expire": 123
                         }
                       },
                       "number": [],
@@ -10981,6 +10995,13 @@
                         "language": {
                           "locale": "",
                           "is_reliable": false
+                        },
+                        "agent_session": {
+                          "status": "",
+                          "agent_bot_user_ids": [],
+                          "agent_statuses": [],
+                          "title": "",
+                          "date_status_processing_expire": 123
                         }
                       },
                       "number": [],
@@ -53269,6 +53290,13 @@
                     "language": {
                       "locale": "",
                       "is_reliable": false
+                    },
+                    "agent_session": {
+                      "status": "",
+                      "agent_bot_user_ids": [],
+                      "agent_statuses": [],
+                      "title": "",
+                      "date_status_processing_expire": 123
                     }
                   }
                 }
@@ -53808,6 +53836,13 @@
                         "language": {
                           "locale": "",
                           "is_reliable": false
+                        },
+                        "agent_session": {
+                          "status": "",
+                          "agent_bot_user_ids": [],
+                          "agent_statuses": [],
+                          "title": "",
+                          "date_status_processing_expire": 123
                         }
                       },
                       "number": [],
@@ -54396,6 +54431,13 @@
                         "language": {
                           "locale": "",
                           "is_reliable": false
+                        },
+                        "agent_session": {
+                          "status": "",
+                          "agent_bot_user_ids": [],
+                          "agent_statuses": [],
+                          "title": "",
+                          "date_status_processing_expire": 123
                         }
                       },
                       "number": [],
@@ -114577,6 +114619,13 @@
                   "language": {
                     "locale": "",
                     "is_reliable": false
+                  },
+                  "agent_session": {
+                    "status": "",
+                    "agent_bot_user_ids": [],
+                    "agent_statuses": [],
+                    "title": "",
+                    "date_status_processing_expire": 123
                   }
                 }
               }
@@ -115116,6 +115165,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],
@@ -115704,6 +115760,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],
@@ -149925,6 +149988,13 @@
                   "language": {
                     "locale": "",
                     "is_reliable": false
+                  },
+                  "agent_session": {
+                    "status": "",
+                    "agent_bot_user_ids": [],
+                    "agent_statuses": [],
+                    "title": "",
+                    "date_status_processing_expire": 123
                   }
                 }
               }
@@ -150464,6 +150534,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],
@@ -151052,6 +151129,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],

--- a/json-logs/samples/api/search.files.json
+++ b/json-logs/samples/api/search.files.json
@@ -9988,6 +9988,13 @@
                   "language": {
                     "locale": "",
                     "is_reliable": false
+                  },
+                  "agent_session": {
+                    "status": "",
+                    "agent_bot_user_ids": [],
+                    "agent_statuses": [],
+                    "title": "",
+                    "date_status_processing_expire": 123
                   }
                 }
               }
@@ -10527,6 +10534,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],
@@ -11115,6 +11129,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],

--- a/json-logs/samples/api/search.files.json
+++ b/json-logs/samples/api/search.files.json
@@ -11262,7 +11262,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -11401,7 +11402,8 @@
               "show_completed_items": false,
               "grouping": {
                 "group_by": "",
-                "group_by_column_id": ""
+                "group_by_column_id": "",
+                "order": ""
               },
               "filters": [
                 {
@@ -16390,7 +16392,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -33906,7 +33909,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {

--- a/json-logs/samples/api/search.files.json
+++ b/json-logs/samples/api/search.files.json
@@ -10570,6 +10570,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -11209,6 +11210,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -11349,6 +11351,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -16335,6 +16338,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -33850,6 +33854,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,

--- a/json-logs/samples/api/search.files.json
+++ b/json-logs/samples/api/search.files.json
@@ -11263,7 +11263,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -11275,7 +11275,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -11403,7 +11413,7 @@
               "grouping": {
                 "group_by": "",
                 "group_by_column_id": "",
-                "order": ""
+                "order": []
               },
               "filters": [
                 {
@@ -11415,7 +11425,17 @@
                   "typed_values": [],
                   "column_id": ""
                 }
-              ]
+              ],
+              "sorts": [],
+              "info_column_filters": [],
+              "calculations": [],
+              "options": {
+                "cover_field": "",
+                "cover_fit": "",
+                "calendar_field": ""
+              },
+              "is_template_initial_view": false,
+              "row_height": 123
             },
             "files": [
               {
@@ -16393,7 +16413,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -16405,7 +16425,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -33910,7 +33940,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -33922,7 +33952,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [

--- a/json-logs/samples/api/search.messages.json
+++ b/json-logs/samples/api/search.messages.json
@@ -9853,6 +9853,13 @@
                     "language": {
                       "locale": "",
                       "is_reliable": false
+                    },
+                    "agent_session": {
+                      "status": "",
+                      "agent_bot_user_ids": [],
+                      "agent_statuses": [],
+                      "title": "",
+                      "date_status_processing_expire": 123
                     }
                   }
                 }
@@ -10392,6 +10399,13 @@
                         "language": {
                           "locale": "",
                           "is_reliable": false
+                        },
+                        "agent_session": {
+                          "status": "",
+                          "agent_bot_user_ids": [],
+                          "agent_statuses": [],
+                          "title": "",
+                          "date_status_processing_expire": 123
                         }
                       },
                       "number": [],
@@ -10980,6 +10994,13 @@
                         "language": {
                           "locale": "",
                           "is_reliable": false
+                        },
+                        "agent_session": {
+                          "status": "",
+                          "agent_bot_user_ids": [],
+                          "agent_statuses": [],
+                          "title": "",
+                          "date_status_processing_expire": 123
                         }
                       },
                       "number": [],
@@ -53268,6 +53289,13 @@
                     "language": {
                       "locale": "",
                       "is_reliable": false
+                    },
+                    "agent_session": {
+                      "status": "",
+                      "agent_bot_user_ids": [],
+                      "agent_statuses": [],
+                      "title": "",
+                      "date_status_processing_expire": 123
                     }
                   }
                 }
@@ -53807,6 +53835,13 @@
                         "language": {
                           "locale": "",
                           "is_reliable": false
+                        },
+                        "agent_session": {
+                          "status": "",
+                          "agent_bot_user_ids": [],
+                          "agent_statuses": [],
+                          "title": "",
+                          "date_status_processing_expire": 123
                         }
                       },
                       "number": [],
@@ -54395,6 +54430,13 @@
                         "language": {
                           "locale": "",
                           "is_reliable": false
+                        },
+                        "agent_session": {
+                          "status": "",
+                          "agent_bot_user_ids": [],
+                          "agent_statuses": [],
+                          "title": "",
+                          "date_status_processing_expire": 123
                         }
                       },
                       "number": [],
@@ -114576,6 +114618,13 @@
                   "language": {
                     "locale": "",
                     "is_reliable": false
+                  },
+                  "agent_session": {
+                    "status": "",
+                    "agent_bot_user_ids": [],
+                    "agent_statuses": [],
+                    "title": "",
+                    "date_status_processing_expire": 123
                   }
                 }
               }
@@ -115115,6 +115164,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],
@@ -115703,6 +115759,13 @@
                       "language": {
                         "locale": "",
                         "is_reliable": false
+                      },
+                      "agent_session": {
+                        "status": "",
+                        "agent_bot_user_ids": [],
+                        "agent_statuses": [],
+                        "title": "",
+                        "date_status_processing_expire": 123
                       }
                     },
                     "number": [],

--- a/json-logs/samples/api/search.messages.json
+++ b/json-logs/samples/api/search.messages.json
@@ -11127,7 +11127,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -11266,7 +11267,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -16255,7 +16257,8 @@
                         "show_completed_items": false,
                         "grouping": {
                           "group_by": "",
-                          "group_by_column_id": ""
+                          "group_by_column_id": "",
+                          "order": ""
                         },
                         "filters": [
                           {
@@ -33771,7 +33774,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -54498,7 +54502,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -54637,7 +54642,8 @@
                 "show_completed_items": false,
                 "grouping": {
                   "group_by": "",
-                  "group_by_column_id": ""
+                  "group_by_column_id": "",
+                  "order": ""
                 },
                 "filters": [
                   {
@@ -59626,7 +59632,8 @@
                         "show_completed_items": false,
                         "grouping": {
                           "group_by": "",
-                          "group_by_column_id": ""
+                          "group_by_column_id": "",
+                          "order": ""
                         },
                         "filters": [
                           {
@@ -77142,7 +77149,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -95033,7 +95041,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -115751,7 +115760,8 @@
                     "show_completed_items": false,
                     "grouping": {
                       "group_by": "",
-                      "group_by_column_id": ""
+                      "group_by_column_id": "",
+                      "order": ""
                     },
                     "filters": [
                       {
@@ -115890,7 +115900,8 @@
               "show_completed_items": false,
               "grouping": {
                 "group_by": "",
-                "group_by_column_id": ""
+                "group_by_column_id": "",
+                "order": ""
               },
               "filters": [
                 {
@@ -120879,7 +120890,8 @@
                       "show_completed_items": false,
                       "grouping": {
                         "group_by": "",
-                        "group_by_column_id": ""
+                        "group_by_column_id": "",
+                        "order": ""
                       },
                       "filters": [
                         {
@@ -135129,7 +135141,8 @@
                   "show_completed_items": false,
                   "grouping": {
                     "group_by": "",
-                    "group_by_column_id": ""
+                    "group_by_column_id": "",
+                    "order": ""
                   },
                   "filters": [
                     {

--- a/json-logs/samples/api/search.messages.json
+++ b/json-logs/samples/api/search.messages.json
@@ -10435,6 +10435,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -11074,6 +11075,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -11214,6 +11216,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -16200,6 +16203,7 @@
                             "channel": []
                           },
                           "emoji": "",
+                          "emoji_url": "",
                           "max": 123,
                           "precision": 123,
                           "show_member_name": false,
@@ -33715,6 +33719,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -53801,6 +53806,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -54440,6 +54446,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -54580,6 +54587,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -59566,6 +59574,7 @@
                             "channel": []
                           },
                           "emoji": "",
+                          "emoji_url": "",
                           "max": 123,
                           "precision": 123,
                           "show_member_name": false,
@@ -77081,6 +77090,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -94971,6 +94981,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -115048,6 +115059,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,
@@ -115687,6 +115699,7 @@
                         "channel": []
                       },
                       "emoji": "",
+                      "emoji_url": "",
                       "max": 123,
                       "precision": 123,
                       "show_member_name": false,
@@ -115827,6 +115840,7 @@
                     "channel": []
                   },
                   "emoji": "",
+                  "emoji_url": "",
                   "max": 123,
                   "precision": 123,
                   "show_member_name": false,
@@ -120813,6 +120827,7 @@
                           "channel": []
                         },
                         "emoji": "",
+                        "emoji_url": "",
                         "max": 123,
                         "precision": 123,
                         "show_member_name": false,
@@ -135062,6 +135077,7 @@
                       "channel": []
                     },
                     "emoji": "",
+                    "emoji_url": "",
                     "max": 123,
                     "precision": 123,
                     "show_member_name": false,

--- a/json-logs/samples/api/search.messages.json
+++ b/json-logs/samples/api/search.messages.json
@@ -11128,7 +11128,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -11140,7 +11140,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -11268,7 +11278,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -11280,7 +11290,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               },
               "files": [
                 {
@@ -16258,7 +16278,7 @@
                         "grouping": {
                           "group_by": "",
                           "group_by_column_id": "",
-                          "order": ""
+                          "order": []
                         },
                         "filters": [
                           {
@@ -16270,7 +16290,17 @@
                             "typed_values": [],
                             "column_id": ""
                           }
-                        ]
+                        ],
+                        "sorts": [],
+                        "info_column_filters": [],
+                        "calculations": [],
+                        "options": {
+                          "cover_field": "",
+                          "cover_fit": "",
+                          "calendar_field": ""
+                        },
+                        "is_template_initial_view": false,
+                        "row_height": 123
                       }
                     ],
                     "integrations": [
@@ -33775,7 +33805,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -33787,7 +33817,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -54503,7 +54543,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -54515,7 +54555,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -54643,7 +54693,7 @@
                 "grouping": {
                   "group_by": "",
                   "group_by_column_id": "",
-                  "order": ""
+                  "order": []
                 },
                 "filters": [
                   {
@@ -54655,7 +54705,17 @@
                     "typed_values": [],
                     "column_id": ""
                   }
-                ]
+                ],
+                "sorts": [],
+                "info_column_filters": [],
+                "calculations": [],
+                "options": {
+                  "cover_field": "",
+                  "cover_fit": "",
+                  "calendar_field": ""
+                },
+                "is_template_initial_view": false,
+                "row_height": 123
               },
               "files": [
                 {
@@ -59633,7 +59693,7 @@
                         "grouping": {
                           "group_by": "",
                           "group_by_column_id": "",
-                          "order": ""
+                          "order": []
                         },
                         "filters": [
                           {
@@ -59645,7 +59705,17 @@
                             "typed_values": [],
                             "column_id": ""
                           }
-                        ]
+                        ],
+                        "sorts": [],
+                        "info_column_filters": [],
+                        "calculations": [],
+                        "options": {
+                          "cover_field": "",
+                          "cover_fit": "",
+                          "calendar_field": ""
+                        },
+                        "is_template_initial_view": false,
+                        "row_height": 123
                       }
                     ],
                     "integrations": [
@@ -77150,7 +77220,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -77162,7 +77232,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -95042,7 +95122,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -95054,7 +95134,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -115761,7 +115851,7 @@
                     "grouping": {
                       "group_by": "",
                       "group_by_column_id": "",
-                      "order": ""
+                      "order": []
                     },
                     "filters": [
                       {
@@ -115773,7 +115863,17 @@
                         "typed_values": [],
                         "column_id": ""
                       }
-                    ]
+                    ],
+                    "sorts": [],
+                    "info_column_filters": [],
+                    "calculations": [],
+                    "options": {
+                      "cover_field": "",
+                      "cover_fit": "",
+                      "calendar_field": ""
+                    },
+                    "is_template_initial_view": false,
+                    "row_height": 123
                   }
                 ],
                 "integrations": [
@@ -115901,7 +116001,7 @@
               "grouping": {
                 "group_by": "",
                 "group_by_column_id": "",
-                "order": ""
+                "order": []
               },
               "filters": [
                 {
@@ -115913,7 +116013,17 @@
                   "typed_values": [],
                   "column_id": ""
                 }
-              ]
+              ],
+              "sorts": [],
+              "info_column_filters": [],
+              "calculations": [],
+              "options": {
+                "cover_field": "",
+                "cover_fit": "",
+                "calendar_field": ""
+              },
+              "is_template_initial_view": false,
+              "row_height": 123
             },
             "files": [
               {
@@ -120891,7 +121001,7 @@
                       "grouping": {
                         "group_by": "",
                         "group_by_column_id": "",
-                        "order": ""
+                        "order": []
                       },
                       "filters": [
                         {
@@ -120903,7 +121013,17 @@
                           "typed_values": [],
                           "column_id": ""
                         }
-                      ]
+                      ],
+                      "sorts": [],
+                      "info_column_filters": [],
+                      "calculations": [],
+                      "options": {
+                        "cover_field": "",
+                        "cover_fit": "",
+                        "calendar_field": ""
+                      },
+                      "is_template_initial_view": false,
+                      "row_height": 123
                     }
                   ],
                   "integrations": [
@@ -135142,7 +135262,7 @@
                   "grouping": {
                     "group_by": "",
                     "group_by_column_id": "",
-                    "order": ""
+                    "order": []
                   },
                   "filters": [
                     {
@@ -135154,7 +135274,17 @@
                       "typed_values": [],
                       "column_id": ""
                     }
-                  ]
+                  ],
+                  "sorts": [],
+                  "info_column_filters": [],
+                  "calculations": [],
+                  "options": {
+                    "cover_field": "",
+                    "cover_fit": "",
+                    "calendar_field": ""
+                  },
+                  "is_template_initial_view": false,
+                  "row_height": 123
                 }
               ],
               "integrations": [

--- a/json-logs/samples/api/slackLists.create.json
+++ b/json-logs/samples/api/slackLists.create.json
@@ -18,7 +18,11 @@
               "label": "",
               "color": ""
             }
-          ]
+          ],
+          "date_format": "",
+          "precision": 12345,
+          "emoji": "",
+          "max": 12345
         }
       }
     ],

--- a/json-logs/samples/api/slackLists.create.json
+++ b/json-logs/samples/api/slackLists.create.json
@@ -22,7 +22,14 @@
           "date_format": "",
           "precision": 12345,
           "emoji": "",
-          "max": 12345
+          "max": 12345,
+          "emoji_team_id": "T00000000",
+          "default_value_typed": {
+            "user": [
+              "U00000000"
+            ]
+          },
+          "notify_users": false
         }
       }
     ],

--- a/json-logs/samples/api/slackLists.items.create.json
+++ b/json-logs/samples/api/slackLists.items.create.json
@@ -29,7 +29,10 @@
           }
         ],
         "checkbox": false,
-        "text": ""
+        "text": "",
+        "user": [
+          "U00000000"
+        ]
       }
     ],
     "updated_timestamp": ""

--- a/json-logs/samples/api/slackLists.items.info.json
+++ b/json-logs/samples/api/slackLists.items.info.json
@@ -41,7 +41,14 @@
             "date_format": "",
             "precision": 12345,
             "emoji": "",
-            "max": 12345
+            "max": 12345,
+            "emoji_team_id": "T00000000",
+            "default_value_typed": {
+              "user": [
+                "U00000000"
+              ]
+            },
+            "notify_users": false
           }
         }
       ],
@@ -173,6 +180,9 @@
               }
             ]
           }
+        ],
+        "user": [
+          "U00000000"
         ]
       }
     ],

--- a/json-logs/samples/api/slackLists.items.info.json
+++ b/json-logs/samples/api/slackLists.items.info.json
@@ -37,7 +37,11 @@
                 "label": "",
                 "color": ""
               }
-            ]
+            ],
+            "date_format": "",
+            "precision": 12345,
+            "emoji": "",
+            "max": 12345
           }
         }
       ],

--- a/json-logs/samples/api/slackLists.items.list.json
+++ b/json-logs/samples/api/slackLists.items.list.json
@@ -30,7 +30,10 @@
             }
           ],
           "checkbox": false,
-          "text": ""
+          "text": "",
+          "user": [
+            "U00000000"
+          ]
         },
         {
           "key": "",

--- a/json-logs/samples/api/slackLists.items.list.json
+++ b/json-logs/samples/api/slackLists.items.list.json
@@ -36,7 +36,28 @@
           "key": "",
           "value": false,
           "checkbox": false,
-          "column_id": ""
+          "column_id": "",
+          "text": "",
+          "rich_text": [
+            {
+              "type": "",
+              "block_id": "",
+              "elements": [
+                {
+                  "type": "",
+                  "elements": [
+                    {
+                      "text": "",
+                      "type": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "user": [
+            "U00000000"
+          ]
         }
       ],
       "updated_timestamp": ""

--- a/json-logs/samples/api/slackLists.items.list.json
+++ b/json-logs/samples/api/slackLists.items.list.json
@@ -40,6 +40,9 @@
           "value": false,
           "checkbox": false,
           "column_id": "",
+          "user": [
+            "U00000000"
+          ],
           "text": "",
           "rich_text": [
             {
@@ -57,9 +60,6 @@
                 }
               ]
             }
-          ],
-          "user": [
-            "U00000000"
           ]
         }
       ],

--- a/json-logs/samples/api/slackLists.items.list.json
+++ b/json-logs/samples/api/slackLists.items.list.json
@@ -36,25 +36,7 @@
           "key": "",
           "value": false,
           "checkbox": false,
-          "column_id": "",
-          "text": "",
-          "rich_text": [
-            {
-              "type": "",
-              "block_id": "",
-              "elements": [
-                {
-                  "type": "",
-                  "elements": [
-                    {
-                      "text": "",
-                      "type": ""
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+          "column_id": ""
         }
       ],
       "updated_timestamp": ""

--- a/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
@@ -320,6 +320,7 @@ public class Actions {
         public static final String slack_ai_mcp_resource_read = "slack_ai_mcp_resource_read";
         public static final String slack_ai_mcp_message_sent = "slack_ai_mcp_message_sent";
         public static final String slack_ai_mcp_link_opened = "slack_ai_mcp_link_opened";
+        public static final String slack_ai_mcp_model_context_updated = "slack_ai_mcp_model_context_updated";
         public static final String custom_tos_link_clicked = "custom_tos_link_clicked";
         public static final String prefs_setting_changed = "prefs_setting_changed";
         public static final String auth_policy_created = "auth_policy_created";

--- a/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
@@ -591,6 +591,7 @@ public class Actions {
         public static final String app_mcp_server_acl_changed = "app_mcp_server_acl_changed";
         public static final String app_mcp_server_auth_strategy_set = "app_mcp_server_auth_strategy_set";
         public static final String app_mcp_tool_acl_changed = "app_mcp_tool_acl_changed";
+        public static final String app_mcp_tool_default_acl_changed = "app_mcp_tool_default_acl_changed";
         public static final String app_dwa_domain_added = "app_dwa_domain_added";
         public static final String app_dwa_domain_removed = "app_dwa_domain_removed";
     }

--- a/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
@@ -348,6 +348,7 @@ public class Actions {
         public static final String mcp_slack_get_file_upload_url_tool_called = "mcp_slack_get_file_upload_url_tool_called";
         public static final String mcp_slack_complete_file_upload_tool_called = "mcp_slack_complete_file_upload_tool_called";
         public static final String mcp_slack_list_user_channels_tool_called = "mcp_slack_list_user_channels_tool_called";
+        public static final String mcp_slack_todos_list_tool_called = "mcp_slack_todos_list_tool_called";
         public static final String ip_allowlist_enabled = "ip_allowlist_enabled";
         public static final String ip_allowlist_disabled = "ip_allowlist_disabled";
         public static final String team_authorized_ip_range_added = "team_authorized_ip_range_added";

--- a/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
+++ b/slack-api-client/src/main/java/com/slack/api/audit/Actions.java
@@ -767,6 +767,8 @@ public class Actions {
         public static final String salesforce_mcp_server_workspace_revoked = "salesforce_mcp_server_workspace_revoked";
         public static final String salesforce_mcp_server_acl_updated = "salesforce_mcp_server_acl_updated";
         public static final String salesforce_mcp_server_tool_acl_updated = "salesforce_mcp_server_tool_acl_updated";
+        public static final String salesforce_mcp_server_tool_default_updated = "salesforce_mcp_server_tool_default_updated";
+        public static final String salesforce_mcp_server_tool_permissions_deleted = "salesforce_mcp_server_tool_permissions_deleted";
     }
 
     public static class Canvas {

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/bots/BotsInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/bots/BotsInfoResponse.java
@@ -21,6 +21,10 @@ public class BotsInfoResponse implements SlackApiTextResponse {
         private BotIcons icons;
         // Returned as true for Slack-certified Workflow Builder connector apps.
         private Boolean isConnectorBot;
+        // Returned as true for bots backing Workflow Builder workflows.
+        private Boolean isWorkflowBot;
+        // Returned as true for bots backing legacy (steps-from-apps) workflows.
+        private Boolean isLegacyWorkflowBot;
     }
 
     private boolean ok;

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/bots/BotsInfoResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/bots/BotsInfoResponse.java
@@ -19,6 +19,8 @@ public class BotsInfoResponse implements SlackApiTextResponse {
         private boolean deleted;
         private Integer updated;
         private BotIcons icons;
+        // Returned as true for Slack-certified Workflow Builder connector apps.
+        private Boolean isConnectorBot;
     }
 
     private boolean ok;

--- a/slack-api-client/src/main/java/com/slack/api/util/json/GsonFactory.java
+++ b/slack-api-client/src/main/java/com/slack/api/util/json/GsonFactory.java
@@ -16,6 +16,7 @@ import com.slack.api.model.block.element.BlockElement;
 import com.slack.api.model.block.element.RichTextElement;
 import com.slack.api.model.event.FunctionExecutedEvent;
 import com.slack.api.model.event.MessageChangedEvent;
+import com.slack.api.model.list.ListView;
 
 import java.time.Instant;
 
@@ -85,6 +86,7 @@ public class GsonFactory {
                 .registerTypeAdapter(AppWorkflow.StepInputValue.class, new GsonAppWorkflowStepInputValueFactory(failOnUnknownProps))
                 .registerTypeAdapter(AppWorkflow.StepInputValueElementDefault.class, new GsonAppWorkflowStepInputValueDefaultFactory(failOnUnknownProps))
                 .registerTypeAdapter(LogsResponse.DetailsChangedValue.class, new GsonAuditLogsDetailsChangedValueFactory(failOnUnknownProps))
-                .registerTypeAdapter(LogsResponse.UserIDs.class, new GsonAuditLogsDetailsUserIDsFactory(failOnUnknownProps));
+                .registerTypeAdapter(LogsResponse.UserIDs.class, new GsonAuditLogsDetailsUserIDsFactory(failOnUnknownProps))
+                .registerTypeAdapter(ListView.Grouping.class, new GsonListViewGroupingFactory(failOnUnknownProps));
     }
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/bots_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/bots_Test.java
@@ -101,4 +101,33 @@ public class bots_Test {
         brokenSlack.methodsAsync(botToken).botsInfo(req -> req.bot(botId)).get();
     }
 
+    @Test
+    public void botsInfo_connectorBot() throws Exception {
+        // is_connector_bot is only returned by bots.info (not users.list/users.info) and
+        // only for Slack-certified Workflow Builder connector apps. Find such a bot, if the
+        // workspace has one installed, so the recorded bots.info sample carries the property.
+        List<User> users = slack.methodsAsync(botToken).usersList(req -> req).get().getMembers();
+        BotsInfoResponse.Bot connectorBot = null;
+        for (User u : users) {
+            if (!u.isBot() || "USLACKBOT".equals(u.getId())) {
+                continue;
+            }
+            String botId = u.getProfile() != null ? u.getProfile().getBotId() : null;
+            if (botId == null) {
+                continue;
+            }
+            BotsInfoResponse response = slack.methodsAsync(botToken).botsInfo(req -> req.bot(botId)).get();
+            if (response.isOk() && response.getBot() != null
+                    && Boolean.TRUE.equals(response.getBot().getIsConnectorBot())) {
+                connectorBot = response.getBot();
+                break;
+            }
+        }
+        if (connectorBot == null) {
+            log.info("No connector bot installed in this workspace; skipping is_connector_bot assertion");
+            return;
+        }
+        assertThat(connectorBot.getIsConnectorBot(), is(true));
+    }
+
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/files_Test.java
@@ -1329,4 +1329,69 @@ public class files_Test {
         assertThat(file1info.getFile().getShares().getPublicChannels().get(randomChannelId), is(notNullValue()));
     }
 
+    @Test
+    public void sharedFileWithReply_recordsReplyShareDetail() throws Exception {
+        // Upload a file into a channel, reply in its thread, then read files.info so the
+        // recorded shares.public entry carries the reply-dependent detail (latest_reply,
+        // reply_count, reply_users, reply_users_count). Without a reply these fields are
+        // absent, so the generated response types would otherwise miss them.
+        File file = new File("src/test/resources/sample.txt");
+        FilesUploadV2Response upload = slack.methods(botToken).filesUploadV2(r -> r
+                .file(file)
+                .channel(channelId)
+                .filename("sample.txt")
+                .title("shared file with reply"));
+        assertThat(upload.getError(), is(nullValue()));
+        assertThat(upload.isOk(), is(true));
+
+        String fileId = upload.getFile().getId();
+
+        // The share ts may not be present immediately after upload; poll files.info for it.
+        String shareTs = null;
+        for (int i = 0; i < 10 && shareTs == null; i++) {
+            com.slack.api.model.File fileObj =
+                    slack.methods(botToken).filesInfo(r -> r.file(fileId)).getFile();
+            if (fileObj.getShares() != null
+                    && fileObj.getShares().getPublicChannels() != null
+                    && fileObj.getShares().getPublicChannels().get(channelId) != null) {
+                shareTs = fileObj.getShares().getPublicChannels().get(channelId).get(0).getTs();
+            }
+            if (shareTs == null) {
+                Thread.sleep(2000L);
+            }
+        }
+        assertThat(shareTs, is(notNullValue()));
+
+        // Reply in the shared message's thread so the API populates the reply detail.
+        final String threadTs = shareTs;
+        ChatPostMessageResponse reply = slack.methods(botToken).chatPostMessage(r -> r
+                .channel(channelId)
+                .threadTs(threadTs)
+                .text("a reply to the shared file"));
+        assertThat(reply.getError(), is(nullValue()));
+        assertThat(reply.isOk(), is(true));
+
+        // Poll files.info until the share detail reflects the reply.
+        com.slack.api.model.File.ShareDetail detail = null;
+        for (int i = 0; i < 10; i++) {
+            com.slack.api.model.File fileObj =
+                    slack.methods(botToken).filesInfo(r -> r.file(fileId)).getFile();
+            com.slack.api.model.File.ShareDetail d =
+                    fileObj.getShares().getPublicChannels().get(channelId).get(0);
+            if (d.getLatestReply() != null) {
+                detail = d;
+                break;
+            }
+            Thread.sleep(2000L);
+        }
+        assertThat(detail, is(notNullValue()));
+        assertThat(detail.getLatestReply(), is(notNullValue()));
+        assertThat(detail.getReplyCount(), is(notNullValue()));
+        assertThat(detail.getReplyUsers(), is(notNullValue()));
+        assertThat(detail.getReplyUsersCount(), is(notNullValue()));
+
+        FilesDeleteResponse deletion = slack.methods(botToken).filesDelete(r -> r.file(fileId));
+        assertThat(deletion.getError(), is(nullValue()));
+    }
+
 }

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/slacklists_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/slacklists_Test.java
@@ -2,6 +2,7 @@ package test_with_remote_apis.methods;
 
 import com.slack.api.Slack;
 import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.response.auth.AuthTestResponse;
 import com.slack.api.methods.response.slack_lists.SlackListsAccessDeleteResponse;
 import com.slack.api.methods.response.slack_lists.SlackListsAccessSetResponse;
 import com.slack.api.methods.response.slack_lists.SlackListsCreateResponse;
@@ -55,6 +56,14 @@ public class slacklists_Test {
 
     @Test
     public void fullSlackListsWorkflow() throws IOException, SlackApiException {
+        // Resolve a real user id and team id so the schema can carry
+        // default_value_typed (user) and emoji_team_id, which the API only
+        // echoes back when populated with valid values.
+        AuthTestResponse auth = slack.methods(botToken).authTest(r -> r);
+        assertThat(auth.getError(), is(nullValue()));
+        String selfUserId = auth.getUserId();
+        String teamId = auth.getTeamId();
+
         // Build schema columns
         ListColumn taskNameCol = ListColumn.builder()
                 .key("task_name")
@@ -83,7 +92,7 @@ public class slacklists_Test {
                         .build())
                 .build();
 
-        // A rating column with emoji/max so the response echoes back emoji and max
+        // A rating column with emoji/max/emoji_team_id so the response echoes those back
         ListColumn ratingCol = ListColumn.builder()
                 .key("priority")
                 .name("Priority")
@@ -91,6 +100,7 @@ public class slacklists_Test {
                 .options(ListColumnOptions.builder()
                         .emoji(":star:")
                         .max(5)
+                        .emojiTeamId(teamId)
                         .build())
                 .build();
 
@@ -123,10 +133,19 @@ public class slacklists_Test {
                 .options(statusOptions)
                 .build();
 
+        // A user column with notify_users and a typed default so the response
+        // echoes back notify_users and default_value_typed (the user variant;
+        // the select variant is rejected by slackLists.create).
         ListColumn assigneeCol = ListColumn.builder()
                 .key("assignee")
                 .name("Assignee")
                 .type("user")
+                .options(ListColumnOptions.builder()
+                        .notifyUsers(true)
+                        .defaultValueTyped(ListColumnOptions.DefaultValue.builder()
+                                .user(Arrays.asList(selfUserId))
+                                .build())
+                        .build())
                 .build();
 
         // create list

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/slacklists_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/slacklists_Test.java
@@ -206,9 +206,14 @@ public class slacklists_Test {
         assertThat(createItemResponse.isOk(), is(true));
         assertThat(createItemResponse.getItem(), is(notNullValue()));
         assertThat(createItemResponse.getItem().getFields(), is(notNullValue()));
-        assertThat(createItemResponse.getItem().getFields().size(), is(1));
-        assertThat(createItemResponse.getItem().getFields().get(0).getColumnId(), is(taskNameColId));
-        assertThat(createItemResponse.getItem().getFields().get(0).getText(), is("Test task item"));
+        // Columns with typed defaults (e.g. the user column) may also come back populated,
+        // so locate the task_name field by column id rather than asserting an exact count.
+        ListRecord.Field taskNameField = createItemResponse.getItem().getFields().stream()
+                .filter(f -> taskNameColId.equals(f.getColumnId()))
+                .findFirst()
+                .orElse(null);
+        assertThat(taskNameField, is(notNullValue()));
+        assertThat(taskNameField.getText(), is("Test task item"));
 
         String itemId = createItemResponse.getItem().getId();
         assertThat(itemId, is(notNullValue()));

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/slacklists_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/slacklists_Test.java
@@ -63,10 +63,35 @@ public class slacklists_Test {
                 .primaryColumn(true)
                 .build();
 
+        // A date column with a dateFormat option so the response echoes back date_format
         ListColumn dueDateCol = ListColumn.builder()
                 .key("due_date")
                 .name("Due Date")
                 .type("date")
+                .options(ListColumnOptions.builder()
+                        .dateFormat("MM/DD/YYYY")
+                        .build())
+                .build();
+
+        // A number column with precision so the response echoes back precision
+        ListColumn estimateCol = ListColumn.builder()
+                .key("estimate")
+                .name("Estimate")
+                .type("number")
+                .options(ListColumnOptions.builder()
+                        .precision(2)
+                        .build())
+                .build();
+
+        // A rating column with emoji/max so the response echoes back emoji and max
+        ListColumn ratingCol = ListColumn.builder()
+                .key("priority")
+                .name("Priority")
+                .type("rating")
+                .options(ListColumnOptions.builder()
+                        .emoji(":star:")
+                        .max(5)
+                        .build())
                 .build();
 
         ListColumnOptions.Choice choice1 = ListColumnOptions.Choice.builder()
@@ -115,7 +140,7 @@ public class slacklists_Test {
                                         .build()))
                                 .build()))
                         .build()))
-                .schema(Arrays.asList(taskNameCol, dueDateCol, statusCol, assigneeCol)));
+                .schema(Arrays.asList(taskNameCol, dueDateCol, estimateCol, ratingCol, statusCol, assigneeCol)));
 
         assertThat(createResponse.getError(), is(nullValue()));
         assertThat(createResponse.isOk(), is(true));

--- a/slack-api-model/src/main/java/com/slack/api/model/Message.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/Message.java
@@ -283,4 +283,30 @@ public class Message {
         @SerializedName("is_reliable")
         private boolean reliable;
     }
+
+    private AgentSession agentSession;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AgentSession {
+        private String status;
+        private List<String> agentBotUserIds;
+        private List<AgentStatus> agentStatuses;
+        private String title;
+        private Long dateStatusProcessingExpire;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AgentStatus {
+        private String agentBotUserId;
+        private String status;
+        @SerializedName("is_stoppable")
+        private boolean stoppable;
+        private Long dateStatusProcessingExpire;
+    }
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/list/ListColumnOptions.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/list/ListColumnOptions.java
@@ -18,6 +18,7 @@ public class ListColumnOptions {
     private String defaultValue; // select
     private DefaultValue defaultValueTyped; // select
     private String emoji; // rating, vote
+    private String emojiUrl; // rating, vote
     private Integer max; // rating
     private Integer precision; // number
     private Boolean showMemberName; // channel

--- a/slack-api-model/src/main/java/com/slack/api/model/list/ListView.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/list/ListView.java
@@ -37,6 +37,7 @@ public class ListView {
     public static class Grouping {
         private String groupBy;
         private String groupByColumnId;
+        private String order;
     }
 
     @Data

--- a/slack-api-model/src/main/java/com/slack/api/model/list/ListView.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/list/ListView.java
@@ -29,6 +29,12 @@ public class ListView {
     private Boolean showCompletedItems;
     private Grouping grouping;
     private List<Filter> filters;
+    private List<Sort> sorts;
+    private List<InfoColumnFilter> infoColumnFilters;
+    private List<Calculation> calculations;
+    private Options options;
+    private Boolean isTemplateInitialView;
+    private Integer rowHeight;
 
     @Data
     @Builder
@@ -37,7 +43,26 @@ public class ListView {
     public static class Grouping {
         private String groupBy;
         private String groupByColumnId;
-        private String order;
+        // Ordered group values; each entry carries the typed value(s) for its group.
+        private List<GroupingOrder> order;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GroupingOrder {
+        private List<String> select;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Sort {
+        private String key;
+        private Boolean ascending;
+        private String columnId;
     }
 
     @Data
@@ -50,6 +75,37 @@ public class ListView {
         private List<String> values;
         private List<TypedValue> typedValues;
         private String columnId;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InfoColumnFilter {
+        private String key;
+        private String operator;
+        private List<String> values;
+        private List<TypedValue> typedValues;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Calculation {
+        private String key;
+        private String operator;
+        private String columnId;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Options {
+        private String coverField;
+        private String coverFit;
+        private String calendarField;
     }
 
     @Data

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonListViewGroupingFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonListViewGroupingFactory.java
@@ -1,0 +1,90 @@
+package com.slack.api.util.json;
+
+import com.google.gson.*;
+import com.slack.api.model.list.ListView.Grouping;
+import com.slack.api.model.list.ListView.GroupingOrder;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GsonListViewGroupingFactory implements JsonDeserializer<Grouping>, JsonSerializer<Grouping> {
+
+    private final boolean failOnUnknownProperties;
+
+    public GsonListViewGroupingFactory() {
+        this(false);
+    }
+
+    public GsonListViewGroupingFactory(boolean failOnUnknownProperties) {
+        this.failOnUnknownProperties = failOnUnknownProperties;
+    }
+
+    @Override
+    public Grouping deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        if (!json.isJsonObject()) {
+            return null;
+        }
+        JsonObject obj = json.getAsJsonObject();
+        Grouping grouping = new Grouping();
+
+        if (obj.has("group_by") && !obj.get("group_by").isJsonNull()) {
+            grouping.setGroupBy(obj.get("group_by").getAsString());
+        }
+        if (obj.has("group_by_column_id") && !obj.get("group_by_column_id").isJsonNull()) {
+            grouping.setGroupByColumnId(obj.get("group_by_column_id").getAsString());
+        }
+
+        if (obj.has("order")) {
+            JsonElement orderElem = obj.get("order");
+            if (orderElem.isJsonArray()) {
+                List<GroupingOrder> orderList = new ArrayList<>();
+                for (JsonElement item : orderElem.getAsJsonArray()) {
+                    if (item.isJsonObject()) {
+                        GroupingOrder go = new GroupingOrder();
+                        JsonObject itemObj = item.getAsJsonObject();
+                        if (itemObj.has("select") && itemObj.get("select").isJsonArray()) {
+                            List<String> selectList = new ArrayList<>();
+                            for (JsonElement s : itemObj.get("select").getAsJsonArray()) {
+                                selectList.add(s.getAsString());
+                            }
+                            go.setSelect(selectList);
+                        }
+                        orderList.add(go);
+                    }
+                }
+                grouping.setOrder(orderList);
+            }
+            // When order is a string (e.g. ""), leave it as null
+        }
+
+        return grouping;
+    }
+
+    @Override
+    public JsonElement serialize(Grouping src, Type typeOfSrc, JsonSerializationContext context) {
+        if (src == null) {
+            return JsonNull.INSTANCE;
+        }
+        JsonObject obj = new JsonObject();
+        obj.addProperty("group_by", src.getGroupBy());
+        obj.addProperty("group_by_column_id", src.getGroupByColumnId());
+        if (src.getOrder() != null) {
+            JsonArray orderArray = new JsonArray();
+            for (GroupingOrder go : src.getOrder()) {
+                JsonObject goObj = new JsonObject();
+                if (go.getSelect() != null) {
+                    JsonArray selectArray = new JsonArray();
+                    for (String s : go.getSelect()) {
+                        selectArray.add(s);
+                    }
+                    goObj.add("select", selectArray);
+                }
+                orderArray.add(goObj);
+            }
+            obj.add("order", orderArray);
+        }
+        return obj;
+    }
+}


### PR DESCRIPTION
Periodic refresh of the Web API response models and recorded samples as of 2026-08-21, plus test changes that make the remote-API tests exercise state the API only returns under specific conditions (so the automatic property-detection mechanism records the fields, and the downstream [node-slack-sdk](https://github.com/slackapi/node-slack-sdk) type generator infers complete types from the samples).

### Response model changes

- **`bots.info`** — detect `is_connector_bot` on the bot object (alongside the existing workflow-bot flags), with doc comments describing when each is returned.
- **`Message`** — add the `agent_session` detail (`status`, `agent_bot_user_ids`) surfaced on messages in agent sessions.
- **Slack Lists** — `ListColumnOptions` gains `emoji_url` (rating/vote columns); `ListView.Grouping` now deserializes via a dedicated adapter (`GsonListViewGroupingFactory`, registered in `GsonFactory`) to tolerate the field being either a string or an array.
- **Audit Logs `Actions`** — add newly-observed action names (MCP-related: `slack_ai_mcp_model_context_updated`, `mcp_slack_todos_list_tool_called`, `app_mcp_tool_default_acl_changed`, `salesforce_mcp_server_tool_default_updated`, `salesforce_mcp_server_tool_permissions_deleted`).

### Test changes (so samples record conditional fields)

Two response shapes were losing detail because the remote-API tests never produced the state that makes Slack return the fields:

- **`slacklists_Test`** — column option variants were never created, so `slackLists.*` samples never contained `options.precision` (number), `options.date_format` (date), or `options.emoji` / `options.max` (rating). Now gives the `due_date` column a `dateFormat`, adds a `number` column (`estimate`) with `precision`, and a `rating` column (`priority`) with `emoji` + `max`. Also exercises `emoji_team_id`, `notify_users`, and `default_value_typed`.
- **`files_Test`** — the `files.info` coverage uploaded/shared a file but never replied in its thread, so `shares.public` lacked the reply-dependent fields. Now uploads to a channel, waits for the share `ts`, posts a threaded reply, and reads `files.info` until the share detail reflects it — asserting `latest_reply` / `reply_count` / `reply_users` / `reply_users_count`. (`date_last_shared` is intentionally not asserted — nullable, conditionally set, not reliably returned.)
- **`bots_Test`** — exercises `is_connector_bot` detection.

### Sample regeneration

Recorded `json-logs/samples/api/*.json` refreshed across `bots.info`, `chat.*` (incl. `chat.stopStream`), `conversations.*`, `files.*`, `pins.list`, `reactions.*`, `search.*`, and `slackLists.*`, plus the audit `actions.json`.

### Category

* [x] **slack-api-client** (Slack API Clients)

### Testing

Dispatch the [java-slack-sdk-runner](https://github.com/slackapi/java-slack-sdk-runner) `Tests` workflow against a test workspace, then confirm the regenerated samples contain the new properties — e.g. `slackLists.create.json` -> `options.precision` / `options.date_format` / `options.emoji` / `options.max`, and `files.info.json` -> `shares.public[].latest_reply` / `reply_count` / `reply_users` / `reply_users_count`.

### Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.