### PR TITLE
feat: Add Block Kit support for file uploads

### DIFF
--- a/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/RequestFormBuilder.java
@@ -2317,6 +2317,14 @@ public class RequestFormBuilder {
         }
         setIfNotNull("initial_comment", req.getInitialComment(), form);
         setIfNotNull("thread_ts", req.getThreadTs(), form);
+        if (req.getBlocksAsString() != null) {
+            form.add("blocks", req.getBlocksAsString());
+        } else if (req.getBlocks() != null) {
+            form.add("blocks", getJsonWithGsonAnonymInnerClassHandling(req.getBlocks()));
+        }
+        if (req.getBlocksAsString() != null && req.getBlocks() != null) {
+            log.warn("Although you set both blocksAsString and blocks, only blocksAsString was used.");
+        }
         return form;
     }
 

--- a/slack-api-client/src/main/java/com/slack/api/methods/impl/FilesUploadV2Helper.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/impl/FilesUploadV2Helper.java
@@ -97,6 +97,8 @@ public class FilesUploadV2Helper implements AutoCloseable {
                 .channels(v2Request.getChannels())
                 .initialComment(v2Request.getInitialComment())
                 .threadTs(v2Request.getThreadTs())
+                .blocks(v2Request.getBlocks())
+                .blocksAsString(v2Request.getBlocksAsString())
         );
         underlyingException.setCompleteResponse(response);
         if (!response.isOk()) {

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesCompleteUploadExternalRequest.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesCompleteUploadExternalRequest.java
@@ -1,6 +1,7 @@
 package com.slack.api.methods.request.files;
 
 import com.slack.api.methods.SlackApiRequest;
+import com.slack.api.model.block.LayoutBlock;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -45,6 +46,18 @@ public class FilesCompleteUploadExternalRequest implements SlackApiRequest {
      * Never use a reply's ts value; use its parent instead.
      */
     private String threadTs;
+
+    /**
+     * A JSON-based array of structured blocks, presented as a URL-encoded string.
+     * If initialComment is provided, this field is ignored.
+     */
+    private List<LayoutBlock> blocks;
+
+    /**
+     * A JSON-based array of structured blocks as a String, presented as a URL-encoded string.
+     * If initialComment is provided, this field is ignored.
+     */
+    private String blocksAsString;
 
     @Data
     @Builder

--- a/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadV2Request.java
+++ b/slack-api-client/src/main/java/com/slack/api/methods/request/files/FilesUploadV2Request.java
@@ -1,6 +1,7 @@
 package com.slack.api.methods.request.files;
 
 import com.slack.api.methods.SlackApiRequest;
+import com.slack.api.model.block.LayoutBlock;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -149,5 +150,17 @@ public class FilesUploadV2Request implements SlackApiRequest {
      * Never use a reply's ts value; use its parent instead.
      */
     private String threadTs;
+
+    /**
+     * A JSON-based array of structured blocks, presented as a URL-encoded string.
+     * If initialComment is provided, this field is ignored.
+     */
+    private List<LayoutBlock> blocks;
+
+    /**
+     * A JSON-based array of structured blocks as a String, presented as a URL-encoded string.
+     * If initialComment is provided, this field is ignored.
+     */
+    private String blocksAsString;
 
 }

--- a/slack-api-client/src/test/java/test_locally/api/methods/FilesUploadV2HelperTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/FilesUploadV2HelperTest.java
@@ -1,0 +1,57 @@
+package test_locally.api.methods;
+
+import com.slack.api.RequestConfigurator;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.impl.FilesUploadV2Helper;
+import com.slack.api.methods.request.files.FilesCompleteUploadExternalRequest;
+import com.slack.api.methods.request.files.FilesUploadV2Request;
+import com.slack.api.methods.response.files.FilesCompleteUploadExternalResponse;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.SectionBlock;
+import com.slack.api.util.http.SlackHttpClient;
+import okhttp3.OkHttpClient;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FilesUploadV2HelperTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void completeUploadsPropagatesBlocks() throws Exception {
+        // GIVEN
+        MethodsClient client = mock(MethodsClient.class);
+        when(client.getSlackHttpClient()).thenReturn(new SlackHttpClient(new OkHttpClient()));
+
+        FilesCompleteUploadExternalResponse response = new FilesCompleteUploadExternalResponse();
+        response.setOk(true);
+        response.setFiles(Collections.emptyList());
+
+        ArgumentCaptor<RequestConfigurator<FilesCompleteUploadExternalRequest.FilesCompleteUploadExternalRequestBuilder>> captor =
+                ArgumentCaptor.forClass(RequestConfigurator.class);
+        when(client.filesCompleteUploadExternal(captor.capture())).thenReturn(response);
+
+        List<LayoutBlock> blocks = Collections.<LayoutBlock>singletonList(SectionBlock.builder().build());
+        FilesUploadV2Request request = FilesUploadV2Request.builder()
+                .blocks(blocks)
+                .blocksAsString("[]")
+                .build();
+
+        // WHEN
+        new FilesUploadV2Helper(client).completeUploads(request, Collections.emptyList());
+
+        // THEN
+        FilesCompleteUploadExternalRequest completeRequest = captor.getValue()
+                .configure(FilesCompleteUploadExternalRequest.builder())
+                .build();
+        assertThat(completeRequest.getBlocks(), is(blocks));
+        assertThat(completeRequest.getBlocksAsString(), is("[]"));
+    }
+}

--- a/slack-api-client/src/test/java/test_locally/api/methods/RequestFormBuilderTest.java
+++ b/slack-api-client/src/test/java/test_locally/api/methods/RequestFormBuilderTest.java
@@ -4,6 +4,7 @@ import com.slack.api.methods.RequestFormBuilder;
 import com.slack.api.methods.request.calls.CallsAddRequest;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import com.slack.api.methods.request.chat.ChatUnfurlRequest;
+import com.slack.api.methods.request.files.FilesCompleteUploadExternalRequest;
 import com.slack.api.model.Attachment;
 import com.slack.api.model.CallParticipant;
 import com.slack.api.model.block.LayoutBlock;
@@ -58,6 +59,43 @@ public class RequestFormBuilderTest {
         final int blocksIndexInForm = 2;
         assertThat(form.name(blocksIndexInForm), is("blocks"));
         assertThat(form.value(blocksIndexInForm), is("[]"));
+    }
+
+    @Test
+    public void testFilesCompleteUploadExternalBlocksJsonSerialization() {
+        // GIVEN
+        List<LayoutBlock> blocks = new ArrayList<>();
+        blocks.add(MyTestBlock.builder().build());
+
+        FilesCompleteUploadExternalRequest request = FilesCompleteUploadExternalRequest.builder()
+                .blocks(blocks)
+                .build();
+
+        // WHEN
+        FormBody form = RequestFormBuilder.toForm(request).build();
+
+        // THEN
+        assertThat(form.name(0), is("blocks"));
+        assertThat(form.value(0), is("[{\"type\":\"myTestBlock\"}]"));
+    }
+
+    @Test
+    public void testFilesCompleteUploadExternalBlocksAsStringTakesPrecedence() {
+        // GIVEN
+        List<LayoutBlock> blocks = new ArrayList<>();
+        blocks.add(MyTestBlock.builder().build());
+
+        FilesCompleteUploadExternalRequest request = FilesCompleteUploadExternalRequest.builder()
+                .blocks(blocks)
+                .blocksAsString("[]")
+                .build();
+
+        // WHEN
+        FormBody form = RequestFormBuilder.toForm(request).build();
+
+        // THEN
+        assertThat(form.name(0), is("blocks"));
+        assertThat(form.value(0), is("[]"));
     }
 
     @Test


### PR DESCRIPTION
Add Block Kit support (`blocks` parameter) for FileUploadV2Request. This PR fixes #1470.

### Category (place an `x` in each of the `[ ]`)

* [ ] **bolt** (Bolt for Java)
* [ ] **bolt-{sub modules}** (Bolt for Java - optional modules)
* [x] **slack-api-client** (Slack API Clients)
* [ ] **slack-api-model** (Slack API Data Models)
* [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
* [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

## Requirements

Please read the [Contributing guidelines](https://github.com/slackapi/java-slack-sdk/blob/main/.github/contributing.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct) before creating this issue or pull request. By submitting, you agree to those rules.
