### PR TITLE
feat(model): add TaskCardBlock and UrlSourceElement

### DIFF
--- a/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
@@ -147,4 +147,10 @@ public class Blocks {
         return configurator.configure(CarouselBlock.builder()).build();
     }
 
+    // TaskCardBlock
+
+    public static TaskCardBlock taskCard(ModelConfigurator<TaskCardBlock.TaskCardBlockBuilder> configurator) {
+        return configurator.configure(TaskCardBlock.builder()).build();
+    }
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/TaskCardBlock.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/TaskCardBlock.java
@@ -1,0 +1,32 @@
+package com.slack.api.model.block;
+
+import com.slack.api.model.block.composition.SlackIconObject;
+import com.slack.api.model.block.element.UrlSourceElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * https://docs.slack.dev/reference/block-kit/blocks/task-card-block
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskCardBlock implements LayoutBlock {
+    public static final String TYPE = "task_card";
+    private final String type = TYPE;
+
+    private String taskId;
+    private String title;
+    private String status;
+    private RichTextBlock details;
+    private RichTextBlock output;
+    private List<UrlSourceElement> sources;
+    private String blockId;
+    private SlackIconObject icon;
+    private Boolean hideTitle;
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/block/element/UrlSourceElement.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/element/UrlSourceElement.java
@@ -1,0 +1,21 @@
+package com.slack.api.model.block.element;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * https://docs.slack.dev/reference/block-kit/block-elements/url-source-element
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UrlSourceElement {
+    public static final String TYPE = "url";
+    private final String type = TYPE;
+
+    private String url;
+    private String text;
+}

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
@@ -33,42 +33,42 @@ public class GsonLayoutBlockFactory implements JsonDeserializer<LayoutBlock>, Js
 
     private Class<? extends LayoutBlock> getLayoutClassInstance(String typeName) {
         switch (typeName) {
-            case SectionBlock.TYPE:
-                return SectionBlock.class;
-            case DividerBlock.TYPE:
-                return DividerBlock.class;
-            case ImageBlock.TYPE:
-                return ImageBlock.class;
-            case ContextBlock.TYPE:
-                return ContextBlock.class;
-            case ContextActionsBlock.TYPE:
-                return ContextActionsBlock.class;
-            case CallBlock.TYPE:
-                return CallBlock.class;
             case ActionsBlock.TYPE:
                 return ActionsBlock.class;
-            case FileBlock.TYPE:
-                return FileBlock.class;
-            case InputBlock.TYPE:
-                return InputBlock.class;
-            case HeaderBlock.TYPE:
-                return HeaderBlock.class;
-            case MarkdownBlock.TYPE:
-                return MarkdownBlock.class;
-            case VideoBlock.TYPE:
-                return VideoBlock.class;
-            case RichTextBlock.TYPE:
-                return RichTextBlock.class;
-            case ShareShortcutBlock.TYPE:
-                return ShareShortcutBlock.class;
             case AlertBlock.TYPE:
                 return AlertBlock.class;
+            case CallBlock.TYPE:
+                return CallBlock.class;
             case CardBlock.TYPE:
                 return CardBlock.class;
             case CarouselBlock.TYPE:
                 return CarouselBlock.class;
+            case ContextActionsBlock.TYPE:
+                return ContextActionsBlock.class;
+            case ContextBlock.TYPE:
+                return ContextBlock.class;
+            case DividerBlock.TYPE:
+                return DividerBlock.class;
+            case FileBlock.TYPE:
+                return FileBlock.class;
+            case HeaderBlock.TYPE:
+                return HeaderBlock.class;
+            case ImageBlock.TYPE:
+                return ImageBlock.class;
+            case InputBlock.TYPE:
+                return InputBlock.class;
+            case MarkdownBlock.TYPE:
+                return MarkdownBlock.class;
+            case RichTextBlock.TYPE:
+                return RichTextBlock.class;
+            case SectionBlock.TYPE:
+                return SectionBlock.class;
+            case ShareShortcutBlock.TYPE:
+                return ShareShortcutBlock.class;
             case TaskCardBlock.TYPE:
                 return TaskCardBlock.class;
+            case VideoBlock.TYPE:
+                return VideoBlock.class;
             default:
                 if (failOnUnknownProperties) {
                     throw new JsonParseException("Unsupported layout block type: " + typeName);

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
@@ -67,6 +67,8 @@ public class GsonLayoutBlockFactory implements JsonDeserializer<LayoutBlock>, Js
                 return CardBlock.class;
             case CarouselBlock.TYPE:
                 return CarouselBlock.class;
+            case TaskCardBlock.TYPE:
+                return TaskCardBlock.class;
             default:
                 if (failOnUnknownProperties) {
                     throw new JsonParseException("Unsupported layout block type: " + typeName);

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -2211,7 +2211,7 @@ public class BlockKitTest {
                 "      \"type\": \"task_card\",\n" +
                 "      \"task_id\": \"task_1\",\n" +
                 "      \"title\": \"Fetching weather data\",\n" +
-                "      \"status\": \"pending\",\n" +
+                "      \"status\": \"in_progress\",\n" +
                 "      \"output\": {\n" +
                 "        \"type\": \"rich_text\",\n" +
                 "        \"elements\": [\n" +

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -2202,4 +2202,80 @@ public class BlockKitTest {
         assertThat(parsedCarousel.getElements().get(0).getBlockId(), is("card1"));
         assertThat(parsedCarousel.getElements().get(0).getActions().size(), is(1));
     }
+
+    @Test
+    public void parseTaskCardBlock() {
+        String json = "{\n" +
+                "  \"blocks\": [\n" +
+                "    {\n" +
+                "      \"type\": \"task_card\",\n" +
+                "      \"task_id\": \"task_1\",\n" +
+                "      \"title\": \"Fetching weather data\",\n" +
+                "      \"status\": \"pending\",\n" +
+                "      \"output\": {\n" +
+                "        \"type\": \"rich_text\",\n" +
+                "        \"elements\": [\n" +
+                "          {\n" +
+                "            \"type\": \"rich_text_section\",\n" +
+                "            \"elements\": [\n" +
+                "              {\n" +
+                "                \"type\": \"text\",\n" +
+                "                \"text\": \"Found weather data for Chicago from 2 sources\"\n" +
+                "              }\n" +
+                "            ]\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      \"sources\": [\n" +
+                "        {\n" +
+                "          \"type\": \"url\",\n" +
+                "          \"url\": \"https://weather.com/\",\n" +
+                "          \"text\": \"weather.com\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "          \"type\": \"url\",\n" +
+                "          \"url\": \"https://www.accuweather.com/\",\n" +
+                "          \"text\": \"accuweather.com\"\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+        Gson gson = GsonFactory.createSnakeCase();
+        Message message = gson.fromJson(json, Message.class);
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getBlocks().size(), is(1));
+
+        TaskCardBlock taskCard = (TaskCardBlock) message.getBlocks().get(0);
+        assertThat(taskCard.getType(), is("task_card"));
+        assertThat(taskCard.getTaskId(), is("task_1"));
+        assertThat(taskCard.getTitle(), is("Fetching weather data"));
+        assertThat(taskCard.getStatus(), is("pending"));
+
+        assertThat(taskCard.getOutput(), is(notNullValue()));
+        assertThat(taskCard.getOutput().getType(), is("rich_text"));
+
+        assertThat(taskCard.getSources().size(), is(2));
+        assertThat(taskCard.getSources().get(0).getType(), is("url"));
+        assertThat(taskCard.getSources().get(0).getUrl(), is("https://weather.com/"));
+        assertThat(taskCard.getSources().get(0).getText(), is("weather.com"));
+        assertThat(taskCard.getSources().get(1).getUrl(), is("https://www.accuweather.com/"));
+        assertThat(taskCard.getSources().get(1).getText(), is("accuweather.com"));
+    }
+
+    @Test
+    public void buildTaskCardBlock() {
+        TaskCardBlock taskCard = Blocks.taskCard(t -> t
+                .taskId("task_42")
+                .title("Processing data")
+                .status("in_progress")
+                .sources(Arrays.asList(
+                        UrlSourceElement.builder().url("https://example.com").text("example").build())));
+        assertThat(taskCard, is(notNullValue()));
+        assertThat(taskCard.getType(), is("task_card"));
+        assertThat(taskCard.getTaskId(), is("task_42"));
+        assertThat(taskCard.getTitle(), is("Processing data"));
+        assertThat(taskCard.getStatus(), is("in_progress"));
+        assertThat(taskCard.getSources().size(), is(1));
+    }
 }

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -2250,7 +2250,7 @@ public class BlockKitTest {
         assertThat(taskCard.getType(), is("task_card"));
         assertThat(taskCard.getTaskId(), is("task_1"));
         assertThat(taskCard.getTitle(), is("Fetching weather data"));
-        assertThat(taskCard.getStatus(), is("pending"));
+        assertThat(taskCard.getStatus(), is("in_progress"));
 
         assertThat(taskCard.getOutput(), is(notNullValue()));
         assertThat(taskCard.getOutput().getType(), is("rich_text"));

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -118,6 +118,11 @@ public class BlocksTest {
     }
 
     @Test
+    public void testTaskCard() {
+        assertThat(taskCard(t -> t.taskId("task_1").title("Do thing").status("complete")), is(notNullValue()));
+    }
+
+    @Test
     public void testImage() {
         assertThat(Blocks.image(i -> i.blockId("block-id").imageUrl("https://www.example.com/")), is(notNullValue()));
         assertThat(Blocks.image(i -> i

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -118,11 +118,6 @@ public class BlocksTest {
     }
 
     @Test
-    public void testTaskCard() {
-        assertThat(taskCard(t -> t.taskId("task_1").title("Do thing").status("complete")), is(notNullValue()));
-    }
-
-    @Test
     public void testImage() {
         assertThat(Blocks.image(i -> i.blockId("block-id").imageUrl("https://www.example.com/")), is(notNullValue()));
         assertThat(Blocks.image(i -> i
@@ -156,6 +151,11 @@ public class BlocksTest {
                 .blockId("block-id")
                 .elements(asElements(button(b -> b.value("v"))))
         ), is(notNullValue()));
+    }
+
+    @Test
+    public void testTaskCard() {
+        assertThat(taskCard(t -> t.taskId("task_1").title("Do thing").status("complete")), is(notNullValue()));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `TaskCardBlock` layout block (`task_card` type) with all fields from [docs](https://docs.slack.dev/reference/block-kit/blocks/task-card-block)
- Adds `UrlSourceElement` for the `sources` field
- Registers in `GsonLayoutBlockFactory`, adds `Blocks.taskCard()` helper
- Includes parse and build tests in `BlockKitTest` and `BlocksTest`

## Fields

| Field | Type | Required |
|-------|------|----------|
| `type` | `"task_card"` | yes |
| `task_id` | String | yes |
| `title` | String | yes |
| `status` | String (`in_progress`, `complete`, `error`) | yes |
| `details` | RichTextBlock | no |
| `output` | RichTextBlock | no |
| `sources` | List\<UrlSourceElement\> | no |
| `block_id` | String | no |
| `icon` | SlackIconObject | no |
| `hide_title` | Boolean | no |

> **Note:** The docs example uses `"pending"` as a status value, but the API rejects it with `invalid_blocks`. Only `in_progress`, `complete`, and `error` are accepted.

## Example usage

```java
import static com.slack.api.model.block.Blocks.*;

var blocks = asBlocks(
    taskCard(t -> t
        .taskId("task_1")
        .title("Fetching weather data")
        .status("complete")
        .output(RichTextBlock.builder()
            .elements(Arrays.asList(
                RichTextSectionElement.builder()
                    .elements(Arrays.asList(
                        RichTextSectionElement.Text.builder()
                            .text("Found weather data for Chicago from 2 sources")
                            .build()
                    ))
                    .build()
            ))
            .build())
        .sources(Arrays.asList(
            UrlSourceElement.builder().url("https://weather.com/").text("weather.com").build(),
            UrlSourceElement.builder().url("https://www.accuweather.com/").text("accuweather.com").build()
        ))
    ),
    taskCard(t -> t
        .taskId("task_2")
        .title("Analyzing results")
        .status("in_progress")
    ),
    taskCard(t -> t
        .taskId("task_3")
        .title("Send notification")
        .status("error")
        .hideTitle(true)
        .output(RichTextBlock.builder()
            .elements(Arrays.asList(
                RichTextSectionElement.builder()
                    .elements(Arrays.asList(
                        RichTextSectionElement.Text.builder()
                            .text("Failed to reach notification service")
                            .build()
                    ))
                    .build()
            ))
            .build())
    )
);
```

## Test plan
- [x] `parseTaskCardBlock` — deserializes JSON from docs example
- [x] `buildTaskCardBlock` — constructs via `Blocks.taskCard()` helper
- [x] `testTaskCard` — static helper test in `BlocksTest`
- [x] Tested in Slack UI via Socket Mode app with `chatPostMessage`