### PR TITLE
feat: add agents.sessions.setStatus and agents.sessions.rename

### DIFF
--- a/json-logs/samples/api/agents.sessions.rename.json
+++ b/json-logs/samples/api/agents.sessions.rename.json
@@ -1,0 +1,8 @@
+{
+  "ok": false,
+  "warning": "",
+  "error": "",
+  "needed": "",
+  "provided": "",
+  "title": ""
+}

--- a/json-logs/samples/api/agents.sessions.setStatus.json
+++ b/json-logs/samples/api/agents.sessions.setStatus.json
@@ -1,0 +1,10 @@
+{
+  "ok": false,
+  "warning": "",
+  "error": "",
+  "needed": "",
+  "provided": "",
+  "status": "",
+  "agent_status": "",
+  "title": ""
+}

--- a/metadata/web-api/rate_limit_tiers.json
+++ b/metadata/web-api/rate_limit_tiers.json
@@ -98,6 +98,8 @@
   "admin.workflows.permissions.lookup": "Tier2",
   "admin.workflows.search": "Tier2",
   "admin.workflows.unpublish": "Tier2",
+  "agents.sessions.rename": "Tier3",
+  "agents.sessions.setStatus": "Tier3",
   "api.test": "Tier4",
   "apps.connections.open": "Tier1",
   "apps.event.authorizations.list": "Tier4",

--- a/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/AsyncMethodsClient.java
@@ -38,6 +38,8 @@ import com.slack.api.methods.request.admin.usergroups.AdminUsergroupsRemoveChann
 import com.slack.api.methods.request.admin.users.*;
 import com.slack.api.methods.request.admin.users.unsupported_versions.AdminUsersUnsupportedVersionsExportRequest;
 import com.slack.api.methods.request.admin.workflows.*;
+import com.slack.api.methods.request.agents.sessions.AgentsSessionsRenameRequest;
+import com.slack.api.methods.request.agents.sessions.AgentsSessionsSetStatusRequest;
 import com.slack.api.methods.request.api.ApiTestRequest;
 import com.slack.api.methods.request.apps.AppsUninstallRequest;
 import com.slack.api.methods.request.apps.connections.AppsConnectionsOpenRequest;
@@ -177,6 +179,8 @@ import com.slack.api.methods.response.admin.usergroups.AdminUsergroupsRemoveChan
 import com.slack.api.methods.response.admin.users.*;
 import com.slack.api.methods.response.admin.users.unsupported_versions.AdminUsersUnsupportedVersionsExportResponse;
 import com.slack.api.methods.response.admin.workflows.*;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsRenameResponse;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsSetStatusResponse;
 import com.slack.api.methods.response.api.ApiTestResponse;
 import com.slack.api.methods.response.apps.AppsUninstallResponse;
 import com.slack.api.methods.response.apps.connections.AppsConnectionsOpenResponse;
@@ -793,6 +797,18 @@ public interface AsyncMethodsClient {
     CompletableFuture<AdminWorkflowsUnpublishResponse> adminWorkflowsUnpublish(AdminWorkflowsUnpublishRequest req);
 
     CompletableFuture<AdminWorkflowsUnpublishResponse> adminWorkflowsUnpublish(RequestConfigurator<AdminWorkflowsUnpublishRequest.AdminWorkflowsUnpublishRequestBuilder> req);
+
+    // ------------------------------
+    // agents.sessions
+    // ------------------------------
+
+    CompletableFuture<AgentsSessionsRenameResponse> agentsSessionsRename(AgentsSessionsRenameRequest req);
+
+    CompletableFuture<AgentsSessionsRenameResponse> agentsSessionsRename(RequestConfigurator<AgentsSessionsRenameRequest.AgentsSessionsRenameRequestBuilder> req);
+
+    CompletableFuture<AgentsSessionsSetStatusResponse> agentsSessionsSetStatus(AgentsSessionsSetStatusRequest req);
+
+    CompletableFuture<AgentsSessionsSetStatusResponse> agentsSessionsSetStatus(RequestConfigurator<AgentsSessionsSetStatusRequest.AgentsSessionsSetStatusRequestBuilder> req);
 
     // ------------------------------
     // api

--- a/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/Methods.java
@@ -220,6 +220,13 @@ public class Methods {
     public static final String ADMIN_WORKFLOWS_UNPUBLISH = "admin.workflows.unpublish";
 
     // ------------------------------
+    // agents.sessions
+    // ------------------------------
+
+    public static final String AGENTS_SESSIONS_RENAME = "agents.sessions.rename";
+    public static final String AGENTS_SESSIONS_SET_STATUS = "agents.sessions.setStatus";
+
+    // ------------------------------
     // api
     // ------------------------------
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsClient.java
@@ -38,6 +38,8 @@ import com.slack.api.methods.request.admin.usergroups.AdminUsergroupsRemoveChann
 import com.slack.api.methods.request.admin.users.*;
 import com.slack.api.methods.request.admin.users.unsupported_versions.AdminUsersUnsupportedVersionsExportRequest;
 import com.slack.api.methods.request.admin.workflows.*;
+import com.slack.api.methods.request.agents.sessions.AgentsSessionsRenameRequest;
+import com.slack.api.methods.request.agents.sessions.AgentsSessionsSetStatusRequest;
 import com.slack.api.methods.request.api.ApiTestRequest;
 import com.slack.api.methods.request.apps.AppsUninstallRequest;
 import com.slack.api.methods.request.apps.connections.AppsConnectionsOpenRequest;
@@ -190,6 +192,8 @@ import com.slack.api.methods.response.admin.usergroups.AdminUsergroupsRemoveChan
 import com.slack.api.methods.response.admin.users.*;
 import com.slack.api.methods.response.admin.users.unsupported_versions.AdminUsersUnsupportedVersionsExportResponse;
 import com.slack.api.methods.response.admin.workflows.*;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsRenameResponse;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsSetStatusResponse;
 import com.slack.api.methods.response.api.ApiTestResponse;
 import com.slack.api.methods.response.apps.AppsUninstallResponse;
 import com.slack.api.methods.response.apps.connections.AppsConnectionsOpenResponse;
@@ -1129,6 +1133,24 @@ public interface MethodsClient {
 
     AdminWorkflowsUnpublishResponse adminWorkflowsUnpublish(
             RequestConfigurator<AdminWorkflowsUnpublishRequest.AdminWorkflowsUnpublishRequestBuilder> req)
+            throws IOException, SlackApiException;
+
+    // ------------------------------
+    // agents.sessions
+    // ------------------------------
+
+    AgentsSessionsRenameResponse agentsSessionsRename(AgentsSessionsRenameRequest req)
+            throws IOException, SlackApiException;
+
+    AgentsSessionsRenameResponse agentsSessionsRename(
+            RequestConfigurator<AgentsSessionsRenameRequest.AgentsSessionsRenameRequestBuilder> req)
+            throws IOException, SlackApiException;
+
+    AgentsSessionsSetStatusResponse agentsSessionsSetStatus(AgentsSessionsSetStatusRequest req)
+            throws IOException, SlackApiException;
+
+    AgentsSessionsSetStatusResponse agentsSessionsSetStatus(
+            RequestConfigurator<AgentsSessionsSetStatusRequest.AgentsSessionsSetStatusRequestBuilder> req)
             throws IOException, SlackApiException;
 
     // ------------------------------

--- a/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/MethodsRateLimits.java
@@ -223,6 +223,9 @@ public class MethodsRateLimits {
         setRateLimitTier(APPS_MANIFEST_VALIDATE, Tier3);
         setRateLimitTier(TOOLING_TOKENS_ROTATE, Tier1); // TODO: change this when the "special" tier is clearly explained in the document
 
+        setRateLimitTier(AGENTS_SESSIONS_RENAME, Tier3);
+        setRateLimitTier(AGENTS_SESSIONS_SET_STATUS, Tier3);
+
         setRateLimitTier(API_TEST, Tier4);
         setRateLimitTier(APPS_CONNECTIONS_OPEN, Tier1);
         setRateLimitTier(APPS_UNINSTALL, Tier1);

--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -39,6 +39,8 @@ import com.slack.api.methods.request.admin.usergroups.AdminUsergroupsRemoveChann
 import com.slack.api.methods.request.admin.users.*;
 import com.slack.api.methods.request.admin.users.unsupported_versions.AdminUsersUnsupportedVersionsExportRequest;
 import com.slack.api.methods.request.admin.workflows.*;
+import com.slack.api.methods.request.agents.sessions.AgentsSessionsRenameRequest;
+import com.slack.api.methods.request.agents.sessions.AgentsSessionsSetStatusRequest;
 import com.slack.api.methods.request.api.ApiTestRequest;
 import com.slack.api.methods.request.apps.AppsUninstallRequest;
 import com.slack.api.methods.request.apps.connections.AppsConnectionsOpenRequest;
@@ -1045,6 +1047,27 @@ public class RequestFormBuilder {
         if (req.getWorkflowIds() != null && req.getWorkflowIds().size() > 0) {
             setIfNotNull("workflow_ids", req.getWorkflowIds().stream().collect(joining(",")), form);
         }
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AgentsSessionsRenameRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("channel_id", req.getChannelId(), form);
+        setIfNotNull("title", req.getTitle(), form);
+        setIfNotNull("thread_ts", req.getThreadTs(), form);
+        return form;
+    }
+
+    public static FormBody.Builder toForm(AgentsSessionsSetStatusRequest req) {
+        FormBody.Builder form = new FormBody.Builder();
+        setIfNotNull("channel_id", req.getChannelId(), form);
+        setIfNotNull("status", req.getStatus(), form);
+        setIfNotNull("thread_ts", req.getThreadTs(), form);
+        setIfNotNull("title", req.getTitle(), form);
+        setIfNotNull("initiator_user_id", req.getInitiatorUserId(), form);
+        setIfNotNull("icon_emoji", req.getIconEmoji(), form);
+        setIfNotNull("icon_url", req.getIconUrl(), form);
+        setIfNotNull("username", req.getUsername(), form);
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/AsyncMethodsClientImpl.java
@@ -43,6 +43,8 @@ import com.slack.api.methods.request.admin.usergroups.AdminUsergroupsRemoveChann
 import com.slack.api.methods.request.admin.users.*;
 import com.slack.api.methods.request.admin.users.unsupported_versions.AdminUsersUnsupportedVersionsExportRequest;
 import com.slack.api.methods.request.admin.workflows.*;
+import com.slack.api.methods.request.agents.sessions.AgentsSessionsRenameRequest;
+import com.slack.api.methods.request.agents.sessions.AgentsSessionsSetStatusRequest;
 import com.slack.api.methods.request.api.ApiTestRequest;
 import com.slack.api.methods.request.apps.AppsUninstallRequest;
 import com.slack.api.methods.request.apps.connections.AppsConnectionsOpenRequest;
@@ -182,6 +184,8 @@ import com.slack.api.methods.response.admin.usergroups.AdminUsergroupsRemoveChan
 import com.slack.api.methods.response.admin.users.*;
 import com.slack.api.methods.response.admin.users.unsupported_versions.AdminUsersUnsupportedVersionsExportResponse;
 import com.slack.api.methods.response.admin.workflows.*;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsRenameResponse;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsSetStatusResponse;
 import com.slack.api.methods.response.api.ApiTestResponse;
 import com.slack.api.methods.response.apps.AppsUninstallResponse;
 import com.slack.api.methods.response.apps.connections.AppsConnectionsOpenResponse;
@@ -1315,6 +1319,26 @@ public class AsyncMethodsClientImpl implements AsyncMethodsClient {
     @Override
     public CompletableFuture<AdminWorkflowsUnpublishResponse> adminWorkflowsUnpublish(RequestConfigurator<AdminWorkflowsUnpublishRequest.AdminWorkflowsUnpublishRequestBuilder> req) {
         return adminWorkflowsUnpublish(req.configure(AdminWorkflowsUnpublishRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<AgentsSessionsRenameResponse> agentsSessionsRename(AgentsSessionsRenameRequest req) {
+        return executor.execute(AGENTS_SESSIONS_RENAME, toMap(req), () -> methods.agentsSessionsRename(req));
+    }
+
+    @Override
+    public CompletableFuture<AgentsSessionsRenameResponse> agentsSessionsRename(RequestConfigurator<AgentsSessionsRenameRequest.AgentsSessionsRenameRequestBuilder> req) {
+        return agentsSessionsRename(req.configure(AgentsSessionsRenameRequest.builder()).build());
+    }
+
+    @Override
+    public CompletableFuture<AgentsSessionsSetStatusResponse> agentsSessionsSetStatus(AgentsSessionsSetStatusRequest req) {
+        return executor.execute(AGENTS_SESSIONS_SET_STATUS, toMap(req), () -> methods.agentsSessionsSetStatus(req));
+    }
+
+    @Override
+    public CompletableFuture<AgentsSessionsSetStatusResponse> agentsSessionsSetStatus(RequestConfigurator<AgentsSessionsSetStatusRequest.AgentsSessionsSetStatusRequestBuilder> req) {
+        return agentsSessionsSetStatus(req.configure(AgentsSessionsSetStatusRequest.builder()).build());
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/MethodsClientImpl.java
@@ -40,6 +40,8 @@ import com.slack.api.methods.request.admin.usergroups.AdminUsergroupsRemoveChann
 import com.slack.api.methods.request.admin.users.*;
 import com.slack.api.methods.request.admin.users.unsupported_versions.AdminUsersUnsupportedVersionsExportRequest;
 import com.slack.api.methods.request.admin.workflows.*;
+import com.slack.api.methods.request.agents.sessions.AgentsSessionsRenameRequest;
+import com.slack.api.methods.request.agents.sessions.AgentsSessionsSetStatusRequest;
 import com.slack.api.methods.request.api.ApiTestRequest;
 import com.slack.api.methods.request.apps.AppsUninstallRequest;
 import com.slack.api.methods.request.apps.connections.AppsConnectionsOpenRequest;
@@ -192,6 +194,8 @@ import com.slack.api.methods.response.admin.usergroups.AdminUsergroupsRemoveChan
 import com.slack.api.methods.response.admin.users.*;
 import com.slack.api.methods.response.admin.users.unsupported_versions.AdminUsersUnsupportedVersionsExportResponse;
 import com.slack.api.methods.response.admin.workflows.*;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsRenameResponse;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsSetStatusResponse;
 import com.slack.api.methods.response.api.ApiTestResponse;
 import com.slack.api.methods.response.apps.AppsUninstallResponse;
 import com.slack.api.methods.response.apps.connections.AppsConnectionsOpenResponse;
@@ -1356,6 +1360,26 @@ public class MethodsClientImpl implements MethodsClient {
     @Override
     public AdminUsersSessionListResponse adminUsersSessionList(RequestConfigurator<AdminUsersSessionListRequest.AdminUsersSessionListRequestBuilder> req) throws IOException, SlackApiException {
         return adminUsersSessionList(req.configure(AdminUsersSessionListRequest.builder()).build());
+    }
+
+    @Override
+    public AgentsSessionsRenameResponse agentsSessionsRename(AgentsSessionsRenameRequest req) throws IOException, SlackApiException {
+        return postFormWithTokenAndParseResponse(toForm(req), Methods.AGENTS_SESSIONS_RENAME, getToken(req), AgentsSessionsRenameResponse.class);
+    }
+
+    @Override
+    public AgentsSessionsRenameResponse agentsSessionsRename(RequestConfigurator<AgentsSessionsRenameRequest.AgentsSessionsRenameRequestBuilder> req) throws IOException, SlackApiException {
+        return agentsSessionsRename(req.configure(AgentsSessionsRenameRequest.builder()).build());
+    }
+
+    @Override
+    public AgentsSessionsSetStatusResponse agentsSessionsSetStatus(AgentsSessionsSetStatusRequest req) throws IOException, SlackApiException {
+        return postFormWithTokenAndParseResponse(toForm(req), Methods.AGENTS_SESSIONS_SET_STATUS, getToken(req), AgentsSessionsSetStatusResponse.class);
+    }
+
+    @Override
+    public AgentsSessionsSetStatusResponse agentsSessionsSetStatus(RequestConfigurator<AgentsSessionsSetStatusRequest.AgentsSessionsSetStatusRequestBuilder> req) throws IOException, SlackApiException {
+        return agentsSessionsSetStatus(req.configure(AgentsSessionsSetStatusRequest.builder()).build());
     }
 
     @Override

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/agents/sessions/AgentsSessionsRenameRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/agents/sessions/AgentsSessionsRenameRequest.java
@@ -1,0 +1,32 @@
+package com.slack.api.methods.request.agents.sessions;
+
+import com.slack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://docs.slack.dev/reference/methods/agents.sessions.rename
+ */
+@Data
+@Builder
+public class AgentsSessionsRenameRequest implements SlackApiRequest {
+
+    private String token;
+
+    /**
+     * ID of the channel containing the agent session.
+     */
+    private String channelId;
+
+    /**
+     * New title for the agent session (1-200 characters). For a session channel, this also renames the channel.
+     */
+    private String title;
+
+    /**
+     * Timestamp of the thread root message the session is scoped to. Required for thread-based sessions in regular
+     * channels and DMs. Must be omitted for session channels.
+     */
+    private String threadTs;
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/agents/sessions/AgentsSessionsSetStatusRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/agents/sessions/AgentsSessionsSetStatusRequest.java
@@ -1,0 +1,62 @@
+package com.slack.api.methods.request.agents.sessions;
+
+import com.slack.api.methods.SlackApiRequest;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * https://docs.slack.dev/reference/methods/agents.sessions.setStatus
+ */
+@Data
+@Builder
+public class AgentsSessionsSetStatusRequest implements SlackApiRequest {
+
+    private String token;
+
+    /**
+     * ID of the channel containing the agent session.
+     */
+    private String channelId;
+
+    /**
+     * The lifecycle status to set. Acceptable values: active, processing, suspended, closed.
+     */
+    private String status;
+
+    /**
+     * Timestamp of the thread root message the session is scoped to. Required for thread-based sessions in regular
+     * channels and DMs. Must be omitted for session channels.
+     */
+    private String threadTs;
+
+    /**
+     * Title for the agent session (max 200 characters). Only used when creating a new session; ignored if the session
+     * already exists. To rename an existing session, use agents.sessions.rename.
+     */
+    private String title;
+
+    /**
+     * The user who initiated the session. Only used when creating a new session; ignored if the session already
+     * exists. Must be a member of the channel.
+     */
+    private String initiatorUserId;
+
+    /**
+     * Emoji to use as the agent's icon. Takes priority over icon_url. Remains in effect until you clear it (pass null)
+     * or set a new value. Requires the chat:write.customize scope.
+     */
+    private String iconEmoji;
+
+    /**
+     * URL to an image to use as the agent's icon. Remains in effect until you clear it (pass null) or set a new value.
+     * Requires the chat:write.customize scope.
+     */
+    private String iconUrl;
+
+    /**
+     * Display name override for the agent (max 200 characters). Remains in effect until you clear it (pass null) or set
+     * a new value. Requires the chat:write.customize scope.
+     */
+    private String username;
+
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/agents/sessions/AgentsSessionsRenameResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/agents/sessions/AgentsSessionsRenameResponse.java
@@ -1,0 +1,21 @@
+package com.slack.api.methods.response.agents.sessions;
+
+import com.slack.api.methods.SlackApiTextResponse;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class AgentsSessionsRenameResponse implements SlackApiTextResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private String title;
+
+    private transient Map<String, List<String>> httpResponseHeaders;
+}

--- a/slack-api-client/src/main/java/com/slack/api/methods/response/agents/sessions/AgentsSessionsSetStatusResponse.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/response/agents/sessions/AgentsSessionsSetStatusResponse.java
@@ -1,0 +1,23 @@
+package com.slack.api.methods.response.agents.sessions;
+
+import com.slack.api.methods.SlackApiTextResponse;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class AgentsSessionsSetStatusResponse implements SlackApiTextResponse {
+
+    private boolean ok;
+    private String warning;
+    private String error;
+    private String needed;
+    private String provided;
+
+    private String status;
+    private String agentStatus;
+    private String title;
+
+    private transient Map<String, List<String>> httpResponseHeaders;
+}

--- a/slack-api-client/src/test/java/test_locally/sample_json_generation/MethodsResponseDumpTest.java
+++ b/slack-api-client/src/test/java/test_locally/sample_json_generation/MethodsResponseDumpTest.java
@@ -1,6 +1,8 @@
 package test_locally.sample_json_generation;
 
 import com.slack.api.methods.response.admin.apps.*;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsRenameResponse;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsSetStatusResponse;
 import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetStatusResponse;
 import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetSuggestedPromptsResponse;
 import com.slack.api.methods.response.asssistant.threads.AssistantThreadsSetTitleResponse;
@@ -166,6 +168,20 @@ public class MethodsResponseDumpTest {
             AdminAppsUninstallResponse response = new AdminAppsUninstallResponse();
             ObjectInitializer.initProperties(response);
             dumper.dump("admin.apps.uninstall", response);
+        }
+    }
+
+    @Test
+    public void agents_sessions() throws Exception {
+        {
+            AgentsSessionsRenameResponse response = new AgentsSessionsRenameResponse();
+            ObjectInitializer.initProperties(response);
+            dumper.dump("agents.sessions.rename", response);
+        }
+        {
+            AgentsSessionsSetStatusResponse response = new AgentsSessionsSetStatusResponse();
+            ObjectInitializer.initProperties(response);
+            dumper.dump("agents.sessions.setStatus", response);
         }
     }
 

--- a/slack-api-client/src/test/java/test_with_remote_apis/methods/agents_sessions_Test.java
+++ b/slack-api-client/src/test/java/test_with_remote_apis/methods/agents_sessions_Test.java
@@ -1,0 +1,94 @@
+package test_with_remote_apis.methods;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsRenameResponse;
+import com.slack.api.methods.response.agents.sessions.AgentsSessionsSetStatusResponse;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.methods.response.conversations.ConversationsListResponse;
+import com.slack.api.model.Conversation;
+import config.Constants;
+import config.SlackTestConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeNotNull;
+
+@Slf4j
+public class agents_sessions_Test {
+
+    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String teamId = null; // Required if testing in an org environment. eg. "T0123ABC"
+
+    static SlackTestConfig testConfig = SlackTestConfig.getInstance();
+    static Slack slack = Slack.getInstance(testConfig.getConfig());
+
+    @AfterClass
+    public static void tearDown() throws InterruptedException {
+        SlackTestConfig.awaitCompletion(testConfig);
+    }
+
+    private String randomChannelId = null;
+
+    void loadRandomChannelId() throws IOException, SlackApiException {
+        if (randomChannelId == null) {
+            ConversationsListResponse channelsListResponse = slack.methods()
+                    .conversationsList(r -> {
+                        r.token(botToken).excludeArchived(true).limit(100);
+                        if (teamId != null) {
+                            r.teamId(teamId);
+                        }
+                        return r;
+                    });
+            assertThat(channelsListResponse.getError(), is(nullValue()));
+            for (Conversation channel : channelsListResponse.getChannels()) {
+                if (channel.getName().equals("random")) {
+                    randomChannelId = channel.getId();
+                    break;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void setStatusAndRename() throws IOException, SlackApiException {
+        assumeNotNull(botToken);
+        loadRandomChannelId();
+
+        // Start a thread with a plain message; its ts scopes the agent session.
+        ChatPostMessageResponse message = slack.methods(botToken).chatPostMessage(r -> r
+                .channel(randomChannelId)
+                .text("Starting an agent session"));
+        assertThat(message.getError(), is(nullValue()));
+        assertThat(message.isOk(), is(true));
+        String threadTs = message.getTs();
+
+        AgentsSessionsSetStatusResponse setStatus = slack.methods(botToken).agentsSessionsSetStatus(r -> r
+                .channelId(randomChannelId)
+                .threadTs(threadTs)
+                .status("processing")
+                .title("Working on your request"));
+        assertThat(setStatus.getError(), is(nullValue()));
+        assertThat(setStatus.isOk(), is(true));
+
+        AgentsSessionsRenameResponse rename = slack.methods(botToken).agentsSessionsRename(r -> r
+                .channelId(randomChannelId)
+                .threadTs(threadTs)
+                .title("Renamed agent session"));
+        assertThat(rename.getError(), is(nullValue()));
+        assertThat(rename.isOk(), is(true));
+
+        AgentsSessionsSetStatusResponse closed = slack.methods(botToken).agentsSessionsSetStatus(r -> r
+                .channelId(randomChannelId)
+                .threadTs(threadTs)
+                .status("closed"));
+        assertThat(closed.getError(), is(nullValue()));
+        assertThat(closed.isOk(), is(true));
+    }
+}


### PR DESCRIPTION
Adds the `agents.sessions.*` Web API methods — the agent-sessions successors to `assistant.threads.setStatus` / `assistant.threads.setTitle`.

## Documentation
- [`agents.sessions.setStatus`](https://docs.slack.dev/reference/methods/agents.sessions.setStatus) — set an agent session's lifecycle status, creating the session if needed.
- [`agents.sessions.rename`](https://docs.slack.dev/reference/methods/agents.sessions.rename) — rename an agent session.

## Methods
- `agents.sessions.setStatus` — `channel_id` (required), `status` (required), optional `thread_ts`, `title`, `initiator_user_id`, `icon_emoji`, `icon_url`, `username`
- `agents.sessions.rename` — `channel_id` (required), `title` (required), optional `thread_ts`

Bot token scope: `chat:write`. Rate limit: Tier 3 (both).

## What's included
- Request classes: `AgentsSessionsSetStatusRequest`, `AgentsSessionsRenameRequest`
- Response classes: `AgentsSessionsSetStatusResponse`, `AgentsSessionsRenameResponse`
- Sync + async client method declarations and implementations
- `RequestFormBuilder` form serialization
- Rate-limit tier registration (`MethodsRateLimits` + `rate_limit_tiers.json`)
- Response-sample dump (`MethodsResponseDumpTest.agents_sessions()`) for downstream type generation
- Remote API tests (`test_with_remote_apis/methods/agents_sessions_Test`) — assume-gated on a bot token, so they skip cleanly without credentials

Mirrors the Python SDK implementation (slackapi/python-slack-sdk#1942). Draft/experimental.