### PR TITLE
feat: add ContainerBlock layout block support

### DIFF
--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/ContainerBlockBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/ContainerBlockBuilder.kt
@@ -11,7 +11,7 @@ import com.slack.api.model.kotlin_extension.block.container.MultiLayoutBlockCont
 @BlockLayoutBuilder
 class ContainerBlockBuilder : Builder<ContainerBlock> {
     private var blockId: String? = null
-    private var title: TextObject? = null
+    private var title: PlainTextObject? = null
     private var richTextTitle: RichTextBlock? = null
     private var subtitle: TextObject? = null
     private var childBlocks: List<LayoutBlock>? = null

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/ContainerBlockBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/ContainerBlockBuilder.kt
@@ -29,7 +29,7 @@ class ContainerBlockBuilder : Builder<ContainerBlock> {
         title = PlainTextObject(text, emoji)
     }
 
-    fun title(textObject: TextObject) {
+    fun title(textObject: PlainTextObject) {
         title = textObject
     }
 

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/ContainerBlockBuilder.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/ContainerBlockBuilder.kt
@@ -1,0 +1,86 @@
+package com.slack.api.model.kotlin_extension.block
+
+import com.slack.api.model.block.ContainerBlock
+import com.slack.api.model.block.LayoutBlock
+import com.slack.api.model.block.RichTextBlock
+import com.slack.api.model.block.composition.PlainTextObject
+import com.slack.api.model.block.composition.TextObject
+import com.slack.api.model.block.element.ImageElement
+import com.slack.api.model.kotlin_extension.block.container.MultiLayoutBlockContainer
+
+@BlockLayoutBuilder
+class ContainerBlockBuilder : Builder<ContainerBlock> {
+    private var blockId: String? = null
+    private var title: TextObject? = null
+    private var richTextTitle: RichTextBlock? = null
+    private var subtitle: TextObject? = null
+    private var childBlocks: List<LayoutBlock>? = null
+    private var width: String? = null
+    private var icon: ImageElement? = null
+    private var isCollapsible: Boolean? = null
+    private var defaultCollapsed: Boolean? = null
+    private var hasHeaderDivider: Boolean? = null
+
+    fun blockId(id: String) {
+        blockId = id
+    }
+
+    fun title(text: String, emoji: Boolean? = null) {
+        title = PlainTextObject(text, emoji)
+    }
+
+    fun title(textObject: TextObject) {
+        title = textObject
+    }
+
+    fun richTextTitle(richText: RichTextBlock) {
+        richTextTitle = richText
+    }
+
+    fun subtitle(text: String, emoji: Boolean? = null) {
+        subtitle = PlainTextObject(text, emoji)
+    }
+
+    fun subtitle(textObject: TextObject) {
+        subtitle = textObject
+    }
+
+    fun childBlocks(builder: MultiLayoutBlockContainer.() -> Unit) {
+        childBlocks = MultiLayoutBlockContainer().apply(builder).underlying
+    }
+
+    fun width(width: String) {
+        this.width = width
+    }
+
+    fun icon(imageUrl: String, altText: String) {
+        icon = ImageElement.builder().imageUrl(imageUrl).altText(altText).build()
+    }
+
+    fun isCollapsible(collapsible: Boolean) {
+        isCollapsible = collapsible
+    }
+
+    fun defaultCollapsed(collapsed: Boolean) {
+        defaultCollapsed = collapsed
+    }
+
+    fun hasHeaderDivider(divider: Boolean) {
+        hasHeaderDivider = divider
+    }
+
+    override fun build(): ContainerBlock {
+        return ContainerBlock.builder()
+            .blockId(blockId)
+            .title(title)
+            .richTextTitle(richTextTitle)
+            .subtitle(subtitle)
+            .childBlocks(childBlocks ?: ArrayList())
+            .width(width)
+            .icon(icon)
+            .isCollapsible(isCollapsible)
+            .defaultCollapsed(defaultCollapsed)
+            .hasHeaderDivider(hasHeaderDivider)
+            .build()
+    }
+}

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/container/MultiLayoutBlockContainer.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/container/MultiLayoutBlockContainer.kt
@@ -67,4 +67,8 @@ class MultiLayoutBlockContainer : LayoutBlockDsl {
     override fun shareShortcut(builder: ShareShortcutBlockBuilder.() -> Unit) {
         underlying += ShareShortcutBlockBuilder().apply(builder).build()
     }
+
+    override fun container(builder: ContainerBlockBuilder.() -> Unit) {
+        underlying += ContainerBlockBuilder().apply(builder).build()
+    }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/container/MultiLayoutBlockContainer.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/container/MultiLayoutBlockContainer.kt
@@ -28,6 +28,10 @@ class MultiLayoutBlockContainer : LayoutBlockDsl {
         underlying += ActionsBlockBuilder().apply(builder).build()
     }
 
+    override fun container(builder: ContainerBlockBuilder.() -> Unit) {
+        underlying += ContainerBlockBuilder().apply(builder).build()
+    }
+
     override fun context(builder: ContextBlockBuilder.() -> Unit) {
         underlying += ContextBlockBuilder().apply(builder).build()
     }
@@ -66,9 +70,5 @@ class MultiLayoutBlockContainer : LayoutBlockDsl {
 
     override fun shareShortcut(builder: ShareShortcutBlockBuilder.() -> Unit) {
         underlying += ShareShortcutBlockBuilder().apply(builder).build()
-    }
-
-    override fun container(builder: ContainerBlockBuilder.() -> Unit) {
-        underlying += ContainerBlockBuilder().apply(builder).build()
     }
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/dsl/LayoutBlockDsl.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/dsl/LayoutBlockDsl.kt
@@ -95,4 +95,11 @@ interface LayoutBlockDsl {
      * @see <a href="https://tools.slack.dev/deno-slack-sdk/">Next generation platform</a>
      */
     fun shareShortcut(builder: ShareShortcutBlockBuilder.() -> Unit)
+
+    /**
+     * A container block groups related blocks together into a visually distinct section.
+     *
+     * @see <a href="https://docs.slack.dev/reference/block-kit/blocks/container-block">Container documentation</a>
+     */
+    fun container(builder: ContainerBlockBuilder.() -> Unit)
 }

--- a/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/dsl/LayoutBlockDsl.kt
+++ b/slack-api-model-kotlin-extension/src/main/kotlin/com/slack/api/model/kotlin_extension/block/dsl/LayoutBlockDsl.kt
@@ -37,6 +37,13 @@ interface LayoutBlockDsl {
     fun actions(builder: ActionsBlockBuilder.() -> Unit)
 
     /**
+     * A container block groups related blocks together into a visually distinct section.
+     *
+     * @see <a href="https://docs.slack.dev/reference/block-kit/blocks/container-block">Container documentation</a>
+     */
+    fun container(builder: ContainerBlockBuilder.() -> Unit)
+
+    /**
      * Displays message context, which can include both images and text.
      *
      * @see <a href="https://docs.slack.dev/reference/block-kit/blocks/context-block">Context documentation</a>
@@ -95,11 +102,4 @@ interface LayoutBlockDsl {
      * @see <a href="https://tools.slack.dev/deno-slack-sdk/">Next generation platform</a>
      */
     fun shareShortcut(builder: ShareShortcutBlockBuilder.() -> Unit)
-
-    /**
-     * A container block groups related blocks together into a visually distinct section.
-     *
-     * @see <a href="https://docs.slack.dev/reference/block-kit/blocks/container-block">Container documentation</a>
-     */
-    fun container(builder: ContainerBlockBuilder.() -> Unit)
 }

--- a/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/ContainerBlockTest.kt
+++ b/slack-api-model-kotlin-extension/src/test/kotlin/test_locally/block/ContainerBlockTest.kt
@@ -1,0 +1,160 @@
+package test_locally.block
+
+import com.slack.api.model.block.ContainerBlock
+import com.slack.api.model.block.DividerBlock
+import com.slack.api.model.block.SectionBlock
+import com.slack.api.model.block.composition.MarkdownTextObject
+import com.slack.api.model.block.composition.PlainTextObject
+import com.slack.api.model.kotlin_extension.block.withBlocks
+import com.slack.api.util.json.GsonFactory
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ContainerBlockTest {
+
+    @Test
+    fun constructBasicContainer() {
+        val gson = GsonFactory.createSnakeCase()
+        val blocks = withBlocks {
+            container {
+                blockId("container-1")
+                title("Container Title")
+                width("wide")
+                isCollapsible(true)
+                defaultCollapsed(false)
+                hasHeaderDivider(true)
+                icon("https://example.com/icon.png", "icon")
+                childBlocks {
+                    divider()
+                }
+            }
+        }
+        assertEquals(1, blocks.size)
+        val container = blocks[0] as ContainerBlock
+        assertEquals("container", container.type)
+        assertEquals("container-1", container.blockId)
+        assertEquals("Container Title", container.title.text)
+        assertEquals("wide", container.width)
+        assertEquals(true, container.isCollapsible)
+        assertEquals(false, container.defaultCollapsed)
+        assertEquals(true, container.hasHeaderDivider)
+        assertNotNull(container.icon)
+        assertEquals(1, container.childBlocks.size)
+        assertTrue(container.childBlocks[0] is DividerBlock)
+
+        val json = gson.toJson(blocks)
+        assertTrue(json.contains("\"type\":\"container\""))
+        assertTrue(json.contains("\"block_id\":\"container-1\""))
+    }
+
+    @Test
+    fun constructContainerWithPlainTextObject() {
+        val titleObj = PlainTextObject.builder().text("Title with emoji").emoji(true).build()
+        val blocks = withBlocks {
+            container {
+                title(titleObj)
+                childBlocks {
+                    divider()
+                }
+            }
+        }
+        val container = blocks[0] as ContainerBlock
+        assertEquals("Title with emoji", container.title.text)
+    }
+
+    @Test
+    fun constructContainerWithSubtitle() {
+        val blocks = withBlocks {
+            container {
+                title("Title")
+                subtitle("Plain subtitle")
+                childBlocks {
+                    divider()
+                }
+            }
+        }
+        val container = blocks[0] as ContainerBlock
+        assertNotNull(container.subtitle)
+        assertEquals("Plain subtitle", container.subtitle.text)
+    }
+
+    @Test
+    fun constructContainerWithMarkdownSubtitle() {
+        val blocks = withBlocks {
+            container {
+                title("Title")
+                subtitle(MarkdownTextObject.builder().text("*Bold* subtitle").build())
+                childBlocks {
+                    divider()
+                }
+            }
+        }
+        val container = blocks[0] as ContainerBlock
+        assertNotNull(container.subtitle)
+        assertEquals("mrkdwn", container.subtitle.type)
+    }
+
+    @Test
+    fun constructContainerWithMultipleChildBlocks() {
+        val blocks = withBlocks {
+            container {
+                title("Title")
+                childBlocks {
+                    section {
+                        markdownText("Section inside container")
+                    }
+                    divider()
+                }
+            }
+        }
+        val container = blocks[0] as ContainerBlock
+        assertEquals(2, container.childBlocks.size)
+        assertTrue(container.childBlocks[0] is SectionBlock)
+        assertTrue(container.childBlocks[1] is DividerBlock)
+    }
+
+    @Test
+    fun constructContainerWithoutOptionalFields() {
+        val blocks = withBlocks {
+            container {
+                title("Minimal")
+                childBlocks {
+                    divider()
+                }
+            }
+        }
+        val container = blocks[0] as ContainerBlock
+        assertNull(container.blockId)
+        assertNull(container.width)
+        assertNull(container.isCollapsible)
+        assertNull(container.defaultCollapsed)
+        assertNull(container.hasHeaderDivider)
+        assertNull(container.icon)
+        assertNull(container.richTextTitle)
+    }
+
+    @Test
+    fun roundTripSerialization() {
+        val gson = GsonFactory.createSnakeCase()
+        val blocks = withBlocks {
+            container {
+                blockId("rt-1")
+                title("Round trip")
+                subtitle("Sub")
+                width("wide")
+                isCollapsible(true)
+                childBlocks {
+                    divider()
+                }
+            }
+        }
+        val json = gson.toJson(blocks)
+        val reparsed = gson.fromJson(json, Array<ContainerBlock>::class.java)
+        assertEquals("rt-1", reparsed[0].blockId)
+        assertEquals("Round trip", reparsed[0].title.text)
+        assertEquals("wide", reparsed[0].width)
+    }
+}

--- a/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
@@ -151,6 +151,8 @@ public class Blocks {
 
     public static ContainerBlock container(ModelConfigurator<ContainerBlock.ContainerBlockBuilder> configurator) {
         return configurator.configure(ContainerBlock.builder()).build();
+    }
+
     // TaskCardBlock
 
     public static TaskCardBlock taskCard(ModelConfigurator<TaskCardBlock.TaskCardBlockBuilder> configurator) {

--- a/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/Blocks.java
@@ -147,4 +147,10 @@ public class Blocks {
         return configurator.configure(CarouselBlock.builder()).build();
     }
 
+    // ContainerBlock
+
+    public static ContainerBlock container(ModelConfigurator<ContainerBlock.ContainerBlockBuilder> configurator) {
+        return configurator.configure(ContainerBlock.builder()).build();
+    }
+
 }

--- a/slack-api-model/src/main/java/com/slack/api/model/block/ContainerBlock.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/ContainerBlock.java
@@ -1,5 +1,6 @@
 package com.slack.api.model.block;
 
+import com.slack.api.model.block.composition.PlainTextObject;
 import com.slack.api.model.block.composition.TextObject;
 import com.slack.api.model.block.element.ImageElement;
 import lombok.AllArgsConstructor;
@@ -21,7 +22,7 @@ public class ContainerBlock implements LayoutBlock {
     public static final String TYPE = "container";
     private final String type = TYPE;
 
-    private TextObject title;
+    private PlainTextObject title;
 
     private RichTextBlock richTextTitle;
 

--- a/slack-api-model/src/main/java/com/slack/api/model/block/ContainerBlock.java
+++ b/slack-api-model/src/main/java/com/slack/api/model/block/ContainerBlock.java
@@ -1,0 +1,44 @@
+package com.slack.api.model.block;
+
+import com.slack.api.model.block.composition.TextObject;
+import com.slack.api.model.block.element.ImageElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * https://docs.slack.dev/reference/block-kit/blocks/container-block
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContainerBlock implements LayoutBlock {
+    public static final String TYPE = "container";
+    private final String type = TYPE;
+
+    private TextObject title;
+
+    private RichTextBlock richTextTitle;
+
+    private TextObject subtitle;
+
+    @Builder.Default
+    private List<LayoutBlock> childBlocks = new ArrayList<>();
+
+    private String width;
+
+    private ImageElement icon;
+
+    private Boolean isCollapsible;
+
+    private Boolean defaultCollapsed;
+
+    private Boolean hasHeaderDivider;
+
+    private String blockId;
+}

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
@@ -67,6 +67,8 @@ public class GsonLayoutBlockFactory implements JsonDeserializer<LayoutBlock>, Js
                 return CardBlock.class;
             case CarouselBlock.TYPE:
                 return CarouselBlock.class;
+            case ContainerBlock.TYPE:
+                return ContainerBlock.class;
             default:
                 if (failOnUnknownProperties) {
                     throw new JsonParseException("Unsupported layout block type: " + typeName);

--- a/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
+++ b/slack-api-model/src/main/java/com/slack/api/util/json/GsonLayoutBlockFactory.java
@@ -43,6 +43,8 @@ public class GsonLayoutBlockFactory implements JsonDeserializer<LayoutBlock>, Js
                 return CardBlock.class;
             case CarouselBlock.TYPE:
                 return CarouselBlock.class;
+            case ContainerBlock.TYPE:
+                return ContainerBlock.class;
             case ContextActionsBlock.TYPE:
                 return ContextActionsBlock.class;
             case ContextBlock.TYPE:

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlockKitTest.java
@@ -2170,6 +2170,154 @@ public class BlockKitTest {
     }
 
     @Test
+    public void parseContainerBlock() {
+        // https://docs.slack.dev/reference/block-kit/blocks/container-block
+        String json = "{\"blocks\":[\n" +
+                "  {\n" +
+                "    \"type\": \"container\",\n" +
+                "    \"block_id\": \"container1\",\n" +
+                "    \"title\": {\n" +
+                "      \"type\": \"plain_text\",\n" +
+                "      \"text\": \"Container Title\"\n" +
+                "    },\n" +
+                "    \"subtitle\": {\n" +
+                "      \"type\": \"mrkdwn\",\n" +
+                "      \"text\": \"*Bold* subtitle\"\n" +
+                "    },\n" +
+                "    \"width\": \"wide\",\n" +
+                "    \"is_collapsible\": true,\n" +
+                "    \"default_collapsed\": false,\n" +
+                "    \"icon\": {\n" +
+                "      \"type\": \"image\",\n" +
+                "      \"image_url\": \"https://example.com/icon.png\",\n" +
+                "      \"alt_text\": \"icon\"\n" +
+                "    },\n" +
+                "    \"child_blocks\": [\n" +
+                "      {\n" +
+                "        \"type\": \"section\",\n" +
+                "        \"text\": {\n" +
+                "          \"type\": \"mrkdwn\",\n" +
+                "          \"text\": \"Section inside container.\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"type\": \"divider\"\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "]}";
+        Gson gson = GsonFactory.createSnakeCase();
+        Message message = gson.fromJson(json, Message.class);
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getBlocks().size(), is(1));
+
+        ContainerBlock container = (ContainerBlock) message.getBlocks().get(0);
+        assertThat(container.getType(), is("container"));
+        assertThat(container.getBlockId(), is("container1"));
+        assertThat(container.getTitle().getType(), is("plain_text"));
+        assertThat(container.getTitle().getText(), is("Container Title"));
+        assertThat(container.getSubtitle().getType(), is("mrkdwn"));
+        assertThat(container.getWidth(), is("wide"));
+        assertThat(container.getIsCollapsible(), is(true));
+        assertThat(container.getDefaultCollapsed(), is(false));
+        assertThat(container.getIcon().getImageUrl(), is("https://example.com/icon.png"));
+        assertThat(container.getChildBlocks().size(), is(2));
+        assertThat(container.getChildBlocks().get(0), is(instanceOf(SectionBlock.class)));
+        assertThat(container.getChildBlocks().get(1), is(instanceOf(DividerBlock.class)));
+
+        // Round-trip
+        Message roundTrip = gson.fromJson(gson.toJson(message), Message.class);
+        ContainerBlock reparsed = (ContainerBlock) roundTrip.getBlocks().get(0);
+        assertThat(reparsed.getBlockId(), is("container1"));
+        assertThat(reparsed.getChildBlocks().size(), is(2));
+    }
+
+    @Test
+    public void parseContainerBlockWithRichTextTitle() {
+        String json = "{\"blocks\":[\n" +
+                "  {\n" +
+                "    \"type\": \"container\",\n" +
+                "    \"rich_text_title\": {\n" +
+                "      \"type\": \"rich_text\",\n" +
+                "      \"elements\": [\n" +
+                "        {\n" +
+                "          \"type\": \"rich_text_section\",\n" +
+                "          \"elements\": [\n" +
+                "            {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"text\": \"Rich Title\"\n" +
+                "            }\n" +
+                "          ]\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    },\n" +
+                "    \"child_blocks\": [\n" +
+                "      {\n" +
+                "        \"type\": \"divider\"\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "]}";
+        Gson gson = GsonFactory.createSnakeCase();
+        Message message = gson.fromJson(json, Message.class);
+        assertThat(message, is(notNullValue()));
+        ContainerBlock container = (ContainerBlock) message.getBlocks().get(0);
+        assertThat(container.getRichTextTitle(), is(notNullValue()));
+        assertThat(container.getRichTextTitle().getType(), is("rich_text"));
+        assertThat(container.getRichTextTitle().getElements().size(), is(1));
+        assertThat(container.getTitle(), is(nullValue()));
+    }
+
+    @Test
+    public void parseContainerBlockWithHeaderDivider() {
+        String json = "{\"blocks\":[\n" +
+                "  {\n" +
+                "    \"type\": \"container\",\n" +
+                "    \"title\": {\n" +
+                "      \"type\": \"plain_text\",\n" +
+                "      \"text\": \"With divider\"\n" +
+                "    },\n" +
+                "    \"has_header_divider\": true,\n" +
+                "    \"child_blocks\": [\n" +
+                "      {\n" +
+                "        \"type\": \"divider\"\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "]}";
+        Gson gson = GsonFactory.createSnakeCase();
+        Message message = gson.fromJson(json, Message.class);
+        ContainerBlock container = (ContainerBlock) message.getBlocks().get(0);
+        assertThat(container.getHasHeaderDivider(), is(true));
+        assertThat(container.getIsCollapsible(), is(nullValue()));
+    }
+
+    @Test
+    public void buildContainerBlock() {
+        ContainerBlock container = container(c -> c
+                .blockId("container1")
+                .title(com.slack.api.model.block.composition.PlainTextObject.builder().text("Title").build())
+                .width("wide")
+                .isCollapsible(true)
+                .childBlocks(Arrays.asList(
+                        divider()
+                ))
+        );
+        assertThat(container.getType(), is("container"));
+        assertThat(container.getBlockId(), is("container1"));
+
+        Gson gson = GsonFactory.createSnakeCase();
+        Message message = new Message();
+        message.setBlocks(asBlocks(container));
+        Message reparsed = gson.fromJson(gson.toJson(message), Message.class);
+        ContainerBlock parsedContainer = (ContainerBlock) reparsed.getBlocks().get(0);
+        assertThat(parsedContainer.getBlockId(), is("container1"));
+        assertThat(parsedContainer.getWidth(), is("wide"));
+        assertThat(parsedContainer.getIsCollapsible(), is(true));
+        assertThat(parsedContainer.getChildBlocks().size(), is(1));
+    }
+
+    @Test
     public void buildCarouselBlock() {
         CarouselBlock carousel = carousel(c -> c
                 .blockId("carousel1")

--- a/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
+++ b/slack-api-model/src/test/java/test_locally/api/model/block/BlocksTest.java
@@ -118,6 +118,14 @@ public class BlocksTest {
     }
 
     @Test
+    public void testContainer() {
+        assertThat(container(c -> c.blockId("container-1")
+                .title(com.slack.api.model.block.composition.PlainTextObject.builder().text("Title").build())
+                .childBlocks(Arrays.asList(divider()))
+        ), is(notNullValue()));
+    }
+
+    @Test
     public void testImage() {
         assertThat(Blocks.image(i -> i.blockId("block-id").imageUrl("https://www.example.com/")), is(notNullValue()));
         assertThat(Blocks.image(i -> i


### PR DESCRIPTION
Add support for the [Container Block](https://docs.slack.dev/reference/block-kit/blocks/container-block/) layout block type.

### Changes

- **`ContainerBlock.java`** — New layout block with all documented properties: `title`, `rich_text_title`, `subtitle`, `child_blocks`, `width`, `icon`, `is_collapsible`, `default_collapsed`, `has_header_divider`, `block_id`
- **`GsonLayoutBlockFactory`** — Registered `container` type for deserialization
- **`Blocks.java`** — Added `container()` static helper
- **Kotlin DSL** — Added `ContainerBlockBuilder`, `LayoutBlockDsl.container()`, and `MultiLayoutBlockContainer.container()`
- **Tests** — Deserialization tests (full properties, rich_text_title, has_header_divider), builder round-trip test, static helper test

<details>
<summary>Example test app (App.java)</summary>

```java
package blockkit;

import com.slack.api.bolt.AppConfig;
import com.slack.api.bolt.socket_mode.SocketModeApp;
import com.slack.api.model.block.RichTextBlock;
import com.slack.api.model.block.composition.MarkdownTextObject;
import com.slack.api.model.block.element.ButtonElement;
import com.slack.api.model.block.element.ImageElement;
import com.slack.api.model.block.element.RichTextInputElement;
import com.slack.api.model.block.element.RichTextSectionElement;


import java.util.Arrays;

import static com.slack.api.model.block.Blocks.*;
import static com.slack.api.model.block.composition.BlockCompositions.plainText;
import static com.slack.api.model.view.Views.*;

public class App {

    public static void main(String[] args) throws Exception {
        var app = new com.slack.api.bolt.App(AppConfig.builder()
                .singleTeamBotToken(System.getenv("SLACK_BOT_TOKEN"))
                .build());
                
        // /container-block — sends container blocks with variant subcommands
        app.command("/container-block", (req, ctx) -> {
            String variant = req.getPayload().getText() != null ? req.getPayload().getText().trim() : "";

            var childBlocks = asBlocks(
                    section(s -> s.text(MarkdownTextObject.builder().text("Section inside a container.").build())),
                    divider(),
                    section(s -> s.text(MarkdownTextObject.builder().text("Another section below the divider.").build()))
            );

            var builder = com.slack.api.model.block.ContainerBlock.builder()
                    .title(plainText("Container Block Test"))
                    .childBlocks(childBlocks);

            switch (variant) {
                case "width":
                    builder.width("wide");
                    break;
                case "mrkdwn-subtitle":
                    builder.subtitle(MarkdownTextObject.builder().text("*Bold* subtitle").build());
                    break;
                case "has-header-divider":
                    builder.hasHeaderDivider(true);
                    break;
                case "default-collapsed":
                    builder.isCollapsible(true);
                    builder.defaultCollapsed(true);
                    break;
                case "icon":
                    builder.icon(ImageElement.builder()
                            .imageUrl("https://api.slack.com/img/blocks/bkb_template_images/plants.png")
                            .altText("icon")
                            .build());
                    break;
                case "rich-text-title":
                    builder.title(null);
                    builder.richTextTitle(RichTextBlock.builder()
                            .elements(Arrays.asList(
                                    RichTextSectionElement.builder()
                                            .elements(Arrays.asList(
                                                    RichTextSectionElement.Text.builder().text("Rich Title").build()
                                            ))
                                            .build()
                            ))
                            .build());
                    break;
                case "all-collapsible":
                    builder.subtitle(plainText("Collapsible variant"));
                    builder.width("wide");
                    builder.icon(ImageElement.builder()
                            .imageUrl("https://api.slack.com/img/blocks/bkb_template_images/plants.png")
                            .altText("icon")
                            .build());
                    builder.isCollapsible(true);
                    break;
                case "all-divider":
                    builder.subtitle(plainText("Header divider variant"));
                    builder.width("wide");
                    builder.icon(ImageElement.builder()
                            .imageUrl("https://api.slack.com/img/blocks/bkb_template_images/plants.png")
                            .altText("icon")
                            .build());
                    builder.hasHeaderDivider(true);
                    break;
                case "all":
                    builder.subtitle(plainText("All compatible properties"));
                    builder.width("wide");
                    builder.icon(ImageElement.builder()
                            .imageUrl("https://api.slack.com/img/blocks/bkb_template_images/plants.png")
                            .altText("icon")
                            .build());
                    builder.isCollapsible(true);
                    break;
                default:
                    builder.subtitle(plainText("Base test (try: width, mrkdwn-subtitle, has-header-divider, default-collapsed, icon, rich-text-title, all)"));
                    break;
            }

            var resp = ctx.client().chatPostMessage(r -> r
                    .channel(req.getPayload().getChannelId())
                    .text("Container block test")
                    .blocks(asBlocks(builder.build())));
            System.out.println("chatPostMessage response - ok: " + resp.isOk() + ", error: " + resp.getError());
            if (resp.getError() != null) {
                System.out.println("Response metadata: " + resp.getResponseMetadata());
            }
            return ctx.ack();
        });


        String appToken = System.getenv("SLACK_APP_TOKEN");
        SocketModeApp socketModeApp = new SocketModeApp(appToken, app);
        socketModeApp.start();
    }
}
```

To run:

```bash
# First, install the SDK snapshot locally (from the java-slack-sdk repo):
./scripts/install_local.sh

# Then, from the bolt-java-block-kit-test directory:
SLACK_BOT_TOKEN=xoxb-... SLACK_APP_TOKEN=xapp-... mvn exec:java
```

Subcommands: `/container-block`, `/container-block width`, `/container-block mrkdwn-subtitle`, `/container-block has-header-divider`, `/container-block default-collapsed`, `/container-block icon`, `/container-block rich-text-title`, `/container-block all-collapsible`, `/container-block all-divider`, `/container-block all`

</details>

> **Note:** `has_header_divider` and `is_collapsible` are mutually exclusive — the Slack API returns `invalid_blocks` if both are `true`.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [ ] **slack-api-client** (Slack API Clients)
* [x] **slack-api-model** (Slack API Data Models)
* [x] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.