### PR TITLE
Fix Javadoc link in Web API basics guide

### DIFF
--- a/docs/english/guides/web-api-basics.md
+++ b/docs/english/guides/web-api-basics.md
@@ -209,7 +209,7 @@ try {
 
 Slack Web API offers [180+ methods](/reference/methods). The way to use others is almost the same: calling methods in `MethodsClient` with a valid token and sufficient parameters.
 
-A good way to check the entire list of methods available in this SDK is to access [the Javadoc](https://oss.sonatype.org/service/local/repositories/releases/archive/com/slack/api/slack-api-client/sdkLatestVersion/slack-api-client-sdkLatestVersion-javadoc.jar/!/com/slack/api/methods/MethodsClient.html).
+A good way to check the entire list of methods available in this SDK is to access [the Javadoc](https://javadoc.io/doc/com.slack.api/slack-api-client/latest/com/slack/api/methods/MethodsClient.html).
 
 #### Call unsupported methods
 


### PR DESCRIPTION
Fixes #1591

The Javadoc link in the Web API basics guide was pointing to the old Sonatype repository URL, which no longer works.

This PR updates the link to the corresponding Javadoc.io page.

### Category

- [ ] **bolt** (Bolt for Java)
- [ ] **bolt-(sub modules)** (Bolt for Java - optional modules)
- [x] **slack-api-client** (Slack API Clients)
- [ ] **slack-api-model** (Slack API Data Models)
- [ ] **slack-api-*-kotlin-extension** (Kotlin Extensions for Slack API Clients)
- [ ] **slack-app-backend** (The primitive layer of Bolt for Java)

### Testing

Verified that the new Javadoc URL returns HTTP 200 OK.